### PR TITLE
Add warning for coord_trans() when resulting x/y value becomes non-finite (#2147)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 2.2.1.9000
 
+* `coord_trans()` now generates a warning when a transformation results in x or y 
+  values being non-finite (@foo-bar-baz-qux, #2147).
+  
 * Legend titles and labels get a little extra space around them. Legend titles
   will no longer overlap the legend at large font sizes (@karawoo, #1881).
 

--- a/R/coord-transform.r
+++ b/R/coord-transform.r
@@ -179,11 +179,12 @@ train_trans <- function(scale, limits, trans, name) {
   out
 }
 
-# Generate warning when finite values are transformed into infinite values
-#
-# @param old_values A vector of pre-transformation values.
-# @param new_values A vector of post-transformation values.
-# @param axis Which axis the values originate from (e.g. x, y).
+#' Generate warning when finite values are transformed into infinite values
+#'
+#' @param old_values A vector of pre-transformation values.
+#' @param new_values A vector of post-transformation values.
+#' @param axis Which axis the values originate from (e.g. x, y).
+#' @noRd
 warn_new_infinites <- function(old_values, new_values, axis) {
   if (any(is.finite(old_values) & !is.finite(new_values))) {
     warning("Transformation introduced infinite values in ", axis, "-axis", call. = FALSE)

--- a/R/coord-transform.r
+++ b/R/coord-transform.r
@@ -119,8 +119,12 @@ CoordTrans <- ggproto("CoordTrans", Coord,
     trans_x <- function(data) transform_value(self$trans$x, data, panel_params$x.range)
     trans_y <- function(data) transform_value(self$trans$y, data, panel_params$y.range)
 
-    data <- transform_position(data, trans_x, trans_y)
-    transform_position(data, squish_infinite, squish_infinite)
+    new_data <- transform_position(data, trans_x, trans_y)
+
+    warn_new_infinites(data$x, new_data$x, "x")
+    warn_new_infinites(data$y, new_data$y, "y")
+
+    transform_position(new_data, squish_infinite, squish_infinite)
   },
 
   setup_panel_params = function(self, scale_x, scale_y, params = list()) {
@@ -173,4 +177,15 @@ train_trans <- function(scale, limits, trans, name) {
   )
   names(out) <- paste(name, names(out), sep = ".")
   out
+}
+
+# Generate warning when finite values are transformed into infinite values
+#
+# @param old_values A vector of pre-transformation values.
+# @param new_values A vector of post-transformation values.
+# @param axis Which axis the values originate from (e.g. x, y).
+warn_new_infinites <- function(old_values, new_values, axis) {
+  if (any(is.finite(old_values) & !is.finite(new_values))) {
+    warning("Transformation introduced infinite values in ", axis, "-axis", call. = FALSE)
+  }
 }

--- a/tests/testthat/test-coord-transform.R
+++ b/tests/testthat/test-coord-transform.R
@@ -1,0 +1,22 @@
+context("coord_trans")
+
+test_that("warnings are generated when cord_trans() results in new infinite values", {
+  p  <- ggplot(head(diamonds, 20)) +
+    geom_bar(aes(x = cut)) +
+    coord_trans(y = "log10")
+
+  p2 <- ggplot(data.frame(a = c(1, 2, 0), b = c(10, 6, 4)), aes(a, b)) +
+    geom_point() +
+    coord_trans(x = "log")
+
+  expect_warning(ggplot_gtable(ggplot_build(p)), "Transformation introduced infinite values in y-axis")
+  expect_warning(ggplot_gtable(ggplot_build(p2)), "Transformation introduced infinite values in x-axis")
+})
+
+test_that("no warnings are generated when original data has Inf values, but no new Inf values created from the transformation", {
+  p <- ggplot(data.frame(x = c(-Inf, 2, 0), y = c(Inf, 6, 4)), aes(x, y)) +
+    geom_point() +
+    coord_trans(x = 'identity')
+
+  expect_silent(benchplot(p))
+})


### PR DESCRIPTION
`coord_trans()` now generates a warning when a transformation results in x or y values being non-finite (#2147).

I've used `#` comments for the internal helper function so it doesn't generate MD documentation files, but not sure what the ggplot2 style is for those functions.

The logic and the message is based on the [transform in the Scale object](https://github.com/tidyverse/ggplot2/blob/4255cd8341ad1072036186e5d34ad2c1b12221b3/R/scale-.r#L207) in order to be consistent.