### PR TITLE
fix in find_global: namespace bug (fixed #323)

### DIFF
--- a/R/scales-.r
+++ b/R/scales-.r
@@ -104,8 +104,8 @@ find_global <- function(name) {
     return(get(name, globalenv()))
   }
   
-  if (exists(name, "package::ggplot2")) {
-    return(get(name, "package::ggplot2"))
+  if (exists(name, "package:ggplot2")) {
+    return(get(name, "package:ggplot2"))
   }
   
   NULL


### PR DESCRIPTION
use `package:XXX` instead of `package::XXX`
