### PR TITLE
derive labels even if not specified in scale

### DIFF
--- a/R/axis-secondary.R
+++ b/R/axis-secondary.R
@@ -102,7 +102,7 @@ AxisSecondary <- ggproto("AxisSecondary", NULL,
   init = function(self, scale) {
     if (self$empty()) return()
     if (!is.formula(self$trans)) stop("transformation for secondary axes must be a formula", call. = FALSE)
-    if (is.derived(self$name)) self$name <- scale$name
+    if (is.derived(self$name) && !is.waive(scale$name)) self$name <- scale$name
     if (is.derived(self$breaks)) self$breaks <- scale$breaks
     if (is.derived(self$labels)) self$labels <- scale$labels
   },

--- a/R/layout.R
+++ b/R/layout.R
@@ -148,6 +148,7 @@ Layout <- ggproto("Layout", NULL,
     } else {
       self$panel_scales$x[[1]]$sec_name()
     } %|W|% labels$sec.x
+    if (is.derived(secondary)) secondary <- primary
     secondary <- self$panel_scales$x[[1]]$make_sec_title(secondary)
     list(primary = primary, secondary = secondary)[self$panel_scales$x[[1]]$axis_order()]
   },
@@ -160,6 +161,7 @@ Layout <- ggproto("Layout", NULL,
     } else {
       self$panel_scales$y[[1]]$sec_name()
     } %|W|% labels$sec.y
+    if (is.derived(secondary)) secondary <- primary
     secondary <- self$panel_scales$y[[1]]$make_sec_title(secondary)
     list(primary = primary, secondary = secondary)[self$panel_scales$y[[1]]$axis_order()]
   },


### PR DESCRIPTION
Fixes #1877

This PR makes it possible to derive name of the primary scale even if the name is not specified in the scale constructor but either derived from the aesthetic or set through labs/xlab/ylab