### PR TITLE
Further refactor titleGrob

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 2.2.1.9000
 
+* Rotated strip labels now correctly understand `hjust` and `vjust` parameters
+  at all angles (@karawoo).
+
 * Strip labels now understand justification relative to the direction of the
   text, meaning that in y facets the strip text can be placed at either end of
   the strip using `hjust` (@karawoo).

--- a/R/labeller.r
+++ b/R/labeller.r
@@ -473,7 +473,16 @@ labeller <- function(..., .rows = NULL, .cols = NULL,
   }
 }
 
-
+#' Build facet strips
+#'
+#' Builds a set of facet strips from a data frame of labels.
+#'
+#' @param label_df Data frame of labels to place in strips.
+#' @param labeller Labelling function.
+#' @param theme A theme object.
+#' @param horizontal Whether the strips are horizontal (e.g. x facets) or not.
+#'
+#' @noRd
 build_strip <- function(label_df, labeller, theme, horizontal) {
   labeller <- match.fun(labeller)
 
@@ -559,8 +568,20 @@ build_strip <- function(label_df, labeller, theme, horizontal) {
   }
 }
 
-# Grob for strip labels - takes the output from title_spec, adds margins,
-# creates gList with strip background and label, and returns gtable matrix
+#' Grob for strip labels
+#'
+#' Takes the output from title_spec, adds margins, creates gList with strip
+#' background and label, and returns gtable matrix.
+#'
+#' @param grobs Output from [title_spec()].
+#' @param theme Theme object.
+#' @param element Theme element (see [calc_element()]).
+#' @param gp Additional graphical parameters.
+#' @param horizontal Whether the strips are horizontal (e.g. x facets) or not.
+#' @param clip should drawing be clipped to the specified cells (‘"on"’),the
+#'   entire table (‘"inherit"’), or not at all (‘"off"’).
+#'
+#' @noRd
 ggstrip <- function(grobs, theme, element, gp, horizontal = TRUE, clip) {
 
   if (horizontal) {

--- a/R/labeller.r
+++ b/R/labeller.r
@@ -597,13 +597,11 @@ ggstrip <- function(grobs, theme, element, gp, horizontal = TRUE, clip) {
     function(label) {
       ggname(
         "strip",
-        absoluteGrob(
-          gList(
+        gTree(
+          children = gList(
             element_render(theme, "strip.background"),
             label[[1]]
-          ),
-          width = grobWidth(label[[1]]),
-          height = grobHeight(label[[1]])
+          )
         )
       )
     })

--- a/R/labeller.r
+++ b/R/labeller.r
@@ -577,9 +577,9 @@ ggstrip <- function(grobs, theme, element, gp, horizontal = TRUE, clip) {
     c(1, 2),
     function(x) {
       add_margins(
-        text_grob = x[[1]]$text_grob,
-        text_height = if (horizontal) heights else x[[1]]$text_height,
-        text_width = if (!horizontal) widths else x[[1]]$text_width,
+        grob = x[[1]]$text_grob,
+        height = if (horizontal) heights else x[[1]]$text_height,
+        width = if (!horizontal) widths else x[[1]]$text_width,
         gp = gp,
         margin = element$margin,
         expand_x = horizontal,

--- a/R/labeller.r
+++ b/R/labeller.r
@@ -585,11 +585,11 @@ build_strip <- function(label_df, labeller, theme, horizontal) {
 ggstrip <- function(grobs, theme, element, gp, horizontal = TRUE, clip) {
 
   if (horizontal) {
-    heights <- max_height(lapply(grobs, function(x) x$text_height))
-    widths <- unit(1, "null")
+    height <- max_height(lapply(grobs, function(x) x$text_height))
+    width <- unit(1, "null")
   } else {
-    heights <- unit(1, "null")
-    widths <- max_width(lapply(grobs, function(x) x$text_width))
+    height <- unit(1, "null")
+    width <- max_width(lapply(grobs, function(x) x$text_width))
   }
 
   # Add margins around text grob
@@ -599,8 +599,8 @@ ggstrip <- function(grobs, theme, element, gp, horizontal = TRUE, clip) {
     function(x) {
       add_margins(
         grob = x[[1]]$text_grob,
-        height = heights,
-        width = widths,
+        height = height,
+        width = width,
         gp = gp,
         margin = element$margin,
         margin_x = TRUE,
@@ -626,9 +626,9 @@ ggstrip <- function(grobs, theme, element, gp, horizontal = TRUE, clip) {
     })
 
   if (horizontal) {
-    heights <- heights + sum(element$margin[c(1, 3)])
+    height <- height + sum(element$margin[c(1, 3)])
   } else {
-    widths <- widths + sum(element$margin[c(2, 4)])
+    width <- width + sum(element$margin[c(2, 4)])
   }
 
  
@@ -645,8 +645,8 @@ ggstrip <- function(grobs, theme, element, gp, horizontal = TRUE, clip) {
       gtable_matrix(
         "strip",
         mat,
-        rep(widths, ncol(mat)),
-        rep(heights, nrow(mat)),
+        rep(width, ncol(mat)),
+        rep(height, nrow(mat)),
         clip = clip
       )
     })

--- a/R/labeller.r
+++ b/R/labeller.r
@@ -578,12 +578,10 @@ ggstrip <- function(grobs, theme, element, gp, horizontal = TRUE, clip) {
     function(x) {
       add_margins(
         grob = x[[1]]$text_grob,
-        height = if (horizontal) heights else x[[1]]$text_height,
-        width = if (!horizontal) widths else x[[1]]$text_width,
+        height = heights,
+        width = widths,
         gp = gp,
         margin = element$margin,
-        expand_x = horizontal,
-        expand_y = !horizontal,
         margin_x = TRUE,
         margin_y = TRUE
       )

--- a/R/margins.R
+++ b/R/margins.R
@@ -21,6 +21,24 @@ margin_width <- function(grob, margins) {
 
   grobWidth(grob) + margins[2] + margins[4]
 }
+ 
+position_trig <- function(angle, hjust, vjust) {  
+  angler <- angle * (pi / 180)
+
+  # Choose whether to use hjust or vjust or a combination
+  xp <- abs((cos(angler) * hjust) + (sin(angler) * vjust))
+  yp <- abs((cos(angler) * vjust) + (sin(angler) * hjust))
+
+  if (90 <= angle & angle < 270) {
+    xp <- 1 - xp
+  }
+  
+  if (180 <= angle & angle < 360) {
+    yp <- 1 - yp
+  }
+
+  list(xp = xp, yp = yp)
+}
 
 title_spec <- function(label, x, y, hjust, vjust, angle, gp = gpar(),
                        debug = FALSE) {
@@ -28,19 +46,9 @@ title_spec <- function(label, x, y, hjust, vjust, angle, gp = gpar(),
   if (is.null(label)) return(zeroGrob())
 
   angle <- angle %% 360
-  if (angle == 90) {
-    xp <- 1 - vjust
-    yp <- hjust
-  } else if (angle == 180) {
-    xp <- 1 - hjust
-    yp <- 1 - vjust
-  } else if (angle == 270) {
-    xp <- vjust
-    yp <- 1 - hjust
-  } else {
-    xp <- hjust
-    yp <- vjust
-  }
+  pos <- position_trig(angle, hjust, vjust)
+  xp <- pos$xp
+  yp <- pos$yp
 
   n <- max(length(x), length(y), 1)
   x <- x %||% unit(rep(xp, n), "npc")

--- a/R/margins.R
+++ b/R/margins.R
@@ -80,18 +80,10 @@ title_spec <- function(label, x, y, hjust, vjust, angle, gp = gpar(),
 }
 
 add_margins <- function(grob, height, width, margin = NULL,
-                        gp = gpar(), margin_x = FALSE, margin_y = FALSE,
-                        expand_x = FALSE, expand_y = FALSE) {
+                        gp = gpar(), margin_x = FALSE, margin_y = FALSE) {
 
   if (is.null(margin)) {
     margin <- margin(0, 0, 0, 0)
-  }
-
-  if (expand_x) {
-    width <- unit(1, "null")
-  }
-  if (expand_y) {
-    height <- unit(1, "null")
   }
 
   if (margin_x && margin_y) {

--- a/R/margins.R
+++ b/R/margins.R
@@ -22,6 +22,16 @@ margin_width <- function(grob, margins) {
   grobWidth(grob) + margins[2] + margins[4]
 }
 
+#' Text grob, height, and width
+#'
+#' This function returns a list containing a text grob (and, optionally,
+#' debugging grobs) and the height and width of the text grob.
+#'
+#' @param x,y x and y locations where the text is to be placed. If `x` and `y`
+#'   are `NULL`, `hjust` and `vjust` are used to determine the location.
+#' @inheritParams titleGrob
+#' 
+#' @noRd
 title_spec <- function(label, x, y, hjust, vjust, angle, gp = gpar(),
                        debug = FALSE) {
 
@@ -79,6 +89,19 @@ title_spec <- function(label, x, y, hjust, vjust, angle, gp = gpar(),
   )
 }
 
+#' Add margins
+#'
+#' Given a text grob, `add_margins()` adds margins around the grob in the
+#' directions determined by `margin_x` and `margin_y`. 
+#' 
+#' @param grob Text grob to add margins to.
+#' @param height,width Usually the height and width of the text grob. Passed as
+#'   separate arguments from the grob itself because in the special case of
+#'   facet strip labels each set of strips should share the same height and
+#'   width, even if the labels are of different length.
+#' @inheritParams titleGrob
+#'
+#' @noRd
 add_margins <- function(grob, height, width, margin = NULL,
                         gp = gpar(), margin_x = FALSE, margin_y = FALSE) {
 
@@ -130,7 +153,25 @@ add_margins <- function(grob, height, width, margin = NULL,
   )
 }
 
-
+#' Create a text grob with the proper location and margins
+#'
+#' `titleGrob()` is called when creating titles and labels for axes, legends,
+#' and facet strips.
+#'
+#' @param label Text to place on the plot. These maybe axis titles, axis labels,
+#'   facet strip titles, etc.
+#' @param x,y x and y locations where the text is to be placed.
+#' @param hjust,vjust Horizontal and vertical justification of the text.
+#' @param angle Angle of rotation of the text.
+#' @param gp Additional graphical parameters in a call to `gpar()`.
+#' @param margin Margins around the text. See [margin()] for more
+#'   details.
+#' @param margin_x,margin_y Whether or not to add margins in the x/y direction.
+#' @param debug If `TRUE`, aids visual debugging by drawing a solid
+#'   rectangle behind the complete text area, and a point where each label
+#'   is anchored.
+#' 
+#' @noRd
 titleGrob <- function(label, x, y, hjust, vjust, angle = 0, gp = gpar(),
                       margin = NULL, margin_x = FALSE, margin_y = FALSE,
                       debug = FALSE) {

--- a/R/margins.R
+++ b/R/margins.R
@@ -21,24 +21,6 @@ margin_width <- function(grob, margins) {
 
   grobWidth(grob) + margins[2] + margins[4]
 }
- 
-position_trig <- function(angle, hjust, vjust) {  
-  angler <- angle * (pi / 180)
-
-  # Choose whether to use hjust or vjust or a combination
-  xp <- abs((cos(angler) * hjust) + (sin(angler) * vjust))
-  yp <- abs((cos(angler) * vjust) + (sin(angler) * hjust))
-
-  if (90 <= angle & angle < 270) {
-    xp <- 1 - xp
-  }
-  
-  if (180 <= angle & angle < 360) {
-    yp <- 1 - yp
-  }
-
-  list(xp = xp, yp = yp)
-}
 
 title_spec <- function(label, x, y, hjust, vjust, angle, gp = gpar(),
                        debug = FALSE) {
@@ -46,9 +28,19 @@ title_spec <- function(label, x, y, hjust, vjust, angle, gp = gpar(),
   if (is.null(label)) return(zeroGrob())
 
   angle <- angle %% 360
-  pos <- position_trig(angle, hjust, vjust)
-  xp <- pos$xp
-  yp <- pos$yp
+  if (0 <= angle & angle < 90) {
+    xp <- hjust
+    yp <- vjust
+  } else if (90 <= angle & angle < 180) {
+    xp <- 1 - vjust
+    yp <- hjust
+  } else if (180 <= angle & angle < 270) {
+    xp <- 1 - hjust
+    yp <- 1 - vjust
+  } else if (270 <= angle & angle < 360) {
+    xp <- vjust
+    yp <- 1 - hjust
+  }
 
   n <- max(length(x), length(y), 1)
   x <- x %||% unit(rep(xp, n), "npc")

--- a/R/margins.R
+++ b/R/margins.R
@@ -79,7 +79,7 @@ title_spec <- function(label, x, y, hjust, vjust, angle, gp = gpar(),
   )
 }
 
-add_margins <- function(text_grob, text_height, text_width, margin = NULL,
+add_margins <- function(grob, height, width, margin = NULL,
                         gp = gpar(), margin_x = FALSE, margin_y = FALSE,
                         expand_x = FALSE, expand_y = FALSE) {
 
@@ -88,15 +88,15 @@ add_margins <- function(text_grob, text_height, text_width, margin = NULL,
   }
 
   if (expand_x) {
-    text_width <- unit(1, "null")
+    width <- unit(1, "null")
   }
   if (expand_y) {
-    text_height <- unit(1, "null")
+    height <- unit(1, "null")
   }
 
   if (margin_x && margin_y) {
-    widths <- unit.c(margin[4], text_width, margin[2])
-    heights <- unit.c(margin[1], text_height, margin[3])
+    widths <- unit.c(margin[4], width, margin[2])
+    heights <- unit.c(margin[1], height, margin[3])
 
     vp <- viewport(
       layout = grid.layout(3, 3, heights = heights, widths = widths),
@@ -104,24 +104,24 @@ add_margins <- function(text_grob, text_height, text_width, margin = NULL,
     )
     child_vp <- viewport(layout.pos.row = 2, layout.pos.col = 2)
   } else if (margin_x) {
-    widths <- unit.c(margin[4], text_width, margin[2])
+    widths <- unit.c(margin[4], width, margin[2])
     vp <- viewport(layout = grid.layout(1, 3, widths = widths), gp = gp)
     child_vp <- viewport(layout.pos.col = 2)
 
     heights <- unit(1, "null")
   } else if (margin_y) {
-    heights <- unit.c(margin[1], text_height, margin[3])
+    heights <- unit.c(margin[1], height, margin[3])
 
     vp <- viewport(layout = grid.layout(3, 1, heights = heights), gp = gp)
     child_vp <- viewport(layout.pos.row = 2)
 
     widths <- unit(1, "null")
   } else {
-    widths <- text_width
-    heights <- text_height
+    widths <- width
+    heights <- height
     return(
       gTree(
-        children = text_grob,
+        children = grob,
         widths = widths,
         heights = heights,
         cl = "titleGrob"
@@ -130,7 +130,7 @@ add_margins <- function(text_grob, text_height, text_width, margin = NULL,
   }
 
   gTree(
-    children = text_grob,
+    children = grob,
     vp = vpTree(vp, vpList(child_vp)),
     widths = widths,
     heights = heights,
@@ -159,9 +159,9 @@ titleGrob <- function(label, x, y, hjust, vjust, angle = 0, gp = gpar(),
   )
 
   add_margins(
-    text_grob = grob_details$text_grob,
-    text_height = grob_details$text_height,
-    text_width = grob_details$text_width,
+    grob = grob_details$text_grob,
+    height = grob_details$text_height,
+    width = grob_details$text_width,
     gp = gp,
     margin = margin,
     margin_x = margin_x,


### PR DESCRIPTION
Here are some improvements to `titleGrob()` and related functions that we talked about:

- [X] In `add_margins()` eliminate `text_` from argument names
- [X] In `ggstrip()`, remove `absoluteGrob()`
- [X] Document these functions
- [X] Fixed `xp` and `yp`. Now `title_spec()` sets them based on the range in which `angle` falls.

I still need to figure out how to prevent rotated text from extending outside of the strip in facet labels.

``` r
df <- data.frame(
  x = 1:2,
  y = 1:2,
  z = c("a", "aaaaaaabc")
)

ggplot(df, aes(x, y)) +
  geom_point() +
  facet_wrap(~ z) +
  theme(strip.text.x = element_text(hjust = 0, vjust = 1, angle = 45, debug = TRUE))
```

![](http://i.imgur.com/cA0oqmC.png)
