### PR TITLE
Fix dist_central_angle bug 

### DIFF
--- a/R/coord-munch.r
+++ b/R/coord-munch.r
@@ -83,6 +83,6 @@ dist_central_angle <- function(lon, lat) {
   hav <- function(x) sin(x / 2) ^ 2
   ahav <- function(x) 2 * asin(x)
   
-  n <- length(lon)
+  n <- length(lat)
   ahav(sqrt(hav(diff(lat)) + cos(lat[-n]) * cos(lat[-1]) * hav(diff(lon))))
 }


### PR DESCRIPTION
This fixes #365.

I think it now correctly implements the haversine formula: 
http://en.wikipedia.org/wiki/Haversine_formula

```
> dist_central_angle(lat=c(-90,90), lon=c(-45,-45))
[1] 3.141593
> dist_central_angle(lat=c(0,0), lon=c(0,180))
[1] 3.141593
```
