### PR TITLE
Documentation alias fix, description was part of alias

### DIFF
--- a/R/aes-colour-fill-alpha.r
+++ b/R/aes-colour-fill-alpha.r
@@ -1,13 +1,13 @@
 #' Colour related aesthetics: colour, fill and alpha
-#' 
-#' @name aes_colour_fill_alpha
-#' @aliases colour color fill alpha 
 #'
-#' This page demonstrates the usage of a sub-group 
+#' This page demonstrates the usage of a sub-group
 #' of aesthetics; colour, fill and alpha.
-#' 
+#'
+#' @name aes_colour_fill_alpha
+#' @aliases colour color fill alpha
+#'
 #' @examples
-#' 
+#'
 #' # Bar chart example
 #' c <- ggplot(mtcars, aes(factor(cyl)))
 #' # Default plotting
@@ -18,7 +18,7 @@
 #' c + geom_bar(colour = "red")
 #' # Combining both, you can see the changes more clearly
 #' c + geom_bar(fill = "white", colour = "red")
-#' 
+#'
 #' # The aesthetic fill also takes different colouring scales
 #' # setting fill equal to a factor varible uses a discrete colour scale
 #' k <- ggplot(mtcars, aes(factor(cyl), fill = factor(vs)))
@@ -35,7 +35,7 @@
 #' b + geom_line(colour = "green")
 #' b + geom_point()
 #' b + geom_point(colour = "red")
-#' 
+#'
 #' # For large datasets with overplotting the alpha
 #' # aesthetic will make the points more transparent
 #' df <- data.frame(x = rnorm(5000), y = rnorm(5000))
@@ -44,15 +44,15 @@
 #' h + geom_point(colour = alpha("black", .5))
 #' h + geom_point(colour = alpha("black", 1/10))
 #'
-#' #If a geom uses both fill and colour, alpha will only modify the fill colour 
+#' #If a geom uses both fill and colour, alpha will only modify the fill colour
 #' c + geom_bar(fill = "dark grey", colour = "black")
 #' c + geom_bar(fill = "dark grey", colour = "black", alpha = 1/3)
-#' 
+#'
 #' # Alpha can also be used to add shading
 #' j <- b + geom_line()
 #' j
 #' yrng <- range(economics$unemploy)
-#' j <- j + geom_rect(aes(NULL, NULL, xmin = start, xmax = end, fill = party), 
+#' j <- j + geom_rect(aes(NULL, NULL, xmin = start, xmax = end, fill = party),
 #' ymin = yrng[1], ymax = yrng[2], data = presidential)
 #' j
 #' j + scale_fill_manual(values = alpha(c("blue", "red"), .3))

--- a/R/aes-linetype-size-shape.r
+++ b/R/aes-linetype-size-shape.r
@@ -1,11 +1,11 @@
 #' Differentiation related aesthetics: linetype, size, shape
-#' 
-#' @name aes_linetype_size_shape
-#' @aliases linetype size shape 
 #'
-#' This page demonstrates the usage of a sub-group 
+#' This page demonstrates the usage of a sub-group
 #' of aesthetics; linetype, size and shape.
-#' 
+#'
+#' @name aes_linetype_size_shape
+#' @aliases linetype size shape
+#'
 #' @examples
 #'
 #' # Line types should be specified with either an integer, a name, or with a string of
@@ -19,24 +19,24 @@
 #' f + geom_line(linetype = 2)
 #' f + geom_line(linetype = "dotdash")
 #
-#' # An example with hex strings, the string "33" specifies three units on followed 
-#' # by three off and "3313" specifies three units on followed by three off followed 
+#' # An example with hex strings, the string "33" specifies three units on followed
+#' # by three off and "3313" specifies three units on followed by three off followed
 #' # by one on and finally three off.
 #' f + geom_line(linetype = "3313")
 #'
 #' # Mapping line type from a variable
-#' ec_scaled <- data.frame(date = economics$date, rescaler(economics[, -(1:2)], "range")) 
+#' ec_scaled <- data.frame(date = economics$date, rescaler(economics[, -(1:2)], "range"))
 #' ecm <- melt(ec_scaled, id = "date")
 #' qplot(date, value, data = ecm, geom = "line", linetype = variable)
-#' 
+#'
 #' # Size examples
-#' # Should be specified with a numerical value (in millimetres), 
+#' # Should be specified with a numerical value (in millimetres),
 #' # or from a variable source
 #' p <- ggplot(mtcars, aes(wt, mpg))
 #' p + geom_point(size = 4)
 #' p + geom_point(aes(size = qsec))
 #' p + geom_point(size = 2.5) + geom_hline(yintercept = 25, size = 3.5)
-#' 
+#'
 #' # Shape examples
 #' # Shape takes four types of values: an integer in [0, 25],
 #' # a single character-- which uses that character as the plotting symbol,
@@ -52,7 +52,7 @@
 #' p + geom_point(aes(shape = factor(cyl)))
 #' # Compare to this plot which uses the values of cyl
 #' p + geom_point(aes(shape = cyl))
-#'  
+#'
 #' # A look at all 25 symbols
 #' df2 <- data.frame(x = 1:5 , y = 1:25, z = 1:25)
 #' s <- ggplot(df2, aes(x = x, y = y))


### PR DESCRIPTION
Moved short description above roxygen tags so that it is not part of aliases.
