### PR TITLE
Add merge capability for scales

### DIFF
--- a/R/scale-.r
+++ b/R/scale-.r
@@ -35,7 +35,7 @@ NULL
 #'   (i.e. \code{\link{scale_colour_gradient2}}, \code{\link{scale_colour_gradientn}}).
 #' @param oob What to do with values outside scale limits (out of bounds)?
 #' @keywords internal
-continuous_scale <- function(aesthetics, scale_name, palette, name = NULL, breaks = waiver(), minor_breaks = waiver(), labels = waiver(), legend = NULL, limits = NULL, rescaler = rescale, oob = censor, expand = waiver(), na.value = NA_real_, trans = "identity", guide="legend") {
+continuous_scale <- function(aesthetics, scale_name, palette, name = NULL, breaks = waiver(), minor_breaks = waiver(), labels = waiver(), legend = NULL, limits = NULL, rescaler = rescale, oob = censor, expand = waiver(), na.value = NA_real_, trans = "identity", guide="legend", clear=F) {
 
   if (!is.null(legend)) {
     gg_dep("0.8.9", "\"legend\" argument in scale_XXX is deprecated. Use guide=\"none\" for suppress the guide display.")
@@ -79,6 +79,7 @@ continuous_scale <- function(aesthetics, scale_name, palette, name = NULL, break
 
     labels = labels, 
     legend = legend,
+    clear = clear,
     guide = guide
   ), class = c(scale_name, "continuous", "scale"))
 }
@@ -122,7 +123,7 @@ continuous_scale <- function(aesthetics, scale_name, palette, name = NULL, break
 #' @param na.value how should missing values be displayed?
 #' @param guide the name of, or actual function, used to create the 
 #'   guide.
-discrete_scale <- function(aesthetics, scale_name, palette, name = NULL, breaks = waiver(), labels = waiver(), legend = NULL, limits = NULL, expand = waiver(), na.value = NA, drop = TRUE, guide="legend") {
+discrete_scale <- function(aesthetics, scale_name, palette, name = NULL, breaks = waiver(), labels = waiver(), legend = NULL, limits = NULL, expand = waiver(), na.value = NA, drop = TRUE, guide="legend", clear=T) {
 
   if (!is.null(legend)) {
     gg_dep("0.8.9", "\"legend\" argument in scale_XXX is deprecated. Use guide=\"none\" for suppress the guide display.")
@@ -157,6 +158,7 @@ discrete_scale <- function(aesthetics, scale_name, palette, name = NULL, breaks 
     labels = labels, 
     legend = legend,
     drop = drop,
+    clear = clear,
     guide = guide
   ), class = c(scale_name, "discrete", "scale"))
 }


### PR DESCRIPTION
If a specific scale is already present, the new scale will be merged
with the current one instead of completely overriding it

Example:
ggplot(data.frame(x=1:12,y=rnorm(12,50),groups=rep(LETTERS[1:3],each=4)),aes(x,y,group=groups)) + geom_line() + scale_y_continuous(expand=c(0,0)) + scale_y_continuous(breaks=c(50))

This makes it easier to create functions returning full-blown ggplots that you can still manipulate with known scale*-functions
