### PR TITLE
Fix bug #1546

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ r_github_packages:
 after_success:
   - Rscript -e 'covr::codecov()'
 
+before_install:
+  Rscript -e 'update.packages(ask = FALSE)'
+
 before_deploy:
   - R -e "install.packages('roxygen2', repos = 'http://cran.rstudio.com')"
   - R -e "staticdocs::build_site(examples = TRUE)"
@@ -31,4 +34,4 @@ deploy:
     local-dir: docs
     upload-dir: current
     on:
-      tags: true
+tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ after_success:
   - Rscript -e 'covr::codecov()'
 
 before_install:
-  Rscript -e 'update.packages(ask = FALSE)'
+  - Rscript -e 'update.packages(ask = FALSE)'
 
 before_deploy:
   - R -e "install.packages('roxygen2', repos = 'http://cran.rstudio.com')"
@@ -34,4 +34,4 @@ deploy:
     local-dir: docs
     upload-dir: current
     on:
-tags: true
+      tags: true

--- a/R/legend-draw.r
+++ b/R/legend-draw.r
@@ -159,7 +159,7 @@ draw_key_smooth <- function(data, params, size) {
   data$alpha <- 1
 
   grobTree(
-    if (isTRUE(params$se)) rectGrob(gp = gpar(col = NA, fill = data$fill)),
+    if (isTRUE(params$se) | is.null(params$se)) rectGrob(gp = gpar(col = NA, fill = data$fill)),
     draw_key_path(data, params)
   )
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,44 @@
+# DO NOT CHANGE the "init" and "install" sections below
+
+# Download script file from GitHub
+init:
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+install:
+  ps: Bootstrap
+
+cache:
+  - C:\RLibrary
+
+# Adapt as necessary starting from here
+
+build_script:
+  - travis-tool.sh install_deps
+
+test_script:
+  - travis-tool.sh run_tests
+
+on_failure:
+  - 7z a failure.zip *.Rcheck\*
+  - appveyor PushArtifact failure.zip
+
+artifacts:
+  - path: '*.Rcheck\**\*.log'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.out'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
+
+  - path: '\*_*.tar.gz'
+    name: Bits
+
+  - path: '\*_*.zip'
+    name: Bits


### PR DESCRIPTION
Hi. I read this bug: #1546
Fill aesthetic does not show in the legend guide for stat_summary
And i want to contribute for its solution.
The results:
```
# using default summary function fill in the legend 
ggplot(mtcars, aes(cyl ,mpg,col=factor(am),fill=factor(am))  )+
  geom_point()+
  stat_summary(aes(cyl,mpg), geom = "smooth")
```
![rplot01](https://cloud.githubusercontent.com/assets/22753863/21594206/cea4d470-d0ed-11e6-9e5d-84013607fa5c.png)
```
# without the parameter "geom=smooth" no fill in the legend 
ggplot(mtcars, aes(cyl ,mpg,col=factor(am),fill=factor(am))  )+
  geom_point()+
  stat_summary()
```
![rplot02](https://cloud.githubusercontent.com/assets/22753863/21594208/cea7a966-d0ed-11e6-88d7-171090576e83.png)
```
# geom smooth with parameter "se=FALSE" no fill in the legend.
ggplot(mtcars, aes(cyl,mpg,col=factor(am),fill=factor(am))  )+
  geom_point()+
  geom_smooth(se=FALSE)
```
![rplot03](https://cloud.githubusercontent.com/assets/22753863/21594207/cea5dc12-d0ed-11e6-9c2d-d7b69deb5634.png)
