### PR TITLE
Add warning when geom_dotplot is used with coord_polar

### DIFF
--- a/R/geom-dotplot.r
+++ b/R/geom-dotplot.r
@@ -174,6 +174,10 @@ GeomDotplot <- proto(Geom, {
       c("x", "y", "size", "shape"), name = "geom_dotplot")
     if (empty(data)) return(zeroGrob())
 
+    if (!is.linear(coordinates)) {
+      warning("geom_dotplot does not work properly with non-linear coordinates.")
+    }
+
     tdata <- coord_transform(coordinates, data, scales)
 
     # Swap axes if using coord_flip


### PR DESCRIPTION
This adds a warning message when `geom_dotplot` is used with `coord_polar`. It addresses #359.
