### PR TITLE
Use rgeos instead of gpclib for fortify polygon operations

### DIFF
--- a/R/fortify-spatial.r
+++ b/R/fortify-spatial.r
@@ -28,7 +28,7 @@ fortify.SpatialPolygonsDataFrame <- function(model, data, region = NULL, ...) {
     message("Regions defined for each Polygons")
   } else {
     cp <- polygons(model)
-    try_require("maptools")
+    try_require(c("rgeos","maptools"))
 
     # Union together all polygons that make up a region
     unioned <- unionSpatialPolygons(cp, attr[, region])


### PR DESCRIPTION
Following a discussion with Roger Bivand (author and contributor of many spatial packages for R) on r-sig-geo mailing list he suggested that rgeos should be used over gpclib (due to gpclib's restrictive license) for polygon operations in the fortify methods for spatial data. 
Original discussion is [here:](http://r-sig-geo.2731867.n2.nabble.com/Help-with-gpclib-tp7580479p7580542.html)
