### PR TITLE
correction to stat_bin documentation

### DIFF
--- a/R/stat-bin.r
+++ b/R/stat-bin.r
@@ -12,13 +12,13 @@
 #' @param center The center of one of the bins.  Note that if center is above or
 #'   below the range of the data, things will be shifted by an appropriate
 #'   number of \code{width}s. To center on integers, for example, use
-#'   \code{width=1} and \code{center=0}, even if \code{0} is outside the range
+#'   \code{width = 1} and \code{center = 0}, even if \code{0} is outside the range
 #'   of the data.  At most one of \code{center} and \code{boundary} may be
 #'   specified.
 #' @param boundary A boundary between two bins. As with \code{center}, things
 #'   are shifted when \code{boundary} is outside the range of the data. For
 #'   example, to center on integers, use \code{width = 1} and \code{boundary =
-#'   0.5}, even if \code{1} is outside the range of the data.  At most one of
+#'   0.5}, even if \code{0.5} is outside the range of the data.  At most one of
 #'   \code{center} and \code{boundary} may be specified.
 #' @param breaks Alternatively, you can supply a numeric vector giving
 #'    the bin boundaries. Overrides \code{binwidth}, \code{bins}, \code{center},


### PR DESCRIPTION
Fix minor typo in description of `boundary` argument and minor stylistic edit to include spaces around `=`.