### PR TITLE
alpha affects text and border in geom_label

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 2.2.0.9000
 
+* `alpha` affects text and border in `geom_label()` (@jiho, #1924)
+
 # ggplot2 2.2.0
 
 ## Major new features

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -83,14 +83,14 @@ GeomLabel <- ggproto("GeomLabel", Geom,
         padding = label.padding,
         r = label.r,
         text.gp = gpar(
-          col = row$colour,
+          col = alpha(row$colour, row$alpha),
           fontsize = row$size * .pt,
           fontfamily = row$family,
           fontface = row$fontface,
           lineheight = row$lineheight
         ),
         rect.gp = gpar(
-          col = row$colour,
+          col = alpha(row$colour, row$alpha),
           fill = alpha(row$fill, row$alpha),
           lwd = label.size * .pt
         )


### PR DESCRIPTION
Alpha is useful to hide plot elements from view. So all pieces of the label should be hidden. I don't see a use case for having only the background of the label transparent.