### PR TITLE
Avoid merge conflicts in NEWS file

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,4 @@ visual_test
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.travis\.yml$
+^/\.gitattributes$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/NEWS merge=union


### PR DESCRIPTION
by using the `union` merge strategy.

This will simplify life for contributors. Unfortunately, GitHub does not seem to support this for browser-based merging, but merges on the command line will not suffer from merge conflicts in `NEWS` anymore.

See also http://krlmlr.github.io/using-gitattributes-to-avoid-merge-conflicts/.
