### PR TITLE
fix a bug (?): support transparency for the filled area of geom_boxplot. (#252)

### DIFF
--- a/R/geom-boxplot.r
+++ b/R/geom-boxplot.r
@@ -82,7 +82,6 @@ GeomBoxplot <- proto(Geom, {
       size = data$size, 
       linetype = data$linetype,
       fill = alpha(data$fill, data$alpha),  
-      alpha = data$alpha, 
       group = 1, 
       stringsAsFactors = FALSE
     )
@@ -91,7 +90,8 @@ GeomBoxplot <- proto(Geom, {
       x = data$x,
       xend = data$x, 
       y = c(data$upper, data$lower), 
-      yend = c(data$ymax, data$ymin), 
+      yend = c(data$ymax, data$ymin),
+      alpha = 1,
       common)
 
     box <- data.frame(
@@ -100,6 +100,7 @@ GeomBoxplot <- proto(Geom, {
       ymin = data$lower, 
       y = data$middle, 
       ymax = data$upper,
+      alpha = data$alpha, 
       common)
     
     if (!is.null(data$outliers) && length(data$outliers[[1]] >= 1)) {


### PR DESCRIPTION
alpha support may be somewhat incoherent.
alpha does not affect the lines of geom_rect, but it affects the lines of geom_line.
