### PR TITLE
combine_elements should work by property name, not position

### DIFF
--- a/R/theme.r
+++ b/R/theme.r
@@ -606,7 +606,7 @@ combine_elements <- function(e1, e2) {
 
   # If e1 has any NULL properties, inherit them from e2
   n <- vapply(e1[names(e2)], is.null, logical(1))
-  e1[n] <- e2[n]
+  e1[names(n[n])] <- e2[names(n[n])]
 
   # Calculate relative sizes
   if (is.rel(e1$size)) {


### PR DESCRIPTION
This is a one line fix that makes sure combine_elements implements inheritance by property name rather than position. This allows child theme elements to have additional properties that the parent elements don't. 

For example, I made a plot where text axis labels have graphical icons attached, by implementing a class that inherited from `element_text`, with additional properties and an `element_grob` method. This worked but required this small change.
