### PR TITLE
use rel() more consistently for linewidths

### DIFF
--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -129,7 +129,7 @@ theme_grey <- function(base_size = 11, base_family = "") {
     panel.background =   element_rect(fill = "grey92", colour = NA),
     panel.border =       element_blank(),
     panel.grid.major =   element_line(colour = "white"),
-    panel.grid.minor =   element_line(colour = "white", size = 0.25),
+    panel.grid.minor =   element_line(colour = "white", size = rel(0.25)),
     panel.spacing =      unit(half_line, "pt"),
     panel.spacing.x =    NULL,
     panel.spacing.y =    NULL,
@@ -181,11 +181,11 @@ theme_bw <- function(base_size = 11, base_family = "") {
       panel.border     = element_rect(fill = NA, colour = "grey20"),
       # make gridlines dark, same contrast with white as in theme_grey
       panel.grid.major = element_line(colour = "grey92"),
-      panel.grid.minor = element_line(colour = "grey92", size = 0.25),
+      panel.grid.minor = element_line(colour = "grey92", size = rel(0.25)),
       # contour strips to match panel contour
       strip.background = element_rect(fill = "grey85", colour = "grey20"),
       # match legend key to background
-      legend.key       = element_rect(fill = "white", colour=NA),
+      legend.key       = element_rect(fill = "white", colour = NA),
 
       complete = TRUE
     )
@@ -200,14 +200,14 @@ theme_linedraw <- function(base_size = 11, base_family = "") {
     theme(
       # black text and ticks on the axes
       axis.text        = element_text(colour = "black", size = rel(0.8)),
-      axis.ticks       = element_line(colour = "black", size = 0.25),
+      axis.ticks       = element_line(colour = "black", size = rel(0.25)),
       # NB: match the *visual* thickness of axis ticks to the panel border
       #     0.5 clipped looks like 0.25
 
       # pure black panel border and grid lines, but thinner
-      panel.border     = element_rect(fill = NA, colour = "black", size = 0.5),
-      panel.grid.major = element_line(colour = "black", size = 0.05),
-      panel.grid.minor = element_line(colour = "black", size = 0.025),
+      panel.border     = element_rect(fill = NA, colour = "black", size = rel(0.5)),
+      panel.grid.major = element_line(colour = "black", size = rel(0.05)),
+      panel.grid.minor = element_line(colour = "black", size = rel(0.025)),
 
       # strips with black background and white text
       strip.background = element_rect(fill = "black"),
@@ -225,14 +225,14 @@ theme_light <- function(base_size = 11, base_family = "") {
     theme(
       # white panel with light grey border
       panel.background = element_rect(fill = "white", colour = NA),
-      panel.border     = element_rect(fill = NA, colour = "grey70", size = 0.5),
+      panel.border     = element_rect(fill = NA, colour = "grey70", size = rel(0.5)),
       # light grey, thinner gridlines
       # => make them slightly darker to keep acceptable contrast
-      panel.grid.major = element_line(colour = "grey87", size = 0.25),
-      panel.grid.minor = element_line(colour = "grey87", size = 0.125),
+      panel.grid.major = element_line(colour = "grey87", size = rel(0.25)),
+      panel.grid.minor = element_line(colour = "grey87", size = rel(0.125)),
 
       # match axes ticks thickness to gridlines and colour to panel border
-      axis.ticks       = element_line(colour = "grey70", size = 0.25),
+      axis.ticks       = element_line(colour = "grey70", size = rel(0.25)),
 
       # match legend key to panel.background
       legend.key       = element_rect(fill = "white", colour = NA),
@@ -256,11 +256,11 @@ theme_dark <- function(base_size = 11, base_family = "") {
       panel.background = element_rect(fill = "grey50", colour = NA),
       # inverse grid lines contrast compared to theme_grey
       # make them thinner and try to keep the same visual contrast as in theme_light
-      panel.grid.major = element_line(colour = "grey42", size = 0.25),
-      panel.grid.minor = element_line(colour = "grey42", size = 0.125),
+      panel.grid.major = element_line(colour = "grey42", size = rel(0.25)),
+      panel.grid.minor = element_line(colour = "grey42", size = rel(0.125)),
 
       # match axes ticks thickness to gridlines
-      axis.ticks       = element_line(colour = "grey20", size = 0.25),
+      axis.ticks       = element_line(colour = "grey20", size = rel(0.25)),
 
       # match legend key to panel.background
       legend.key       = element_rect(fill = "grey50", colour = NA),
@@ -302,13 +302,13 @@ theme_classic <- function(base_size = 11, base_family = ""){
       panel.grid.minor = element_blank(),
 
       # show axes
-      axis.line      = element_line(colour = "black", size = 0.5),
+      axis.line      = element_line(colour = "black", size = rel(0.5)),
 
       # match legend key to panel.background
       legend.key       = element_blank(),
 
       # simple, black and white strips
-      strip.background = element_rect(fill = "white", colour = "black", size = 1),
+      strip.background = element_rect(fill = "white", colour = "black", size = rel(1)),
       # NB: size is 1 but clipped, it looks like the 0.5 of the axes
 
       complete = TRUE


### PR DESCRIPTION
Small plots (e.g. in the margins of tufte-style books) tend to look heavy with the current linewidth settings, and after investigating I noticed some inconsistencies in the use of `rel()`.