### PR TITLE
adding offset argument to stat_bin()

### DIFF
--- a/man/stat_bin.Rd
+++ b/man/stat_bin.Rd
@@ -4,11 +4,13 @@
 \usage{
 stat_bin(mapping = NULL, data = NULL, geom = "bar", position = "stack",
   width = 0.9, drop = FALSE, right = FALSE, binwidth = NULL,
-  origin = NULL, breaks = NULL, ...)
+  offset = 0, origin = NULL, breaks = NULL, ...)
 }
 \arguments{
   \item{binwidth}{Bin width to use. Defaults to 1/30 of the
   range of the data}
+
+  \item{offset}{an amount to shift bars by (default=0)}
 
   \item{breaks}{Actual breaks to use.  Overrides bin width
   and origin}


### PR DESCRIPTION
I've added an `offset` argument to `stat_bin()` so that one can change shift the bins left or right without having to specify all the breaks.  Currently, this only affects things when both `breaks` and `origin` are NULL, but one could imagine expanding the use case.

As is, it is now simple to choose a width and control the centers/edges of bins without needing to query the data and create breaks manually.   For example, to get bins centered on integers, use 

``` r
binwidth = 1, offset=0.5
```

I have not added any examples, but the offset argument is documented in the usage section.
