### PR TITLE
Geom text style (issue #60)

### DIFF
--- a/R/geom-text.r
+++ b/R/geom-text.r
@@ -33,6 +33,13 @@
 #'    geom=c("point", "text"))
 #' qplot(wt, mpg, data = mtcars, label = rownames(mtcars), size = wt) +
 #'   geom_text(colour = "red")
+#'
+#' # You can specify fontfamily, fontface and lineheight
+#' p <- ggplot(mtcars, aes(x=wt, y=mpg, label=rownames(mtcars)))
+#' p + geom_text(fontface=3)
+#' p + geom_text(fontface=am+1)
+#' p + geom_text(aes(family=c("serif", "mono")[am+1]))
+
 GeomText <- proto(Geom, {
   objname <- "text"
 
@@ -42,10 +49,10 @@ GeomText <- proto(Geom, {
     if (parse) {
       lab <- parse(text = lab)
     }
-    
+
     with(coordinates$transform(data, scales), 
       textGrob(lab, x, y, default.units="native", hjust=hjust, vjust=vjust, rot=angle, 
-      gp=gpar(col=alpha(colour, alpha), fontsize=size * .pt)) 
+      gp=gpar(col=alpha(colour, alpha), fontsize=size * .pt, fontfamily=family, fontface=fontface, lineheight=lineheight))
     )
   }
 
@@ -61,7 +68,7 @@ GeomText <- proto(Geom, {
   icon <- function(.) textGrob("text", rot=45, gp=gpar(cex=1.2))
   default_stat <- function(.) StatIdentity
   required_aes <- c("x", "y", "label")
-  default_aes <- function(.) aes(colour="black", size=5 , angle=0, hjust=0.5, vjust=0.5, alpha = 1)
+  default_aes <- function(.) aes(colour="black", size=5 , angle=0, hjust=0.5, vjust=0.5, alpha = 1, family="", fontface=1, lineheight=1.2)
   guide_geom <- function(x) "text"
   
 })


### PR DESCRIPTION
I modified geom_text so as to users specify fontfamily, fontface, and lineheight.
Note that the implementation is very simple, just pass the params to gpar.
So users need to set fontfamily via quartzFonts, pdfFonts, windowsFonts, etc, before using this function.
