### PR TITLE
aes_auto: wisely detect aes vars from data

### DIFF
--- a/R/aes.r
+++ b/R/aes.r
@@ -118,19 +118,17 @@ aes_all <- function(vars) {
   )  
 }
 
-#' .. content for \description{} (no empty lines) ..
+#' Automatic aesthetic mapping
 #'
-#' .. content for \details{} ..
-#' @title 
-#' @param data data.frame or names of data.frame
+#' @param data data.frame or names of variables
 #' @param ... aesthetics that need to be explicitly mapped.
 #' @export
 #' @examples
-#' df <- data.frame(x = 1:3, y = 1:3, colour = 1:3, label = letters[1:3])
+#' df <- data.frame(x = 1, y = 1, colour = 1, label = 1, pch = 1)
 #' aes_auto(df)
 #' aes_auto(names(df))
 #' 
-#' df <- data.frame(xp = 1:3, y = 1:3, colour = 1:3, txt = letters[1:3], foo = 1:3)
+#' df <- data.frame(xp = 1, y = 1, colour = 1, txt = 1, foo = 1)
 #' aes_auto(df, x = xp, label = txt)
 #' aes_auto(names(df), x = xp, label = txt)
 #' 
@@ -151,13 +149,14 @@ aes_auto <- function(data = NULL, ...) {
   vars <- intersect(.all_aesthetics, vars)
   names(vars) <- vars
   aes <- lapply(vars, function(x) parse(text=x)[[1]])
-  
+
   # explicitly defined aes
   if (length(match.call()) > 2) {
-    aes <- c(aes, as.list(match.call()[-(1:2)]))
+    args <- as.list(match.call()[-1])
+    aes <- c(aes, args[names(args) != "data"])
   }
-  
-  structure(aes, class = "uneval")
+
+  structure(rename_aes(aes), class = "uneval")
 }
 
 # Aesthetic defaults

--- a/inst/tests/test-aes.r
+++ b/inst/tests/test-aes.r
@@ -1,0 +1,62 @@
+context("Creating aesthetic mappings")
+
+test_that("function aes", {
+  expect_equal(aes(x = mpg, y = wt),
+               structure(list(x = bquote(mpg), y = bquote(wt)), class = "uneval"))
+  
+  expect_equal(aes(x = mpg ^ 2, y = wt / cyl),
+               structure(list(x = bquote(mpg ^ 2), y = bquote(wt / cyl)), class = "uneval"))
+  
+})
+
+test_that("function aes_string", {
+  expect_equal(aes_string(x = "mpg", y = "wt"),
+               structure(list(x = bquote(mpg), y = bquote(wt)), class = "uneval"))
+  
+  expect_equal(aes_string(x = "mpg ^ 2", y = "wt / cyl"),
+               structure(list(x = bquote(mpg ^ 2), y = bquote(wt / cyl)), class = "uneval"))
+})
+
+test_that("function aes_all", {
+  expect_equal(aes_all(names(mtcars)),
+               structure(
+                 list(
+                   mpg = bquote(mpg),
+                   cyl = bquote(cyl),
+                   disp = bquote(disp),
+                   hp = bquote(hp),
+                   drat = bquote(drat),
+                   wt = bquote(wt),
+                   qsec = bquote(qsec),
+                   vs = bquote(vs),
+                   am = bquote(am),
+                   gear = bquote(gear),
+                   carb = bquote(carb)),
+                 class = "uneval"))
+  
+  expect_equal(aes_all(c("x", "y", "col", "pch")),
+               structure(list(x = bquote(x), y = bquote(y), colour = bquote(col), shape = bquote(pch)), class = "uneval"))
+})
+
+test_that("function aes_auto", {
+  df <- data.frame(x = 1, y = 1, colour = 1, label = 1, pch = 1)
+  expect_equal(aes_auto(df),
+               structure(list(colour = bquote(colour), label = bquote(label), shape = bquote(pch), x = bquote(x), y = bquote(y)), class = "uneval"))
+
+  expect_equal(aes_auto(names(df)),
+               structure(list(colour = bquote(colour), label = bquote(label), shape = bquote(pch), x = bquote(x), y = bquote(y)), class = "uneval"))
+
+  df <- data.frame(xp = 1:3, y = 1:3, colour = 1:3, txt = letters[1:3], foo = 1:3)
+  expect_equal(aes_auto(df, x = xp, label = txt),
+               structure(list(colour = bquote(colour), y = bquote(y), x = bquote(xp), label = bquote(txt)), class = "uneval"))
+  expect_equal(aes_auto(names(df), x = xp, label = txt),
+               structure(list(colour = bquote(colour), y = bquote(y), x = bquote(xp), label = bquote(txt)), class = "uneval"))
+  expect_equal(aes_auto(x = xp, label = txt, data = df),
+               structure(list(colour = bquote(colour), y = bquote(y), x = bquote(xp), label = bquote(txt)), class = "uneval"))
+
+  df <- data.frame(foo = 1:3)
+  expect_equal(aes_auto(df, x = xp, y = yp),
+               structure(list(x = bquote(xp), y = bquote(yp)), class = "uneval"))
+  expect_equal(aes_auto(df), structure(setNames(list(), character(0)), class = "uneval"))
+})
+                            


### PR DESCRIPTION
here is a typical usege:

```
> df <- data.frame(x = 1, y = 1, col = 1, txt = 1)
> aes_auto(df)
List of 3
 $ colour: symbol col
 $ x     : symbol x
 $ y     : symbol y
```

extra arguments are interpreted as manual aes-mapping (here, label = txt):

```
> aes_auto(df, label = txt)
List of 4
 $ colour: symbol col
 $ x     : symbol x
 $ y     : symbol y
 $ label : symbol txt
```
