### PR TITLE
xintercept and yintercept part of x and y scales

### DIFF
--- a/R/scale-continuous.r
+++ b/R/scale-continuous.r
@@ -58,14 +58,14 @@
 #' #   * log scaling
 #' qplot(rating, votes, data=movies, log="xy")
 scale_x_continuous <- function(..., expand = c(0.05, 0)) {
-  continuous_scale(c("x", "xmin", "xmax", "xend"), "position_c", identity,
+  continuous_scale(c("x", "xmin", "xmax", "xend", "xintercept"), "position_c", identity,
     ..., expand = expand, legend = FALSE)
 }
 
 #' @rdname scale_continuous
 #' @export
 scale_y_continuous <- function(..., expand = c(0.05, 0)) {
-  continuous_scale(c("y", "ymin", "ymax", "yend"), "position_c", identity,
+  continuous_scale(c("y", "ymin", "ymax", "yend", "yintercept"), "position_c", identity,
     ..., expand = expand, legend = FALSE)
 }
 

--- a/inst/tests/test-scales.r
+++ b/inst/tests/test-scales.r
@@ -60,7 +60,8 @@ test_that("position scales updated by all position aesthetics", {
   aesthetics <- list(
     aes(xend = x, yend = x),
     aes(xmin = x, ymin = x),
-    aes(xmax = x, ymax = x)
+    aes(xmax = x, ymax = x),
+    aes(xintercept = x, yintercept = y)
   )
   
   base <- ggplot(df, aes(x = 1, y = 1)) + geom_point()


### PR DESCRIPTION
xintercept was added to the x scale (which already had xmin, xmax, and
xend). Similar for y.  Also added a to the tests (although did not pass
tests before change).  Fixes #206
