### PR TITLE
train_position: combine data with rbind.fill before training scales

### DIFF
--- a/R/panel.r
+++ b/R/panel.r
@@ -72,24 +72,23 @@ train_position <- function(panel, data, x_scale, y_scale) {
     panel$y_scales <- rlply(max(layout$SCALE_Y), scale_clone(y_scale))
   }
   
-  # loop over each layer, training x and y scales in turn
-  for(layer_data in data) {
+  # Combine the data frames, then train the scales
+  layer_data <- do.call(rbind.fill, data)
     
-    match_id <- match(layer_data$PANEL, layout$PANEL)
-    
-    if (!is.null(x_scale)) {
-      x_vars <- intersect(x_scale$aesthetics, names(layer_data))
-      SCALE_X <- layout$SCALE_X[match_id]
-      
-      scale_apply(layer_data, x_vars, scale_train, SCALE_X, panel$x_scales)
-    }
+  match_id <- match(layer_data$PANEL, layout$PANEL)
 
-    if (!is.null(y_scale)) {
-      y_vars <- intersect(y_scale$aesthetics, names(layer_data))
-      SCALE_Y <- layout$SCALE_Y[match_id]
-      
-      scale_apply(layer_data, y_vars, scale_train, SCALE_Y, panel$y_scales)
-    }
+  if (!is.null(x_scale)) {
+    x_vars <- intersect(x_scale$aesthetics, names(layer_data))
+    SCALE_X <- layout$SCALE_X[match_id]
+    
+    scale_apply(layer_data, x_vars, scale_train, SCALE_X, panel$x_scales)
+  }
+
+  if (!is.null(y_scale)) {
+    y_vars <- intersect(y_scale$aesthetics, names(layer_data))
+    SCALE_Y <- layout$SCALE_Y[match_id]
+
+    scale_apply(layer_data, y_vars, scale_train, SCALE_Y, panel$y_scales)
   }
 
   panel


### PR DESCRIPTION
This is a potential fix for #577.

Instead of training the scales on each layer separately, the data frames in the list `data` are combined first with `rbind.fill`, and then the scales are trained.

It fixes the test cases from above. Here are some more tests. It now gives warnings about when you mix in layers with continuous values.

``` R
# Mixing discrete and continuous - Warning
ggplot() + p1 + p2 + geom_point(aes(x,y), data=data.frame(x=1.2, y=1.8), colour="blue")
# With extra column - Warning
ggplot() + p1 + p2 + geom_point(aes(x,y,colour=g), data=data.frame(x=1.2, y=1.8, g="foo"))
# Warning message:
# In `[<-.factor`(`*tmp*`, rng, value = c(1L, 2L, 1L, NA)) :
#   invalid factor level, NAs generated


# Layer with data with new factor levels - OK
ggplot() + p1 + p2 + geom_point(aes(x,y), data=data.frame(x=1.3, y="c"), colour="blue")
# With extra column - OK
ggplot() + p1 + p2 + geom_point(aes(x,y,colour=g), data=data.frame(x=1.3, y="c", g="foo"))
```

This change passes all tests. But I have a feeling that there are cases where adding in layers with different data and aesthetics might have different behavior now.
