### PR TITLE
Remove `x` as a required aesthetic for `geom_errorbarh`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -351,6 +351,8 @@ There were a number of tweaks to the theme elements that control legends:
 
 * Fixed issue where `coord_map()` fails when given an explicit `parameters`
   argument (@tdmcarthur, #1729)
+  
+* Fixed issue where `geom_errorbarh()` had a required `x` aesthetic (#1933)  
 
 # ggplot2 2.0.0
 

--- a/R/geom-errorbarh.r
+++ b/R/geom-errorbarh.r
@@ -55,7 +55,7 @@ GeomErrorbarh <- ggproto("GeomErrorbarh", Geom,
 
   draw_key = draw_key_path,
 
-  required_aes = c("x", "xmin", "xmax", "y"),
+  required_aes = c("xmin", "xmax", "y"),
 
   setup_data = function(data, params) {
     data$height <- data$height %||%


### PR DESCRIPTION
Closes #1933 

`errorbar` is able to plot without putting a point at the midpoint of the error bar, but `errorbarh` was not able to.

An outstanding issue - It seems the `roxygen2`-generated documentation now does not pick up that `x` is an aesthetic that `geom_errorbarh` understands.

The result of this is that the user will need to use `geom_errorbarh` as well as `geom_point`.  I'm not sure how to fix this.