### PR TITLE
fix in stat_ecdf for Inf and NA values

### DIFF
--- a/R/stat-ecdf.r
+++ b/R/stat-ecdf.r
@@ -29,7 +29,8 @@ StatEcdf <- proto(Stat, {
     if (is.null(n)) {
       xvals <- unique(data$x)
     } else {
-      xvals <- seq(min(data$x), max(data$x), length.out = n)
+      xfinite <- data$x[!is.na(data$x) & !is.infinite(data$x)]
+      xvals <- seq(min(xfinite), max(xfinite), length.out = n)
     }
 
     y <- ecdf(data$x)(xvals)


### PR DESCRIPTION
`stat_ecdf` fails when at least one value in `data$x` is `NA` or `Inf`:
- for `NA`, the `min`/`max` become `NA`, leading to an error in `seq`
- for `Inf` the min/max become infinite, and the finite end of the range is the only finite point in the result of the `seq`-call. 

The fix removes `NA` and `Inf` for the purpose of computing the x-range. Note that all values are still included in the call to `ecdf` (which removes NAs, but handles `Inf`s correctly).
