### PR TITLE
Fix a broken link in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -81,7 +81,7 @@ There are two main places to get help with ggplot2:
     questions about ggplot2. You must be a member to post messages, 
     but anyone can read the archived discussions.
 
-1.  [stackoverflow](so) is a great source of answers to common ggplot2
+1.  [stackoverflow][so] is a great source of answers to common ggplot2
     questions. It is also a great place to get help, once you have
     created a reproducible example that illustrates your problem.
 


### PR DESCRIPTION
A link to StackOverflow seems broken.

Sorry, I couldn't knit README.Rmd due to an error: `pandoc.exe: Could not fetch https://img.shields.io/codecov/c/github/tidyverse/ggplot2/master.svg`. Could you knit it after merging this?