### PR TITLE
Don't let codecov fail build with "No report found to compare against"

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,7 @@
 comment: false
+coverage:
+  status:
+    project:
+      default:
+        target: auto           # this is default
+        if_not_found: success  # no commit found? still set a success


### PR DESCRIPTION
From here: https://github.com/codecov/support/issues/173#issuecomment-216067683

This might help with codecov failing to find a report for the base commit. Let's find out ...