### PR TITLE
fix in coord-polar: flip axis title when theta = "y"

### DIFF
--- a/R/coord-polar.r
+++ b/R/coord-polar.r
@@ -233,7 +233,7 @@ coord_render_fg.polar <- function(coord, details, theme) {
   )
 }  
 
-#' @S3method coord_labels poler
+#' @S3method coord_labels polar
 coord_labels.polar <- function(coord, scales) {
   if (coord$theta == "y") {
     list(x = scales$y, y = scales$x)


### PR DESCRIPTION
here is an example:

```
cxc <- ggplot(mtcars, aes(x = factor(cyl))) + 
  geom_bar(width = 1, colour = "black")
cxc + coord_polar() # x = factor(cyl), y = count
cxc + coord_polar(theta = "y") # x = count, y = factor(cyl)
```
