### PR TITLE
Call to maps::map in map_data should be explicit. 

### DIFF
--- a/R/fortify-map.r
+++ b/R/fortify-map.r
@@ -70,7 +70,7 @@ fortify.map <- function(model, data, ...) {
 #' }
 map_data <- function(map, region = ".", exact = FALSE, ...) {
   try_require("maps", "map_data")
-  fortify(map(map, region, exact = exact, plot = FALSE, fill = TRUE, ...))
+  fortify(maps::map(map, region, exact = exact, plot = FALSE, fill = TRUE, ...))
 }
 
 #' Create a layer of map borders


### PR DESCRIPTION
this was to eliminate confusion with purrr::map which can happen when calling library("tidyverse") as an example.

This came up when I tried to knit an Rmd file like the file here: https://gist.githubusercontent.com/restonslacker/249b8916ad9799f057564bbe721707a5/raw/c68f0fde05dd864893a90d49430326ba65b2f61f/ggplot2_issue.Rmd

Reversing the order of the calls to `library` solves the issue at the expense of calls to `purrr::map` later in the workflow.

It seemed a more permanent solution would be to make the minor change in this PR.


