### PR TITLE
colour bar guides can correctly handle the expression labels

### DIFF
--- a/R/guide-colorbar.r
+++ b/R/guide-colorbar.r
@@ -103,6 +103,7 @@ guide_colourbar <- function(
   label.theme = NULL,
   label.hjust = NULL,
   label.vjust = NULL,
+  parse = FALSE,                            
 
   # bar
   barwidth = NULL,
@@ -139,6 +140,7 @@ guide_colourbar <- function(
     label.theme = label.theme,
     label.hjust = label.hjust,
     label.vjust = label.vjust,
+    parse = parse,             
 
     # bar
     barwidth = barwidth,
@@ -292,7 +294,9 @@ guide_gengrob.colorbar <- function(guide, theme) {
       switch(guide$direction, horizontal = {x <- label_pos; y <- vjust}, "vertical" = {x <- hjust; y <- label_pos})
       
       label <- guide$key$.label
-      if (any(laply(label, is.expression)) || any(laply(label, is.call))) {
+      if (guide$parse) {
+        label <- parse(text = label)
+      } else if (any(laply(label, is.expression)) || any(laply(label, is.call))) {
         label <- llply(label, function(l) if (is.call(l)) substitute(expression(x), list(x = l)))
         label <- do.call("c", label)
       }

--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -34,6 +34,8 @@
 #'   label text.
 #' @param label.vjust A numeric specifying vertical justification of the label
 #'   text.
+#' @param parse If TRUE, the labels will be parsed into expressions and
+#'   displayed as described in ?plotmath
 #' @param keywidth A numeric or a unit object specifying the width of the
 #'   legend key. Default value is \code{legend.key.width} or
 #'   \code{legend.key.size} in \code{\link{theme}} or theme.
@@ -130,6 +132,7 @@ guide_legend <- function(
   label.theme = NULL,
   label.hjust = NULL,
   label.vjust = NULL,
+  parse = FALSE,                         
                          
   # key
   keywidth = NULL,
@@ -163,6 +166,7 @@ guide_legend <- function(
     label.theme = label.theme,
     label.hjust = label.hjust,
     label.vjust = label.vjust,
+    parse = parse,
 
     # size of key
     keywidth = keywidth,
@@ -336,6 +340,7 @@ guide_gengrob.legend <- function(guide, theme) {
 
       lapply(guide$key$.label,
         function(label, ...) {
+          if (guide$parse) label <- parse(text = label)
           g <- element_grob(element = label.theme, label = label, 
             x = x, y = y, hjust = hjust, vjust = vjust)
           ggname("guide.label", g)


### PR DESCRIPTION
Passed all unit test and probably also visual test.
see this thread: https://groups.google.com/group/ggplot2/browse_thread/thread/3a9efa6d01b8500e

but maybe the xxx_format should return the list of expression instead of list of call.
