### PR TITLE
Add `reverse` argument to `position_dodge2()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 2.2.1.9000
 
+* `position_dodge2()` now has a `reverse` parameter that allows you to reverse
+  the placement order of bars and boxes (@karawoo, #2171).
+
 * Box plot position is now controlled by `position_dodge2()`, which can also be
   used for bars and rectangles. `position_dodge2()` compares the `xmin` and
   `xmax` values of each element to determine which ones overlap, and dodges them

--- a/R/position-dodge2.r
+++ b/R/position-dodge2.r
@@ -2,12 +2,15 @@
 #' @rdname position_dodge
 #' @param padding Padding between elements at the same position. Elements are
 #'   shrunk by this proportion to allow space between them. Defaults to 0.1.
+#' @param reverse If `TRUE`, will reverse the default stacking order.
+#'   This is useful if you're rotating both the plot and legend.
 position_dodge2 <- function(width = NULL, preserve = c("single", "total"),
-                              padding = 0.1) {
+                            padding = 0.1, reverse = FALSE) {
   ggproto(NULL, PositionDodge2,
     width = width,
     preserve = match.arg(preserve),
-    padding = padding
+    padding = padding,
+    reverse = reverse
   )  
 }
 
@@ -18,6 +21,8 @@ position_dodge2 <- function(width = NULL, preserve = c("single", "total"),
 PositionDodge2 <- ggproto("PositionDodge2", PositionDodge,
   preserve = "single",
   padding = 0.1,
+  reverse = FALSE,
+  
   setup_params = function(self, data) {
     if (is.null(data$xmin) && is.null(data$xmax) && is.null(self$width)) {
       warning("Width not defined. Set with `position_dodge2(width = ?)`",
@@ -35,7 +40,8 @@ PositionDodge2 <- ggproto("PositionDodge2", PositionDodge,
     list(
       width = self$width,
       n = n,
-      padding = self$padding
+      padding = self$padding,
+      reverse = self$reverse
     )
   },
                           
@@ -47,7 +53,8 @@ PositionDodge2 <- ggproto("PositionDodge2", PositionDodge,
       strategy = pos_dodge2,
       n = params$n,
       padding = params$padding,
-      check.width = FALSE
+      check.width = FALSE,
+      reverse = params$reverse
     )
   }
 )

--- a/man/position_dodge.Rd
+++ b/man/position_dodge.Rd
@@ -8,7 +8,7 @@
 position_dodge(width = NULL, preserve = c("total", "single"))
 
 position_dodge2(width = NULL, preserve = c("single", "total"),
-  padding = 0.1)
+  padding = 0.1, reverse = FALSE)
 }
 \arguments{
 \item{width}{Dodging width, when different to the width of the individual
@@ -20,6 +20,9 @@ at a position, or the width of a single element?}
 
 \item{padding}{Padding between elements at the same position. Elements are
 shrunk by this proportion to allow space between them. Defaults to 0.1.}
+
+\item{reverse}{If \code{TRUE}, will reverse the default stacking order.
+This is useful if you're rotating both the plot and legend.}
 }
 \description{
 Dodging preserves the vertical position of an geom while adjusting the


### PR DESCRIPTION
Fixes #2171 

``` r
# Regular:
ggplot(mtcars, aes(factor(cyl), fill = factor(vs))) +
  geom_bar(position = "dodge2") 
```

![](http://i.imgur.com/FlVuSIq.png)

``` r
# Reversed:
ggplot(mtcars, aes(factor(cyl), fill = factor(vs))) +
  geom_bar(position = position_dodge2(reverse = TRUE)) 
```

![](http://i.imgur.com/UaMgDVh.png)