### PR TITLE
Delete space between panels in theme_bw()

### DIFF
--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -75,6 +75,7 @@ theme_bw <- function(base_size = 12, base_family = "") {
       legend.key        = element_rect(colour = "grey80"),
       panel.background  = element_rect(fill = "white", colour = NA),
       panel.border      = element_rect(fill = NA, colour = "grey50"),
+      panel.margin      = unit(0,"cm"),
       panel.grid.major  = element_line(colour = "grey90", size = 0.2),
       panel.grid.minor  = element_line(colour = "grey98", size = 0.5),
       strip.background  = element_rect(fill = "grey80", colour = "grey50"),


### PR DESCRIPTION
The current behavior of theme_bw() takes the same panel.margin=unit(0.25,"lines") as theme_grey(). This setting makes sense for theme_grey() since you need white space as a border to distinguish the different panels. However, theme_bw() uses a grey line for the panel border, yielding the white space un-necessary. In fact, as shown below on page 63 of Envisioning Information by Edward Tufte, the "grid boxes" or space between panels, are a bad design (top). A better design is grey boxes around each panel with no white space between them (bottom).

![thick-facets-are-bad](https://f.cloud.github.com/assets/932850/870117/ce885c36-f820-11e2-9852-7719686c54a1.png)

On the left: the current default output when using theme_bw() in ggplot2. On the right: the same plot with theme_bw() after applying my patch, which changes only one line of code.

![space-nospace](https://f.cloud.github.com/assets/932850/870110/7068ffac-f820-11e2-894c-e8440d87c151.png)
