### PR TITLE
Change proto() to gg(proto()). Fixes #583

### DIFF
--- a/R/aaa-.r
+++ b/R/aaa-.r
@@ -1,6 +1,9 @@
 # INCLUDES <- "web/graphics"
 # FILETYPE <- "html"
 
+gg <- function(x) structure(x, class = c("ggproto", class(x)))
+
+
 # Upper case first letter of string
 # This comes from the examples of some R function.
 # 
@@ -9,7 +12,7 @@ firstUpper <- function(s) {
   paste(toupper(substring(s, 1,1)), substring(s, 2), sep="")
 }
 
-TopLevel <- proto(expr = {
+TopLevel <- gg(proto(expr = {
   find_all <- function(., only.documented = FALSE) {
     names <- ls(pattern=paste("^", firstUpper(.$class()), "[A-Z].+", sep=""), parent.env(TopLevel))
     objs <- structure(lapply(names, get), names=names)
@@ -45,10 +48,10 @@ TopLevel <- proto(expr = {
     param[setdiff(names(param), aesthetics)]
   }
 
-})
+}))
 
-#' @S3method print proto
-print.proto <- function(x, ...) x$pprint(...)
+#' @S3method print ggproto
+print.ggproto <- function(x, ...) x$pprint(...)
 pprint <- function(x, ...) print(as.list(x), ...)
 # name.proto <- function (...) {
 #        proto(print.proto = print.default, f = proto::name.proto)$f(...)

--- a/R/annotation-custom.r
+++ b/R/annotation-custom.r
@@ -43,7 +43,7 @@ annotation_custom <- function (grob, xmin = -Inf, xmax = Inf, ymin = -Inf, ymax 
     position = "identity", data = NULL, inherit.aes = TRUE)
 }
 
-GeomCustomAnn <- proto(Geom, {
+GeomCustomAnn <- gg(proto(Geom, {
   objname <- "custom_ann"
   
   draw_groups <- function(., data, scales, coordinates, grob, xmin, xmax,
@@ -66,4 +66,4 @@ GeomCustomAnn <- proto(Geom, {
   
   default_aes <- function(.) 
     aes(xmin = -Inf, xmax = Inf, ymin = -Inf, ymax = Inf)  
-})
+}))

--- a/R/annotation-logticks.r
+++ b/R/annotation-logticks.r
@@ -77,7 +77,7 @@ annotation_logticks <- function (base = 10, sides = "bl", scaled = TRUE,
                    short = short, mid = mid, long = long, ...)
 }
 
-GeomLogticks <- proto(Geom, {
+GeomLogticks <- gg(proto(Geom, {
   objname <- "logticks"
 
   draw <- function(., data, scales, coordinates, base = 10, sides = "bl", scaled = TRUE,
@@ -155,7 +155,7 @@ GeomLogticks <- proto(Geom, {
 
   default_stat <- function(.) StatIdentity
   default_aes <- function(.) aes(colour = "black", size = 0.5, linetype = 1, alpha = 1)
-})
+}))
 
 
 # Calculate the position of log tick marks

--- a/R/annotation-map.r
+++ b/R/annotation-map.r
@@ -37,7 +37,7 @@ annotation_map <- function(map, ...) {
     NULL, inherit.aes = FALSE)
 }
 
-GeomAnnotationMap <- proto(GeomMap, {
+GeomAnnotationMap <- gg(proto(GeomMap, {
   objname <- "map"
 
   draw_groups <- function(., data, scales, coordinates, map, ...) {
@@ -56,4 +56,4 @@ GeomAnnotationMap <- proto(GeomMap, {
   
   required_aes <- c()
   
-})
+}))

--- a/R/annotation-raster.r
+++ b/R/annotation-raster.r
@@ -44,7 +44,7 @@ annotation_raster <- function (raster, xmin, xmax, ymin, ymax, interpolate = FAL
     stat = "identity", position = "identity", data = NULL, inherit.aes = TRUE)
 }
 
-GeomRasterAnn <- proto(GeomRaster, {
+GeomRasterAnn <- gg(proto(GeomRaster, {
   objname <- "raster_ann"
   reparameterise <- function(., df, params) {
     df
@@ -66,4 +66,4 @@ GeomRasterAnn <- proto(GeomRaster, {
       diff(x_rng), diff(y_rng), default.units = "native", 
       just = c("left","bottom"), interpolate = interpolate)
   }
-})
+}))

--- a/R/geom-.r
+++ b/R/geom-.r
@@ -1,4 +1,4 @@
-Geom <- proto(TopLevel, expr={
+Geom <- gg(proto(TopLevel, expr={
   class <- function(.) "geom"
 
   parameters <- function(.) {
@@ -45,4 +45,4 @@ Geom <- proto(TopLevel, expr={
 
     
   
-})
+}))

--- a/R/geom-abline.r
+++ b/R/geom-abline.r
@@ -61,7 +61,7 @@ geom_abline <- function (mapping = NULL, data = NULL, stat = "abline", position 
   GeomAbline$new(mapping = mapping, data = data, stat = stat, position = position, show_guide = show_guide, ...)
 }
 
-GeomAbline <- proto(Geom, {
+GeomAbline <- gg(proto(Geom, {
   objname <- "abline"
 
   new <- function(., mapping = NULL, ...) {
@@ -95,4 +95,4 @@ GeomAbline <- proto(Geom, {
         lineend="butt")))
     )
   }
-})
+}))

--- a/R/geom-bar-.r
+++ b/R/geom-bar-.r
@@ -112,7 +112,7 @@ geom_bar <- function (mapping = NULL, data = NULL, stat = "bin", position = "sta
   GeomBar$new(mapping = mapping, data = data, stat = stat, position = position, ...)
 }
 
-GeomBar <- proto(Geom, {
+GeomBar <- gg(proto(Geom, {
   objname <- "bar"
   
   default_stat <- function(.) StatBin
@@ -134,4 +134,4 @@ GeomBar <- proto(Geom, {
     GeomRect$draw_groups(data, scales, coordinates, ...)
   }
   guide_geom <- function(.) "polygon"
-})
+}))

--- a/R/geom-bar-histogram.r
+++ b/R/geom-bar-histogram.r
@@ -117,6 +117,6 @@ geom_histogram <- function (mapping = NULL, data = NULL, stat = "bin", position 
   GeomHistogram$new(mapping = mapping, data = data, stat = stat, position = position, ...)
 }
 
-GeomHistogram <- proto(GeomBar, {
+GeomHistogram <- gg(proto(GeomBar, {
   objname <- "histogram"
-})
+}))

--- a/R/geom-bin2d.r
+++ b/R/geom-bin2d.r
@@ -15,7 +15,7 @@ geom_bin2d <- function (mapping = NULL, data = NULL, stat = "bin2d", position = 
   GeomBin2d$new(mapping = mapping, data = data, stat = stat, position = position, ...)
 }
 
-GeomBin2d <- proto(Geom, {
+GeomBin2d <- gg(proto(Geom, {
   draw <- function(., data, scales, coordinates, ...) {
     GeomRect$draw(data, scales, coordinates, ...)
   }
@@ -30,4 +30,4 @@ GeomBin2d <- proto(Geom, {
     aes(colour = NA, fill = "grey60", size = 0.5, linetype = 1, weight = 1, , alpha = NA)
   }
 
-})
+}))

--- a/R/geom-blank.r
+++ b/R/geom-blank.r
@@ -25,7 +25,7 @@ geom_blank <- function (mapping = NULL, data = NULL, stat = "identity", position
   GeomBlank$new(mapping = mapping, data = data, stat = stat, position = position, ...)
 }
 
-GeomBlank <- proto(Geom, {
+GeomBlank <- gg(proto(Geom, {
   objname <- "blank"
 
   default_stat <- function(.) StatIdentity
@@ -35,4 +35,4 @@ GeomBlank <- proto(Geom, {
     zeroGrob()
   }
   
-})
+}))

--- a/R/geom-boxplot.r
+++ b/R/geom-boxplot.r
@@ -101,7 +101,7 @@ notch = FALSE, notchwidth = .5, ...) {
   outlier.size = outlier.size, notch = notch, notchwidth = notchwidth, ...)
 }
 
-GeomBoxplot <- proto(Geom, {
+GeomBoxplot <- gg(proto(Geom, {
   objname <- "boxplot"
 
   reparameterise <- function(., df, params) {
@@ -194,4 +194,4 @@ GeomBoxplot <- proto(Geom, {
   default_aes <- function(.) aes(weight=1, colour="grey20", fill="white", size=0.5, alpha = NA, shape = 16, linetype = "solid")
   required_aes <- c("x", "lower", "upper", "middle", "ymin", "ymax")
 
-})
+}))

--- a/R/geom-crossbar.r
+++ b/R/geom-crossbar.r
@@ -18,7 +18,7 @@ fatten = 2, ...) {
   position = position, fatten = fatten, ...)
 }
 
-GeomCrossbar <- proto(Geom, {
+GeomCrossbar <- gg(proto(Geom, {
   objname <- "crossbar"
   
   reparameterise <- function(., df, params) {
@@ -72,4 +72,4 @@ GeomCrossbar <- proto(Geom, {
       GeomSegment$draw(middle, scales, coordinates, ...)
     )))
   }
-})
+}))

--- a/R/geom-dotplot.r
+++ b/R/geom-dotplot.r
@@ -104,7 +104,7 @@ stackratio = 1, dotsize = 1, stackgroups = FALSE, ...) {
   stackdir = stackdir, stackratio = stackratio, dotsize = dotsize, stackgroups = stackgroups, ...)
 }
 
-GeomDotplot <- proto(Geom, {
+GeomDotplot <- gg(proto(Geom, {
   objname <- "dotplot"
 
   new <- function(., mapping = NULL, data = NULL, stat = NULL, position = NULL, ...){
@@ -269,4 +269,4 @@ GeomDotplot <- proto(Geom, {
   required_aes <- c("x", "y")
   default_aes <- function(.) aes(y=..count.., colour="black", fill = "black", alpha = NA)
   
-})
+}))

--- a/R/geom-error.r
+++ b/R/geom-error.r
@@ -48,7 +48,7 @@ geom_errorbar <- function (mapping = NULL, data = NULL, stat = "identity", posit
   GeomErrorbar$new(mapping = mapping, data = data, stat = stat, position = position, ...)
 }
 
-GeomErrorbar <- proto(Geom, {
+GeomErrorbar <- gg(proto(Geom, {
   objname <- "errorbar"
   
   default_stat <- function(.) StatIdentity
@@ -78,4 +78,4 @@ GeomErrorbar <- proto(Geom, {
       row.names = 1:(nrow(data) * 8)
     )), scales, coordinates, ...)
   }
-})
+}))

--- a/R/geom-errorh.r
+++ b/R/geom-errorh.r
@@ -25,7 +25,7 @@ geom_errorbarh <- function (mapping = NULL, data = NULL, stat = "identity", posi
   GeomErrorbarh$new(mapping = mapping, data = data, stat = stat, position = position, ...)
 }
 
-GeomErrorbarh <- proto(Geom, {
+GeomErrorbarh <- gg(proto(Geom, {
   objname <- "errorbarh"
   
   default_stat <- function(.) StatIdentity
@@ -56,4 +56,4 @@ GeomErrorbarh <- proto(Geom, {
     )), scales, coordinates, ...)
   }
   
-})
+}))

--- a/R/geom-freqpoly.r
+++ b/R/geom-freqpoly.r
@@ -20,11 +20,11 @@ geom_freqpoly <- function (mapping = NULL, data = NULL, stat = "bin", position =
   GeomFreqpoly$new(mapping = mapping, data = data, stat = stat, position = position, ...)
 }
 
-GeomFreqpoly <- proto(Geom, {
+GeomFreqpoly <- gg(proto(Geom, {
   objname <- "freqpoly"
   
   default_aes <- function(.) GeomPath$default_aes()
   default_stat <- function(.) StatBin
   draw <- function(., ...) GeomPath$draw(...)
   guide_geom <- function(.) "path"
-})
+}))

--- a/R/geom-hex.r
+++ b/R/geom-hex.r
@@ -11,7 +11,7 @@ geom_hex <- function (mapping = NULL, data = NULL, stat = "binhex", position = "
   GeomHex$new(mapping = mapping, data = data, stat = stat, position = position, ...)
 }
 
-GeomHex <- proto(Geom, {
+GeomHex <- gg(proto(Geom, {
   objname <- "hex"
 
   draw <- function(., data, scales, coordinates, ...) { 
@@ -26,7 +26,7 @@ GeomHex <- proto(Geom, {
   default_stat <- function(.) StatBinhex
   guide_geom <- function(.) "polygon"
   
-})
+}))
 
 
 # Draw hexagon grob

--- a/R/geom-hline.r
+++ b/R/geom-hline.r
@@ -41,7 +41,7 @@ geom_hline <- function (mapping = NULL, data = NULL, stat = "hline", position = 
   GeomHline$new(mapping = mapping, data = data, stat = stat, position = position, show_guide = show_guide, ...)
 }
 
-GeomHline <- proto(Geom, {
+GeomHline <- gg(proto(Geom, {
   objname <- "hline"
 
   new <- function(., data = NULL, mapping = NULL, yintercept = NULL, ...) {
@@ -66,4 +66,4 @@ GeomHline <- proto(Geom, {
   default_stat <- function(.) StatHline
   default_aes <- function(.) aes(colour="black", size=0.5, linetype=1, alpha = NA)
   guide_geom <- function(.) "path"
-})
+}))

--- a/R/geom-linerange.r
+++ b/R/geom-linerange.r
@@ -35,7 +35,7 @@ geom_linerange <- function (mapping = NULL, data = NULL, stat = "identity", posi
   GeomLinerange$new(mapping = mapping, data = data, stat = stat, position = position, ...)
 }
  
-GeomLinerange <- proto(Geom, {
+GeomLinerange <- gg(proto(Geom, {
   objname <- "linerange"
 
   default_stat <- function(.) StatIdentity
@@ -48,4 +48,4 @@ GeomLinerange <- proto(Geom, {
     ggname(.$my_name(), GeomSegment$draw(transform(data, xend=x, y=ymin, yend=ymax), scales, coordinates, ...))
   }
   
-})
+}))

--- a/R/geom-map.r
+++ b/R/geom-map.r
@@ -67,7 +67,7 @@ geom_map <- function(mapping = NULL, data = NULL, map, stat = "identity", ...) {
     data = data, stat = stat, ...)
 }
 
-GeomMap <- proto(GeomPolygon, {
+GeomMap <- gg(proto(GeomPolygon, {
   objname <- "map"
 
   draw_groups <- function(., data, scales, coordinates, map, ...) {
@@ -94,4 +94,4 @@ GeomMap <- proto(GeomPolygon, {
   
   required_aes <- c("map_id")
   
-})
+}))

--- a/R/geom-path-.r
+++ b/R/geom-path-.r
@@ -99,7 +99,7 @@ lineend = "butt", linejoin = "round", linemitre = 1, na.rm = FALSE, arrow = NULL
   lineend = lineend, linejoin = linejoin, linemitre = linemitre, na.rm = na.rm, arrow = arrow, ...)
 }
 
-GeomPath <- proto(Geom, {
+GeomPath <- gg(proto(Geom, {
   objname <- "path"
 
   draw_groups <- function(., ...) .$draw(...)
@@ -203,5 +203,5 @@ GeomPath <- proto(Geom, {
   default_aes <- function(.) aes(colour="black", size=0.5, linetype=1, alpha = NA)
   guide_geom <- function(.) "path"
   
-})
+}))
 

--- a/R/geom-path-contour.r
+++ b/R/geom-path-contour.r
@@ -15,11 +15,11 @@ lineend = "butt", linejoin = "round", linemitre = 1, na.rm = FALSE, ...) {
   lineend = lineend, linejoin = linejoin, linemitre = linemitre, na.rm = na.rm, ...)
 }
 
-GeomContour <- proto(GeomPath, {
+GeomContour <- gg(proto(GeomPath, {
   objname <- "contour"
 
   default_aes <- function(.) aes(weight=1, colour="#3366FF", size = 0.5, linetype = 1, alpha = NA)
 
   default_stat <- function(.) StatContour  
-})
+}))
 

--- a/R/geom-path-density2d.r
+++ b/R/geom-path-density2d.r
@@ -21,9 +21,9 @@ lineend = "butt", linejoin = "round", linemitre = 1, na.rm = FALSE, ...) {
   lineend = lineend, linejoin = linejoin, linemitre = linemitre, na.rm = na.rm, ...)
 }
   
-GeomDensity2d <- proto(GeomPath, {
+GeomDensity2d <- gg(proto(GeomPath, {
   objname <- "density2d"
 
   default_stat <- function(.) StatDensity2d
   default_aes <- function(.) aes(weight=1, colour="#3366FF", size = 0.5, linetype = 1, alpha = NA)  
-})
+}))

--- a/R/geom-path-line.r
+++ b/R/geom-path-line.r
@@ -64,7 +64,7 @@ geom_line <- function (mapping = NULL, data = NULL, stat = "identity", position 
   GeomLine$new(mapping = mapping, data = data, stat = stat, position = position, ...)
 }
 
-GeomLine <- proto(GeomPath, {
+GeomLine <- gg(proto(GeomPath, {
   objname <- "line"
   
   draw <- function(., data, scales, coordinates, arrow = NULL, ...) {
@@ -74,4 +74,4 @@ GeomLine <- proto(GeomPath, {
   
   default_stat <- function(.) StatIdentity
   
-})
+}))

--- a/R/geom-path-step.r
+++ b/R/geom-path-step.r
@@ -31,7 +31,7 @@ direction = "hv", ...) {
   direction = direction, ...)
 }
 
-GeomStep <- proto(Geom, {
+GeomStep <- gg(proto(Geom, {
   objname <- "step"
 
   details <- "Equivalent to plot(type='s')."
@@ -45,7 +45,7 @@ GeomStep <- proto(Geom, {
   guide_geom <- function(.) "path"
 
   default_stat <- function(.) StatIdentity
-})
+}))
 
 
 # Calculate stairsteps

--- a/R/geom-point-.r
+++ b/R/geom-point-.r
@@ -108,7 +108,7 @@ na.rm = FALSE, ...) {
   na.rm = na.rm, ...)
 }
       
-GeomPoint <- proto(Geom, {
+GeomPoint <- gg(proto(Geom, {
   objname <- "point"
 
   draw_groups <- function(., ...) .$draw(...)
@@ -140,4 +140,4 @@ GeomPoint <- proto(Geom, {
   required_aes <- c("x", "y")
   default_aes <- function(.) aes(shape=16, colour="black", size=2, fill = NA, alpha = NA)
   
-})
+}))

--- a/R/geom-point-jitter.r
+++ b/R/geom-point-jitter.r
@@ -38,9 +38,9 @@ na.rm = FALSE, ...) {
   na.rm = na.rm, ...)
 }
 
-GeomJitter <- proto(GeomPoint, {
+GeomJitter <- gg(proto(GeomPoint, {
   objname <- "jitter"
 
   default_stat <- function(.) StatIdentity
   default_pos <- function(.) PositionJitter
-})
+}))

--- a/R/geom-pointrange.r
+++ b/R/geom-pointrange.r
@@ -17,7 +17,7 @@ geom_pointrange <- function (mapping = NULL, data = NULL, stat = "identity", pos
   GeomPointrange$new(mapping = mapping, data = data, stat = stat, position = position, ...)
 }
 
-GeomPointrange <- proto(Geom, {
+GeomPointrange <- gg(proto(Geom, {
   objname <- "pointrange"
 
   default_stat <- function(.) StatIdentity
@@ -42,4 +42,4 @@ GeomPointrange <- proto(Geom, {
     )
   }
   
-})
+}))

--- a/R/geom-polygon.r
+++ b/R/geom-polygon.r
@@ -50,7 +50,7 @@ geom_polygon <- function (mapping = NULL, data = NULL, stat = "identity", positi
   GeomPolygon$new(mapping = mapping, data = data, stat = stat, position = position, ...)
 }
 
-GeomPolygon <- proto(Geom, {
+GeomPolygon <- gg(proto(Geom, {
   objname <- "polygon"
 
   draw <- function(., data, scales, coordinates, ...) {
@@ -81,5 +81,5 @@ GeomPolygon <- proto(Geom, {
     ))
   }
 
-})
+}))
 

--- a/R/geom-quantile.r
+++ b/R/geom-quantile.r
@@ -17,10 +17,10 @@ lineend = "butt", linejoin = "round", linemitre = 1, na.rm = FALSE, ...) {
   lineend = lineend, linejoin = linejoin, linemitre = linemitre, na.rm = na.rm, ...)
 }
 
-GeomQuantile <- proto(GeomPath, {  
+GeomQuantile <- gg(proto(GeomPath, {
   objname <- "quantile"
 
   default_stat <- function(.) StatQuantile
   default_aes <- function(.) defaults(aes(weight=1, colour="#3366FF", size=0.5), GeomPath$default_aes())
   guide_geom <- function(.) "path"
-})
+}))

--- a/R/geom-raster.r
+++ b/R/geom-raster.r
@@ -59,7 +59,7 @@ geom_raster <- function (mapping = NULL, data = NULL, stat = "identity", positio
   GeomRaster$new(mapping = mapping, data = data, stat = stat, position = position, hjust = hjust, vjust = vjust, interpolate = interpolate, ...)
 }
 
-GeomRaster <- proto(Geom, {
+GeomRaster <- gg(proto(Geom, {
   objname <- "raster"
   
   reparameterise <- function(., df, params) {
@@ -111,4 +111,4 @@ GeomRaster <- proto(Geom, {
   default_aes <- function(.) aes(fill = "grey20", alpha = NA)
   required_aes <- c("x", "y")
   guide_geom <- function(.) "polygon"
-})
+}))

--- a/R/geom-rect.r
+++ b/R/geom-rect.r
@@ -16,7 +16,7 @@ geom_rect <- function (mapping = NULL, data = NULL, stat = "identity", position 
   GeomRect$new(mapping = mapping, data = data, stat = stat, position = position, ...)
 }
 
-GeomRect <- proto(Geom, {
+GeomRect <- gg(proto(Geom, {
   objname <- "rect"
   
   default_stat <- function(.) StatIdentity
@@ -57,7 +57,7 @@ GeomRect <- proto(Geom, {
   }
   guide_geom <- function(.) "polygon"
 
-})
+}))
 
 # Convert rectangle to polygon
 # Useful for non-Cartesian coordinate systems where it's easy to work purely in terms of locations, rather than locations and dimensions.

--- a/R/geom-ribbon-.r
+++ b/R/geom-ribbon-.r
@@ -47,7 +47,7 @@ na.rm = FALSE, ...) {
   na.rm = na.rm, ...)
 }
 
-GeomRibbon <- proto(Geom, {
+GeomRibbon <- gg(proto(Geom, {
   objname <- "ribbon"
 
   default_stat <- function(.) StatIdentity
@@ -93,7 +93,7 @@ GeomRibbon <- proto(Geom, {
     ))
   }
 
-})
+}))
 
 #' Area plot.
 #' 
@@ -117,7 +117,7 @@ na.rm = FALSE, ...) {
   na.rm = na.rm, ...)
 }
 
-GeomArea <- proto(GeomRibbon,{
+GeomArea <- gg(proto(GeomRibbon,{
   objname <- "area"
 
   default_aes <- function(.) aes(colour=NA, fill="grey20", size=0.5, linetype=1, alpha = NA)
@@ -128,4 +128,4 @@ GeomArea <- proto(GeomRibbon,{
     transform(df, ymin = 0, ymax = y)
   }
 
-})
+}))

--- a/R/geom-ribbon-density.r
+++ b/R/geom-ribbon-density.r
@@ -17,11 +17,11 @@ na.rm = FALSE, ...) {
   na.rm = na.rm, ...)
 }
 
-GeomDensity <- proto(GeomArea, {
+GeomDensity <- gg(proto(GeomArea, {
   objname <- "density"
 
   default_stat <- function(.) StatDensity
   default_pos <- function(.) PositionIdentity
   
   default_aes <- function(.) defaults(aes(fill=NA, weight=1, colour="black", alpha = NA), GeomArea$default_aes())
-})
+}))

--- a/R/geom-rug.r
+++ b/R/geom-rug.r
@@ -19,7 +19,7 @@ geom_rug <- function (mapping = NULL, data = NULL, stat = "identity", position =
   GeomRug$new(mapping = mapping, data = data, stat = stat, position = position, sides = sides, ...)
 }
 
-GeomRug <- proto(Geom, {
+GeomRug <- gg(proto(Geom, {
   objname <- "rug"
 
   draw <- function(., data, scales, coordinates, sides, ...) {
@@ -67,4 +67,4 @@ GeomRug <- proto(Geom, {
   default_stat <- function(.) StatIdentity
   default_aes <- function(.) aes(colour="black", size=0.5, linetype=1, alpha = NA)
   guide_geom <- function(.) "path"
-})
+}))

--- a/R/geom-segment.r
+++ b/R/geom-segment.r
@@ -45,7 +45,7 @@ geom_segment <- function (mapping = NULL, data = NULL, stat = "identity", positi
   GeomSegment$new(mapping = mapping, data = data, stat = stat, position = position, arrow = arrow, lineend = lineend, ...)
 }
 
-GeomSegment <- proto(Geom, {
+GeomSegment <- gg(proto(Geom, {
   objname <- "segment"
 
   draw <- function(., data, scales, coordinates, arrow = NULL, lineend = "butt", ...) {
@@ -73,5 +73,5 @@ GeomSegment <- proto(Geom, {
   required_aes <- c("x", "y", "xend", "yend")
   default_aes <- function(.) aes(colour="black", size=0.5, linetype=1, alpha = NA)
   guide_geom <- function(.) "path"
-})
+}))
 

--- a/R/geom-smooth.r
+++ b/R/geom-smooth.r
@@ -35,7 +35,7 @@ geom_smooth <- function (mapping = NULL, data = NULL, stat = "smooth", position 
   GeomSmooth$new(mapping = mapping, data = data, stat = stat, position = position, ...)
 }
 
-GeomSmooth <- proto(Geom, {
+GeomSmooth <- gg(proto(Geom, {
   objname <- "smooth"
 
   draw <- function(., data, scales, coordinates, ...) {
@@ -72,4 +72,4 @@ GeomSmooth <- proto(Geom, {
     }
   }
 
-})
+}))

--- a/R/geom-text.r
+++ b/R/geom-text.r
@@ -58,7 +58,7 @@ parse = FALSE, ...) {
   parse = parse, ...)
 }
 
-GeomText <- proto(Geom, {
+GeomText <- gg(proto(Geom, {
   objname <- "text"
 
   draw_groups <- function(., ...) .$draw(...)
@@ -94,4 +94,4 @@ GeomText <- proto(Geom, {
     vjust=0.5, alpha = NA, family="", fontface=1, lineheight=1.2)
   guide_geom <- function(x) "text"
   
-})
+}))

--- a/R/geom-tile.r
+++ b/R/geom-tile.r
@@ -71,7 +71,7 @@ geom_tile <- function (mapping = NULL, data = NULL, stat = "identity", position 
   GeomTile$new(mapping = mapping, data = data, stat = stat, position = position, ...)
 }
 
-GeomTile <- proto(Geom, {
+GeomTile <- gg(proto(Geom, {
   objname <- "tile"
 
   reparameterise <- function(., df, params) {
@@ -94,4 +94,4 @@ GeomTile <- proto(Geom, {
   default_aes <- function(.) aes(fill="grey20", colour=NA, size=0.1, linetype=1, alpha = NA)
   required_aes <- c("x", "y")
   guide_geom <- function(.) "polygon"
-})
+}))

--- a/R/geom-violin.r
+++ b/R/geom-violin.r
@@ -68,7 +68,7 @@ trim = TRUE, scale = "equal", ...) {
   position = position, trim = trim, scale = scale, ...)
 }
 
-GeomViolin <- proto(Geom, {
+GeomViolin <- gg(proto(Geom, {
   objname <- "violin"
 
   reparameterise <- function(., df, params) {
@@ -108,4 +108,4 @@ GeomViolin <- proto(Geom, {
   default_aes <- function(.) aes(weight=1, colour="grey20", fill="white", size=0.5, alpha = NA, linetype = "solid")
   required_aes <- c("x", "y")
 
-})
+}))

--- a/R/geom-vline.r
+++ b/R/geom-vline.r
@@ -45,7 +45,7 @@ geom_vline <- function (mapping = NULL, data = NULL, stat = "vline", position = 
   GeomVline$new(mapping = mapping, data = data, stat = stat, position = position, show_guide = show_guide, ...)
 }
 
-GeomVline <- proto(Geom, {
+GeomVline <- gg(proto(Geom, {
   objname <- "vline"
 
   new <- function(., data = NULL, mapping = NULL, xintercept = NULL, ...) {
@@ -81,4 +81,4 @@ GeomVline <- proto(Geom, {
     )
   }
 
-})
+}))

--- a/R/layer.r
+++ b/R/layer.r
@@ -11,7 +11,7 @@
 #  * flag for display guide: TRUE/FALSE/NA. in the case of NA, decision depends on a guide itself.
 # 
 # Can think about grob creation as a series of data frame transformations.
-Layer <- proto(expr = {  
+Layer <- gg(proto(expr = {
   geom <- NULL
   geom_params <- NULL
   stat <- NULL
@@ -70,14 +70,14 @@ Layer <- proto(expr = {
       geom_params <- rename_aes(geom_params)
     }
     
-    proto(., 
+    gg(proto(.,
       geom=geom, geom_params=geom_params, 
       stat=stat, stat_params=stat_params, 
       data=data, mapping=mapping, subset=subset,
       position=position,
       inherit.aes = inherit.aes,
       show_guide = show_guide,
-    )
+    ))
   }
   
   clone <- function(.) as.proto(.$as.list(all.names=TRUE))
@@ -250,7 +250,7 @@ Layer <- proto(expr = {
   }
 
   class <- function(.) "layer"
-})
+}))
 
 #' Create a new layer
 #' 

--- a/R/position-.r
+++ b/R/position-.r
@@ -1,7 +1,7 @@
 # Position adjustment occurs over all groups within a geom
 # They work only with discrete x scales and may affect x and y position.
 # Should occur after statistics and scales have been applied.
-Position <- proto(TopLevel, expr = {
+Position <- gg(proto(TopLevel, expr = {
   adjust <- function(., data, scales, ...) data
 
   class <- function(.) "position"
@@ -25,7 +25,7 @@ Position <- proto(TopLevel, expr = {
     if (newline) cat("\n")
   }
   
-})
+}))
 
 
 # Convenience function to ensure that all position variables 

--- a/R/position-dodge.r
+++ b/R/position-dodge.r
@@ -29,7 +29,7 @@ position_dodge <- function (width = NULL, height = NULL) {
   PositionDodge$new(width = width, height = height)
 }
 
-PositionDodge <- proto(Position, {
+PositionDodge <- gg(proto(Position, {
   objname <- "dodge"
 
   adjust <- function(., data) {
@@ -39,5 +39,5 @@ PositionDodge <- proto(Position, {
     collide(data, .$width, .$my_name(), pos_dodge, check.width = FALSE)
   }  
 
-})
+}))
 

--- a/R/position-fill.r
+++ b/R/position-fill.r
@@ -23,7 +23,7 @@ position_fill <- function (width = NULL, height = NULL) {
   PositionFill$new(width = width, height = height)
 }
   
-PositionFill <- proto(Position, {
+PositionFill <- gg(proto(Position, {
   objname <- "fill"
 
   adjust <- function(., data) {
@@ -34,4 +34,4 @@ PositionFill <- proto(Position, {
     collide(data, .$width, .$my_name(), pos_fill)
   }  
 
-})
+}))

--- a/R/position-identity.r
+++ b/R/position-identity.r
@@ -10,6 +10,6 @@ position_identity <- function (width = NULL, height = NULL) {
   PositionIdentity$new(width = width, height = height)
 }
 
-PositionIdentity <- proto(Position, {
+PositionIdentity <- gg(proto(Position, {
   objname <- "identity"
-})
+}))

--- a/R/position-jitter.r
+++ b/R/position-jitter.r
@@ -26,7 +26,7 @@ position_jitter <- function (width = NULL, height = NULL) {
   PositionJitter$new(width = width, height = height)
 }
 
-PositionJitter <- proto(Position, {
+PositionJitter <- gg(proto(Position, {
   objname <- "jitter"
  
   adjust <- function(., data) {
@@ -48,4 +48,4 @@ PositionJitter <- proto(Position, {
     transform_position(data, trans_x, trans_y)
   }
   
-})
+}))

--- a/R/position-stack.r
+++ b/R/position-stack.r
@@ -32,7 +32,7 @@ position_stack <- function (width = NULL, height = NULL) {
   PositionStack$new(width = width, height = height)
 }
 
-PositionStack <- proto(Position, {
+PositionStack <- gg(proto(Position, {
   objname <- "stack"
 
   adjust <- function(., data) {
@@ -53,4 +53,4 @@ PositionStack <- proto(Position, {
     collide(data, .$width, .$my_name(), pos_stack)
   }  
 
-})
+}))

--- a/R/stat-.r
+++ b/R/stat-.r
@@ -1,4 +1,4 @@
-Stat <- proto(TopLevel, expr={
+Stat <- gg(proto(TopLevel, expr={
   objname <- "" 
   desc <- ""
 
@@ -67,4 +67,4 @@ Stat <- proto(TopLevel, expr={
     do.call("layer", list(mapping=mapping, data=data, geom=geom, stat=., position=position, ...))
   }
 
-})
+}))

--- a/R/stat-bin.r
+++ b/R/stat-bin.r
@@ -50,7 +50,7 @@ width = 0.9, drop = FALSE, right = FALSE, binwidth = NULL, origin = NULL, breaks
   width = width, drop = drop, right = right, binwidth = binwidth, origin = origin, breaks = breaks, ...)
 }
 
-StatBin <- proto(Stat, {
+StatBin <- gg(proto(Stat, {
   objname <- "bin"
   informed <- FALSE
   
@@ -74,7 +74,7 @@ StatBin <- proto(Stat, {
   required_aes <- c("x")
   default_geom <- function(.) GeomBar
   
-})
+}))
 
 bin <- function(x, weight=NULL, binwidth=NULL, origin=NULL, breaks=NULL, range=NULL, width=0.9, drop = FALSE, right = TRUE) {
   

--- a/R/stat-bin2d.r
+++ b/R/stat-bin2d.r
@@ -42,7 +42,7 @@ bins = 30, drop = TRUE, ...) {
   bins = bins, drop = drop, ...)
 }
 
-StatBin2d <- proto(Stat, {
+StatBin2d <- gg(proto(Stat, {
   objname <- "bin2d"
 
   default_aes <- function(.) aes(fill = ..count..)
@@ -118,4 +118,4 @@ StatBin2d <- proto(Stat, {
       density <- count / sum(count, na.rm = TRUE)
     })
   }  
-})
+}))

--- a/R/stat-bindot.r
+++ b/R/stat-bindot.r
@@ -51,7 +51,7 @@ binpositions = "bygroup", drop = FALSE, right = TRUE, na.rm = FALSE, ...) {
 }
 
 
-StatBindot <- proto(Stat, {
+StatBindot <- gg(proto(Stat, {
   objname <- "bindot"
   informed <- FALSE
   
@@ -167,7 +167,7 @@ StatBindot <- proto(Stat, {
   required_aes <- c("x")
   default_geom <- function(.) GeomDotplot
   
-})
+}))
 
 # This does density binning, but does not collapse each bin with a count.
 # It returns a data frame with the original data (x), weights, bin #, and the bin centers.

--- a/R/stat-binhex.r
+++ b/R/stat-binhex.r
@@ -36,7 +36,7 @@ bins = 30, na.rm = FALSE, ...) {
   bins = bins, na.rm = na.rm, ...)
 }
 
-StatBinhex <- proto(Stat, {
+StatBinhex <- gg(proto(Stat, {
   objname <- "binhex"
 
   default_aes <- function(.) aes(fill = ..count..)
@@ -59,7 +59,7 @@ StatBinhex <- proto(Stat, {
   }
 
   
-})
+}))
 
 # Bin 2d plane into hexagons
 # Wrapper around \code{\link[hexbin]{hcell2xy}} that returns a data frame

--- a/R/stat-boxplot.r
+++ b/R/stat-boxplot.r
@@ -26,7 +26,7 @@ na.rm = FALSE, coef = 1.5, ...) {
   position = position, na.rm = na.rm, coef = coef, ...)
 }
   
-StatBoxplot <- proto(Stat, {
+StatBoxplot <- gg(proto(Stat, {
   objname <- "boxplot"
   
   required_aes <- c("x", "y")
@@ -80,4 +80,4 @@ StatBoxplot <- proto(Stat, {
       )
     })
   }
-})
+}))

--- a/R/stat-contour.r
+++ b/R/stat-contour.r
@@ -58,7 +58,7 @@ na.rm = FALSE, ...) {
   position = position, na.rm = na.rm, ...)
 }
 
-StatContour <- proto(Stat, {
+StatContour <- gg(proto(Stat, {
   objname <- "contour"
 
   calculate <- function(., data, scales, bins=NULL, binwidth=NULL, breaks = NULL, complete = FALSE, na.rm = FALSE, ...) {
@@ -84,7 +84,7 @@ StatContour <- proto(Stat, {
   default_geom <- function(.) GeomPath
   default_aes <- function(.) aes(order = ..level..)
   required_aes <- c("x", "y", "z")
-})
+}))
 
 
 # v3d <- reshape2::melt(volcano)

--- a/R/stat-density-2d.r
+++ b/R/stat-density-2d.r
@@ -59,7 +59,7 @@ na.rm = FALSE, contour = TRUE, n = 100, ...) {
   position = position, na.rm = na.rm, contour = contour, n = n, ...)
 }
 
-StatDensity2d <- proto(Stat, {
+StatDensity2d <- gg(proto(Stat, {
   objname <- "density2d"
   
   default_geom <- function(.) GeomDensity2d
@@ -85,4 +85,4 @@ StatDensity2d <- proto(Stat, {
       df
     }
   }  
-})
+}))

--- a/R/stat-density.r
+++ b/R/stat-density.r
@@ -93,7 +93,7 @@ adjust = 1, kernel = "gaussian", trim = FALSE, na.rm = FALSE, ...) {
   adjust = adjust, kernel = kernel, trim = trim, na.rm = na.rm, ...)
 }
   
-StatDensity <- proto(Stat, {
+StatDensity <- gg(proto(Stat, {
   objname <- "density"
 
   calculate <- function(., data, scales, adjust=1, kernel="gaussian", trim=FALSE, na.rm = FALSE, ...) {
@@ -121,4 +121,4 @@ StatDensity <- proto(Stat, {
   default_aes <- function(.) aes(y = ..density.., fill=NA)
   required_aes <- c("x")
 
-})
+}))

--- a/R/stat-ecdf.r
+++ b/R/stat-ecdf.r
@@ -20,7 +20,7 @@ stat_ecdf <- function (mapping = NULL, data = NULL, geom = "step", position = "i
   StatEcdf$new(mapping = mapping, data = data, geom = geom, position = position, n = n, ...)
 }
 
-StatEcdf <- proto(Stat, {
+StatEcdf <- gg(proto(Stat, {
   objname <- "ecdf"
   
   calculate <- function(., data, scales, n = NULL, ...) {
@@ -54,5 +54,5 @@ StatEcdf <- proto(Stat, {
   required_aes <- c("x")
   default_geom <- function(.) GeomStep
 
-})
+}))
 

--- a/R/stat-function.r
+++ b/R/stat-function.r
@@ -45,7 +45,7 @@ fun, n = 101, args = list(), ...) {
   position = position, fun = fun, n = n, args = args, ...)
 }
 
-StatFunction <- proto(Stat, {
+StatFunction <- gg(proto(Stat, {
   objname <- "function"
 
   default_geom <- function(.) GeomPath
@@ -60,4 +60,4 @@ StatFunction <- proto(Stat, {
       y = do.call(fun, c(list(xseq), args))
     )
   }  
-})
+}))

--- a/R/stat-identity.r
+++ b/R/stat-identity.r
@@ -22,7 +22,7 @@ stat_identity <- function (mapping = NULL, data = NULL, geom = "point", position
   position = position, ...)
 }
 
-StatIdentity <- proto(Stat, {
+StatIdentity <- gg(proto(Stat, {
   objname <- "identity"
 
   default_geom <- function(.) GeomPoint
@@ -30,4 +30,4 @@ StatIdentity <- proto(Stat, {
   
   desc_outputs <- list()
   
-})
+}))

--- a/R/stat-qq.r
+++ b/R/stat-qq.r
@@ -44,7 +44,7 @@ distribution = qnorm, dparams = list(), na.rm = FALSE, ...) {
   distribution = distribution, dparams = dparams, na.rm = na.rm, ...)
 }
   
-StatQq <- proto(Stat, {
+StatQq <- gg(proto(Stat, {
   objname <- "qq"
 
   default_geom <- function(.) GeomPoint
@@ -70,4 +70,4 @@ StatQq <- proto(Stat, {
   }
   
   
-})
+}))

--- a/R/stat-quantile.r
+++ b/R/stat-quantile.r
@@ -46,7 +46,7 @@ na.rm = FALSE, ...) {
   method = method, na.rm = na.rm, ...)
 }
 
-StatQuantile <- proto(Stat, {
+StatQuantile <- gg(proto(Stat, {
   objname <- "quantile"
 
   default_geom <- function(.) GeomQuantile
@@ -76,4 +76,4 @@ StatQuantile <- proto(Stat, {
     )
   }
   
-})
+}))

--- a/R/stat-smooth.r
+++ b/R/stat-smooth.r
@@ -105,7 +105,7 @@ level = 0.95, na.rm = FALSE, ...) {
   level = level, na.rm = na.rm, ...)
 }
 
-StatSmooth <- proto(Stat, {
+StatSmooth <- gg(proto(Stat, {
   objname <- "smooth"
 
   calculate_groups <- function(., data, scales, method="auto", formula=y~x, ...) {
@@ -177,4 +177,4 @@ StatSmooth <- proto(Stat, {
 
   required_aes <- c("x", "y")
   default_geom <- function(.) GeomSmooth
-})
+}))

--- a/R/stat-spoke.r
+++ b/R/stat-spoke.r
@@ -21,7 +21,7 @@ stat_spoke <- function (mapping = NULL, data = NULL, geom = "segment", position 
   StatSpoke$new(mapping = mapping, data = data, geom = geom, position = position, ...)
 }
 
-StatSpoke <- proto(Stat, {
+StatSpoke <- gg(proto(Stat, {
   objname <- "spoke"
 
   retransform <- FALSE
@@ -36,4 +36,4 @@ StatSpoke <- proto(Stat, {
   required_aes <- c("x", "y", "angle", "radius")
   default_geom <- function(.) GeomSegment
     
-})
+}))

--- a/R/stat-sum.r
+++ b/R/stat-sum.r
@@ -49,7 +49,7 @@ stat_sum <- function (mapping = NULL, data = NULL, geom = "point", position = "i
   StatSum$new(mapping = mapping, data = data, geom = geom, position = position, ...)
 }
   
-StatSum <- proto(Stat, {
+StatSum <- gg(proto(Stat, {
   objname <- "sum"
 
   default_aes <- function(.) aes(size = ..prop..)
@@ -67,4 +67,4 @@ StatSum <- proto(Stat, {
     counts$prop <- ave(counts$n, counts$group, FUN = prop.table)
     counts
   }
-})
+}))

--- a/R/stat-summary-2d.r
+++ b/R/stat-summary-2d.r
@@ -38,7 +38,7 @@ bins = 30, drop = TRUE, fun = mean, ...) {
   bins = bins, drop = drop, fun = fun, ...)
 }
 
-StatSummary2d <- proto(Stat, {
+StatSummary2d <- gg(proto(Stat, {
   objname <- "Summary2d"
 
   default_aes <- function(.) aes(fill = ..value..)
@@ -113,4 +113,4 @@ StatSummary2d <- proto(Stat, {
       ymax <- breaks$y[yint + 1]
     })
   }
-})
+}))

--- a/R/stat-summary-hex.r
+++ b/R/stat-summary-hex.r
@@ -36,7 +36,7 @@ bins = 30, drop = TRUE, fun = mean, ...) {
   bins = bins, drop = drop, fun = fun, ...)
 }
 
-StatSummaryhex <- proto(Stat, {
+StatSummaryhex <- gg(proto(Stat, {
   objname <- "summaryhex"
 
   default_aes <- function(.) aes(fill = ..value..)
@@ -86,4 +86,4 @@ StatSummaryhex <- proto(Stat, {
     if (drop) ret <- na.omit(ret)
     ret
   }
-})
+}))

--- a/R/stat-summary.r
+++ b/R/stat-summary.r
@@ -110,7 +110,7 @@ stat_summary <- function (mapping = NULL, data = NULL, geom = "pointrange", posi
   StatSummary$new(mapping = mapping, data = data, geom = geom, position = position, ...)
 }
   
-StatSummary <- proto(Stat, {
+StatSummary <- gg(proto(Stat, {
   objname <- "summary"
 
   default_geom <- function(.) GeomPointrange
@@ -139,7 +139,7 @@ StatSummary <- proto(Stat, {
   }
   
   
-})
+}))
 
 # Summarise a data.frame by parts
 # Summarise a data frame by unique value of x

--- a/R/stat-unique.r
+++ b/R/stat-unique.r
@@ -12,11 +12,11 @@ stat_unique <- function (mapping = NULL, data = NULL, geom = "point", position =
   StatUnique$new(mapping = mapping, data = data, geom = geom, position = position, ...)
 }
   
-StatUnique <- proto(Stat, {
+StatUnique <- gg(proto(Stat, {
   objname <- "unique" 
   desc <- "Remove duplicates"
   
   default_geom <- function(.) GeomPoint
   
   calculate_groups <- function(., data, scales, ...) unique(data)
-})
+}))

--- a/R/stat-vline.r
+++ b/R/stat-vline.r
@@ -10,7 +10,7 @@ stat_abline <- function (mapping = NULL, data = NULL, geom = "abline", position 
   StatAbline$new(mapping = mapping, data = data, geom = geom, position = position, ...)
 }
 
-StatAbline <- proto(Stat, {
+StatAbline <- gg(proto(Stat, {
   objname <- "abline"
 
   calculate <- function(., data, scales, intercept = NULL, slope = NULL, ...) {
@@ -30,7 +30,7 @@ StatAbline <- proto(Stat, {
   }
   
   default_geom <- function(.) GeomAbline
-})
+}))
 
 #' Add a vertical line
 #'
@@ -46,7 +46,7 @@ xintercept, ...) {
   xintercept = xintercept, ...)
 }
 
-StatVline <- proto(Stat, {
+StatVline <- gg(proto(Stat, {
   objname <- "vline"
 
   calculate <- function(., data, scales, xintercept = NULL, intercept, ...) {
@@ -63,7 +63,7 @@ StatVline <- proto(Stat, {
   
   required_aes <- c()
   default_geom <- function(.) GeomVline
-})
+}))
 
 #' Add a horizontal line
 #'
@@ -79,7 +79,7 @@ yintercept, ...) {
   yintercept = yintercept, ...)
 }
   
-StatHline <- proto(Stat, {
+StatHline <- gg(proto(Stat, {
   calculate <- function(., data, scales, yintercept = NULL, intercept, ...) {
     if (!missing(intercept)) {
       stop("stat_hline now uses yintercept instead of intercept")
@@ -102,7 +102,7 @@ StatHline <- proto(Stat, {
   examples <- function(.) {
     # See geom_hline for examples
   }
-})
+}))
 
 
 # Compute intercept for vline and hline from data and parameters

--- a/R/stat-ydensity.r
+++ b/R/stat-ydensity.r
@@ -32,7 +32,7 @@ adjust = 1, kernel = "gaussian", trim = TRUE, scale = "equal", na.rm = FALSE, ..
   na.rm = na.rm, ...)
 }
   
-StatYdensity <- proto(Stat, {
+StatYdensity <- gg(proto(Stat, {
   objname <- "ydensity"
 
   calculate_groups <- function(., data, na.rm = FALSE, width = NULL,
@@ -86,4 +86,4 @@ StatYdensity <- proto(Stat, {
   default_geom <- function(.) GeomViolin
   required_aes <- c("x", "y")
 
-})
+}))


### PR DESCRIPTION
This fixes #583. It passes all tests, and visual tests are unchanged.

I'm not sure it should be merged though -- although it solves the printing problem, it'll break all code where people define their own geoms and stats in external packages.

There's also some weird behavior with printing that I don't understand. Depending on how you print it, it might or might not tell you that it's a `ggproto` object:

``` R
str(z)
# proto object 
#  $ mapping    : NULL 
#  $ geom_params:List of 1 
#  $ stat_params: Named list() 
#  $ stat       :proto object  
#   ..parent: proto object  
#  .. .. parent: proto object  
#  $ inherit.aes: logi TRUE 
#  $ geom       :proto object  
#   ..parent: proto object  
#  .. .. parent: proto object  
#  $ position   :proto object  
#   ..parent: proto object  
#  .. .. parent: proto object  
#  .. .. .. parent: proto object  
#  $ subset     : NULL 
#  $ data       : list() 
#   ..- attr(*, "class")= chr "waiver" 
#  $ show_guide : logi NA 
#  parent: proto object 

z
# geom_point: na.rm = FALSE 
# stat_identity:  
# <environment: 0x10c9fcb08>
# attr(,"class")
# [1] "proto"       "environment"

class(z)
# [1] "ggproto"     "proto"       "environment"
```

There's another bizarre property of proto objects. If you set the class via `structure()`, even if you _don't_ assign it back to the variable, it modifies the class of the object.

``` R
class(z)
# [1] "ggproto"     "proto"       "environment"

structure(z, class = c("foo", class(z)))
# geom_point: na.rm = FALSE 
# stat_identity:  
# <environment: 0x10c9fcb08>
# attr(,"class")
# [1] "proto"       "environment"

class(z)
# [1] "foo"         "ggproto"     "proto"       "environment"
```

I'm concerned that, because proto is so opaque and confusing, there may be unintended consequences of this change.
