### PR TITLE
Apply scale transformations in stat_function

### DIFF
--- a/R/stat-function.r
+++ b/R/stat-function.r
@@ -54,10 +54,13 @@ StatFunction <- proto(Stat, {
   calculate <- function(., data, scales, fun, n=101, args = list(), ...) {
     range <- scale_dimension(scales$x, c(0, 0))
     xseq <- seq(range[1], range[2], length=n)
+    x_v = if (is.null(scales$x)) xseq else scales$x$trans$inverse(xseq)
+    y_v = do.call(fun, c(list(x_v), args))
+    y = if (is.null(scales$y)) y_v else scales$y$trans$transform(y_v)
     
     data.frame(
       x = xseq,
-      y = do.call(fun, c(list(xseq), args))
+      y = y
     )
   }  
 })


### PR DESCRIPTION
stat_function is ignoring scale transformations when passing arguments to its function.

For example,

``` R
qplot(1:10, log10(1:10)) + stat_function(fun=function(x) x)
qplot(1:10, log10(1:10)) + stat_function(fun=function(x) x) + scale_x_log10()
```

In the first plot, the function y=x sits far above the data points. After applying the scale transformation, the function now crosses the data points.

This patch fixes this bug.
