### PR TITLE
Add margins on all sides of strips by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # ggplot2 2.2.1.9000
 
+* Strips gain margins on all sides by default. This means that to fully justify
+  text to the edge of a strip, you will need to also set the margins to 0
+  (@karawoo).
+
 * Strip labels now understand justification relative to the direction of the
   text, meaning that in y facets the strip text can be placed at either end of
   the strip using `hjust` (@karawoo).

--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -149,9 +149,13 @@ theme_grey <- function(base_size = 11, base_family = "",
     panel.ontop    =     FALSE,
 
     strip.background =   element_rect(fill = "grey85", colour = NA),
-    strip.text =         element_text(colour = "grey10", size = rel(0.8)),
-    strip.text.x =       element_text(margin = margin(t = half_line, b = half_line)),
-    strip.text.y =       element_text(angle = -90, margin = margin(l = half_line, r = half_line)),
+    strip.text =         element_text(
+                           colour = "grey10",
+                           size = rel(0.8),
+                           margin = margin(half_line, half_line, half_line, half_line)
+                         ),
+    strip.text.x =       NULL,
+    strip.text.y =       element_text(angle = -90),
     strip.placement =    "inside",
     strip.placement.x =  NULL,
     strip.placement.y =  NULL,
@@ -216,6 +220,8 @@ theme_bw <- function(base_size = 11, base_family = "",
 theme_linedraw <- function(base_size = 11, base_family = "",
                            base_line_size = base_size / 22,
                            base_rect_size = base_size / 22) {
+  half_line <- base_size / 2
+  
   # Starts with theme_bw and then modify some parts
   # = replace all greys with pure black or white
   theme_bw(
@@ -238,7 +244,11 @@ theme_linedraw <- function(base_size = 11, base_family = "",
 
       # strips with black background and white text
       strip.background = element_rect(fill = "black"),
-      strip.text       = element_text(colour = "white", size = rel(0.8)),
+      strip.text       = element_text(
+                           colour = "white",
+                           size = rel(0.8),
+                           margin = margin(half_line, half_line, half_line, half_line)
+                         ),
 
       complete = TRUE
     )
@@ -249,6 +259,8 @@ theme_linedraw <- function(base_size = 11, base_family = "",
 theme_light <- function(base_size = 11, base_family = "",
                         base_line_size = base_size / 22,
                         base_rect_size = base_size / 22) {
+  half_line <- base_size / 2
+  
   # Starts with theme_grey and then modify some parts
   theme_grey(
     base_size = base_size,
@@ -273,7 +285,11 @@ theme_light <- function(base_size = 11, base_family = "",
 
       # dark strips with light text (inverse contrast compared to theme_grey)
       strip.background = element_rect(fill = "grey70", colour = NA),
-      strip.text       = element_text(colour = "white", size = rel(0.8)),
+      strip.text       = element_text(
+                           colour = "white",
+                           size = rel(0.8),
+                           margin = margin(half_line, half_line, half_line, half_line)
+                         ),
 
       complete = TRUE
     )
@@ -285,6 +301,8 @@ theme_light <- function(base_size = 11, base_family = "",
 theme_dark <- function(base_size = 11, base_family = "",
                        base_line_size = base_size / 22,
                        base_rect_size = base_size / 22) {
+  half_line <- base_size / 2
+  
   # Starts with theme_grey and then modify some parts
   theme_grey(
     base_size = base_size,
@@ -308,7 +326,11 @@ theme_dark <- function(base_size = 11, base_family = "",
 
       # dark strips with light text (inverse contrast compared to theme_grey)
       strip.background = element_rect(fill = "grey15", colour = NA),
-      strip.text       = element_text(colour = "grey90", size = rel(0.8)),
+      strip.text       = element_text(
+                           colour = "grey90",
+                           size = rel(0.8),
+                           margin = margin(half_line, half_line, half_line, half_line)
+                         ),
 
       complete = TRUE
     )
@@ -375,6 +397,8 @@ theme_classic <- function(base_size = 11, base_family = "",
 theme_void <- function(base_size = 11, base_family = "",
                        base_line_size = base_size / 22,
                        base_rect_size = base_size / 22) {
+  half_line <- base_size / 2
+  
   theme(
     # Use only inherited elements and make almost everything blank
     # Only keep indispensable text
@@ -390,7 +414,10 @@ theme_void <- function(base_size = 11, base_family = "",
     axis.title =       element_blank(),
     legend.text =        element_text(size = rel(0.8)),
     legend.title =       element_text(hjust = 0),
-    strip.text =         element_text(size = rel(0.8)),
+    strip.text =         element_text(
+                           size = rel(0.8),
+                           margin = margin(half_line, half_line, half_line, half_line)
+                         ),
     plot.margin =        unit(c(0, 0, 0, 0), "lines"),
 
     complete = TRUE
@@ -480,9 +507,13 @@ theme_test <- function(base_size = 11, base_family = "",
     panel.ontop    =     FALSE,
 
     strip.background =   element_rect(fill = "grey85", colour = "grey20"),
-    strip.text =         element_text(colour = "grey10", size = rel(0.8)),
-    strip.text.x =       element_text(margin = margin(t = half_line, b = half_line)),
-    strip.text.y =       element_text(angle = -90, margin = margin(l = half_line, r = half_line)),
+    strip.text =         element_text(
+                           colour = "grey10",
+                           size = rel(0.8),
+                           margin = margin(half_line, half_line, half_line, half_line)
+                         ),
+    strip.text.x =       NULL,
+    strip.text.y =       element_text(angle = -90),
     strip.placement =    "inside",
     strip.placement.x =  NULL,
     strip.placement.y =  NULL,

--- a/tests/figs/themes/theme-void-large.svg
+++ b/tests/figs/themes/theme-void-large.svg
@@ -13,33 +13,33 @@
 </defs>
 <rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
 <defs>
-  <clipPath id='cpMi43NHw2NjMuNDJ8NTczLjI2fDY1LjQy'>
-    <rect x='2.74' y='65.42' width='660.68' height='507.84' />
+  <clipPath id='cpMi43NHw2NjMuNDJ8NTczLjI2fDg3LjM0'>
+    <rect x='2.74' y='87.34' width='660.68' height='485.92' />
   </clipPath>
 </defs>
-<circle cx='32.77' cy='550.18' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMi43NHw2NjMuNDJ8NTczLjI2fDY1LjQy)' />
-<circle cx='333.08' cy='319.34' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMi43NHw2NjMuNDJ8NTczLjI2fDY1LjQy)' />
-<circle cx='633.39' cy='88.51' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMi43NHw2NjMuNDJ8NTczLjI2fDY1LjQy)' />
+<circle cx='32.77' cy='551.17' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMi43NHw2NjMuNDJ8NTczLjI2fDg3LjM0)' />
+<circle cx='333.08' cy='330.30' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMi43NHw2NjMuNDJ8NTczLjI2fDg3LjM0)' />
+<circle cx='633.39' cy='109.43' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMi43NHw2NjMuNDJ8NTczLjI2fDg3LjM0)' />
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />
   </clipPath>
 </defs>
 <defs>
-  <clipPath id='cpMi43NHw2NjMuNDJ8NjUuNDJ8MzYuNTg='>
-    <rect x='2.74' y='36.58' width='660.68' height='28.85' />
+  <clipPath id='cpMi43NHw2NjMuNDJ8ODcuMzR8MzYuNTg='>
+    <rect x='2.74' y='36.58' width='660.68' height='50.77' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMi43NHw2NjMuNDJ8NjUuNDJ8MzYuNTg=)'><text x='325.85' y='59.95' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpMi43NHw2NjMuNDJ8ODcuMzR8MzYuNTg=)'><text x='325.85' y='70.90' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>1</text></g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='680.43' y='307.00' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>z</text></g>
-<circle cx='689.07' cy='327.36' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<circle cx='689.07' cy='345.38' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='699.87' y='336.31' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>a</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='699.87' y='354.32' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>b</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='680.43' y='317.96' style='font-size: 33.00px; font-family: Liberation Sans;' textLength='16.50px' lengthAdjust='spacingAndGlyphs'>z</text></g>
+<circle cx='689.07' cy='338.32' r='1.95pt' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='689.07' cy='356.34' r='1.95pt' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='699.87' y='347.27' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>a</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='699.87' y='365.28' style='font-size: 26.40px; font-family: Liberation Sans;' textLength='14.46px' lengthAdjust='spacingAndGlyphs'>b</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='2.74' y='27.52' style='font-size: 39.60px; font-family: Liberation Sans;' textLength='317.99px' lengthAdjust='spacingAndGlyphs'>theme_void_large</text></g>
 </svg>


### PR DESCRIPTION
Recent changes to text placement make it possible for strips to have margins around all sides. This adds margins around all sides of strips. Default plots where the strip labels are centered will look the same, but this fully fixes #1887 because the margins are defined in `strip.text` instead of `strip.text.x` and `strip.text.y`.

In some cases where text is rotated, this also prevents the edges of the text from being cut off the strip.

``` r
df <- data.frame(
  x = 1,
  y = 1,
  z = c("aaaaaaabc")
)

ggplot(df, aes(x, y)) +
  facet_wrap( ~ z) +
  theme(strip.text = element_text(angle = 45, hjust = 0, vjust = 0, debug = TRUE))
```

![](http://i.imgur.com/uByjse2.png)

Margins will need to manually be set to 0 if users want to fully justify text with the edges of the strips.

This change added a little extra space above and below the strip label in the `theme_void` visual test plot with large text size. I've included the updated visual test case.