### PR TITLE
Make `debug = TRUE` work when `expand_x` and `expand_y` are FALSE

### DIFF
--- a/R/margins.R
+++ b/R/margins.R
@@ -61,7 +61,9 @@ titleGrob <- function(label, x, y, hjust, vjust, angle = 0, gp = gpar(),
   text_height <- unit(1, "grobheight", text_grob) + cos(angle / 180 * pi) * descent
   text_width <- unit(1, "grobwidth", text_grob) + sin(angle / 180 * pi) * descent
 
-  if (debug) {
+  if (is.null(debug)) {
+    children <- gList(text_grob)
+  } else if (debug) {
     children <- gList(
       rectGrob(gp = gpar(fill = "cornsilk", col = NA)),
       pointsGrob(x, y, pch = 20, gp = gpar(col = "gold")),

--- a/R/margins.R
+++ b/R/margins.R
@@ -61,6 +61,16 @@ titleGrob <- function(label, x, y, hjust, vjust, angle = 0, gp = gpar(),
   text_height <- unit(1, "grobheight", text_grob) + cos(angle / 180 * pi) * descent
   text_width <- unit(1, "grobwidth", text_grob) + sin(angle / 180 * pi) * descent
 
+  if (debug) {
+    children <- gList(
+      rectGrob(gp = gpar(fill = "cornsilk", col = NA)),
+      pointsGrob(x, y, pch = 20, gp = gpar(col = "gold")),
+      text_grob
+    )
+  } else {
+    children <- gList(text_grob)
+  }
+ 
   if (expand_x && expand_y) {
     widths <- unit.c(margin[4], text_width, margin[2])
     heights <- unit.c(margin[1], text_height, margin[3])
@@ -81,17 +91,16 @@ titleGrob <- function(label, x, y, hjust, vjust, angle = 0, gp = gpar(),
 
     widths <- unit(1, "null")
   } else {
-    return(text_grob)
-  }
-
-  if (debug) {
-    children <- gList(
-      rectGrob(gp = gpar(fill = "cornsilk", col = NA)),
-      pointsGrob(x, y, pch = 20, gp = gpar(col = "gold")),
-      text_grob
-    )
-  } else {
-    children <- gList(text_grob)
+    widths <- unit(1, "grobwidth", text_grob)
+    heights <- unit(1, "grobheight", text_grob)
+    return(
+      gTree(
+        children = children,
+        widths = widths,
+        heights = heights,
+        cl = "titleGrob"
+      )
+    )        
   }
 
   gTree(

--- a/R/margins.R
+++ b/R/margins.R
@@ -61,9 +61,7 @@ titleGrob <- function(label, x, y, hjust, vjust, angle = 0, gp = gpar(),
   text_height <- unit(1, "grobheight", text_grob) + cos(angle / 180 * pi) * descent
   text_width <- unit(1, "grobwidth", text_grob) + sin(angle / 180 * pi) * descent
 
-  if (is.null(debug)) {
-    children <- gList(text_grob)
-  } else if (debug) {
+  if (isTRUE(debug)) {
     children <- gList(
       rectGrob(gp = gpar(fill = "cornsilk", col = NA)),
       pointsGrob(x, y, pch = 20, gp = gpar(col = "gold")),


### PR DESCRIPTION
Currently `titleGrob()`'s `debug = TRUE` argument has no effect when `expand_x` and `expand_y` are both `FALSE` because the function returns output before the debugging conditional is reached. This fixes the issue by moving the debugging conditional up and ensuring that all of the `children` are returned.

Previous behavior:

```r

df <- data.frame(x = 1:10, y = 1:10, color = LETTERS[1:2])

p <- ggplot(df, aes(x, y, color = color)) +
  geom_point() +
  theme(
    legend.title = element_text(debug = TRUE),
    legend.text = element_text(debug = TRUE)
  )

p # note no debugging output
```

![debug_pre](https://user-images.githubusercontent.com/4452678/28345731-e8b41450-6be0-11e7-84a9-ab47e065ac9f.png)

After this PR:

```r
p
```

![debug-post](https://user-images.githubusercontent.com/4452678/28345735-f082fbc4-6be0-11e7-9faa-5c479a0b6ab7.png)

We could also address #1881 here by using `text_height` and `text_width` instead of `unit(1, "grobheight", text_grob)` and `unit(1, "grobwidth", text_grob)` for the widths and heights. This puts more spacing between the legend title and the legend elements, so the visual tests break.