### PR TITLE
clarify geom_smooth auto message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -223,6 +223,9 @@ There were a number of tweaks to the theme elements that control legends:
 
 * `Scale` extensions can now override the `make_title` and `make_sec_title` 
   methods to let the scale modify the axis/legend titles.
+  
+* `geom_smooth`'s message for `method="auto"` now reports the formula used,
+  in addition to the name of the smoothing function (@davharris #1951).
 
 # ggplot2 2.1.0
 

--- a/R/stat-smooth.r
+++ b/R/stat-smooth.r
@@ -85,7 +85,8 @@ StatSmooth <- ggproto("StatSmooth", Stat,
         params$method <- "gam"
         params$formula <- y ~ s(x, bs = "cs")
       }
-      message("`geom_smooth()` using method = '", params$method, "'")
+      message("`geom_smooth()` using method = '", params$method, 
+              "' and formula '", deparse(params$formula), "'")
     }
     if (identical(params$method, "gam")) {
       params$method <- mgcv::gam


### PR DESCRIPTION
Currently, `stat_smooth`'s "auto" method reports the function that it chooses, but not the formula. Since the formula depends on the function it chooses, reporting it seems like a good idea.

This is already in the docs, but putting it in the message will make it less likely for users to forget that they need to rewrite the formula (and tell their boss that the splines are just very close to being linear 😳).