### PR TITLE
Clarify stat/geom_smooth docs to show method takes a fn, not a character

### DIFF
--- a/R/geom-smooth.r
+++ b/R/geom-smooth.r
@@ -39,18 +39,18 @@
 #' # Instead of a loess smooth, you can use any other modelling function:
 #' ggplot(mpg, aes(displ, hwy)) +
 #'   geom_point() +
-#'   geom_smooth(method = "lm", se = FALSE)
+#'   geom_smooth(method = lm, se = FALSE)
 #'
 #' ggplot(mpg, aes(displ, hwy)) +
 #'   geom_point() +
-#'   geom_smooth(method = "lm", formula = y ~ splines::bs(x, 3), se = FALSE)
+#'   geom_smooth(method = lm, formula = y ~ splines::bs(x, 3), se = FALSE)
 #'
 #' # Smoothes are automatically fit to each group (defined by categorical
 #' # aesthetics or the group aesthetic) and for each facet
 #'
 #' ggplot(mpg, aes(displ, hwy, colour = class)) +
 #'   geom_point() +
-#'   geom_smooth(se = FALSE, method = "lm")
+#'   geom_smooth(se = FALSE, method = lm)
 #' ggplot(mpg, aes(displ, hwy)) +
 #'   geom_point() +
 #'   geom_smooth(span = 0.8) +

--- a/R/stat-smooth.r
+++ b/R/stat-smooth.r
@@ -1,5 +1,5 @@
-#' @param method smoothing method (function) to use, eg. "lm", "glm",
-#'   "gam", "loess", "rlm".
+#' @param method smoothing method (function) to use, eg. `lm`, `glm`,
+#'   `gam`, `loess`, `MASS::rlm`.
 #'
 #'   For `method = "auto"` the smoothing method is chosen based on the
 #'   size of the largest group (across all panels). [loess()] is

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -43,8 +43,8 @@ often aesthetics, used to set an aesthetic to a fixed value, like
 \code{color = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 
-\item{method}{smoothing method (function) to use, eg. "lm", "glm",
-"gam", "loess", "rlm".
+\item{method}{smoothing method (function) to use, eg. \code{lm}, \code{glm},
+\code{gam}, \code{loess}, \code{MASS::rlm}.
 
 For \code{method = "auto"} the smoothing method is chosen based on the
 size of the largest group (across all panels). \code{\link[=loess]{loess()}} is
@@ -132,18 +132,18 @@ ggplot(mpg, aes(displ, hwy)) +
 # Instead of a loess smooth, you can use any other modelling function:
 ggplot(mpg, aes(displ, hwy)) +
   geom_point() +
-  geom_smooth(method = "lm", se = FALSE)
+  geom_smooth(method = lm, se = FALSE)
 
 ggplot(mpg, aes(displ, hwy)) +
   geom_point() +
-  geom_smooth(method = "lm", formula = y ~ splines::bs(x, 3), se = FALSE)
+  geom_smooth(method = lm, formula = y ~ splines::bs(x, 3), se = FALSE)
 
 # Smoothes are automatically fit to each group (defined by categorical
 # aesthetics or the group aesthetic) and for each facet
 
 ggplot(mpg, aes(displ, hwy, colour = class)) +
   geom_point() +
-  geom_smooth(se = FALSE, method = "lm")
+  geom_smooth(se = FALSE, method = lm)
 ggplot(mpg, aes(displ, hwy)) +
   geom_point() +
   geom_smooth(span = 0.8) +


### PR DESCRIPTION
stat/geom_smooth lists 'rlm' as a possible method
for calulating a smooth, but method='rlm' fails
becuase rlm() is in MASS and is not imported. This
fixes this by importing MASS::rlm.