### PR TITLE
Update packages before installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ r_github_packages:
 after_success:
   - Rscript -e 'covr::codecov()'
 
+before_install:
+  Rscript -e 'update.packages(ask = FALSE)'
+
 before_deploy:
   - R -e "install.packages('roxygen2', repos = 'http://cran.rstudio.com')"
   - R -e "staticdocs::build_site(examples = TRUE)"


### PR DESCRIPTION
This fixes issues when the Debian recommended packages lag behind the
CRAN versions
(https://github.com/travis-ci/travis-ci/issues/6850#issuecomment-264739865)