### PR TITLE
Suspected typo / thinko: should use `axis.text` instead of `axis.ticks`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -457,7 +457,7 @@ There is now an official mechanism for defining Stats, Geoms, and Positions in o
   or stat, use `ggplot()` instead.
 
 * The theme setting `axis.ticks.margin` has been deprecated: now use the margin 
-  property of `axis.ticks`.
+  property of `axis.text`.
   
 * `stat_abline()`, `stat_hline()` and `stat_vline()` have been removed:
   these were never suitable for use other than with `geom_abline()` etc

--- a/vignettes/releases/ggplot2-2.0.0.Rmd
+++ b/vignettes/releases/ggplot2-2.0.0.Rmd
@@ -298,7 +298,7 @@ I've given the documentation a thorough overhaul:
   or stat, use `ggplot()` instead.
 
 * The theme setting `axis.ticks.margin` has been deprecated: now use the margin 
-  property of `axis.ticks`.
+  property of `axis.text`.
   
 * `stat_abline()`, `stat_hline()` and `stat_vline()` have been removed:
   these were never suitable for use other than with their corresponding


### PR DESCRIPTION
This pull request changes two document files to match what is said in [`theme.r`](https://github.com/tidyverse/ggplot2/blob/master/R/theme.r#L330). I believe the warning message in the code is correct and the documents have a typo / thinko.