### PR TITLE
Make manual palettes work (fix #384)

### DIFF
--- a/R/scale-.r
+++ b/R/scale-.r
@@ -211,8 +211,7 @@ scale_map.continuous <- function(scale, x) {
 scale_map.discrete <- function(scale, x) {
   limits <- scale_limits(scale)
 
-  n <- length(limits)
-  pal <- scale$palette(n)
+  pal <- scale$palette(limits = limits)
   
   if (is.null(names(pal))) {
     pal_match <- pal[match(as.character(x), limits)]


### PR DESCRIPTION
This fixes #384. For this fix to work, it requires the update to scales at hadley/scales#11.

The fix in scales should not break anything else. However, if this pull request is merged without the change in scales, ggplot will probably be completely broken with discrete scales.
