### PR TITLE
Note that scale_*_distiller passes ... args to continuous_scale, not discrete_scale

### DIFF
--- a/R/scale-brewer.r
+++ b/R/scale-brewer.r
@@ -28,6 +28,9 @@
 #' @inheritParams scale_colour_hue
 #' @inheritParams scale_colour_gradient
 #' @inheritParams scales::gradient_n_pal
+#' @param ... Other arguments passed on to \code{\link{discrete_scale}} or, for
+#'   ‘distiller’ scales, \code{\link{continuous_scale}} to control name, limits,
+#'   breaks, labels and so forth.
 #' @family colour scales
 #' @rdname scale_brewer
 #' @export

--- a/R/scale-brewer.r
+++ b/R/scale-brewer.r
@@ -29,8 +29,8 @@
 #' @inheritParams scale_colour_gradient
 #' @inheritParams scales::gradient_n_pal
 #' @param ... Other arguments passed on to \code{\link{discrete_scale}} or, for
-#'   ‘distiller’ scales, \code{\link{continuous_scale}} to control name, limits,
-#'   breaks, labels and so forth.
+#'   \code{distiller} scales, \code{\link{continuous_scale}} to control name,
+#'   limits, breaks, labels and so forth.
 #' @family colour scales
 #' @rdname scale_brewer
 #' @export

--- a/man/scale_brewer.Rd
+++ b/man/scale_brewer.Rd
@@ -22,8 +22,9 @@ scale_fill_distiller(..., type = "seq", palette = 1, direction = -1,
   guide = "colourbar")
 }
 \arguments{
-\item{...}{Other arguments passed on to \code{\link{discrete_scale}}
-to control name, limits, breaks, labels and so forth.}
+\item{...}{Other arguments passed on to \code{\link{discrete_scale}} or, for
+‘distiller’ scales, \code{\link{continuous_scale}} to control name, limits,
+breaks, labels and so forth.}
 
 \item{type}{One of seq (sequential), div (diverging) or qual (qualitative)}
 

--- a/man/scale_brewer.Rd
+++ b/man/scale_brewer.Rd
@@ -23,8 +23,8 @@ scale_fill_distiller(..., type = "seq", palette = 1, direction = -1,
 }
 \arguments{
 \item{...}{Other arguments passed on to \code{\link{discrete_scale}} or, for
-‘distiller’ scales, \code{\link{continuous_scale}} to control name, limits,
-breaks, labels and so forth.}
+\code{distiller} scales, \code{\link{continuous_scale}} to control name,
+limits, breaks, labels and so forth.}
 
 \item{type}{One of seq (sequential), div (diverging) or qual (qualitative)}
 


### PR DESCRIPTION
Fixes #2069. The inherited parameter documentation for brewer/distiller scales said that `...` arguments were passed to `discrete_scale`, which is true for the brewer scales but not for distiller scales (for distiller scales they go to `continuous_scale`).