### PR TITLE
Supress outliers: add and document parameter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -217,5 +217,5 @@ Collate:
     'zxx.r'
     'zzz.r'
 VignetteBuilder: knitr
-RoxygenNote: 6.0.0
+RoxygenNote: 6.0.0.9000
 Remotes: hadley/svglite

--- a/R/geom-boxplot.r
+++ b/R/geom-boxplot.r
@@ -2,7 +2,8 @@
 #'
 #' The boxplot compactly displays the distribution of a continuous variable.
 #' It visualises five summary statistics (the median, two hinges
-#' and two whiskers), and all "outlying" points individually.
+#' and two whiskers), and all "outlying" points individually unless explicitly
+#' signaled by the user.
 #'
 #' @section Summary statistics:
 #' The lower and upper hinges correspond to the first and third quartiles

--- a/R/stat-boxplot.r
+++ b/R/stat-boxplot.r
@@ -19,7 +19,8 @@ stat_boxplot <- function(mapping = NULL, data = NULL,
                          coef = 1.5,
                          na.rm = FALSE,
                          show.legend = NA,
-                         inherit.aes = TRUE) {
+                         inherit.aes = TRUE,
+                         report.outliers = TRUE) {
   layer(
     data = data,
     mapping = mapping,
@@ -31,6 +32,7 @@ stat_boxplot <- function(mapping = NULL, data = NULL,
     params = list(
       na.rm = na.rm,
       coef = coef,
+      report.outliers = report.outliers,
       ...
     )
   )
@@ -57,7 +59,7 @@ StatBoxplot <- ggproto("StatBoxplot", Stat,
     params
   },
 
-  compute_group = function(data, scales, width = NULL, na.rm = FALSE, coef = 1.5) {
+  compute_group = function(data, scales, width = NULL, na.rm = FALSE, coef = 1.5, report.outliers = TRUE) {
     qs <- c(0, 0.25, 0.5, 0.75, 1)
 
     if (!is.null(data$weight)) {
@@ -78,7 +80,9 @@ StatBoxplot <- ggproto("StatBoxplot", Stat,
       width <- diff(range(data$x)) * 0.9
 
     df <- as.data.frame(as.list(stats))
-    df$outliers <- list(data$y[outliers])
+    if(report.outliers) {
+      df$outliers <- list(data$y[outliers])
+    }
 
     if (is.null(data$weight)) {
       n <- sum(!is.na(data$y))

--- a/man/geom_boxplot.Rd
+++ b/man/geom_boxplot.Rd
@@ -14,7 +14,7 @@ geom_boxplot(mapping = NULL, data = NULL, stat = "boxplot",
 
 stat_boxplot(mapping = NULL, data = NULL, geom = "boxplot",
   position = "dodge", ..., coef = 1.5, na.rm = FALSE, show.legend = NA,
-  inherit.aes = TRUE)
+  inherit.aes = TRUE, report.outliers = TRUE)
 }
 \arguments{
 \item{mapping}{Set of aesthetic mappings created by \code{\link{aes}} or
@@ -83,7 +83,8 @@ the default plot specification, e.g. \code{\link{borders}}.}
 \description{
 The boxplot compactly displays the distribution of a continuous variable.
 It visualises five summary statistics (the median, two hinges
-and two whiskers), and all "outlying" points individually.
+and two whiskers), and all "outlying" points individually unless explicitly
+signaled by the user.
 }
 \section{Summary statistics}{
 


### PR DESCRIPTION
A new parameter was added to stat-boxplot.r to supress storing the outliers in the dataframe passed to geom-boxplot.r (or any other function that may call it). The outliers are taken into acocunt at every step of the stat array calculation, but not returned.

This feature was requested in #2026. It was motivated by some cases in which the outliers were not significant for the a given study and remove valuable information from a particular plot. A nice and compact solution is desired to deal with this unusual situation. The two following plots show the issue and the solution as implemented.

Issue:
![issue](https://cloud.githubusercontent.com/assets/16158157/22565838/a34cacee-e957-11e6-80d1-ffc8c8d06c85.png)

Solution:
![solved](https://cloud.githubusercontent.com/assets/16158157/22565859/b3f4185c-e957-11e6-8576-de65ff07f8c6.png)

Added parameter ```report.outliers```:
```R
ggplot(data = dt, aes(x = strategy, y = y_, fill = strategy)) +
    geom_boxplot(report.outliers = FALSE) +
    facet_wrap( ~ struct, nrow = 2, scales = 'free')
```