### PR TITLE
Fix density calculations for groups with one or two elements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # ggplot2 2.2.1.9000
 
+* `geom_density` drops groups with fewer than two data points and throws a
+  warning. For groups with two data points, the density values are now
+  calculated with `stats::density` (@karawoo, #2127).
+
 * `geom_smooth` now orders by the `x` aesthetic, making it easier to pass 
   pre-computed values without manual ordering (@izahn, #2028).
 

--- a/R/stat-density.r
+++ b/R/stat-density.r
@@ -85,14 +85,15 @@ compute_density <- function(x, w, from, to, bw = "nrd0", adjust = 1,
     w <- rep(1 / nx, nx)
   }
 
-  # if less than 3 points, spread density evenly over points
-  if (nx < 3) {
+  # if less than 2 points return data frame of NAs and a warning
+  if (nx < 2) {
+    warning("Groups with fewer than two data points have been dropped.")
     return(data.frame(
-      x = x,
-      density = w / sum(w),
-      scaled = w / max(w),
-      count = 1,
-      n = nx
+      x = NA,
+      density = NA,
+      scaled = NA,
+      count = NA,
+      n = NA
     ))
   }
 

--- a/R/stat-density.r
+++ b/R/stat-density.r
@@ -87,7 +87,7 @@ compute_density <- function(x, w, from, to, bw = "nrd0", adjust = 1,
 
   # if less than 2 points return data frame of NAs and a warning
   if (nx < 2) {
-    warning("Groups with fewer than two data points have been dropped.")
+    warning("Groups with fewer than two data points have been dropped.", call. = FALSE)
     return(data.frame(
       x = NA,
       density = NA,

--- a/tests/testthat/test-stat-density.R
+++ b/tests/testthat/test-stat-density.R
@@ -5,9 +5,9 @@ test_that("compute_density succeeds when variance is zero", {
   expect_equal(dens$n, rep(10, 512))
 })
 
-test_that("compute_density returns useful df when <3 values", {
-  dens <- compute_density(c(1, 2), NULL, from = 0, to = 0)
+test_that("compute_density returns useful df and throws warning when <2 values", {
+  expect_warning(dens <- compute_density(1, NULL, from = 0, to = 0))
 
-  expect_equal(nrow(dens), 2)
+  expect_equal(nrow(dens), 1)
   expect_equal(names(dens), c("x", "density", "scaled", "count", "n"))
 })


### PR DESCRIPTION
Fixes #2127.

`compute_density()` now uses `stats::density()` to compute the density for two-element groups, resulting in plots that look like this (where group 5 has only two data points):

![example_scaled](https://cloud.githubusercontent.com/assets/4452678/26430444/fc173dc0-40a1-11e7-9aa9-f062644ac978.png)

In the case where there is only a single point in the group (where it doesn't really make sense to calculate density), the group gets dropped with a warning.

```R
## Create some data with a couple very small groups
library("tidyverse")
set.seed(1958)
dat <- tibble(x = c(rnorm(n = 10, mean = 7, sd = 2),
                    rpois(n = 10, lambda = 2),
                    1, 9, 4),
              group = c(rep(c("a", "b"), each = 10), "c", "c", "d"))

## Plot
ggplot(dat, aes(x = x, fill = group)) +
  geom_density(alpha = 0.5)
```

```
Warning message:
In compute_density(data$x, data$weight, from = range[1], to = range[2],  :
  Groups with fewer than two data points have been dropped.
```

![dropped_group](https://cloud.githubusercontent.com/assets/4452678/26430495/83089194-40a2-11e7-8cee-e5b051da4364.png)

There is still a legend element for the dropped group; not sure if that should be kept or not.