### PR TITLE
Add string options for `ggsave()` (#2156)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 2.2.1.9000
 
+* The `ggsave()` DPI parameter now supports 3 string options: "retina" (320
+  DPI), "print" (300 DPI), and "screen" (72 DPI) (@foo-bar-baz-qux, #2156).
+
 * `position_dodge2()` now has a `reverse` parameter that allows you to reverse
   the placement order of bars and boxes (@karawoo, #2171).
 

--- a/R/save.r
+++ b/R/save.r
@@ -68,15 +68,18 @@ ggsave <- function(filename, plot = last_plot(),
 #' @return Parsed DPI input value
 #' @noRd
 parse_dpi <- function(dpi) {
-  if (is.character(dpi)) {
-    dpi <- switch(dpi, screen = 72, print = 300, retina = 320, NULL)
-
-    if (is.null(dpi)) {
-      stop("Invalid string DPI value", call. = FALSE)
-    }
+  if (is.character(dpi) && length(dpi) == 1) {
+    switch(dpi,
+      screen = 72,
+      print = 300,
+      retina = 320,
+      stop("Unknown DPI string", call. = FALSE)
+    )
+  } else if (is.numeric(dpi) && length(dpi) == 1) {
+    dpi
+  } else {
+    stop("DPI must be a single number or string", call. = FALSE)
   }
-
-  dpi
 }
 
 plot_dim <- function(dim = c(NA, NA), scale = 1, units = c("in", "cm", "mm"),

--- a/R/save.r
+++ b/R/save.r
@@ -14,7 +14,8 @@
 #' @param scale Multiplicative scaling factor.
 #' @param width,height,units Plot size in `units` ("in", "cm", or "mm").
 #'   If not supplied, uses the size of current graphics device.
-#' @param dpi Plot resolution. Applies only to raster output types.
+#' @param dpi Plot resolution. Also accepts a string input: "retina" (320),
+#'   "print" (300), or "screen" (72). Applies only to raster output types.
 #' @param limitsize When `TRUE` (the default), `ggsave` will not
 #'   save images larger than 50x50 inches, to prevent the common error of
 #'   specifying dimensions in pixels.
@@ -44,6 +45,7 @@ ggsave <- function(filename, plot = last_plot(),
                    width = NA, height = NA, units = c("in", "cm", "mm"),
                    dpi = 300, limitsize = TRUE, ...) {
 
+  dpi <- parse_dpi(dpi)
   dev <- plot_dev(device, filename, dpi = dpi)
   dim <- plot_dim(c(width, height), scale = scale, units = units,
     limitsize = limitsize)
@@ -56,6 +58,25 @@ ggsave <- function(filename, plot = last_plot(),
   grid.draw(plot)
 
   invisible()
+}
+
+#' Parse a DPI input from the user
+#'
+#' Allows handling of special strings when user specifies a DPI like "print".
+#'
+#' @param dpi Input value from user
+#' @return Parsed DPI input value
+#' @noRd
+parse_dpi <- function(dpi) {
+  if (is.character(dpi)) {
+    dpi <- switch(dpi, screen = 72, print = 300, retina = 320, NULL)
+
+    if (is.null(dpi)) {
+      stop("Invalid string DPI value", call. = FALSE)
+    }
+  }
+
+  dpi
 }
 
 plot_dim <- function(dim = c(NA, NA), scale = 1, units = c("in", "cm", "mm"),

--- a/man/ggsave.Rd
+++ b/man/ggsave.Rd
@@ -24,7 +24,8 @@ ggsave(filename, plot = last_plot(), device = NULL, path = NULL,
 \item{width, height, units}{Plot size in \code{units} ("in", "cm", or "mm").
 If not supplied, uses the size of current graphics device.}
 
-\item{dpi}{Plot resolution. Applies only to raster output types.}
+\item{dpi}{Plot resolution. Also accepts a string input: "retina" (320),
+"print" (300), or "screen" (72). Applies only to raster output types.}
 
 \item{limitsize}{When \code{TRUE} (the default), \code{ggsave} will not
 save images larger than 50x50 inches, to prevent the common error of

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -62,12 +62,20 @@ test_that("if device is NULL, guess from extension", {
 # parse_dpi ---------------------------------------------------------------
 
 test_that("DPI string values are parsed correctly", {
-  expect_is(parse_dpi("print"), "numeric")
-  expect_is(parse_dpi("screen"), "numeric")
-  expect_is(parse_dpi("retina"), "numeric")
-  expect_is(parse_dpi(100), "numeric")
+  expect_type(parse_dpi("print"), "double")
+  expect_type(parse_dpi("screen"), "double")
+  expect_type(parse_dpi("retina"), "double")
+  expect_type(parse_dpi(100), "double")
+  expect_type(parse_dpi(300L), "integer")
 })
 
-test_that("invalid DPI string values throw an error", {
-  expect_error(parse_dpi("abc"), "Invalid string DPI value")
+test_that("invalid single-string DPI values throw an error", {
+  expect_error(parse_dpi("abc"), "Unknown DPI string")
+})
+
+test_that("invalid non-single-string DPI values throw an error", {
+  expect_error(parse_dpi(factor(100)), "DPI must be a single number or string")
+  expect_error(parse_dpi(c("print", "screen")), "DPI must be a single number or string")
+  expect_error(parse_dpi(c(150, 300)), "DPI must be a single number or string")
+  expect_error(parse_dpi(list(150)), "DPI must be a single number or string")
 })

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -57,3 +57,17 @@ test_that("text converted to function", {
 test_that("if device is NULL, guess from extension", {
   expect_identical(body(plot_dev(NULL, "test.png"))[[1]], quote(grDevices::png))
 })
+
+
+# parse_dpi ---------------------------------------------------------------
+
+test_that("DPI string values are parsed correctly", {
+  expect_is(parse_dpi("print"), "numeric")
+  expect_is(parse_dpi("screen"), "numeric")
+  expect_is(parse_dpi("retina"), "numeric")
+  expect_is(parse_dpi(100), "numeric")
+})
+
+test_that("invalid DPI string values throw an error", {
+  expect_error(parse_dpi("abc"), "Invalid string DPI value")
+})


### PR DESCRIPTION
Add feature request #2156. 

3 new string options for `ggsave()`: "screen" (72 DPI), "print" (300 DPI), and "retina" (320 DPI).

One question was what DPI the "retina" option should be. As mentioned in the issue, it's not so straightforward to pick a single DPI number. The standard for retina is to double the DPI, but from what baseline DPI?

There is no such thing as a baseline DPI for Apple because they define their `@1x` baseline, non-retina template using pixel dimensions (which all designs should be based on and then scaled for output). Retina output is `@2x` and sometimes `@3x` for the newer phones. For their phones, [this roughly corresponds to ~160 DPI](http://sebastien-gabriel.com/designers-guide-to-dpi/#ios), and ~130 DPI for their tablets. For Android, the baseline MDPI (equivalent to `@1x` for Apple) is similarly around a DPI of 160, and their [baseline calculations for density independence assume 160 DPI](https://developer.android.com/guide/practices/screens_support.html).

Accordingly, I think it's best to go with 2x this baseline of ~160 DPI, making the retina option 320 DPI.