### PR TITLE
Start using @inheritDotParams in documentation

### DIFF
--- a/R/fortify-map.r
+++ b/R/fortify-map.r
@@ -86,7 +86,7 @@ map_data <- function(map, region = ".", exact = FALSE, ...) {
 #' @param colour border colour
 #' @param xlim,ylim latitudinal and logitudinal range for extracting map
 #'   polygons, see [maps::map()] for details.
-#' @param ... other arguments passed onto [geom_polygon()]
+#' @inheritDotParams geom_polygon
 #' @export
 #' @examples
 #' if (require("maps")) {

--- a/R/ggproto.r
+++ b/R/ggproto.r
@@ -193,7 +193,7 @@ make_proto_method <- function(self, f) {
 #' @param x A ggproto object to convert to a list.
 #' @param inherit If `TRUE` (the default), flatten all inherited items into
 #'   the returned list. If `FALSE`, do not include any inherited items.
-#' @param ... Further arguments to pass to `as.list.environment`.
+#' @inheritDotParams base::as.list.environment -x
 #' @export
 #' @keywords internal
 as.list.ggproto <- function(x, inherit = TRUE, ...) {

--- a/R/scale-discrete-.r
+++ b/R/scale-discrete-.r
@@ -6,9 +6,7 @@
 #' level, and increasing by one for each level (i.e. the labels are placed
 #' at integer positions).  This is what allows jittering to work.
 #'
-#' @param ... common discrete scale parameters: `name`, `breaks`,
-#'  `labels`, `na.value`, `limits` and `guide`.  See
-#'  [discrete_scale()] for more details
+#' @inheritDotParams discrete_scale -expand -position
 #' @param expand a numeric vector of length two giving multiplicative and
 #'   additive expansion constants. These constants ensure that the data is
 #'   placed some distance away from the axes.

--- a/R/scale-gradient.r
+++ b/R/scale-gradient.r
@@ -15,8 +15,7 @@
 #' @param low,high Colours for low and high ends of the gradient.
 #' @param guide Type of legend. Use `"colourbar"` for continuous
 #'   colour bar, or `"legend"` for discrete colour legend.
-#' @param ... Other arguments passed on to [continuous_scale()]
-#'   to control name, limits, breaks, labels and so forth.
+#' @inheritDotParams continuous_scale -na.value -guide
 #' @seealso [scales::seq_gradient_pal()] for details on underlying
 #'   palette
 #' @family colour scales

--- a/R/scale-grey.r
+++ b/R/scale-grey.r
@@ -5,6 +5,7 @@
 #'
 #' @inheritParams scales::grey_pal
 #' @inheritParams scale_colour_hue
+#' @inheritDotParams discrete_scale
 #' @family colour scales
 #' @rdname scale_grey
 #' @export

--- a/R/scale-hue.r
+++ b/R/scale-hue.r
@@ -5,8 +5,7 @@
 #' colour-blind safe palettes.
 #'
 #' @param na.value Colour to use for missing values
-#' @param ... Other arguments passed on to [discrete_scale()]
-#'   to control name, limits, breaks, labels and so forth.
+#' @inheritDotParams discrete_scale
 #' @inheritParams scales::hue_pal
 #' @rdname scale_hue
 #' @export

--- a/R/scale-linetype.r
+++ b/R/scale-linetype.r
@@ -5,6 +5,7 @@
 #' line types.
 #'
 #' @inheritParams scale_x_discrete
+#' @inheritDotParams discrete_scale -expand -position -na.value
 #' @param na.value The linetype to use for `NA` values.
 #' @rdname scale_linetype
 #' @export

--- a/R/scale-manual.r
+++ b/R/scale-manual.r
@@ -4,6 +4,7 @@
 #' data to aesthetic values.
 #'
 #' @inheritParams scale_x_discrete
+#' @inheritDotParams discrete_scale -expand -position
 #' @param values a set of aesthetic values to map data values to. If this
 #'   is a named vector, then the values will be matched based on the names.
 #'   If unnamed, values will be matched in order (usually alphabetical) with

--- a/R/scale-shape.r
+++ b/R/scale-shape.r
@@ -9,6 +9,7 @@
 #' @param solid Should the shapes be solid, `TRUE`, or hollow,
 #'   `FALSE`?
 #' @inheritParams scale_x_discrete
+#' @inheritDotParams discrete_scale -expand -position
 #' @rdname scale_shape
 #' @export
 #' @examples

--- a/R/scale-size.r
+++ b/R/scale-size.r
@@ -67,8 +67,7 @@ scale_size_discrete <- function(..., range = c(2, 6)) {
   }, ...)
 }
 
-#' @param ... Other arguments passed on to [continuous_scale()]
-#'   to control name, limits, breaks, labels and so forth.
+#' @inheritDotParams continuous_scale -aesthetics -scale_name -palette -rescaler
 #' @param max_size Size of largest points.
 #' @export
 #' @rdname scale_size

--- a/R/utilities-break.r
+++ b/R/utilities-break.r
@@ -9,7 +9,7 @@
 #' @param x numeric vector
 #' @param n number of intervals to create, OR
 #' @param length length of each interval
-#' @param ... other arguments passed on to [cut()]
+#' @inheritDotParams base::cut.default -x
 #' @export
 #' @examples
 #' table(cut_interval(1:100, 10))

--- a/man/as.list.ggproto.Rd
+++ b/man/as.list.ggproto.Rd
@@ -12,7 +12,14 @@
 \item{inherit}{If \code{TRUE} (the default), flatten all inherited items into
 the returned list. If \code{FALSE}, do not include any inherited items.}
 
-\item{...}{Further arguments to pass to \code{as.list.environment}.}
+\item{...}{Arguments passed on to \code{base::as.list.environment}
+\describe{
+  \item{all.names}{a logical indicating whether to copy all values or
+    (default) only those whose names do not begin with a dot.}
+  \item{sorted}{a logical indicating whether the \code{\link{names}} of
+    the resulting list should be sorted (increasingly).  Note that this
+    is somewhat costly, but may be useful for comparison of environments.}
+}}
 }
 \description{
 This will not include the object's \code{super} member.

--- a/man/borders.Rd
+++ b/man/borders.Rd
@@ -19,7 +19,39 @@ borders(database = "world", regions = ".", fill = NA, colour = "grey50",
 \item{xlim, ylim}{latitudinal and logitudinal range for extracting map
 polygons, see \code{\link[maps:map]{maps::map()}} for details.}
 
-\item{...}{other arguments passed onto \code{\link[=geom_polygon]{geom_polygon()}}}
+\item{...}{Arguments passed on to \code{geom_polygon}
+\describe{
+  \item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
+\code{\link[=aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
+default), it is combined with the default mapping at the top level of the
+plot. You must supply \code{mapping} if there is no plot mapping.}
+  \item{data}{The data to be displayed in this layer. There are three
+options:
+
+If \code{NULL}, the default, the data is inherited from the plot
+data as specified in the call to \code{\link[=ggplot]{ggplot()}}.
+
+A \code{data.frame}, or other object, will override the plot
+data. All objects will be fortified to produce a data frame. See
+\code{\link[=fortify]{fortify()}} for which variables will be created.
+
+A \code{function} will be called with a single argument,
+the plot data. The return value must be a \code{data.frame.}, and
+will be used as the layer data.}
+  \item{stat}{The statistical transformation to use on the data for this
+layer, as a string.}
+  \item{position}{Position adjustment, either as a string, or the result of
+a call to a position adjustment function.}
+  \item{show.legend}{logical. Should this layer be included in the legends?
+\code{NA}, the default, includes if any aesthetics are mapped.
+\code{FALSE} never includes, and \code{TRUE} always includes.}
+  \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
+rather than combining with them. This is most useful for helper functions
+that define both data and aesthetics and shouldn't inherit behaviour from
+the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
+  \item{na.rm}{If \code{FALSE}, the default, missing values are removed with
+a warning. If \code{TRUE}, missing values are silently removed.}
+}}
 }
 \description{
 This is a quick and dirty way to get map data (from the maps package)

--- a/man/cut_interval.Rd
+++ b/man/cut_interval.Rd
@@ -20,7 +20,24 @@ cut_width(x, width, center = NULL, boundary = NULL, closed = c("right",
 
 \item{length}{length of each interval}
 
-\item{...}{other arguments passed on to \code{\link[=cut]{cut()}}}
+\item{...}{Arguments passed on to \code{base::cut.default}
+\describe{
+  \item{breaks}{either a numeric vector of two or more unique cut points or a
+    single number (greater than or equal to 2) giving the number of
+    intervals into which \code{x} is to be cut.}
+  \item{labels}{labels for the levels of the resulting category.  By default,
+    labels are constructed using \code{"(a,b]"} interval notation.  If
+    \code{labels = FALSE}, simple integer codes are returned instead of
+    a factor.}
+  \item{include.lowest}{logical, indicating if an \sQuote{x[i]} equal to
+    the lowest (or highest, for \code{right = FALSE}) \sQuote{breaks}
+    value should be included.}
+  \item{right}{logical, indicating if the intervals should be closed on
+    the right (and open on the left) or vice versa.}
+  \item{dig.lab}{integer which is used when labels are not given.  It
+    determines the number of digits used in formatting the break numbers.}
+  \item{ordered_result}{logical: should the result be an ordered factor?}
+}}
 
 \item{width}{The bin width.}
 

--- a/man/geom_histogram.Rd
+++ b/man/geom_histogram.Rd
@@ -194,6 +194,6 @@ ggplot(mtlong, aes(value)) + facet_wrap(~variable, scales = 'free_x') +
 }
 \seealso{
 \code{\link[=stat_count]{stat_count()}}, which counts the number of cases at each x
-posotion, without binning. It is suitable for both discrete and continuous
+position, without binning. It is suitable for both discrete and continuous
 x data, whereas \link{stat_bin} is suitable only for continuous x data.
 }

--- a/man/scale_discrete.Rd
+++ b/man/scale_discrete.Rd
@@ -10,9 +10,49 @@ scale_x_discrete(..., expand = waiver(), position = "bottom")
 scale_y_discrete(..., expand = waiver(), position = "left")
 }
 \arguments{
-\item{...}{common discrete scale parameters: \code{name}, \code{breaks},
-\code{labels}, \code{na.value}, \code{limits} and \code{guide}.  See
-\code{\link[=discrete_scale]{discrete_scale()}} for more details}
+\item{...}{Arguments passed on to \code{discrete_scale}
+\describe{
+  \item{breaks}{One of:
+\itemize{
+\item \code{NULL} for no breaks
+\item \code{waiver()} for the default breaks computed by the
+transformation object
+\item A character vector of breaks
+\item A function that takes the limits as input and returns breaks
+as output
+}}
+  \item{limits}{A character vector that defines possible values of the scale
+and their order.}
+  \item{drop}{Should unused factor levels be omitted from the scale?
+The default, \code{TRUE}, uses the levels that appear in the data;
+\code{FALSE} uses all the levels in the factor.}
+  \item{na.translate}{Unlike continuous scales, discrete scales can easily show
+missing values, and do so by default. If you want to remove missing values
+from a discrete scale, specify \code{na.translate = FALSE}.}
+  \item{na.value}{If \code{na.translate = TRUE}, what value aesthetic
+value should missing be displayed as? Does not apply to position scales
+where \code{NA} is always placed at the far right.}
+  \item{aesthetics}{The names of the aesthetics that this scale works with}
+  \item{scale_name}{The name of the scale}
+  \item{palette}{A palette function that when called with a single integer
+argument (the number of levels in the scale) returns the values that
+they should take}
+  \item{name}{The name of the scale. Used as axis or legend title. If
+\code{NULL}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic.}
+  \item{labels}{One of:
+\itemize{
+\item \code{NULL} for no labels
+\item \code{waiver()} for the default labels computed by the
+transformation object
+\item A character vector giving labels (must be same length as \code{breaks})
+\item A function that takes the breaks as input and returns labels
+as output
+}}
+  \item{guide}{A function used to create a guide or its name. See
+\code{\link[=guides]{guides()}} for more info.}
+  \item{super}{The super class to use for the constructed scale}
+}}
 
 \item{expand}{a numeric vector of length two giving multiplicative and
 additive expansion constants. These constants ensure that the data is

--- a/man/scale_gradient.Rd
+++ b/man/scale_gradient.Rd
@@ -40,8 +40,68 @@ scale_fill_gradientn(..., colours, values = NULL, space = "Lab",
   na.value = "grey50", guide = "colourbar", colors)
 }
 \arguments{
-\item{...}{Other arguments passed on to \code{\link[=continuous_scale]{continuous_scale()}}
-to control name, limits, breaks, labels and so forth.}
+\item{...}{Arguments passed on to \code{continuous_scale}
+\describe{
+  \item{aesthetics}{The names of the aesthetics that this scale works with}
+  \item{scale_name}{The name of the scale}
+  \item{palette}{A palette function that when called with a single integer
+argument (the number of levels in the scale) returns the values that
+they should take}
+  \item{name}{The name of the scale. Used as axis or legend title. If
+\code{NULL}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic.}
+  \item{breaks}{One of:
+\itemize{
+\item \code{NULL} for no breaks
+\item \code{waiver()} for the default breaks computed by the
+transformation object
+\item A numeric vector of positions
+\item A function that takes the limits as input and returns breaks
+as output
+}}
+  \item{minor_breaks}{One of:
+\itemize{
+\item \code{NULL} for no minor breaks
+\item \code{waiver()} for the default breaks (one minor break between
+each major break)
+\item A numeric vector of positions
+\item A function that given the limits returns a vector of minor breaks.
+}}
+  \item{labels}{One of:
+\itemize{
+\item \code{NULL} for no labels
+\item \code{waiver()} for the default labels computed by the
+transformation object
+\item A character vector giving labels (must be same length as \code{breaks})
+\item A function that takes the breaks as input and returns labels
+as output
+}}
+  \item{limits}{A numeric vector of length two providing limits of the scale.
+Use \code{NA} to refer to the existing minimum or maximum.}
+  \item{rescaler}{Used by diverging and n colour gradients
+(i.e. \code{\link[=scale_colour_gradient2]{scale_colour_gradient2()}}, \code{\link[=scale_colour_gradientn]{scale_colour_gradientn()}}).
+A function used to scale the input values to the range \eqn{[0, 1]}.}
+  \item{oob}{Function that handles limits outside of the scale limits
+(out of bounds). The default replaces out of bounds values with NA.}
+  \item{expand}{A numeric vector of length two giving multiplicative and
+additive expansion constants. These constants ensure that the data is
+placed some distance away from the axes. The defaults are
+\code{c(0.05, 0)} for continuous variables, and \code{c(0, 0.6)} for
+discrete variables.}
+  \item{trans}{Either the name of a transformation object, or the
+object itself. Built-in transformations include "asn", "atanh",
+"boxcox", "exp", "identity", "log", "log10", "log1p", "log2",
+"logit", "probability", "probit", "reciprocal", "reverse" and "sqrt".
+
+A transformation object bundles together a transform, it's inverse,
+and methods for generating breaks and labels. Transformation objects
+are defined in the scales package, and are called \code{name_trans}, e.g.
+\code{\link[scales:boxcox_trans]{scales::boxcox_trans()}}. You can create your own
+transformation with \code{\link[scales:trans_new]{scales::trans_new()}}.}
+  \item{position}{The position of the axis. "left" or "right" for vertical
+scales, "top" or "bottom" for horizontal scales}
+  \item{super}{The super class to use for the constructed scale}
+}}
 
 \item{low, high}{Colours for low and high ends of the gradient.}
 

--- a/man/scale_grey.Rd
+++ b/man/scale_grey.Rd
@@ -11,8 +11,56 @@ scale_colour_grey(..., start = 0.2, end = 0.8, na.value = "red")
 scale_fill_grey(..., start = 0.2, end = 0.8, na.value = "red")
 }
 \arguments{
-\item{...}{Other arguments passed on to \code{\link[=discrete_scale]{discrete_scale()}}
-to control name, limits, breaks, labels and so forth.}
+\item{...}{Arguments passed on to \code{discrete_scale}
+\describe{
+  \item{breaks}{One of:
+\itemize{
+\item \code{NULL} for no breaks
+\item \code{waiver()} for the default breaks computed by the
+transformation object
+\item A character vector of breaks
+\item A function that takes the limits as input and returns breaks
+as output
+}}
+  \item{limits}{A character vector that defines possible values of the scale
+and their order.}
+  \item{drop}{Should unused factor levels be omitted from the scale?
+The default, \code{TRUE}, uses the levels that appear in the data;
+\code{FALSE} uses all the levels in the factor.}
+  \item{na.translate}{Unlike continuous scales, discrete scales can easily show
+missing values, and do so by default. If you want to remove missing values
+from a discrete scale, specify \code{na.translate = FALSE}.}
+  \item{na.value}{If \code{na.translate = TRUE}, what value aesthetic
+value should missing be displayed as? Does not apply to position scales
+where \code{NA} is always placed at the far right.}
+  \item{aesthetics}{The names of the aesthetics that this scale works with}
+  \item{scale_name}{The name of the scale}
+  \item{palette}{A palette function that when called with a single integer
+argument (the number of levels in the scale) returns the values that
+they should take}
+  \item{name}{The name of the scale. Used as axis or legend title. If
+\code{NULL}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic.}
+  \item{labels}{One of:
+\itemize{
+\item \code{NULL} for no labels
+\item \code{waiver()} for the default labels computed by the
+transformation object
+\item A character vector giving labels (must be same length as \code{breaks})
+\item A function that takes the breaks as input and returns labels
+as output
+}}
+  \item{expand}{A numeric vector of length two giving multiplicative and
+additive expansion constants. These constants ensure that the data is
+placed some distance away from the axes. The defaults are
+\code{c(0.05, 0)} for continuous variables, and \code{c(0, 0.6)} for
+discrete variables.}
+  \item{guide}{A function used to create a guide or its name. See
+\code{\link[=guides]{guides()}} for more info.}
+  \item{position}{The position of the axis. "left" or "right" for vertical
+scales, "top" or "bottom" for horizontal scales}
+  \item{super}{The super class to use for the constructed scale}
+}}
 
 \item{start}{gray value at low end of palette}
 

--- a/man/scale_hue.Rd
+++ b/man/scale_hue.Rd
@@ -16,8 +16,56 @@ scale_fill_hue(..., h = c(0, 360) + 15, c = 100, l = 65, h.start = 0,
   direction = 1, na.value = "grey50")
 }
 \arguments{
-\item{...}{Other arguments passed on to \code{\link[=discrete_scale]{discrete_scale()}}
-to control name, limits, breaks, labels and so forth.}
+\item{...}{Arguments passed on to \code{discrete_scale}
+\describe{
+  \item{breaks}{One of:
+\itemize{
+\item \code{NULL} for no breaks
+\item \code{waiver()} for the default breaks computed by the
+transformation object
+\item A character vector of breaks
+\item A function that takes the limits as input and returns breaks
+as output
+}}
+  \item{limits}{A character vector that defines possible values of the scale
+and their order.}
+  \item{drop}{Should unused factor levels be omitted from the scale?
+The default, \code{TRUE}, uses the levels that appear in the data;
+\code{FALSE} uses all the levels in the factor.}
+  \item{na.translate}{Unlike continuous scales, discrete scales can easily show
+missing values, and do so by default. If you want to remove missing values
+from a discrete scale, specify \code{na.translate = FALSE}.}
+  \item{na.value}{If \code{na.translate = TRUE}, what value aesthetic
+value should missing be displayed as? Does not apply to position scales
+where \code{NA} is always placed at the far right.}
+  \item{aesthetics}{The names of the aesthetics that this scale works with}
+  \item{scale_name}{The name of the scale}
+  \item{palette}{A palette function that when called with a single integer
+argument (the number of levels in the scale) returns the values that
+they should take}
+  \item{name}{The name of the scale. Used as axis or legend title. If
+\code{NULL}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic.}
+  \item{labels}{One of:
+\itemize{
+\item \code{NULL} for no labels
+\item \code{waiver()} for the default labels computed by the
+transformation object
+\item A character vector giving labels (must be same length as \code{breaks})
+\item A function that takes the breaks as input and returns labels
+as output
+}}
+  \item{expand}{A numeric vector of length two giving multiplicative and
+additive expansion constants. These constants ensure that the data is
+placed some distance away from the axes. The defaults are
+\code{c(0.05, 0)} for continuous variables, and \code{c(0, 0.6)} for
+discrete variables.}
+  \item{guide}{A function used to create a guide or its name. See
+\code{\link[=guides]{guides()}} for more info.}
+  \item{position}{The position of the axis. "left" or "right" for vertical
+scales, "top" or "bottom" for horizontal scales}
+  \item{super}{The super class to use for the constructed scale}
+}}
 
 \item{h}{range of hues to use, in [0, 360]}
 

--- a/man/scale_linetype.Rd
+++ b/man/scale_linetype.Rd
@@ -13,9 +13,46 @@ scale_linetype_continuous(...)
 scale_linetype_discrete(..., na.value = "blank")
 }
 \arguments{
-\item{...}{common discrete scale parameters: \code{name}, \code{breaks},
-\code{labels}, \code{na.value}, \code{limits} and \code{guide}.  See
-\code{\link[=discrete_scale]{discrete_scale()}} for more details}
+\item{...}{Arguments passed on to \code{discrete_scale}
+\describe{
+  \item{breaks}{One of:
+\itemize{
+\item \code{NULL} for no breaks
+\item \code{waiver()} for the default breaks computed by the
+transformation object
+\item A character vector of breaks
+\item A function that takes the limits as input and returns breaks
+as output
+}}
+  \item{limits}{A character vector that defines possible values of the scale
+and their order.}
+  \item{drop}{Should unused factor levels be omitted from the scale?
+The default, \code{TRUE}, uses the levels that appear in the data;
+\code{FALSE} uses all the levels in the factor.}
+  \item{na.translate}{Unlike continuous scales, discrete scales can easily show
+missing values, and do so by default. If you want to remove missing values
+from a discrete scale, specify \code{na.translate = FALSE}.}
+  \item{aesthetics}{The names of the aesthetics that this scale works with}
+  \item{scale_name}{The name of the scale}
+  \item{palette}{A palette function that when called with a single integer
+argument (the number of levels in the scale) returns the values that
+they should take}
+  \item{name}{The name of the scale. Used as axis or legend title. If
+\code{NULL}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic.}
+  \item{labels}{One of:
+\itemize{
+\item \code{NULL} for no labels
+\item \code{waiver()} for the default labels computed by the
+transformation object
+\item A character vector giving labels (must be same length as \code{breaks})
+\item A function that takes the breaks as input and returns labels
+as output
+}}
+  \item{guide}{A function used to create a guide or its name. See
+\code{\link[=guides]{guides()}} for more info.}
+  \item{super}{The super class to use for the constructed scale}
+}}
 
 \item{na.value}{The linetype to use for \code{NA} values.}
 }

--- a/man/scale_manual.Rd
+++ b/man/scale_manual.Rd
@@ -23,9 +23,49 @@ scale_linetype_manual(..., values)
 scale_alpha_manual(..., values)
 }
 \arguments{
-\item{...}{common discrete scale parameters: \code{name}, \code{breaks},
-\code{labels}, \code{na.value}, \code{limits} and \code{guide}.  See
-\code{\link[=discrete_scale]{discrete_scale()}} for more details}
+\item{...}{Arguments passed on to \code{discrete_scale}
+\describe{
+  \item{breaks}{One of:
+\itemize{
+\item \code{NULL} for no breaks
+\item \code{waiver()} for the default breaks computed by the
+transformation object
+\item A character vector of breaks
+\item A function that takes the limits as input and returns breaks
+as output
+}}
+  \item{limits}{A character vector that defines possible values of the scale
+and their order.}
+  \item{drop}{Should unused factor levels be omitted from the scale?
+The default, \code{TRUE}, uses the levels that appear in the data;
+\code{FALSE} uses all the levels in the factor.}
+  \item{na.translate}{Unlike continuous scales, discrete scales can easily show
+missing values, and do so by default. If you want to remove missing values
+from a discrete scale, specify \code{na.translate = FALSE}.}
+  \item{na.value}{If \code{na.translate = TRUE}, what value aesthetic
+value should missing be displayed as? Does not apply to position scales
+where \code{NA} is always placed at the far right.}
+  \item{aesthetics}{The names of the aesthetics that this scale works with}
+  \item{scale_name}{The name of the scale}
+  \item{palette}{A palette function that when called with a single integer
+argument (the number of levels in the scale) returns the values that
+they should take}
+  \item{name}{The name of the scale. Used as axis or legend title. If
+\code{NULL}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic.}
+  \item{labels}{One of:
+\itemize{
+\item \code{NULL} for no labels
+\item \code{waiver()} for the default labels computed by the
+transformation object
+\item A character vector giving labels (must be same length as \code{breaks})
+\item A function that takes the breaks as input and returns labels
+as output
+}}
+  \item{guide}{A function used to create a guide or its name. See
+\code{\link[=guides]{guides()}} for more info.}
+  \item{super}{The super class to use for the constructed scale}
+}}
 
 \item{values}{a set of aesthetic values to map data values to. If this
 is a named vector, then the values will be matched based on the names.

--- a/man/scale_shape.Rd
+++ b/man/scale_shape.Rd
@@ -9,9 +9,49 @@
 scale_shape(..., solid = TRUE)
 }
 \arguments{
-\item{...}{common discrete scale parameters: \code{name}, \code{breaks},
-\code{labels}, \code{na.value}, \code{limits} and \code{guide}.  See
-\code{\link[=discrete_scale]{discrete_scale()}} for more details}
+\item{...}{Arguments passed on to \code{discrete_scale}
+\describe{
+  \item{breaks}{One of:
+\itemize{
+\item \code{NULL} for no breaks
+\item \code{waiver()} for the default breaks computed by the
+transformation object
+\item A character vector of breaks
+\item A function that takes the limits as input and returns breaks
+as output
+}}
+  \item{limits}{A character vector that defines possible values of the scale
+and their order.}
+  \item{drop}{Should unused factor levels be omitted from the scale?
+The default, \code{TRUE}, uses the levels that appear in the data;
+\code{FALSE} uses all the levels in the factor.}
+  \item{na.translate}{Unlike continuous scales, discrete scales can easily show
+missing values, and do so by default. If you want to remove missing values
+from a discrete scale, specify \code{na.translate = FALSE}.}
+  \item{na.value}{If \code{na.translate = TRUE}, what value aesthetic
+value should missing be displayed as? Does not apply to position scales
+where \code{NA} is always placed at the far right.}
+  \item{aesthetics}{The names of the aesthetics that this scale works with}
+  \item{scale_name}{The name of the scale}
+  \item{palette}{A palette function that when called with a single integer
+argument (the number of levels in the scale) returns the values that
+they should take}
+  \item{name}{The name of the scale. Used as axis or legend title. If
+\code{NULL}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic.}
+  \item{labels}{One of:
+\itemize{
+\item \code{NULL} for no labels
+\item \code{waiver()} for the default labels computed by the
+transformation object
+\item A character vector giving labels (must be same length as \code{breaks})
+\item A function that takes the breaks as input and returns labels
+as output
+}}
+  \item{guide}{A function used to create a guide or its name. See
+\code{\link[=guides]{guides()}} for more info.}
+  \item{super}{The super class to use for the constructed scale}
+}}
 
 \item{solid}{Should the shapes be solid, \code{TRUE}, or hollow,
 \code{FALSE}?}

--- a/man/scale_size.Rd
+++ b/man/scale_size.Rd
@@ -64,8 +64,63 @@ transformation with \code{\link[scales:trans_new]{scales::trans_new()}}.}
 \item{guide}{A function used to create a guide or its name. See
 \code{\link[=guides]{guides()}} for more info.}
 
-\item{...}{Other arguments passed on to \code{\link[=continuous_scale]{continuous_scale()}}
-to control name, limits, breaks, labels and so forth.}
+\item{...}{Arguments passed on to \code{continuous_scale}
+\describe{
+  \item{name}{The name of the scale. Used as axis or legend title. If
+\code{NULL}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic.}
+  \item{breaks}{One of:
+\itemize{
+\item \code{NULL} for no breaks
+\item \code{waiver()} for the default breaks computed by the
+transformation object
+\item A numeric vector of positions
+\item A function that takes the limits as input and returns breaks
+as output
+}}
+  \item{minor_breaks}{One of:
+\itemize{
+\item \code{NULL} for no minor breaks
+\item \code{waiver()} for the default breaks (one minor break between
+each major break)
+\item A numeric vector of positions
+\item A function that given the limits returns a vector of minor breaks.
+}}
+  \item{labels}{One of:
+\itemize{
+\item \code{NULL} for no labels
+\item \code{waiver()} for the default labels computed by the
+transformation object
+\item A character vector giving labels (must be same length as \code{breaks})
+\item A function that takes the breaks as input and returns labels
+as output
+}}
+  \item{limits}{A numeric vector of length two providing limits of the scale.
+Use \code{NA} to refer to the existing minimum or maximum.}
+  \item{oob}{Function that handles limits outside of the scale limits
+(out of bounds). The default replaces out of bounds values with NA.}
+  \item{expand}{A numeric vector of length two giving multiplicative and
+additive expansion constants. These constants ensure that the data is
+placed some distance away from the axes. The defaults are
+\code{c(0.05, 0)} for continuous variables, and \code{c(0, 0.6)} for
+discrete variables.}
+  \item{na.value}{Missing values will be replaced with this value.}
+  \item{trans}{Either the name of a transformation object, or the
+object itself. Built-in transformations include "asn", "atanh",
+"boxcox", "exp", "identity", "log", "log10", "log1p", "log2",
+"logit", "probability", "probit", "reciprocal", "reverse" and "sqrt".
+
+A transformation object bundles together a transform, it's inverse,
+and methods for generating breaks and labels. Transformation objects
+are defined in the scales package, and are called \code{name_trans}, e.g.
+\code{\link[scales:boxcox_trans]{scales::boxcox_trans()}}. You can create your own
+transformation with \code{\link[scales:trans_new]{scales::trans_new()}}.}
+  \item{guide}{A function used to create a guide or its name. See
+\code{\link[=guides]{guides()}} for more info.}
+  \item{position}{The position of the axis. "left" or "right" for vertical
+scales, "top" or "bottom" for horizontal scales}
+  \item{super}{The super class to use for the constructed scale}
+}}
 
 \item{max_size}{Size of largest points.}
 }


### PR DESCRIPTION
See #2164

This uses `@inheritDotParams` for some `...` parameters. There are still some other places where we might be able to switch to `@inheritDotParams`. 

There's an issue when the dot parameters come from another package and include links. For example the `map_data` function passes `...` to `maps::map()`, but some of those params have links to other stuff within the maps package, and with `@inheritDotParams` the links get written to Rd as e.g. `\link{county}` when they need to be `\link[maps:county]{county}`