### PR TITLE
Removing remaining documentation referrences to reshape

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+* `ggstructure` and `ggorder`, which call `ggpcp`, no longer have a 
+  `scale` argument since `ggpcp` does not have one.
+
 * built in datasets have been checked to make sure they use characters,
   factors and ordered factors appropriately
 

--- a/R/templates.r
+++ b/R/templates.r
@@ -2,7 +2,7 @@
 #' 
 #' One way to think about a parallel coordinates plot, is as plotting 
 #' the data after it has been transformed to gain a new variable.  This
-#' function does this using \code{\link[reshape]{melt}}.
+#' function does this using \code{\link[reshape2]{melt}}.
 #' 
 #' This gives us enormous flexibility as we have separated out the 
 #' type of drawing (lines by tradition) and can now use any of the existing
@@ -148,13 +148,11 @@ ggmissing <- function(data, avoid="stack", order=TRUE, missing.only = TRUE) {
 #' A plot which aims to reveal gross structural anomalies in the data.
 #' 
 #' @param data data set to plot
-#' @param scale type of scaling to use.  See \code{\link[reshape]{rescaler}}
-#'   for options
 #' @export
 #' @examples
 #' ggstructure(mtcars)
-ggstructure <- function(data, scale = "rank") {
-  ggpcp(data, scale=scale) + 
+ggstructure <- function(data) {
+  ggpcp(data) + 
     aes_string(y="ROWID", fill="value", x="variable") +
     geom_tile() +
     scale_y_continuous("row number", expand = c(0, 1)) +
@@ -164,11 +162,9 @@ ggstructure <- function(data, scale = "rank") {
 #' A plot to investigate the order in which observations were recorded.
 #' 
 #' @param data data set to plot
-#' @param scale type of scaling to use.  See \code{\link[reshape]{rescaler}}
-#'   for options
 #' @export
-ggorder <- function(data, scale="rank") {
-  ggpcp(data, scale="rank") +
+ggorder <- function(data) {
+  ggpcp(data) +
     aes_string(x="ROWID", group="variable", y="value") +
     facet_grid(. ~ variable) +
     geom_line() +

--- a/man/ggorder.Rd
+++ b/man/ggorder.Rd
@@ -2,13 +2,10 @@
 \alias{ggorder}
 \title{A plot to investigate the order in which observations were recorded.}
 \usage{
-  ggorder(data, scale = "rank")
+  ggorder(data)
 }
 \arguments{
   \item{data}{data set to plot}
-
-  \item{scale}{type of scaling to use.  See
-  \code{\link[reshape]{rescaler}} for options}
 }
 \description{
   A plot to investigate the order in which observations

--- a/man/ggpcp.Rd
+++ b/man/ggpcp.Rd
@@ -16,7 +16,7 @@
   One way to think about a parallel coordinates plot, is as
   plotting the data after it has been transformed to gain a
   new variable.  This function does this using
-  \code{\link[reshape]{melt}}.
+  \code{\link[reshape2]{melt}}.
 }
 \details{
   This gives us enormous flexibility as we have separated

--- a/man/ggstructure.Rd
+++ b/man/ggstructure.Rd
@@ -2,13 +2,10 @@
 \alias{ggstructure}
 \title{A plot which aims to reveal gross structural anomalies in the data.}
 \usage{
-  ggstructure(data, scale = "rank")
+  ggstructure(data)
 }
 \arguments{
   \item{data}{data set to plot}
-
-  \item{scale}{type of scaling to use.  See
-  \code{\link[reshape]{rescaler}} for options}
 }
 \description{
   A plot which aims to reveal gross structural anomalies in


### PR DESCRIPTION
ggpcp stated it was using reshape::melt, but it is actually
using reshape2::melt.

The scale arguments to ggorder and ggstructure had a scale
argument that was no longer used (corresponding argument in
ggpcp removed in 030fadf59a0fd896865b28fd9e76da9698164ec2.
Removed this argument (and its documentation which referenced
reshape).

Since I didn't have reshape installed on my newest R installation, these references were generating a NOTE in R CMD check for me. Since ggplot2 doesn't rely on reshape, but rather reshape2, now, I figured I would hunt down the source.
