### PR TITLE
Limit map gridline range. Fixes #562

### DIFF
--- a/R/coord-map.r
+++ b/R/coord-map.r
@@ -137,6 +137,13 @@ coord_train.map <- function(coord, scales) {
 coord_render_bg.map <- function(coord, details, theme) {    
   xrange <- expand_range(details$x.range, 0.2)
   yrange <- expand_range(details$y.range, 0.2)
+
+  # Limit ranges so that lines don't wrap around globe
+  xrange[xrange < 0]   <- 0
+  xrange[xrange > 360] <- 360
+  yrange[yrange < -90] <- -90
+  yrange[yrange > 90]  <- 90
+
   xgrid <- with(details, expand.grid(
     y = c(seq(yrange[1], yrange[2], len = 50), NA),
     x = x.major


### PR DESCRIPTION
This fixes #562. Examples that are fixed by this:

``` R
sky2 <- data.frame(RA=0, Dec=0)

skyplot2 <- qplot(RA,Dec,data=sky2,xlim=c(0,360),ylim=c(-89.999,89.999))

skyplot2 + coord_map(projection="aitoff",orientation=c(89.999,180,0)) + 
  scale_y_continuous(breaks=(-2:2)*30,limits=c(-89,89)) + 
  scale_x_continuous(breaks=(0:8)*45,limits=c(0,360), labels=c("","","","","","","","","")) +
   theme(panel.grid.major = theme_line(colour='black'))


skyplot2 + coord_map(projection="lagrange",orientation=c(89.999,180,0)) + 
  scale_y_continuous(breaks=(-2:2)*30,limits=c(-89.999,89.999)) + 
  scale_x_continuous(breaks=(0:8)*45,limits=c(0,360), labels=c("","","","","","","","","")) +
  theme(panel.grid.major = theme_line(colour='black'))
```
