### PR TITLE
Fix a bug in facet-null layout mapping when unusual column name (e.g., `0%`) is used.

### DIFF
--- a/R/facet-null.r
+++ b/R/facet-null.r
@@ -20,7 +20,8 @@ facet_train_layout.null <- function(facet, data) {
 #' @S3method facet_map_layout null
 facet_map_layout.null <- function(facet, data, layout) {
   if (empty(data)) return(data.frame(PANEL = 1))
-  transform(data, PANEL = 1)
+  data$PANEL <- 1L
+  data
 }
 
 #' @S3method facet_render null


### PR DESCRIPTION
Here is the bug report (from boxplot example):

```
> abc <- adply(matrix(rnorm(100), ncol = 5), 2, quantile, c(0, .25, .5, .75, 1))
> ggplot(abc, aes(x = X1, ymin = `0%`, lower = `25%`, middle = `50%`, upper = `75%`, ymax = `100%`)) +
+   geom_boxplot(stat = "identity")
Error in eval(expr, envir, enclos) : object '0%' not found
> ggplot(abc, aes(x = X1, y = `50%`)) + geom_point()
Error in eval(expr, envir, enclos) : object '50%' not found
> abc
  X1        0%        25%         50%       75%     100%
1  1 -1.714925 -0.6468398  0.17065804 0.4393230 1.201247
2  2 -1.189586 -0.6724862 -0.09751418 0.4884423 1.134490
3  3 -1.689927 -0.3296100  0.23288596 0.5751145 2.424042
4  4 -1.504052 -0.8237122 -0.33161341 0.3219800 1.507830
5  5 -2.463395 -0.7655001 -0.27450750 0.1631618 1.648378
```

This is because `transform` in `facet_map_layout.null` changes the column name.

```
> transform(abc, P=1)
  X1       X0.       X25.         X50.      X75.    X100. P
1  1 -2.584666 -0.5943572  0.200944872 0.7742156 2.166626 1
2  2 -2.115618 -0.4283542  0.004670815 0.3936428 1.808468 1
3  3 -2.638751 -0.7368470 -0.265173043 0.4781000 1.571617 1
4  4 -1.476560 -0.3720931  0.182308241 0.8797875 1.924785 1
5  5 -2.999939 -0.6789793 -0.214186432 1.0083131 1.775713 1
```

fixed it.
