### PR TITLE
Fix calculation of theme defaults

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -135,6 +135,8 @@
 
 * `position_jitter()` gains a `seed` argument that allows specifying a random seed for reproducible jittering (#1996, @krlmlr).
 
+* Fixed bug where a new complete `theme` may fail to override all elements of the default `theme`.
+  (@has2k1, #2058, #2079)
 
 ### sf
 

--- a/R/labeller.r
+++ b/R/labeller.r
@@ -509,7 +509,9 @@ build_strip <- function(label_df, labeller, theme, horizontal) {
     grobs_right <- apply(grobs_right, 1, function(strips) {
       gtable_matrix("strip", matrix(strips, nrow = 1), widths, unit(1, "null"), clip = "on")
     })
-    theme$strip.text.y$angle <- adjust_angle(theme$strip.text.y$angle)
+    if (inherits(theme$strip.text.y, "element_text")) {
+      theme$strip.text.y$angle <- adjust_angle(theme$strip.text.y$angle)
+    }
     grobs_left <- apply(labels, c(1, 2), ggstrip, theme = theme,
       horizontal = horizontal)
     widths <- unit(apply(grobs_left, 2, max_width), "cm")

--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -400,6 +400,18 @@ theme_void <- function(base_size = 11, base_family = "",
     panel.ontop =        FALSE,
     panel.spacing =      unit(half_line, "pt"),
     plot.margin =        unit(c(0, 0, 0, 0), "lines"),
+    plot.title =         element_text(
+                           size = rel(1.2),
+                           hjust = 0, vjust = 1,
+                           margin = margin(t = half_line * 1.2)),
+    plot.subtitle =      element_text(
+                           size = rel(0.9),
+                           hjust = 0, vjust = 1,
+                           margin = margin(t = half_line * 0.9)),
+    plot.caption =       element_text(
+                           size = rel(0.9),
+                           hjust = 1, vjust = 1,
+                           margin = margin(t = half_line * 0.9)),
 
     complete = TRUE
   )

--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -375,6 +375,7 @@ theme_classic <- function(base_size = 11, base_family = "",
 theme_void <- function(base_size = 11, base_family = "",
                        base_line_size = base_size / 22,
                        base_rect_size = base_size / 22) {
+  half_line <- base_size / 2
   theme(
     # Use only inherited elements and make almost everything blank
     # Only keep indispensable text
@@ -389,11 +390,15 @@ theme_void <- function(base_size = 11, base_family = "",
     axis.text =        element_blank(),
     axis.title =       element_blank(),
     axis.ticks.length =  unit(0, "pt"),
+    legend.key.size =    unit(1.2, "lines"),
     legend.position =    "right",
     legend.text =        element_text(size = rel(0.8)),
     legend.title =       element_text(hjust = 0),
     strip.text =         element_text(size = rel(0.8)),
+    strip.switch.pad.grid = unit(0.1, "cm"),
+    strip.switch.pad.wrap = unit(0.1, "cm"),
     panel.ontop =        FALSE,
+    panel.spacing =      unit(half_line, "pt"),
     plot.margin =        unit(c(0, 0, 0, 0), "lines"),
 
     complete = TRUE

--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -388,9 +388,12 @@ theme_void <- function(base_size = 11, base_family = "",
                          ),
     axis.text =        element_blank(),
     axis.title =       element_blank(),
+    axis.ticks.length =  unit(0, "pt"),
+    legend.position =    "right",
     legend.text =        element_text(size = rel(0.8)),
     legend.title =       element_text(hjust = 0),
     strip.text =         element_text(size = rel(0.8)),
+    panel.ontop =        FALSE,
     plot.margin =        unit(c(0, 0, 0, 0), "lines"),
 
     complete = TRUE

--- a/R/theme.r
+++ b/R/theme.r
@@ -416,7 +416,14 @@ theme <- function(line,
 
 # Combine plot defaults with current theme to get complete theme for a plot
 plot_theme <- function(x) {
-  defaults(x$theme, theme_get())
+  complete <- attr(x$theme, "complete")
+  if (is.null(complete)) {
+    theme_get()
+  } else if (complete) {
+    x$theme
+  } else {
+    defaults(x$theme, theme_get())
+  }
 }
 
 #' Modify properties of an element in a theme object

--- a/R/theme.r
+++ b/R/theme.r
@@ -415,14 +415,14 @@ theme <- function(line,
 
 
 # Combine plot defaults with current theme to get complete theme for a plot
-plot_theme <- function(x) {
+plot_theme <- function(x, default_theme=theme_get()) {
   complete <- attr(x$theme, "complete")
   if (is.null(complete)) {
-    theme_get()
+    default_theme
   } else if (complete) {
     x$theme
   } else {
-    defaults(x$theme, theme_get())
+    defaults(x$theme, default_theme)
   }
 }
 

--- a/tests/figs/themes/theme-void-large.svg
+++ b/tests/figs/themes/theme-void-large.svg
@@ -2,7 +2,7 @@
 <svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
 <defs>
   <style type='text/css'><![CDATA[
-    line, polyline, polygon, path, rect, circle {
+    line, polyline, path, rect, circle {
       fill: none;
       stroke: #000000;
       stroke-linecap: round;
@@ -13,33 +13,33 @@
 </defs>
 <rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
 <defs>
-  <clipPath id='cpMi43NHw2NjMuNDJ8NTczLjI2fDY1LjQy'>
-    <rect x='2.74' y='65.42' width='660.68' height='507.84' />
+  <clipPath id='cpMHw2ODAuMjA1fDU3Nnw2OC43MjY='>
+    <rect x='0.00' y='68.73' width='680.20' height='507.27' />
   </clipPath>
 </defs>
-<circle cx='32.77' cy='550.18' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMi43NHw2NjMuNDJ8NTczLjI2fDY1LjQy)' />
-<circle cx='333.08' cy='319.34' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMi43NHw2NjMuNDJ8NTczLjI2fDY1LjQy)' />
-<circle cx='633.39' cy='88.51' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMi43NHw2NjMuNDJ8NTczLjI2fDY1LjQy)' />
+<circle cx='30.92' cy='552.94' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMHw2ODAuMjA1fDU3Nnw2OC43MjY=)' />
+<circle cx='340.10' cy='322.36' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMHw2ODAuMjA1fDU3Nnw2OC43MjY=)' />
+<circle cx='649.29' cy='91.78' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMHw2ODAuMjA1fDU3Nnw2OC43MjY=)' />
 <defs>
-  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+  <clipPath id='cpMHw3MjB8NTc2fDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />
   </clipPath>
 </defs>
 <defs>
-  <clipPath id='cpMi43NHw2NjMuNDJ8NjUuNDJ8MzYuNTg='>
-    <rect x='2.74' y='36.58' width='660.68' height='28.85' />
+  <clipPath id='cpMHw2ODAuMjA1fDY4LjcyNnw1MC43MjY='>
+    <rect x='0.00' y='50.73' width='680.20' height='18.00' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMi43NHw2NjMuNDJ8NjUuNDJ8MzYuNTg=)'><text x='325.85' y='59.95' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpMHw2ODAuMjA1fDY4LjcyNnw1MC43MjY=)'><text x='332.76' y='68.73' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.69px' lengthAdjust='spacingAndGlyphs'>1</text></g>
 <defs>
-  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+  <clipPath id='cpMHw3MjB8NTc2fDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='680.43' y='307.00' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>z</text></g>
-<circle cx='689.07' cy='327.36' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<circle cx='689.07' cy='345.38' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='699.87' y='336.31' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>a</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='699.87' y='354.32' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>b</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='2.74' y='27.52' style='font-size: 39.60px; font-family: Liberation Sans;' textLength='317.99px' lengthAdjust='spacingAndGlyphs'>theme_void_large</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='685.87' y='310.11' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>z</text></g>
+<circle cx='694.51' cy='330.61' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<circle cx='694.51' cy='348.61' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='705.31' y='339.61' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.69px' lengthAdjust='spacingAndGlyphs'>a</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='705.31' y='357.61' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.69px' lengthAdjust='spacingAndGlyphs'>b</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='0.00' y='47.73' style='font-size: 39.60px; font-family: Liberation Sans;' textLength='314.76px' lengthAdjust='spacingAndGlyphs'>theme_void_large</text></g>
 </svg>

--- a/tests/figs/themes/theme-void.svg
+++ b/tests/figs/themes/theme-void.svg
@@ -2,7 +2,7 @@
 <svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
 <defs>
   <style type='text/css'><![CDATA[
-    line, polyline, polygon, path, rect, circle {
+    line, polyline, path, rect, circle {
       fill: none;
       stroke: #000000;
       stroke-linecap: round;
@@ -13,33 +13,33 @@
 </defs>
 <rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
 <defs>
-  <clipPath id='cpMi43NHw2NzIuODh8NTczLjI2fDM1LjA1'>
-    <rect x='2.74' y='35.05' width='670.14' height='538.21' />
+  <clipPath id='cpMHw2ODkuOTk4fDU3NnwyNi41NzUz'>
+    <rect x='0.00' y='26.58' width='690.00' height='549.42' />
   </clipPath>
 </defs>
-<circle cx='33.20' cy='548.80' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMi43NHw2NzIuODh8NTczLjI2fDM1LjA1)' />
-<circle cx='337.81' cy='304.16' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMi43NHw2NzIuODh8NTczLjI2fDM1LjA1)' />
-<circle cx='642.42' cy='59.51' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMi43NHw2NzIuODh8NTczLjI2fDM1LjA1)' />
+<circle cx='31.36' cy='551.03' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMHw2ODkuOTk4fDU3NnwyNi41NzUz)' />
+<circle cx='345.00' cy='301.29' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMHw2ODkuOTk4fDU3NnwyNi41NzUz)' />
+<circle cx='658.63' cy='51.55' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMHw2ODkuOTk4fDU3NnwyNi41NzUz)' />
 <defs>
-  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+  <clipPath id='cpMHw3MjB8NTc2fDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />
   </clipPath>
 </defs>
 <defs>
-  <clipPath id='cpMi43NHw2NzIuODh8MzUuMDV8MTcuOTA='>
-    <rect x='2.74' y='17.90' width='670.14' height='17.15' />
+  <clipPath id='cpMHw2ODkuOTk4fDI2LjU3NTN8MTkuNTc1Mw=='>
+    <rect x='0.00' y='19.58' width='690.00' height='7.00' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMi43NHw2NzIuODh8MzUuMDV8MTcuOTA=)'><text x='335.31' y='29.57' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpMHw2ODkuOTk4fDI2LjU3NTN8MTkuNTc1Mw==)'><text x='342.55' y='26.58' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
 <defs>
-  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+  <clipPath id='cpMHw3MjB8NTc2fDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='689.89' y='288.77' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>z</text></g>
-<circle cx='698.53' cy='301.19' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<circle cx='698.53' cy='318.47' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='709.33' y='304.28' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>a</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='709.33' y='321.56' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>b</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='2.74' y='8.94' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='67.21px' lengthAdjust='spacingAndGlyphs'>theme_void</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='695.67' y='286.01' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>z</text></g>
+<circle cx='704.31' cy='298.65' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<circle cx='704.31' cy='315.93' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMHw3MjB8NTc2fDA=)' />
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='715.11' y='302.15' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>a</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='715.11' y='319.43' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text></g>
+<g clip-path='url(#cpMHw3MjB8NTc2fDA=)'><text x='0.00' y='16.58' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='68.26px' lengthAdjust='spacingAndGlyphs'>theme_void</text></g>
 </svg>

--- a/tests/testthat/test-theme.r
+++ b/tests/testthat/test-theme.r
@@ -164,19 +164,6 @@ test_that("Complete and non-complete themes interact correctly with ggplot objec
   expect_equal(p$plot$theme$text$colour, "red")
   expect_equal(p$plot$theme$text$face, "italic")
 
-  # The final calculated plot theme should not blend a complete theme
-  # with the default theme
-  default_theme <- theme_gray() + theme(axis.text.x = element_text(colour = "red"))
-
-  ptheme <- plot_theme(qplot(1:3, 1:3) + theme_void(), default_theme)
-  expect_null(ptheme$axis.text.x)
-
-  ptheme <- plot_theme(qplot(1:3, 1:3) + theme_gray(), default_theme)
-  expect_true(is.null(ptheme$axis.text.x$colour) || ptheme$axis.text.x$colour != "red")
-
-  ptheme <- plot_theme(qplot(1:3, 1:3) + theme(axis.text.y = element_text(colour = "blue")), default_theme)
-  expect_equal(ptheme$axis.text.x$colour, "red")
-  expect_equal(ptheme$axis.text.y$colour, "blue")
 })
 
 test_that("theme(validate=FALSE) means do not validate_element", {
@@ -238,6 +225,19 @@ test_that("Elements can be merged", {
   )
 })
 
+test_that("Final calculated plot theme should not blend a complete theme with the default theme", {
+  default_theme <- theme_gray() + theme(axis.text.x = element_text(colour = "red"))
+
+  ptheme <- plot_theme(qplot(1:3, 1:3) + theme_void(), default_theme)
+  expect_null(ptheme$axis.text.x)
+
+  ptheme <- plot_theme(qplot(1:3, 1:3) + theme_gray(), default_theme)
+  expect_true(is.null(ptheme$axis.text.x$colour) || ptheme$axis.text.x$colour != "red")
+
+  ptheme <- plot_theme(qplot(1:3, 1:3) + theme(axis.text.y = element_text(colour = "blue")), default_theme)
+  expect_equal(ptheme$axis.text.x$colour, "red")
+  expect_equal(ptheme$axis.text.y$colour, "blue")
+})
 
 # Visual tests ------------------------------------------------------------
 

--- a/tests/testthat/test-theme.r
+++ b/tests/testthat/test-theme.r
@@ -163,6 +163,20 @@ test_that("Complete and non-complete themes interact correctly with ggplot objec
   expect_false(attr(p$plot$theme, "complete"))
   expect_equal(p$plot$theme$text$colour, "red")
   expect_equal(p$plot$theme$text$face, "italic")
+
+  # The final calculated plot theme should not blend a complete theme
+  # with the default theme
+  default_theme <- theme_gray() + theme(axis.text.x = element_text(colour = "red"))
+
+  ptheme <- plot_theme(qplot(1:3, 1:3) + theme_void(), default_theme)
+  expect_null(ptheme$axis.text.x)
+
+  ptheme <- plot_theme(qplot(1:3, 1:3) + theme_gray(), default_theme)
+  expect_true(is.null(ptheme$axis.text.x$colour) || ptheme$axis.text.x$colour != "red")
+
+  ptheme <- plot_theme(qplot(1:3, 1:3) + theme(axis.text.y = element_text(colour = "blue")), default_theme)
+  expect_equal(ptheme$axis.text.x$colour, "red")
+  expect_equal(ptheme$axis.text.y$colour, "blue")
 })
 
 test_that("theme(validate=FALSE) means do not validate_element", {


### PR DESCRIPTION
**Issue**
At plot time, the calculation of theme elements always fell back
to the default theme. As a consequence, the default theme would
leak into complete themes where some of the elements were
unspecified.

**Solution**
Be more specific when calculating the theme defaults.

**Clean Up**
`theme_void` was insufficiently specified. The solution exposed
missing elements that had to be specified.

Fixes #2058
Fixes #2079