### PR TITLE
fix grouping bug in stat-sum

### DIFF
--- a/R/stat-sum.r
+++ b/R/stat-sum.r
@@ -54,13 +54,15 @@ StatSum <- proto(Stat, {
   default_geom <- function(.) GeomPoint
   icon <- function(.) textGrob(expression(Sigma), gp=gpar(cex=4))
   
-  calculate <- function(., data, scales, ...) {
+  calculate_groups <- function(., data, scales, ...) {
+
     if (is.null(data$weight)) data$weight <- 1
 
-    counts <- count(data, c("x", "y"), wt_var = "weight")
-    counts <- rename(counts, c(freq = "n"))
-    counts$prop <- prop.table(counts$n)
+    group_by <- setdiff(intersect(names(data), .all_aesthetics), "weight")
 
+    counts <- count(data, group_by, wt_var = "weight")
+    counts <- rename(counts, c(freq = "n"))
+    counts$prop <- ave(counts$n, counts$group, FUN = prop.table)
     counts
   }
 })

--- a/inst/tests/test-stats.r
+++ b/inst/tests/test-stats.r
@@ -13,3 +13,54 @@ test_that("plot succeeds even if some computation fails", {
   expect_equal(length(b2$data), 2)
   
 })
+
+# helper function for stat calc tests.
+test_stat <- function(stat) {
+  stat$data <- transform(stat$data, PANEL = 1)
+  dat <- stat$compute_aesthetics(stat$data, ggplot())
+  dat <- add_group(dat)
+  stat$calc_statistic(dat, NULL)
+}
+
+context("stat-sum")
+
+test_that("stat_sum", {
+  d <- diamonds[1:1000, ]
+
+  ret <- test_stat(stat_sum(aes(x = cut, y = clarity), data =  d))
+  expect_equal(dim(ret), c(38, 5))
+  expect_equal(sum(ret$n), nrow(d))
+  expect_true(all(ret$prop == 1))
+  
+  ret <- test_stat(stat_sum(aes(x = cut, y = clarity, group = 1), data =  d))
+  expect_equal(dim(ret), c(38, 5))
+  expect_equal(sum(ret$n), nrow(d))
+  expect_equal(sum(ret$prop), 1)
+  
+  ret <- test_stat(stat_sum(aes(x = cut, y = clarity, group = cut), data =  d))
+  expect_equal(dim(ret), c(38, 5))
+  expect_equal(sum(ret$n), nrow(d))
+  expect_true(all(ddply(ret, .(x), summarize, prop = sum(prop))$prop == 1))
+
+  ret <- test_stat(stat_sum(aes(x = cut, y = clarity, group = cut, colour = cut), data =  d))
+  expect_equal(dim(ret), c(38, 6))
+  expect_equal(ret$x, ret$colour)
+  expect_equal(sum(ret$n), nrow(d))
+  expect_true(all(ddply(ret, .(x), summarize, prop = sum(prop))$prop == 1))
+  
+  ret <- test_stat(stat_sum(aes(x = cut, y = clarity, group = clarity), data =  d))
+  expect_equal(dim(ret), c(38, 5))
+  expect_equal(sum(ret$n), nrow(d))
+  expect_true(all(ddply(ret, .(y), summarize, prop = sum(prop))$prop == 1))
+
+  ret <- test_stat(stat_sum(aes(x = cut, y = clarity, group = clarity, colour = cut), data =  d))
+  expect_equal(dim(ret), c(38, 6))
+  expect_equal(ret$x, ret$colour)
+  expect_equal(sum(ret$n), nrow(d))
+  expect_true(all(ddply(ret, .(y), summarize, prop = sum(prop))$prop == 1))
+  
+  ret <- test_stat(stat_sum(aes(x = cut, y = clarity, group = 1, weight = price), data =  d))
+  expect_equal(dim(ret), c(38, 5))
+  expect_equal(sum(ret$n), sum(d$price))
+  expect_equal(sum(ret$prop), 1)
+})


### PR DESCRIPTION
now aes (e.g., colour, fill, etc) is not dropped during stats calculation.
Is there any reason why `stat_sum` only use `calculate_groups` but not use `calculate`?
