### PR TITLE
fix bug :annotation_logticks() and coord_flip() are mutulaly excluded

### DIFF
--- a/R/annotation-logticks.r
+++ b/R/annotation-logticks.r
@@ -108,7 +108,17 @@ GeomLogticks <- proto(Geom, {
     short <- convertUnit(short, "cm", valueOnly = TRUE)
     mid   <- convertUnit(mid,   "cm", valueOnly = TRUE)
     long  <- convertUnit(long,  "cm", valueOnly = TRUE)
-
+    
+    # Swap scales names if using coord_flip 
+    # and remove it from class attributes to jump to next Method
+    is.flip <- "flip" %in% attr(coordinates, "class")
+    
+    if(is.flip){
+    	scales <- flip_labels(scales)  
+    	attr(coordinates, "class") <- 
+    		attr(coordinates, "class")[attr(coordinates, "class") != "flip"]
+    }
+    
 
     if (grepl("[b|t]", sides)) {
 
@@ -168,7 +178,9 @@ GeomLogticks <- proto(Geom, {
         ))
       }
     }
-
+		## add flip if removed for further layers    
+    if (is.flip)  coordinates <-
+    	structure(coordinates, class = c("flip", class(coordinates)))
     gTree(children = do.call("gList", ticks))
   }
 

--- a/annotation.R
+++ b/annotation.R
@@ -1,0 +1,8 @@
+vcontext("annotation")
+
+ggplot(mtcars, aes(x=mpg, y=disp)) + 
+	geom_line() + 
+	annotation_logticks(sides="bt")  + 
+	coord_flip()
+
+end_vcontext()


### PR DESCRIPTION
this commit fix bug : annotation_logticks() and coord_flip() are mutually excluded 

see : https://github.com/hadley/ggplot2/issues/881
