### PR TITLE
Add base_line_size and base_rect_size parameters to theme defaults

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # ggplot2 2.2.1.9000
 
+* Theme functions now have the optional parameters `base_line_size` and
+  `base_rect_size` to control the default sizes of line and rectangle elements
+  (@karawoo, #2176).
+
 * Fixed bug in `coord_polar` that prevented secondary axis ticks and labels
   from being drawn (@dylan-stark, #2072)
 

--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -67,16 +67,9 @@ NULL
 #' @export
 #' @rdname ggtheme
 theme_grey <- function(base_size = 11, base_family = "",
-                       base_line_size, base_rect_size) {
+                       base_line_size = base_size / 22,
+                       base_rect_size = base_size / 22) {
   half_line <- base_size / 2
-
-  if (missing(base_line_size)) {
-    base_line_size <- base_size / 22
-  }
-
-  if (missing(base_rect_size)) {
-    base_rect_size <- base_size / 22
-  }
 
   theme(
     # Elements in this first block aren't used directly, but are inherited
@@ -193,7 +186,8 @@ theme_gray <- theme_grey
 #' @export
 #' @rdname ggtheme
 theme_bw <- function(base_size = 11, base_family = "",
-                     base_line_size, base_rect_size) {
+                     base_line_size = base_size / 22,
+                     base_rect_size = base_size / 22) {
   # Starts with theme_grey and then modify some parts
   theme_grey(
     base_size = base_size,
@@ -220,7 +214,8 @@ theme_bw <- function(base_size = 11, base_family = "",
 #' @export
 #' @rdname ggtheme
 theme_linedraw <- function(base_size = 11, base_family = "",
-                           base_line_size, base_rect_size) {
+                           base_line_size = base_size / 22,
+                           base_rect_size = base_size / 22) {
   # Starts with theme_bw and then modify some parts
   # = replace all greys with pure black or white
   theme_bw(
@@ -252,7 +247,8 @@ theme_linedraw <- function(base_size = 11, base_family = "",
 #' @export
 #' @rdname ggtheme
 theme_light <- function(base_size = 11, base_family = "",
-                        base_line_size, base_rect_size) {
+                        base_line_size = base_size / 22,
+                        base_rect_size = base_size / 22) {
   # Starts with theme_grey and then modify some parts
   theme_grey(
     base_size = base_size,
@@ -287,7 +283,8 @@ theme_light <- function(base_size = 11, base_family = "",
 #' @export
 #' @rdname ggtheme
 theme_dark <- function(base_size = 11, base_family = "",
-                       base_line_size, base_rect_size) {
+                       base_line_size = base_size / 22,
+                       base_rect_size = base_size / 22) {
   # Starts with theme_grey and then modify some parts
   theme_grey(
     base_size = base_size,
@@ -320,7 +317,8 @@ theme_dark <- function(base_size = 11, base_family = "",
 #' @export
 #' @rdname ggtheme
 theme_minimal <- function(base_size = 11, base_family = "",
-                          base_line_size, base_rect_size) {
+                          base_line_size = base_size / 22,
+                          base_rect_size = base_size / 22) {
   # Starts with theme_bw and remove most parts
   theme_bw(
     base_size = base_size,
@@ -344,7 +342,8 @@ theme_minimal <- function(base_size = 11, base_family = "",
 #' @export
 #' @rdname ggtheme
 theme_classic <- function(base_size = 11, base_family = "",
-                          base_line_size, base_rect_size) {
+                          base_line_size = base_size / 22,
+                          base_rect_size = base_size / 22) {
   theme_bw(
     base_size = base_size,
     base_family = base_family,
@@ -374,7 +373,8 @@ theme_classic <- function(base_size = 11, base_family = "",
 #' @export
 #' @rdname ggtheme
 theme_void <- function(base_size = 11, base_family = "",
-                       base_line_size, base_rect_size) {
+                       base_line_size = base_size / 22,
+                       base_rect_size = base_size / 22) {
   theme(
     # Use only inherited elements and make almost everything blank
     # Only keep indispensable text
@@ -400,16 +400,9 @@ theme_void <- function(base_size = 11, base_family = "",
 #' @export
 #' @rdname ggtheme
 theme_test <- function(base_size = 11, base_family = "",
-                       base_line_size, base_rect_size) {
+                       base_line_size = base_size / 22,
+                       base_rect_size = base_size / 22) {
   half_line <- base_size / 2
-
-  if (missing(base_line_size)) {
-    base_line_size <- base_size / 22
-  }
-
-  if (missing(base_rect_size)) {
-    base_rect_size <- base_size / 22
-  }
   
   theme(
     line =               element_line(

--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -6,6 +6,8 @@
 #'
 #' @param base_size base font size
 #' @param base_family base font family
+#' @param base_line_size base size for line elements
+#' @param base_rect_size base size for rect elements
 #'
 #' @details
 #' \describe{
@@ -64,16 +66,29 @@ NULL
 #' @include theme.r
 #' @export
 #' @rdname ggtheme
-theme_grey <- function(base_size = 11, base_family = "") {
+theme_grey <- function(base_size = 11, base_family = "",
+                       base_line_size, base_rect_size) {
   half_line <- base_size / 2
+
+  if (missing(base_line_size)) {
+    base_line_size <- base_size / 22
+  }
+
+  if (missing(base_rect_size)) {
+    base_rect_size <- base_size / 22
+  }
 
   theme(
     # Elements in this first block aren't used directly, but are inherited
     # by others
-    line =               element_line(colour = "black", size = 0.5, linetype = 1,
-                            lineend = "butt"),
-    rect =               element_rect(fill = "white", colour = "black",
-                            size = 0.5, linetype = 1),
+    line =               element_line(
+                           colour = "black", size = base_line_size,
+                           linetype = 1, lineend = "butt"
+                         ),
+    rect =               element_rect(
+                           fill = "white", colour = "black",
+                           size = base_rect_size, linetype = 1
+                         ),
     text =               element_text(
                             family = base_family, face = "plain",
                             colour = "black", size = base_size,
@@ -177,9 +192,15 @@ theme_gray <- theme_grey
 
 #' @export
 #' @rdname ggtheme
-theme_bw <- function(base_size = 11, base_family = "") {
+theme_bw <- function(base_size = 11, base_family = "",
+                     base_line_size, base_rect_size) {
   # Starts with theme_grey and then modify some parts
-  theme_grey(base_size = base_size, base_family = base_family) %+replace%
+  theme_grey(
+    base_size = base_size,
+    base_family = base_family,
+    base_line_size = base_line_size,
+    base_rect_size = base_rect_size
+  ) %+replace%
     theme(
       # white background and dark border
       panel.background = element_rect(fill = "white", colour = NA),
@@ -198,10 +219,16 @@ theme_bw <- function(base_size = 11, base_family = "") {
 
 #' @export
 #' @rdname ggtheme
-theme_linedraw <- function(base_size = 11, base_family = "") {
+theme_linedraw <- function(base_size = 11, base_family = "",
+                           base_line_size, base_rect_size) {
   # Starts with theme_bw and then modify some parts
   # = replace all greys with pure black or white
-  theme_bw(base_size = base_size, base_family = base_family) %+replace%
+  theme_bw(
+    base_size = base_size,
+    base_family = base_family,
+    base_line_size = base_line_size,
+    base_rect_size = base_rect_size
+  ) %+replace%
     theme(
       # black text and ticks on the axes
       axis.text        = element_text(colour = "black", size = rel(0.8)),
@@ -224,9 +251,15 @@ theme_linedraw <- function(base_size = 11, base_family = "") {
 
 #' @export
 #' @rdname ggtheme
-theme_light <- function(base_size = 11, base_family = "") {
+theme_light <- function(base_size = 11, base_family = "",
+                        base_line_size, base_rect_size) {
   # Starts with theme_grey and then modify some parts
-  theme_grey(base_size = base_size, base_family = base_family) %+replace%
+  theme_grey(
+    base_size = base_size,
+    base_family = base_family,
+    base_line_size = base_line_size,
+    base_rect_size = base_rect_size
+  ) %+replace%
     theme(
       # white panel with light grey border
       panel.background = element_rect(fill = "white", colour = NA),
@@ -253,9 +286,15 @@ theme_light <- function(base_size = 11, base_family = "") {
 
 #' @export
 #' @rdname ggtheme
-theme_dark <- function(base_size = 11, base_family = "") {
+theme_dark <- function(base_size = 11, base_family = "",
+                       base_line_size, base_rect_size) {
   # Starts with theme_grey and then modify some parts
-  theme_grey(base_size = base_size, base_family = base_family) %+replace%
+  theme_grey(
+    base_size = base_size,
+    base_family = base_family,
+    base_line_size = base_line_size,
+    base_rect_size = base_rect_size
+  ) %+replace%
     theme(
       # dark panel
       panel.background = element_rect(fill = "grey50", colour = NA),
@@ -280,9 +319,15 @@ theme_dark <- function(base_size = 11, base_family = "") {
 
 #' @export
 #' @rdname ggtheme
-theme_minimal <- function(base_size = 11, base_family = "") {
+theme_minimal <- function(base_size = 11, base_family = "",
+                          base_line_size, base_rect_size) {
   # Starts with theme_bw and remove most parts
-  theme_bw(base_size = base_size, base_family = base_family) %+replace%
+  theme_bw(
+    base_size = base_size,
+    base_family = base_family,
+    base_line_size = base_line_size,
+    base_rect_size = base_rect_size
+  ) %+replace%
     theme(
       axis.ticks      = element_blank(),
       legend.background = element_blank(),
@@ -298,8 +343,14 @@ theme_minimal <- function(base_size = 11, base_family = "") {
 
 #' @export
 #' @rdname ggtheme
-theme_classic <- function(base_size = 11, base_family = ""){
-  theme_bw(base_size = base_size, base_family = base_family) %+replace%
+theme_classic <- function(base_size = 11, base_family = "",
+                          base_line_size, base_rect_size) {
+  theme_bw(
+    base_size = base_size,
+    base_family = base_family,
+    base_line_size = base_line_size,
+    base_rect_size = base_rect_size
+  ) %+replace%
     theme(
       # no background and no grid
       panel.border     = element_blank(),
@@ -322,7 +373,8 @@ theme_classic <- function(base_size = 11, base_family = ""){
 
 #' @export
 #' @rdname ggtheme
-theme_void <- function(base_size = 11, base_family = "") {
+theme_void <- function(base_size = 11, base_family = "",
+                       base_line_size, base_rect_size) {
   theme(
     # Use only inherited elements and make almost everything blank
     # Only keep indispensable text
@@ -347,14 +399,27 @@ theme_void <- function(base_size = 11, base_family = "") {
 
 #' @export
 #' @rdname ggtheme
-theme_test <- function(base_size = 11, base_family = "") {
+theme_test <- function(base_size = 11, base_family = "",
+                       base_line_size, base_rect_size) {
   half_line <- base_size / 2
 
+  if (missing(base_line_size)) {
+    base_line_size <- base_size / 22
+  }
+
+  if (missing(base_rect_size)) {
+    base_rect_size <- base_size / 22
+  }
+  
   theme(
-    line =               element_line(colour = "black", size = 0.5, linetype = 1,
-                            lineend = "butt"),
-    rect =               element_rect(fill = "white", colour = "black",
-                            size = 0.5, linetype = 1),
+    line =               element_line(
+                           colour = "black", size = base_line_size,
+                           linetype = 1, lineend = "butt"
+                         ),
+    rect =               element_rect(
+                           fill = "white", colour = "black",
+                           size = base_rect_size, linetype = 1
+                         ),
     text =               element_text(
                             family = base_family, face = "plain",
                             colour = "black", size = base_size,

--- a/man/ggtheme.Rd
+++ b/man/ggtheme.Rd
@@ -13,30 +13,38 @@
 \alias{theme_test}
 \title{Complete themes}
 \usage{
-theme_grey(base_size = 11, base_family = "")
+theme_grey(base_size = 11, base_family = "", base_line_size, base_rect_size)
 
-theme_gray(base_size = 11, base_family = "")
+theme_gray(base_size = 11, base_family = "", base_line_size, base_rect_size)
 
-theme_bw(base_size = 11, base_family = "")
+theme_bw(base_size = 11, base_family = "", base_line_size, base_rect_size)
 
-theme_linedraw(base_size = 11, base_family = "")
+theme_linedraw(base_size = 11, base_family = "", base_line_size,
+  base_rect_size)
 
-theme_light(base_size = 11, base_family = "")
+theme_light(base_size = 11, base_family = "", base_line_size,
+  base_rect_size)
 
-theme_dark(base_size = 11, base_family = "")
+theme_dark(base_size = 11, base_family = "", base_line_size, base_rect_size)
 
-theme_minimal(base_size = 11, base_family = "")
+theme_minimal(base_size = 11, base_family = "", base_line_size,
+  base_rect_size)
 
-theme_classic(base_size = 11, base_family = "")
+theme_classic(base_size = 11, base_family = "", base_line_size,
+  base_rect_size)
 
-theme_void(base_size = 11, base_family = "")
+theme_void(base_size = 11, base_family = "", base_line_size, base_rect_size)
 
-theme_test(base_size = 11, base_family = "")
+theme_test(base_size = 11, base_family = "", base_line_size, base_rect_size)
 }
 \arguments{
 \item{base_size}{base font size}
 
 \item{base_family}{base font family}
+
+\item{base_line_size}{base size for line elements}
+
+\item{base_rect_size}{base size for rect elements}
 }
 \description{
 These are complete themes which control all non-data display. Use

--- a/tests/figs/themes/theme-bw-large.svg
+++ b/tests/figs/themes/theme-bw-large.svg
@@ -1,0 +1,92 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 3.20; stroke: #FFFFFF; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz'>
+    <rect x='109.00' y='116.93' width='537.98' height='370.80' />
+  </clipPath>
+</defs>
+<rect x='109.00' y='116.93' width='537.98' height='370.80' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,428.74 646.98,428.74 ' style='stroke-width: 1.60; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,344.47 646.98,344.47 ' style='stroke-width: 1.60; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,260.20 646.98,260.20 ' style='stroke-width: 1.60; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,175.92 646.98,175.92 ' style='stroke-width: 1.60; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='194.59,487.74 194.59,116.93 ' style='stroke-width: 1.60; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='316.86,487.74 316.86,116.93 ' style='stroke-width: 1.60; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='439.13,487.74 439.13,116.93 ' style='stroke-width: 1.60; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='561.40,487.74 561.40,116.93 ' style='stroke-width: 1.60; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,470.88 646.98,470.88 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,386.61 646.98,386.61 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,302.33 646.98,302.33 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,218.06 646.98,218.06 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,133.79 646.98,133.79 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='133.46,487.74 133.46,116.93 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='255.72,487.74 255.72,116.93 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='377.99,487.74 377.99,116.93 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='500.26,487.74 500.26,116.93 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='622.53,487.74 622.53,116.93 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='133.46' cy='470.88' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='377.99' cy='302.33' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='622.53' cy='133.79' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<rect x='109.00' y='116.93' width='537.98' height='370.80' style='stroke-width: 3.20; stroke: #333333;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY='>
+    <rect x='109.00' y='66.16' width='537.98' height='50.77' />
+  </clipPath>
+</defs>
+<rect x='109.00' y='66.16' width='537.98' height='50.77' style='stroke-width: 3.20; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY=)' />
+<g clip-path='url(#cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY=)'><text x='370.76' y='100.49' style='font-size: 26.40px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<polyline points='133.46,495.95 133.46,487.74 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='255.72,495.95 255.72,487.74 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='377.99,495.95 377.99,487.74 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='500.26,495.95 500.26,487.74 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='622.53,495.95 622.53,487.74 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='115.38' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='237.65' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='359.92' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='482.19' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='604.46' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='479.83' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='395.55' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='311.28' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='227.01' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='142.73' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<polyline points='100.78,470.88 109.00,470.88 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,386.61 109.00,386.61 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,302.33 109.00,302.33 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,218.06 109.00,218.06 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,133.79 109.00,133.79 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='369.74' y='559.56' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(39.14,310.58) rotate(-90)' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>y</text></g>
+<rect x='658.32' y='265.26' width='45.24' height='74.14' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='663.99' y='293.63' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>z</text></g>
+<rect x='663.99' y='297.95' width='17.28' height='17.89' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='672.63' cy='306.90' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<rect x='663.99' y='315.84' width='17.28' height='17.89' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='672.63' cy='324.79' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='683.43' y='315.84' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>a</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='683.43' y='333.74' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>b</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='109.00' y='43.95' style='font-size: 39.60px; font-family: Liberation Sans;' textLength='295.74px' lengthAdjust='spacingAndGlyphs'>theme_bw_large</text></g>
+</svg>

--- a/tests/figs/themes/theme-classic-large.svg
+++ b/tests/figs/themes/theme-classic-large.svg
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 3.20; stroke: #FFFFFF; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz'>
+    <rect x='109.00' y='116.93' width='537.98' height='370.80' />
+  </clipPath>
+</defs>
+<rect x='109.00' y='116.93' width='537.98' height='370.80' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='133.46' cy='470.88' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='377.99' cy='302.33' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='622.53' cy='133.79' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY='>
+    <rect x='109.00' y='66.16' width='537.98' height='50.77' />
+  </clipPath>
+</defs>
+<rect x='109.00' y='66.16' width='537.98' height='50.77' style='stroke-width: 6.40; fill: #FFFFFF;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY=)' />
+<g clip-path='url(#cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY=)'><text x='370.76' y='100.49' style='font-size: 26.40px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<polyline points='109.00,487.74 646.98,487.74 ' style='stroke-width: 3.20; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='133.46,495.95 133.46,487.74 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='255.72,495.95 255.72,487.74 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='377.99,495.95 377.99,487.74 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='500.26,495.95 500.26,487.74 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='622.53,495.95 622.53,487.74 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='115.38' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='237.65' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='359.92' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='482.19' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='604.46' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<polyline points='109.00,487.74 109.00,116.93 ' style='stroke-width: 3.20; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='479.83' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='395.55' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='311.28' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='227.01' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='142.73' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<polyline points='100.78,470.88 109.00,470.88 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,386.61 109.00,386.61 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,302.33 109.00,302.33 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,218.06 109.00,218.06 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,133.79 109.00,133.79 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='369.74' y='559.56' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(39.14,310.58) rotate(-90)' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>y</text></g>
+<rect x='658.32' y='265.26' width='45.24' height='74.14' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='663.99' y='293.63' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>z</text></g>
+<circle cx='672.63' cy='306.90' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='672.63' cy='324.79' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='683.43' y='315.84' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>a</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='683.43' y='333.74' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>b</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='109.00' y='43.95' style='font-size: 39.60px; font-family: Liberation Sans;' textLength='364.63px' lengthAdjust='spacingAndGlyphs'>theme_classic_large</text></g>
+</svg>

--- a/tests/figs/themes/theme-dark-large.svg
+++ b/tests/figs/themes/theme-dark-large.svg
@@ -1,0 +1,91 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 3.20; stroke: #FFFFFF; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz'>
+    <rect x='109.00' y='116.93' width='537.98' height='370.80' />
+  </clipPath>
+</defs>
+<rect x='109.00' y='116.93' width='537.98' height='370.80' style='stroke-width: 3.20; stroke: none; fill: #7F7F7F;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,428.74 646.98,428.74 ' style='stroke-width: 0.80; stroke: #6B6B6B; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,344.47 646.98,344.47 ' style='stroke-width: 0.80; stroke: #6B6B6B; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,260.20 646.98,260.20 ' style='stroke-width: 0.80; stroke: #6B6B6B; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,175.92 646.98,175.92 ' style='stroke-width: 0.80; stroke: #6B6B6B; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='194.59,487.74 194.59,116.93 ' style='stroke-width: 0.80; stroke: #6B6B6B; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='316.86,487.74 316.86,116.93 ' style='stroke-width: 0.80; stroke: #6B6B6B; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='439.13,487.74 439.13,116.93 ' style='stroke-width: 0.80; stroke: #6B6B6B; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='561.40,487.74 561.40,116.93 ' style='stroke-width: 0.80; stroke: #6B6B6B; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,470.88 646.98,470.88 ' style='stroke-width: 1.60; stroke: #6B6B6B; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,386.61 646.98,386.61 ' style='stroke-width: 1.60; stroke: #6B6B6B; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,302.33 646.98,302.33 ' style='stroke-width: 1.60; stroke: #6B6B6B; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,218.06 646.98,218.06 ' style='stroke-width: 1.60; stroke: #6B6B6B; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,133.79 646.98,133.79 ' style='stroke-width: 1.60; stroke: #6B6B6B; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='133.46,487.74 133.46,116.93 ' style='stroke-width: 1.60; stroke: #6B6B6B; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='255.72,487.74 255.72,116.93 ' style='stroke-width: 1.60; stroke: #6B6B6B; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='377.99,487.74 377.99,116.93 ' style='stroke-width: 1.60; stroke: #6B6B6B; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='500.26,487.74 500.26,116.93 ' style='stroke-width: 1.60; stroke: #6B6B6B; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='622.53,487.74 622.53,116.93 ' style='stroke-width: 1.60; stroke: #6B6B6B; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='133.46' cy='470.88' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='377.99' cy='302.33' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='622.53' cy='133.79' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY='>
+    <rect x='109.00' y='66.16' width='537.98' height='50.77' />
+  </clipPath>
+</defs>
+<rect x='109.00' y='66.16' width='537.98' height='50.77' style='stroke-width: 3.20; stroke: none; fill: #262626;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY=)' />
+<g clip-path='url(#cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY=)'><text x='370.76' y='100.49' style='font-size: 26.40px; fill: #E5E5E5; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<polyline points='133.46,495.95 133.46,487.74 ' style='stroke-width: 1.60; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='255.72,495.95 255.72,487.74 ' style='stroke-width: 1.60; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='377.99,495.95 377.99,487.74 ' style='stroke-width: 1.60; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='500.26,495.95 500.26,487.74 ' style='stroke-width: 1.60; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='622.53,495.95 622.53,487.74 ' style='stroke-width: 1.60; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='115.38' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='237.65' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='359.92' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='482.19' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='604.46' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='479.83' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='395.55' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='311.28' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='227.01' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='142.73' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<polyline points='100.78,470.88 109.00,470.88 ' style='stroke-width: 1.60; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,386.61 109.00,386.61 ' style='stroke-width: 1.60; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,302.33 109.00,302.33 ' style='stroke-width: 1.60; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,218.06 109.00,218.06 ' style='stroke-width: 1.60; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,133.79 109.00,133.79 ' style='stroke-width: 1.60; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='369.74' y='559.56' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(39.14,310.58) rotate(-90)' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>y</text></g>
+<rect x='658.32' y='265.26' width='45.24' height='74.14' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='663.99' y='293.63' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>z</text></g>
+<rect x='663.99' y='297.95' width='17.28' height='17.89' style='stroke-width: 3.20; stroke: none; fill: #7F7F7F;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='672.63' cy='306.90' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<rect x='663.99' y='315.84' width='17.28' height='17.89' style='stroke-width: 3.20; stroke: none; fill: #7F7F7F;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='672.63' cy='324.79' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='683.43' y='315.84' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>a</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='683.43' y='333.74' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>b</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='109.00' y='43.95' style='font-size: 39.60px; font-family: Liberation Sans;' textLength='322.42px' lengthAdjust='spacingAndGlyphs'>theme_dark_large</text></g>
+</svg>

--- a/tests/figs/themes/theme-gray-large.svg
+++ b/tests/figs/themes/theme-gray-large.svg
@@ -1,0 +1,91 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 3.20; stroke: #FFFFFF; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz'>
+    <rect x='109.00' y='116.93' width='537.98' height='370.80' />
+  </clipPath>
+</defs>
+<rect x='109.00' y='116.93' width='537.98' height='370.80' style='stroke-width: 3.20; stroke: none; fill: #EBEBEB;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,428.74 646.98,428.74 ' style='stroke-width: 1.60; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,344.47 646.98,344.47 ' style='stroke-width: 1.60; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,260.20 646.98,260.20 ' style='stroke-width: 1.60; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,175.92 646.98,175.92 ' style='stroke-width: 1.60; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='194.59,487.74 194.59,116.93 ' style='stroke-width: 1.60; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='316.86,487.74 316.86,116.93 ' style='stroke-width: 1.60; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='439.13,487.74 439.13,116.93 ' style='stroke-width: 1.60; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='561.40,487.74 561.40,116.93 ' style='stroke-width: 1.60; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,470.88 646.98,470.88 ' style='stroke-width: 3.20; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,386.61 646.98,386.61 ' style='stroke-width: 3.20; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,302.33 646.98,302.33 ' style='stroke-width: 3.20; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,218.06 646.98,218.06 ' style='stroke-width: 3.20; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,133.79 646.98,133.79 ' style='stroke-width: 3.20; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='133.46,487.74 133.46,116.93 ' style='stroke-width: 3.20; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='255.72,487.74 255.72,116.93 ' style='stroke-width: 3.20; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='377.99,487.74 377.99,116.93 ' style='stroke-width: 3.20; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='500.26,487.74 500.26,116.93 ' style='stroke-width: 3.20; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='622.53,487.74 622.53,116.93 ' style='stroke-width: 3.20; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='133.46' cy='470.88' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='377.99' cy='302.33' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='622.53' cy='133.79' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY='>
+    <rect x='109.00' y='66.16' width='537.98' height='50.77' />
+  </clipPath>
+</defs>
+<rect x='109.00' y='66.16' width='537.98' height='50.77' style='stroke-width: 3.20; stroke: none; fill: #D9D9D9;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY=)' />
+<g clip-path='url(#cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY=)'><text x='370.76' y='100.49' style='font-size: 26.40px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<polyline points='133.46,495.95 133.46,487.74 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='255.72,495.95 255.72,487.74 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='377.99,495.95 377.99,487.74 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='500.26,495.95 500.26,487.74 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='622.53,495.95 622.53,487.74 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='115.38' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='237.65' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='359.92' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='482.19' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='604.46' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='479.83' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='395.55' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='311.28' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='227.01' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='142.73' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<polyline points='100.78,470.88 109.00,470.88 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,386.61 109.00,386.61 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,302.33 109.00,302.33 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,218.06 109.00,218.06 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,133.79 109.00,133.79 ' style='stroke-width: 3.20; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='369.74' y='559.56' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(39.14,310.58) rotate(-90)' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>y</text></g>
+<rect x='658.32' y='265.26' width='45.24' height='74.14' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='663.99' y='293.63' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>z</text></g>
+<rect x='663.99' y='297.95' width='17.28' height='17.89' style='stroke-width: 3.20; stroke: #FFFFFF; fill: #F2F2F2;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='672.63' cy='306.90' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<rect x='663.99' y='315.84' width='17.28' height='17.89' style='stroke-width: 3.20; stroke: #FFFFFF; fill: #F2F2F2;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='672.63' cy='324.79' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='683.43' y='315.84' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>a</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='683.43' y='333.74' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>b</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='109.00' y='43.95' style='font-size: 39.60px; font-family: Liberation Sans;' textLength='322.42px' lengthAdjust='spacingAndGlyphs'>theme_gray_large</text></g>
+</svg>

--- a/tests/figs/themes/theme-light-large.svg
+++ b/tests/figs/themes/theme-light-large.svg
@@ -1,0 +1,92 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 3.20; stroke: #FFFFFF; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz'>
+    <rect x='109.00' y='116.93' width='537.98' height='370.80' />
+  </clipPath>
+</defs>
+<rect x='109.00' y='116.93' width='537.98' height='370.80' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,428.74 646.98,428.74 ' style='stroke-width: 0.80; stroke: #DEDEDE; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,344.47 646.98,344.47 ' style='stroke-width: 0.80; stroke: #DEDEDE; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,260.20 646.98,260.20 ' style='stroke-width: 0.80; stroke: #DEDEDE; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,175.92 646.98,175.92 ' style='stroke-width: 0.80; stroke: #DEDEDE; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='194.59,487.74 194.59,116.93 ' style='stroke-width: 0.80; stroke: #DEDEDE; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='316.86,487.74 316.86,116.93 ' style='stroke-width: 0.80; stroke: #DEDEDE; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='439.13,487.74 439.13,116.93 ' style='stroke-width: 0.80; stroke: #DEDEDE; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='561.40,487.74 561.40,116.93 ' style='stroke-width: 0.80; stroke: #DEDEDE; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,470.88 646.98,470.88 ' style='stroke-width: 1.60; stroke: #DEDEDE; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,386.61 646.98,386.61 ' style='stroke-width: 1.60; stroke: #DEDEDE; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,302.33 646.98,302.33 ' style='stroke-width: 1.60; stroke: #DEDEDE; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,218.06 646.98,218.06 ' style='stroke-width: 1.60; stroke: #DEDEDE; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,133.79 646.98,133.79 ' style='stroke-width: 1.60; stroke: #DEDEDE; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='133.46,487.74 133.46,116.93 ' style='stroke-width: 1.60; stroke: #DEDEDE; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='255.72,487.74 255.72,116.93 ' style='stroke-width: 1.60; stroke: #DEDEDE; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='377.99,487.74 377.99,116.93 ' style='stroke-width: 1.60; stroke: #DEDEDE; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='500.26,487.74 500.26,116.93 ' style='stroke-width: 1.60; stroke: #DEDEDE; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='622.53,487.74 622.53,116.93 ' style='stroke-width: 1.60; stroke: #DEDEDE; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='133.46' cy='470.88' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='377.99' cy='302.33' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='622.53' cy='133.79' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<rect x='109.00' y='116.93' width='537.98' height='370.80' style='stroke-width: 3.20; stroke: #B3B3B3;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY='>
+    <rect x='109.00' y='66.16' width='537.98' height='50.77' />
+  </clipPath>
+</defs>
+<rect x='109.00' y='66.16' width='537.98' height='50.77' style='stroke-width: 3.20; stroke: none; fill: #B3B3B3;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY=)' />
+<g clip-path='url(#cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY=)'><text x='370.76' y='100.49' style='font-size: 26.40px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<polyline points='133.46,495.95 133.46,487.74 ' style='stroke-width: 1.60; stroke: #B3B3B3; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='255.72,495.95 255.72,487.74 ' style='stroke-width: 1.60; stroke: #B3B3B3; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='377.99,495.95 377.99,487.74 ' style='stroke-width: 1.60; stroke: #B3B3B3; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='500.26,495.95 500.26,487.74 ' style='stroke-width: 1.60; stroke: #B3B3B3; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='622.53,495.95 622.53,487.74 ' style='stroke-width: 1.60; stroke: #B3B3B3; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='115.38' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='237.65' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='359.92' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='482.19' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='604.46' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='479.83' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='395.55' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='311.28' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='227.01' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='142.73' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<polyline points='100.78,470.88 109.00,470.88 ' style='stroke-width: 1.60; stroke: #B3B3B3; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,386.61 109.00,386.61 ' style='stroke-width: 1.60; stroke: #B3B3B3; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,302.33 109.00,302.33 ' style='stroke-width: 1.60; stroke: #B3B3B3; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,218.06 109.00,218.06 ' style='stroke-width: 1.60; stroke: #B3B3B3; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,133.79 109.00,133.79 ' style='stroke-width: 1.60; stroke: #B3B3B3; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='369.74' y='559.56' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(39.14,310.58) rotate(-90)' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>y</text></g>
+<rect x='658.32' y='265.26' width='45.24' height='74.14' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='663.99' y='293.63' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>z</text></g>
+<rect x='663.99' y='297.95' width='17.28' height='17.89' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='672.63' cy='306.90' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<rect x='663.99' y='315.84' width='17.28' height='17.89' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='672.63' cy='324.79' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='683.43' y='315.84' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>a</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='683.43' y='333.74' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>b</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='109.00' y='43.95' style='font-size: 39.60px; font-family: Liberation Sans;' textLength='317.99px' lengthAdjust='spacingAndGlyphs'>theme_light_large</text></g>
+</svg>

--- a/tests/figs/themes/theme-linedraw-large.svg
+++ b/tests/figs/themes/theme-linedraw-large.svg
@@ -1,0 +1,92 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 3.20; stroke: #FFFFFF; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz'>
+    <rect x='109.00' y='116.93' width='537.98' height='370.80' />
+  </clipPath>
+</defs>
+<rect x='109.00' y='116.93' width='537.98' height='370.80' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,428.74 646.98,428.74 ' style='stroke-width: 0.16; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,344.47 646.98,344.47 ' style='stroke-width: 0.16; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,260.20 646.98,260.20 ' style='stroke-width: 0.16; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,175.92 646.98,175.92 ' style='stroke-width: 0.16; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='194.59,487.74 194.59,116.93 ' style='stroke-width: 0.16; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='316.86,487.74 316.86,116.93 ' style='stroke-width: 0.16; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='439.13,487.74 439.13,116.93 ' style='stroke-width: 0.16; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='561.40,487.74 561.40,116.93 ' style='stroke-width: 0.16; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,470.88 646.98,470.88 ' style='stroke-width: 0.32; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,386.61 646.98,386.61 ' style='stroke-width: 0.32; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,302.33 646.98,302.33 ' style='stroke-width: 0.32; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,218.06 646.98,218.06 ' style='stroke-width: 0.32; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,133.79 646.98,133.79 ' style='stroke-width: 0.32; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='133.46,487.74 133.46,116.93 ' style='stroke-width: 0.32; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='255.72,487.74 255.72,116.93 ' style='stroke-width: 0.32; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='377.99,487.74 377.99,116.93 ' style='stroke-width: 0.32; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='500.26,487.74 500.26,116.93 ' style='stroke-width: 0.32; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='622.53,487.74 622.53,116.93 ' style='stroke-width: 0.32; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='133.46' cy='470.88' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='377.99' cy='302.33' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='622.53' cy='133.79' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<rect x='109.00' y='116.93' width='537.98' height='370.80' style='stroke-width: 3.20;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY='>
+    <rect x='109.00' y='66.16' width='537.98' height='50.77' />
+  </clipPath>
+</defs>
+<rect x='109.00' y='66.16' width='537.98' height='50.77' style='stroke-width: 3.20; fill: #000000;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY=)' />
+<g clip-path='url(#cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY=)'><text x='370.76' y='100.49' style='font-size: 26.40px; fill: #FFFFFF; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<polyline points='133.46,495.95 133.46,487.74 ' style='stroke-width: 1.60; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='255.72,495.95 255.72,487.74 ' style='stroke-width: 1.60; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='377.99,495.95 377.99,487.74 ' style='stroke-width: 1.60; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='500.26,495.95 500.26,487.74 ' style='stroke-width: 1.60; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='622.53,495.95 622.53,487.74 ' style='stroke-width: 1.60; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='115.38' y='520.42' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='237.65' y='520.42' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='359.92' y='520.42' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='482.19' y='520.42' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='604.46' y='520.42' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='479.83' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='395.55' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='311.28' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='227.01' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='142.73' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<polyline points='100.78,470.88 109.00,470.88 ' style='stroke-width: 1.60; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,386.61 109.00,386.61 ' style='stroke-width: 1.60; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,302.33 109.00,302.33 ' style='stroke-width: 1.60; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,218.06 109.00,218.06 ' style='stroke-width: 1.60; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='100.78,133.79 109.00,133.79 ' style='stroke-width: 1.60; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='369.74' y='559.56' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(39.14,310.58) rotate(-90)' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>y</text></g>
+<rect x='658.32' y='265.26' width='45.24' height='74.14' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='663.99' y='293.63' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>z</text></g>
+<rect x='663.99' y='297.95' width='17.28' height='17.89' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='672.63' cy='306.90' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<rect x='663.99' y='315.84' width='17.28' height='17.89' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='672.63' cy='324.79' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='683.43' y='315.84' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>a</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='683.43' y='333.74' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>b</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='109.00' y='43.95' style='font-size: 39.60px; font-family: Liberation Sans;' textLength='393.57px' lengthAdjust='spacingAndGlyphs'>theme_linedraw_large</text></g>
+</svg>

--- a/tests/figs/themes/theme-minimal-large.svg
+++ b/tests/figs/themes/theme-minimal-large.svg
@@ -1,0 +1,75 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz'>
+    <rect x='109.00' y='116.93' width='537.98' height='370.80' />
+  </clipPath>
+</defs>
+<polyline points='109.00,428.74 646.98,428.74 ' style='stroke-width: 1.60; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,344.47 646.98,344.47 ' style='stroke-width: 1.60; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,260.20 646.98,260.20 ' style='stroke-width: 1.60; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,175.92 646.98,175.92 ' style='stroke-width: 1.60; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='194.59,487.74 194.59,116.93 ' style='stroke-width: 1.60; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='316.86,487.74 316.86,116.93 ' style='stroke-width: 1.60; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='439.13,487.74 439.13,116.93 ' style='stroke-width: 1.60; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='561.40,487.74 561.40,116.93 ' style='stroke-width: 1.60; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,470.88 646.98,470.88 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,386.61 646.98,386.61 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,302.33 646.98,302.33 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,218.06 646.98,218.06 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='109.00,133.79 646.98,133.79 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='133.46,487.74 133.46,116.93 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='255.72,487.74 255.72,116.93 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='377.99,487.74 377.99,116.93 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='500.26,487.74 500.26,116.93 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<polyline points='622.53,487.74 622.53,116.93 ' style='stroke-width: 3.20; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='133.46' cy='470.88' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='377.99' cy='302.33' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<circle cx='622.53' cy='133.79' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMTA5LjAwfDY0Ni45OHw0ODcuNzR8MTE2Ljkz)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY='>
+    <rect x='109.00' y='66.16' width='537.98' height='50.77' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTA5LjAwfDY0Ni45OHwxMTYuOTN8NjYuMTY=)'><text x='370.76' y='100.49' style='font-size: 26.40px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='115.38' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='237.65' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='359.92' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='482.19' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='604.46' y='520.42' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='479.83' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='395.55' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>1.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='311.28' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='227.01' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.06' y='142.73' style='font-size: 26.40px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='36.14px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='369.74' y='559.56' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(39.14,310.58) rotate(-90)' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>y</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='663.99' y='293.63' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>z</text></g>
+<circle cx='672.63' cy='306.90' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='672.63' cy='324.79' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='683.43' y='315.84' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>a</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='683.43' y='333.74' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>b</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='109.00' y='43.95' style='font-size: 39.60px; font-family: Liberation Sans;' textLength='382.40px' lengthAdjust='spacingAndGlyphs'>theme_minimal_large</text></g>
+</svg>

--- a/tests/figs/themes/theme-void-large.svg
+++ b/tests/figs/themes/theme-void-large.svg
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMi43NHw2NjMuNDJ8NTczLjI2fDY1LjQy'>
+    <rect x='2.74' y='65.42' width='660.68' height='507.84' />
+  </clipPath>
+</defs>
+<circle cx='32.77' cy='550.18' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMi43NHw2NjMuNDJ8NTczLjI2fDY1LjQy)' />
+<circle cx='333.08' cy='319.34' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMi43NHw2NjMuNDJ8NTczLjI2fDY1LjQy)' />
+<circle cx='633.39' cy='88.51' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMi43NHw2NjMuNDJ8NTczLjI2fDY1LjQy)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMi43NHw2NjMuNDJ8NjUuNDJ8MzYuNTg='>
+    <rect x='2.74' y='36.58' width='660.68' height='28.85' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMi43NHw2NjMuNDJ8NjUuNDJ8MzYuNTg=)'><text x='325.85' y='59.95' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='680.43' y='310.64' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>z</text></g>
+<circle cx='689.07' cy='323.91' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='689.07' cy='341.80' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='699.87' y='332.85' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>a</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='699.87' y='350.74' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>b</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='2.74' y='27.52' style='font-size: 39.60px; font-family: Liberation Sans;' textLength='317.99px' lengthAdjust='spacingAndGlyphs'>theme_void_large</text></g>
+</svg>

--- a/tests/testthat/test-theme.r
+++ b/tests/testthat/test-theme.r
@@ -253,3 +253,18 @@ test_that("themes don't change without acknowledgement", {
   vdiffr::expect_doppelganger("theme_linedraw", plot + theme_linedraw())
 })
 
+test_that("themes look decent at larger base sizes", {
+  df <- data.frame(x = 1:3, y = 1:3, z = c("a", "b", "a"), a = 1)
+  plot <- ggplot(df, aes(x, y, colour = z)) +
+    geom_point() +
+    facet_wrap(~ a)
+
+  vdiffr::expect_doppelganger("theme_bw_large", plot + theme_bw(base_size = 33))
+  vdiffr::expect_doppelganger("theme_classic_large", plot + theme_classic(base_size = 33))
+  vdiffr::expect_doppelganger("theme_dark_large", plot + theme_dark(base_size = 33))
+  vdiffr::expect_doppelganger("theme_minimal_large", plot + theme_minimal(base_size = 33))
+  vdiffr::expect_doppelganger("theme_gray_large", plot + theme_gray(base_size = 33))
+  vdiffr::expect_doppelganger("theme_light_large", plot + theme_light(base_size = 33))
+  vdiffr::expect_doppelganger("theme_void_large", plot + theme_void(base_size = 33))
+  vdiffr::expect_doppelganger("theme_linedraw_large", plot + theme_linedraw(base_size = 33))
+})


### PR DESCRIPTION
Closes #2176. These optional parameters control the default sizes of line and rectangle elements and are set to `base_size / 22` by default. As requested [here](https://github.com/tidyverse/ggplot2/pull/2174#issuecomment-309593094) I've added new tests at `base_size = 33`.