### PR TITLE
Allow alpha to affect colour

### DIFF
--- a/R/geom-boxplot.r
+++ b/R/geom-boxplot.r
@@ -177,7 +177,7 @@ GeomBoxplot <- proto(Geom, {
   guide_geom <- function(.) "boxplot"  
   draw_legend <- function(., data, ...)  {
     data <- aesdefaults(data, .$default_aes(), list(...))
-    gp <- with(data, gpar(col=colour, fill=alpha(fill, alpha), lwd=size * .pt))
+    gp <- with(data, gpar(col=alpha(colour, alpha), fill=alpha(fill, alpha), lwd=size * .pt))
     gTree(gp = gp, children = gList(
       linesGrob(0.5, c(0.1, 0.25)),
       linesGrob(0.5, c(0.75, 0.9)),

--- a/R/geom-hex.r
+++ b/R/geom-hex.r
@@ -13,7 +13,7 @@ GeomHex <- proto(Geom, {
 
   draw <- function(., data, scales, coordinates, ...) { 
     with(coord_transform(coordinates, data, scales), 
-      ggname(.$my_name(), hexGrob(x, y, col=colour, 
+      ggname(.$my_name(), hexGrob(x, y, col=alpha(colour, alpha), 
         fill = alpha(fill, alpha)))
     )
   }

--- a/R/geom-map.r
+++ b/R/geom-map.r
@@ -85,7 +85,7 @@ GeomMap <- proto(GeomPolygon, {
 
     polygonGrob(coords$x, coords$y, default.units = "native", id = grob_id,
       gp = gpar(
-        col = data$colour, fill = alpha(data$fill, data$alpha), 
+        col = alpha(data$colour, data$alpha), fill = alpha(data$fill, data$alpha), 
         lwd = data$size * .pt))
   }
   

--- a/R/geom-polygon.r
+++ b/R/geom-polygon.r
@@ -57,7 +57,7 @@ GeomPolygon <- proto(Geom, {
     ggname(.$my_name(), gTree(children=gList(
       with(coord_munch(coordinates,data, scales), 
         polygonGrob(x, y, default.units="native",
-        gp=gpar(col=colour, fill=alpha(fill, alpha), lwd=size * .pt,
+        gp=gpar(col=alpha(colour, alpha), fill=alpha(fill, alpha), lwd=size * .pt,
          lty=linetype))
       )
       #GeomPath$draw(data, scales, coordinates)
@@ -75,8 +75,8 @@ GeomPolygon <- proto(Geom, {
     data <- aesdefaults(data, .$default_aes(), list(...))
   
     with(data, grobTree(
-      rectGrob(gp = gpar(col = colour, fill = alpha(fill, alpha), lty = linetype)),
-      linesGrob(gp = gpar(col = colour, lwd = size * .pt, lineend="butt", lty = linetype))
+      rectGrob(gp = gpar(col = alpha(colour, alpha), fill = alpha(fill, alpha), lty = linetype)),
+      linesGrob(gp = gpar(col = alpha(colour, alpha), lwd = size * .pt, lineend="butt", lty = linetype))
     ))
   }
 

--- a/R/geom-rect.r
+++ b/R/geom-rect.r
@@ -44,7 +44,7 @@ GeomRect <- proto(Geom, {
           width = xmax - xmin, height = ymax - ymin, 
           default.units = "native", just = c("left", "top"), 
           gp=gpar(
-            col=colour, fill=alpha(fill, alpha), 
+            col=alpha(colour, alpha), fill=alpha(fill, alpha), 
             lwd=size * .pt, lty=linetype, lineend="butt"
           )
         ))

--- a/R/geom-ribbon-.r
+++ b/R/geom-ribbon-.r
@@ -84,7 +84,7 @@ GeomRibbon <- proto(Geom, {
       default.units = "native",
       gp = gpar(
         fill = alpha(aes$fill, aes$alpha), 
-        col = aes$colour, 
+        col = alpha(aes$colour, aes$alpha),
         lwd = aes$size * .pt, 
         lty = aes$linetype)
     ))


### PR DESCRIPTION
For all filled shapes (polygons, reactangles, etc.) alpha affected fill only.
One could set the stroke to be a transparent colour using

```
colour=scales::alpha("blue", 0.5)
```

outside of aes() for example. But there was no way to map the colour of the
stroke to a semi transparent colour. This commit fixes it.
