### PR TITLE
theme docs: added more explanation of plot.margin

### DIFF
--- a/R/theme.r
+++ b/R/theme.r
@@ -152,7 +152,8 @@ print.theme <- function(x, ...) str(x)
 #'   plot.title       \tab plot title (text appearance)
 #'                    (\code{element_text}; inherits from \code{title}) \cr
 #'   plot.margin      \tab margin around entire plot
-#'                    (\code{unit}) \cr
+#'                    (\code{unit} with the sizes of the top, right, bottom, and
+#'                     left margins) \cr
 #'
 #'   strip.background \tab background of facet labels
 #'                    (\code{element_rect}; inherits from \code{rect}) \cr

--- a/man/theme.Rd
+++ b/man/theme.Rd
@@ -120,8 +120,9 @@
   (\code{element_rect}; inherits from \code{rect}) \cr
   plot.title \tab plot title (text appearance)
   (\code{element_text}; inherits from \code{title}) \cr
-  plot.margin \tab margin around entire plot (\code{unit})
-  \cr
+  plot.margin \tab margin around entire plot (\code{unit}
+  with the sizes of the top, right, bottom, and left
+  margins) \cr
 
   strip.background \tab background of facet labels
   (\code{element_rect}; inherits from \code{rect}) \cr


### PR DESCRIPTION
The documentation of the `plot.margin` element in `themes` did not indicate what margins its elements correspond to.
