### PR TITLE
fix a bug in geom_text with data contains NA.

### DIFF
--- a/R/geom-text.r
+++ b/R/geom-text.r
@@ -56,7 +56,7 @@ GeomText <- proto(Geom, {
   objname <- "text"
 
   draw_groups <- function(., ...) .$draw(...)
-  draw <- function(., data, scales, coordinates, ..., parse = FALSE) {
+  draw <- function(., data, scales, coordinates, ..., parse = FALSE, na.rm = FALSE) {
     data <- remove_missing(data, na.rm, 
       c("x", "y", "label"), name = "geom_text")
     


### PR DESCRIPTION
error occurs in remove_missing if data contains NA. Probably because of unevaled promise or something else.
