### PR TITLE
Add warning for non-cartesian coords and free scales

### DIFF
--- a/R/facet-wrap.r
+++ b/R/facet-wrap.r
@@ -101,6 +101,14 @@ facet_map_layout.wrap <- function(facet, data, layout) {
 #' @S3method facet_render wrap
 facet_render.wrap <- function(facet, panel, coord, theme, geom_grobs) {
   
+  # If coord is (non-cartesian or flip) and (x is free or y is free)
+  # then print a warning
+  if ((!inherits(coord, "cartesian") || inherits(coord, "flip")) &&
+    (facet$free$x || facet$free$y)) {
+    warning("When free scales are used with a non-cartesian coord or with coord_flip,\n",
+      "  the axis range and ticks may not display correctly.")
+  }
+
   # If user hasn't set aspect ratio, and we have fixed scales, then
   # ask the coordinate system if it wants to specify one
   aspect_ratio <- theme$aspect.ratio


### PR DESCRIPTION
This fixes #673.
