### PR TITLE
Change wrong package name in README file

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -28,7 +28,7 @@ ggplot2 is a system for declaratively creating graphics, based on [The Grammar o
 # The easiest way to get ggplot2 is to install the whole tidyverse:
 install.packages("tidyverse")
 
-# Alternatively, install just readr:
+# Alternatively, install just ggplot2:
 install.packages("ggplot2")
 
 # Or the the development version from GitHub:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Installation
 # The easiest way to get ggplot2 is to install the whole tidyverse:
 install.packages("tidyverse")
 
-# Alternatively, install just readr:
+# Alternatively, install just ggplot2:
 install.packages("ggplot2")
 
 # Or the the development version from GitHub:


### PR DESCRIPTION
When showing how to install ggplot2 package there is line 

> # Alternatively, install just readr

 but should be 

> # Alternatively, install just ggplot2