### PR TITLE
Add informative error message if user forgets data arg in ggplot()

### DIFF
--- a/R/fortify.r
+++ b/R/fortify.r
@@ -23,8 +23,8 @@ fortify.default <- function(model, data, ...) {
     "ggplot2 doesn't know how to deal with data of class ",
     paste(class(model), collapse = "/"), "."
   )
-  if (class(model) == "uneval") {
-    msg <- paste0(msg, " Did you forget the data argument in ggplot()?")
+  if (inherits(model, "uneval")) {
+    msg <- paste0(msg, " Did you forget the `data` argument in ggplot()?")
   }
   stop(msg, call. = FALSE)
 }

--- a/R/fortify.r
+++ b/R/fortify.r
@@ -24,7 +24,7 @@ fortify.default <- function(model, data, ...) {
     paste(class(model), collapse = "/"), "."
   )
   if (inherits(model, "uneval")) {
-    msg <- paste0(msg, " Did you forget the `data` argument in ggplot()?")
+    msg <- paste0(msg, " Did you accidentally provide the results of `aes()` to the `data` argument?")
   }
   stop(msg, call. = FALSE)
 }

--- a/R/fortify.r
+++ b/R/fortify.r
@@ -19,9 +19,12 @@ fortify.NULL <- function(model, data, ...) waiver()
 fortify.function <- function(model, data, ...) model
 #' @export
 fortify.default <- function(model, data, ...) {
-  stop(
+  msg <- paste0(
     "ggplot2 doesn't know how to deal with data of class ",
-    paste(class(model), collapse = "/"),
-    call. = FALSE
+    paste(class(model), collapse = "/"), "."
   )
+  if (class(model) == "uneval") {
+    msg <- paste0(msg, " Did you forget the data argument in ggplot()?")
+  }
+  stop(msg, call. = FALSE)
 }

--- a/tests/testthat/test-fortify.r
+++ b/tests/testthat/test-fortify.r
@@ -41,7 +41,7 @@ test_that("fortify.default proves a helpful error with class uneval", {
     ggplot(aes(x = x)),
     regex = paste0(
       "ggplot2 doesn't know how to deal with data of class uneval. ",
-      "Did you forget the data argument in ggplot()"
+      "Did you forget the `data` argument in ggplot()"
     )
   )
 })

--- a/tests/testthat/test-fortify.r
+++ b/tests/testthat/test-fortify.r
@@ -35,3 +35,13 @@ test_that("Spatial polygons have correct ordering", {
   expect_equivalent(fortify(fake_sp), plyr::arrange(fortify(fake_sp2), id, order))
 
 })
+
+test_that("fortify.default proves a helpful error with class uneval", {
+  expect_error(
+    ggplot(aes(x = x)),
+    regex = paste0(
+      "ggplot2 doesn't know how to deal with data of class uneval. ",
+      "Did you forget the data argument in ggplot()"
+    )
+  )
+})

--- a/tests/testthat/test-fortify.r
+++ b/tests/testthat/test-fortify.r
@@ -41,7 +41,7 @@ test_that("fortify.default proves a helpful error with class uneval", {
     ggplot(aes(x = x)),
     regex = paste0(
       "ggplot2 doesn't know how to deal with data of class uneval. ",
-      "Did you forget the `data` argument in ggplot()"
+      "Did you accidentally provide the results of `aes\\(\\)` to the `data` argument?"
     )
   )
 })


### PR DESCRIPTION
The error message `"gglot2 doesn't know how to deal with data of class uneval"` is one of the more common ones that I see, and one that perplexes new users of ggplot2. I added a note about the most common reason for and fix of this error message.

If a `data` argument was omitted from `ggplot()`, the old behavior was

```
> ggplot(aes(x = x))
Error: ggplot2 doesn't know how to deal with data of class uneval
```
The new behavior is
```
> ggplot(aes(x = x))
Error: ggplot2 doesn't know how to deal with data of class uneval. Did you forget the data argument  in ggplot()?
```