### PR TITLE
Add facet headers to facet_grid

### DIFF
--- a/R/facet-grid-.r
+++ b/R/facet-grid-.r
@@ -278,29 +278,34 @@ build_strip <- function(panel, label_df, labeller, theme, side = "right") {
   }
   
   # Render as grobs
-  grobs <- apply(labels, c(1,2), ggstrip, theme = theme,
+  text_grobs <- apply(labels, c(1,2), striptext_grob, theme = theme,
     horizontal = horizontal)
+  title_grob <- striptitle_grob(names(label_df), horizontal, theme)
   
   # Create layout
   name <- paste("strip", side, sep = "-")
   if (horizontal) {
-    grobs <- t(grobs)
+    text_grobs <- t(text_grobs)
     
     # Each row is as high as the highest and as a wide as the panel
     row_height <- function(row) max(laply(row, height_cm))
-    heights <- unit(apply(grobs, 1, row_height), "cm")
-    widths <- unit(rep(1, ncol(grobs)), "null")
+    heights <- unit(apply(text_grobs, 1, row_height), "cm")
+    widths <- unit(rep(1, ncol(text_grobs)), "null")
   } else {
     # Each row is wide as the widest and as high as the panel
     col_width <- function(col) max(laply(col, width_cm))
-    widths <- unit(apply(grobs, 2, col_width), "cm")
-    heights <- unit(rep(1, nrow(grobs)), "null")
+    widths <- unit(apply(text_grobs, 2, col_width), "cm")
+    heights <- unit(rep(1, nrow(text_grobs)), "null")
   }
-  strips <- gtable_matrix(name, grobs, heights = heights, widths = widths)
+  strips <- gtable_matrix(name, text_grobs, heights = heights, widths = widths)
   
   if (horizontal) {
+    strips <- gtable_add_rows(strips, unit(height_cm(title_grob), "cm"), pos = 0)
+    strips <- gtable_add_grob(strips, title_grob, t=1, b=1, l=1, r=-1)
     gtable_add_col_space(strips, theme$panel.margin)
   } else {
+    strips <- gtable_add_cols(strips, unit(width_cm(title_grob), "cm"), pos = -1)
+    strips <- gtable_add_grob(strips, title_grob, t=1, b=-1, l=-1, r=-1)
     gtable_add_row_space(strips, theme$panel.margin)
   }
 }

--- a/R/facet-labels.r
+++ b/R/facet-labels.r
@@ -63,15 +63,31 @@ label_bquote <- function(expr = beta ^ .(x)) {
 }
 
 # Grob for strip labels
-ggstrip <- function(text, horizontal=TRUE, theme) {
+striptext_grob <- function(text, horizontal=TRUE, theme) {
   text_theme <- if (horizontal) "strip.text.x" else "strip.text.y"
   if (is.list(text)) text <- text[[1]]
 
   label <- element_render(theme, text_theme, text)
 
-  ggname("strip", absoluteGrob(
+  ggname("strip.text", absoluteGrob(
     gList(
       element_render(theme, "strip.background"),
+      label
+    ),
+    width = grobWidth(label) + unit(0.5, "lines"),
+    height = grobHeight(label) + unit(0.5, "lines")
+  ))
+}
+
+# Grob for strip title
+striptitle_grob <- function(title, horizontal = TRUE, theme) {
+  text_theme <- if (horizontal) "strip.title.x" else "strip.title.y"
+
+  label <- element_render(theme, text_theme, title)
+
+  ggname("strip.title", absoluteGrob(
+    gList(
+      element_render(theme, "strip.title.background"),
       label
     ),
     width = grobWidth(label) + unit(0.5, "lines"),

--- a/R/facet-wrap.r
+++ b/R/facet-wrap.r
@@ -211,7 +211,7 @@ facet_strips.wrap <- function(facet, panel, theme) {
   
   labels <- apply(labels_df, 1, paste, collapse=", ")
 
-  list(t = llply(labels, ggstrip, theme = theme))
+  list(t = llply(labels, striptext_grob, theme = theme))
 }
 
 #' @S3method facet_axes wrap

--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -50,6 +50,9 @@ theme_grey <- function(base_size = 12, base_family = "") {
     strip.background =   element_rect(fill = "grey80", colour = NA),
     strip.text.x =       element_text(),
     strip.text.y =       element_text(angle = -90),
+    strip.title.background = element_rect(fill = "grey80", colour = NA),
+    strip.title.x =      element_text(),
+    strip.title.y =      element_text(angle = -90),
 
     plot.background =    element_rect(colour = "white"),
     plot.title =         element_text(size = rel(1.2)),
@@ -78,7 +81,7 @@ theme_bw <- function(base_size = 12, base_family = "") {
       panel.grid.major  = element_line(colour = "grey90", size = 0.2),
       panel.grid.minor  = element_line(colour = "grey98", size = 0.5),
       strip.background  = element_rect(fill = "grey80", colour = "grey50"),
-      strip.background  = element_rect(fill = "grey80", colour = "grey50")
+      strip.title.background = element_rect(fill = "grey80", colour = "grey50")
     )
 }
 
@@ -96,6 +99,7 @@ theme_minimal <- function(base_size = 12, base_family = "") {
       panel.background  = element_blank(),
       panel.border      = element_blank(),
       strip.background  = element_blank(),
+      strip.title.background  = element_blank(),
       plot.background   = element_blank()
     )
 }

--- a/R/theme-elements.r
+++ b/R/theme-elements.r
@@ -276,6 +276,7 @@ el_def <- function(class = NULL, inherit = NULL, description = NULL) {
   panel.grid.major    = el_def("element_line", "panel.grid"),
   panel.grid.minor    = el_def("element_line", "panel.grid"),
   strip.text          = el_def("element_text", "text"),
+  strip.title         = el_def("element_text", "title"),
 
   axis.line.x         = el_def("element_line", "axis.line"),
   axis.line.y         = el_def("element_line", "axis.line"),
@@ -314,6 +315,9 @@ el_def <- function(class = NULL, inherit = NULL, description = NULL) {
   strip.background    = el_def("element_rect", "rect"),
   strip.text.x        = el_def("element_text", "strip.text"),
   strip.text.y        = el_def("element_text", "strip.text"),
+  strip.title.background = el_def("element_rect", "rect"),
+  strip.title.x       = el_def("element_text", "strip.title"),
+  strip.title.y       = el_def("element_text", "strip.title"),
 
   plot.background     = el_def("element_rect", "rect"),
   plot.title          = el_def("element_text", "title"),


### PR DESCRIPTION
This is a first pass at adding facet headers. Examples here: http://rpubs.com/wch/1306

Things that need to be done:
- Improve appearance
- Decide whether to allow this for `facet_wrap`, and if so, how
- Control over whether each header is drawn
- Syntax for setting header labels to something other than the default
- Figure out what to do when facet has two variables on one axis, like `facet_grid(. ~ am + cyl)`

Maybe the labels could be controlled like this:

```
facet_grid(am ~ cyl, titles = "auto/manual" ~ NULL)
```

Where `NULL` means not to draw facet headers for that variable.
