### PR TITLE
Update documentation of discrete_scale params that differ from continuous_scale

### DIFF
--- a/R/scale-.r
+++ b/R/scale-.r
@@ -611,6 +611,16 @@ continuous_scale <- function(aesthetics, scale_name, palette, name = waiver(),
 #'
 #' @export
 #' @inheritParams continuous_scale
+#' @param breaks One of: \itemize{
+#'   \item \code{NULL} for no breaks
+#'   \item \code{waiver()} for the default breaks computed by the
+#'     transformation object
+#'   \item A character vector of breaks
+#'   \item A function that takes the limits as input and returns breaks
+#'     as output
+#' }
+#' @param limits A character vector of all possible values of the scale and
+#'   their order.
 #' @param drop Should unused factor levels be omitted from the scale?
 #'    The default, \code{TRUE}, uses the levels that appear in the data;
 #'    \code{FALSE} uses all the levels in the factor.

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -619,8 +619,8 @@ continuous_scale <- function(aesthetics, scale_name, palette, name = waiver(),
 #'   \item A function that takes the limits as input and returns breaks
 #'     as output
 #' }
-#' @param limits A character vector of all possible values of the scale and
-#'   their order.
+#' @param limits A character vector that defines possible values of the scale
+#'   and their order.
 #' @param drop Should unused factor levels be omitted from the scale?
 #'    The default, \code{TRUE}, uses the levels that appear in the data;
 #'    \code{FALSE} uses all the levels in the factor.

--- a/man/discrete_scale.Rd
+++ b/man/discrete_scale.Rd
@@ -26,7 +26,7 @@ mapping used for that aesthetic.}
   \item \code{NULL} for no breaks
   \item \code{waiver()} for the default breaks computed by the
     transformation object
-  \item A numeric vector of positions
+  \item A character vector of breaks
   \item A function that takes the limits as input and returns breaks
     as output
 }}
@@ -40,8 +40,8 @@ mapping used for that aesthetic.}
     as output
 }}
 
-\item{limits}{A numeric vector of length two providing limits of the scale.
-Use \code{NA} to refer to the existing minimum or maximum.}
+\item{limits}{A character vector of all possible values of the scale and
+their order.}
 
 \item{expand}{A numeric vector of length two giving multiplicative and
 additive expansion constants. These constants ensure that the data is

--- a/man/discrete_scale.Rd
+++ b/man/discrete_scale.Rd
@@ -40,8 +40,8 @@ mapping used for that aesthetic.}
     as output
 }}
 
-\item{limits}{A character vector of all possible values of the scale and
-their order.}
+\item{limits}{A character vector that defines possible values of the scale
+and their order.}
 
 \item{expand}{A numeric vector of length two giving multiplicative and
 additive expansion constants. These constants ensure that the data is


### PR DESCRIPTION
Fixes #2068. `discrete_scale` inherits params from `continuous_scale`, but the `breaks` and `limits` arguments behave differently for discrete vs. continuous scales. This adds new `breaks` and `limits` parameter documentation for `discrete_scale` that overrides the inherited parameter documentation.