### PR TITLE
Don't use label as a grouping var (fix #465)

### DIFF
--- a/R/utilities-layer.r
+++ b/R/utilities-layer.r
@@ -2,7 +2,7 @@
 #
 # If the \code{group} variable is not present, then a new group
 # variable is generated from the interaction of all discrete (factor or
-# character) vectors.
+# character) vectors, excluding \code{label}.
 # 
 # @param data.frame
 # @value data.frame with group variable
@@ -12,6 +12,7 @@ add_group <- function(data) {
   
   if (is.null(data$group)) {
     disc <- vapply(data, is.discrete, logical(1))
+    disc[names(disc) == "label"] <- FALSE
     
     if (any(disc)) {
       data$group <- id(data[disc], drop = TRUE)      

--- a/inst/tests/test-aes-grouping.r
+++ b/inst/tests/test-aes-grouping.r
@@ -22,6 +22,13 @@ test_that("one group per combination of discrete vars", {
   expect_that(groups(plot), equals(4))
 })
 
+test_that("label is not used as a grouping var", {
+  plot <- ggplot(df, aes(x, x, label = a)) + geom_point()
+  expect_that(group(plot), equals(c(1, 1, 1, 1)))
+
+  plot <- ggplot(df, aes(x, x, colour = a, label = b)) + geom_point()
+  expect_that(group(plot), equals(c(1, 1, 2, 2)))
+})
 
 test_that("group aesthetic overrides defaults", {
   plot <- ggplot(df, aes(x, x, group = x)) + geom_point()


### PR DESCRIPTION
This excludes `label` as a grouping variable and adds tests. (fixes #465)
