### PR TITLE
geom_segment: remove cases where linetype is NA. Fixes #623

### DIFF
--- a/R/geom-segment.r
+++ b/R/geom-segment.r
@@ -41,15 +41,20 @@
 #' b + geom_segment(aes(x = 2, y = 15, xend = 2, yend = 25))
 #' b + geom_segment(aes(x = 2, y = 15, xend = 3, yend = 15))
 #' b + geom_segment(aes(x = 5, y = 30, xend = 3.5, yend = 25), arrow = arrow(length = unit(0.5, "cm")))
-geom_segment <- function (mapping = NULL, data = NULL, stat = "identity", position = "identity", arrow = NULL, lineend = "butt", ...) {
-  GeomSegment$new(mapping = mapping, data = data, stat = stat, position = position, arrow = arrow, lineend = lineend, ...)
+geom_segment <- function (mapping = NULL, data = NULL, stat = "identity",
+  position = "identity", arrow = NULL, lineend = "butt", na.rm = FALSE, ...) {
+
+  GeomSegment$new(mapping = mapping, data = data, stat = stat,
+    position = position, arrow = arrow, lineend = lineend, na.rm = na.rm, ...)
 }
 
 GeomSegment <- proto(Geom, {
   objname <- "segment"
 
-  draw <- function(., data, scales, coordinates, arrow = NULL, lineend = "butt", ...) {
-    data <- remove_missing(data, na.rm = FALSE,
+  draw <- function(., data, scales, coordinates, arrow = NULL,
+    lineend = "butt", na.rm = FALSE, ...) {
+
+    data <- remove_missing(data, na.rm = na.rm,
       c("x", "y", "xend", "yend", "linetype", "size", "shape"),
       name = "geom_segment")
     if (empty(data)) return(zeroGrob())


### PR DESCRIPTION
Fixes #623.

The code is essentially copied over from `geom_point`, except that `na.rm` is set to FALSE so it will always display the warning message; there's not the option to change it.

It also checks x, y, xend, yend, size, and shape for NA.

I also tried modifying `scale_linetype_discrete` so that it would use `na.value="01"`, hoping it would make a blank line, but grid apparently doesn't like zeros in the `lty`:

```
Error in grid.Call.graphics(L_segments, x$x0, x$y0, x$x1, x$y1, x$arrow) : 
  invalid line type: zeroes are not allowed
```
