### PR TITLE
Fix bug: Margins don't affect strip.text

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ r_github_packages:
 after_success:
   - Rscript -e 'covr::codecov()'
 
-before_install:
-  Rscript -e 'update.packages(ask = FALSE)'
-
 before_deploy:
   - R -e "install.packages('roxygen2', repos = 'http://cran.rstudio.com')"
   - R -e "staticdocs::build_site(examples = TRUE)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ r_github_packages:
 after_success:
   - Rscript -e 'covr::codecov()'
 
+before_install:
+  Rscript -e 'update.packages(ask = FALSE)'
+
 before_deploy:
   - R -e "install.packages('roxygen2', repos = 'http://cran.rstudio.com')"
   - R -e "staticdocs::build_site(examples = TRUE)"

--- a/R/labeller.r
+++ b/R/labeller.r
@@ -527,7 +527,12 @@ build_strip <- function(label_df, labeller, theme, horizontal) {
 ggstrip <- function(text, horizontal = TRUE, theme) {
   text_theme <- if (horizontal) "strip.text.x" else "strip.text.y"
   if (is.list(text)) text <- text[[1]]
-
+  
+  order_margin_default<-if (horizontal) 1:4 else c(4,1,2,3)
+  if (identical(as.vector(theme[[text_theme]]$margin),c(5.5,0,5.5,0)[order_margin_default])){
+    theme[[text_theme]]$margin<-theme$strip.text$margin[order_margin_default]
+  }
+  
   element <- calc_element(text_theme, theme)
   if (inherits(element, "element_blank"))
     return(zeroGrob())


### PR DESCRIPTION
With this request you can solve the issue of @Eluvias. For example:
``` python
p <- ggplot(mpg, aes(displ, cty)) + geom_point() + facet_grid(. ~ cyl)
p + theme(strip.text = element_text(margin = margin(l=-40, b = 15,t=15)))
``` 

![rplot](https://cloud.githubusercontent.com/assets/22753863/22520534/a633f24e-e882-11e6-82e9-deaf1f586908.png)
