### PR TITLE
Allow setting one of the limits of scale

### DIFF
--- a/R/limits.r
+++ b/R/limits.r
@@ -52,7 +52,7 @@ ylim <- function(...) {
 limits <- function(lims, var) UseMethod("limits")
 limits.numeric <- function(lims, var) {
   stopifnot(length(lims) == 2)
-  if (sum(is.na(lims)) == 0 &lims[1] > lims[2]) {
+  if (!any(is.na(lims)) && lims[1] > lims[2]) {
     trans <- "reverse"
   } else {
     trans <- "identity"

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -291,10 +291,15 @@ scale_limits <- function(scale) {
   
 
 #' @S3method scale_limits default
+#  if scale contains a NULL, use the default scale range
+#  if scale contains a NA, use the default range for that axis, otherwise
+#  use the user defined limit for that axis
 scale_limits.default <- function(scale) {
-  if(!is.null(scale$limits)) 
-    ifelse(!is.na(scale$limits),scale$limits,scale$range$range) 
-  else scale$range$range
+  if(!is.null(scale$limits)) { 
+    ifelse(!is.na(scale$limits), scale$limits, scale$range$range) 
+  } else {
+    scale$range$range
+  }
 }
 
 # @kohske


### PR DESCRIPTION
Implements setting of only one limit of a continuous scale by specifying
NA for the limit which you don't want to set.  See #557.

I had to use NA instead of NULL to implement this, as is.null() is not 
vectorized, a vector with null at any location is TRUE.
