### PR TITLE
Fix for issue #825 so that dotplot now works with qplot.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@ ggplot2 0.9.3.1.99
   calculation of the other limit by passing NA to to the limit function,
   `xlim()` or `ylim()` (@jimhester, #557).
 
+* `geom_dotplot` now works with qplot. (@rasmusab. Fixes #825)
+
 * `stat_smooth()` checks for `method = "auto"` and `method = "glm"` in
   a safer way.
 

--- a/R/geom-dotplot.r
+++ b/R/geom-dotplot.r
@@ -95,6 +95,9 @@
 #'
 #' ggplot(mtcars, aes(x = 1, y = mpg, fill = factor(cyl))) +
 #'   geom_dotplot(binaxis = "y", stackgroups = TRUE, binwidth = 1, method = "histodot")
+#'   
+#' # Use qplot instead
+#' qplot(mpg, data = mtcars, geom = "dotplot")
 #'
 geom_dotplot <- function (mapping = NULL, data = NULL, stat = "bindot", position = "identity",
 na.rm = FALSE, binwidth = NULL, binaxis = "x", method="dotdensity", binpositions = "bygroup", stackdir = "up",
@@ -152,7 +155,7 @@ GeomDotplot <- proto(Geom, {
       params$width %||% (resolution(df$x, FALSE) * 0.9)
 
     # Set up the stacking function and range
-    if(params$stackdir == "up") {
+    if(is.null(params$stackdir) || params$stackdir == "up") {
       stackdots <- function(a)  a - .5
       stackaxismin <- 0
       stackaxismax <- 1
@@ -176,8 +179,9 @@ GeomDotplot <- proto(Geom, {
 
     # Next part will set the position of each dot within each stack
     # If stackgroups=TRUE, split only on x (or y) and panel; if not stacking, also split by group
-    plyvars <- c(params$binaxis, "PANEL")
-    if (!params$stackgroups)
+    plyvars <- params$binaxis %||% "x"
+    plyvars <- c(plyvars, "PANEL")
+    if (is.null(params$stackgroups) || !params$stackgroups)
       plyvars <- c(plyvars, "group")
 
     # Within each x, or x+group, set countidx=1,2,3, and set stackpos according to stack function
@@ -189,7 +193,7 @@ GeomDotplot <- proto(Geom, {
 
 
     # Set the bounding boxes for the dots
-    if (params$binaxis == "x") {
+    if (is.null(params$binaxis) || params$binaxis == "x") {
       # ymin, ymax, xmin, and xmax define the bounding rectangle for each stack
       # Can't do bounding box per dot, because y position isn't real.
       # After position code is rewritten, each dot should have its own bounding box.

--- a/R/quick-plot.r
+++ b/R/quick-plot.r
@@ -73,6 +73,7 @@
 #' # Use different geoms
 #' qplot(mpg, wt, data = mtcars, geom="path")
 #' qplot(factor(cyl), wt, data = mtcars, geom=c("boxplot", "jitter"))
+#' qplot(mpg, data = mtcars, geom = "dotplot")
 #' }
 qplot <- function(x, y = NULL, ..., data, facets = NULL, margins=FALSE, geom = "auto", stat=list(NULL), position=list(NULL), xlim = c(NA, NA), ylim = c(NA, NA), log = "", main = NULL, xlab = deparse(substitute(x)), ylab = deparse(substitute(y)), asp = NA) {
 

--- a/man/geom_dotplot.Rd
+++ b/man/geom_dotplot.Rd
@@ -139,6 +139,9 @@ ggplot(mtcars, aes(x = mpg, fill = factor(cyl))) +
 
 ggplot(mtcars, aes(x = 1, y = mpg, fill = factor(cyl))) +
   geom_dotplot(binaxis = "y", stackgroups = TRUE, binwidth = 1, method = "histodot")
+
+# Use qplot instead
+qplot(mpg, data = mtcars, geom = "dotplot")
 }
 \references{
 Wilkinson, L. (1999) Dot plots. The American Statistician,

--- a/man/qplot.Rd
+++ b/man/qplot.Rd
@@ -107,6 +107,7 @@ qplot(y = mpg, data = mtcars)
 # Use different geoms
 qplot(mpg, wt, data = mtcars, geom="path")
 qplot(factor(cyl), wt, data = mtcars, geom=c("boxplot", "jitter"))
+qplot(mpg, data = mtcars, geom = "dotplot")
 }
 }
 


### PR DESCRIPTION
This is a fix for issue #825.

It seems that when a dotplot is created using `geom_dotplot` a couple of parameters (binaxis, stackdir, stackgroups, etc.) are assigned default values. When a dotplot is created using  `qplot(mpg, data=mtcars, geom="dotplot")` these params are not defined. The `reparameterise` function of GeomDotplot expect some of these params to be defined thus dotplot does not work with qplot.

The easy fix for this for `reparameterise` to check if these params are defined and if not use defaults. I've implemented these checks and have used the same defaults as used in the `geom_dotplot` function. Using this fix 

`qplot(mpg, data=mtcars, geom="dotplot")`

does not result in an error and gives the same output as

`ggplot(mtcars, aes(x = mpg)) + geom_dotplot()`

https://github.com/hadley/ggplot2/issues/825
