### PR TITLE
Adhere to tidyverse style in guide-legend.r

### DIFF
--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -140,40 +140,41 @@
 #' p4 + geom_line(show.legend = c(color = FALSE))
 #'
 #' }
-guide_legend <- function(
+guide_legend <- function(# title
+                         title = waiver(),
+                         title.position = NULL,
+                         title.theme = NULL,
+                         title.hjust = NULL,
+                         title.vjust = NULL,
 
-  # title
-  title = waiver(),
-  title.position = NULL,
-  title.theme = NULL,
-  title.hjust = NULL,
-  title.vjust = NULL,
+                         # label
+                         label = TRUE,
+                         label.position = NULL,
+                         label.theme = NULL,
+                         label.hjust = NULL,
+                         label.vjust = NULL,
 
-  # label
-  label = TRUE,
-  label.position = NULL,
-  label.theme = NULL,
-  label.hjust = NULL,
-  label.vjust = NULL,
+                         # key
+                         keywidth = NULL,
+                         keyheight = NULL,
 
-  # key
-  keywidth = NULL,
-  keyheight = NULL,
+                         # general
+                         direction = NULL,
+                         default.unit = "line",
+                         override.aes = list(),
+                         nrow = NULL,
+                         ncol = NULL,
+                         byrow = FALSE,
+                         reverse = FALSE,
+                         order = 0,
+                         ...) {
 
-  # general
-  direction = NULL,
-  default.unit = "line",
-  override.aes = list(),
-  nrow = NULL,
-  ncol = NULL,
-  byrow = FALSE,
-  reverse = FALSE,
-  order = 0,
-
-  ...) {
-
-  if (!is.null(keywidth) && !is.unit(keywidth)) keywidth <- unit(keywidth, default.unit)
-  if (!is.null(keyheight) && !is.unit(keyheight)) keyheight <- unit(keyheight, default.unit)
+  if (!is.null(keywidth) && !is.unit(keywidth)) {
+    keywidth <- unit(keywidth, default.unit)
+  }
+  if (!is.null(keyheight) && !is.unit(keyheight)) {
+    keyheight <- unit(keyheight, default.unit)
+  }
 
   structure(
     list(
@@ -216,11 +217,14 @@ guide_legend <- function(
 #' @export
 guide_train.legend <- function(guide, scale) {
   breaks <- scale$get_breaks()
-  if (length(breaks) == 0 || all(is.na(breaks)))
+  if (length(breaks) == 0 || all(is.na(breaks))) {
     return()
+  }
 
-  key <- as.data.frame(setNames(list(scale$map(breaks)), scale$aesthetics[1]),
-    stringsAsFactors = FALSE)
+  key <- as.data.frame(
+    setNames(list(scale$map(breaks)), scale$aesthetics[1]),
+    stringsAsFactors = FALSE
+  )
   key$.label <- scale$get_labels(breaks)
 
   # Drop out-of-range values for continuous scale
@@ -235,7 +239,10 @@ guide_train.legend <- function(guide, scale) {
   if (guide$reverse) key <- key[nrow(key):1, ]
 
   guide$key <- key
-  guide$hash <- with(guide, digest::digest(list(title, key$.label, direction, name)))
+  guide$hash <- with(
+    guide,
+    digest::digest(list(title, key$.label, direction, name))
+  )
   guide
 }
 
@@ -243,7 +250,9 @@ guide_train.legend <- function(guide, scale) {
 guide_merge.legend <- function(guide, new_guide) {
   guide$key <- merge(guide$key, new_guide$key, sort = FALSE)
   guide$override.aes <- c(guide$override.aes, new_guide$override.aes)
-  if (any(duplicated(names(guide$override.aes)))) warning("Duplicated override.aes is ignored.")
+  if (any(duplicated(names(guide$override.aes)))) {
+    warning("Duplicated override.aes is ignored.")
+  }
   guide$override.aes <- guide$override.aes[!duplicated(names(guide$override.aes))]
   guide
 }
@@ -261,7 +270,8 @@ guide_geom.legend <- function(guide, layers, default_mapping) {
       # if show.legend is a logical or a named logical vector
       if (!is.null(names(layer$show.legend))) {
         layer$show.legend <- rename_aes(layer$show.legend)
-        include <- is.na(layer$show.legend[matched]) || layer$show.legend[matched]
+        include <- is.na(layer$show.legend[matched]) ||
+          layer$show.legend[matched]
       } else {
         include <- is.na(layer$show.legend) || layer$show.legend
       }
@@ -328,7 +338,7 @@ guide_gengrob.legend <- function(guide, theme) {
 
   title_width <- width_cm(grob.title)
   title_height <- height_cm(grob.title)
-  
+
   # gap between keys etc
   hgap <- width_cm(theme$legend.spacing.x  %||% unit(0.3, "line"))
   vgap <- height_cm(theme$legend.spacing.y %||% 0.5 * unit(title_height, "cm"))
@@ -364,8 +374,12 @@ guide_gengrob.legend <- function(guide, theme) {
   label_heights <- height_cm(grob.labels)
 
   # Keys
-  key_width <- width_cm(guide$keywidth %||% theme$legend.key.width %||% theme$legend.key.size)
-  key_height <- height_cm(guide$keyheight %||% theme$legend.key.height %||% theme$legend.key.size)
+  key_width <- width_cm(
+    guide$keywidth %||% theme$legend.key.width %||% theme$legend.key.size
+  )
+  key_height <- height_cm(
+    guide$keyheight %||% theme$legend.key.height %||% theme$legend.key.size
+  )
 
   key_size_mat <- do.call("cbind", lapply(guide$geoms, function(g) g$data$size / 10))
   if (nrow(key_size_mat) == 0 || ncol(key_size_mat) == 0) {
@@ -373,8 +387,13 @@ guide_gengrob.legend <- function(guide, theme) {
   }
   key_sizes <- apply(key_size_mat, 1, max)
 
-  if (!is.null(guide$nrow) && !is.null(guide$ncol) && guide$nrow * guide$ncol < nbreak)
-    stop("`nrow` * `ncol` needs to be larger than the number of breaks", call. = FALSE)
+  if (!is.null(guide$nrow) && !is.null(guide$ncol) &&
+      guide$nrow * guide$ncol < nbreak) {
+    stop(
+      "`nrow` * `ncol` needs to be larger than the number of breaks",
+      call. = FALSE
+    )
+  }
 
   # If neither nrow/ncol specified, guess with "reasonable" values
   if (is.null(guide$nrow) && is.null(guide$ncol)) {
@@ -387,18 +406,36 @@ guide_gengrob.legend <- function(guide, theme) {
   legend.nrow <- guide$nrow %||% ceiling(nbreak / guide$ncol)
   legend.ncol <- guide$ncol %||% ceiling(nbreak / guide$nrow)
 
-  key_sizes <- matrix(c(key_sizes, rep(0, legend.nrow * legend.ncol - nbreak)),
-                      legend.nrow, legend.ncol, byrow = guide$byrow)
+  key_sizes <- matrix(
+    c(key_sizes, rep(0, legend.nrow * legend.ncol - nbreak)),
+    legend.nrow,
+    legend.ncol,
+    byrow = guide$byrow
+  )
 
   key_widths <- pmax(key_width, apply(key_sizes, 2, max))
   key_heights <- pmax(key_height, apply(key_sizes, 1, max))
 
-  label_widths <- apply(matrix(c(label_widths, rep(0, legend.nrow * legend.ncol - nbreak)),
-                                 legend.nrow, legend.ncol, byrow = guide$byrow),
-                          2, max)
-  label_heights <- apply(matrix(c(label_heights, rep(0, legend.nrow * legend.ncol - nbreak)),
-                                  legend.nrow, legend.ncol, byrow = guide$byrow),
-                           1, max)
+  label_widths <- apply(
+    matrix(
+      c(label_widths, rep(0, legend.nrow * legend.ncol - nbreak)),
+      legend.nrow,
+      legend.ncol,
+      byrow = guide$byrow
+    ),
+    2,
+    max
+  )
+  label_heights <- apply(
+    matrix(
+      c(label_heights, rep(0, legend.nrow * legend.ncol - nbreak)),
+      legend.nrow,
+      legend.ncol,
+      byrow = guide$byrow
+    ),
+    1,
+    max
+  )
 
   if (guide$byrow) {
     vps <- data.frame(
@@ -412,77 +449,187 @@ guide_gengrob.legend <- function(guide, theme) {
 
   # layout of key-label depends on the direction of the guide
   if (guide$byrow == TRUE) {
-    switch(label.position,
+    switch(
+      label.position,
       "top" = {
         kl_widths <- pmax(label_widths, key_widths)
-        kl_heights <- utils::head(interleave(label_heights, vgap/2, key_heights, vgap/2), -1)
-        vps <- transform(vps, key.row = R * 4 - 1, key.col = C, label.row = R * 4 - 3, label.col = C)
+        kl_heights <- utils::head(
+          interleave(label_heights, vgap / 2, key_heights, vgap / 2),
+          -1
+        )
+        vps <- transform(
+          vps,
+          key.row = R * 4 - 1,
+          key.col = C,
+          label.row = R * 4 - 3,
+          label.col = C
+        )
       },
       "bottom" = {
         kl_widths <- pmax(label_widths, key_widths)
-        kl_heights <- utils::head(interleave(key_heights, vgap/2, label_heights, vgap/2), -1)
-        vps <- transform(vps, key.row = R * 4 - 3, key.col = C, label.row = R * 4 - 1, label.col = C)
+        kl_heights <- utils::head(
+          interleave(key_heights, vgap / 2, label_heights, vgap / 2),
+          -1
+        )
+        vps <- transform(
+          vps,
+          key.row = R * 4 - 3,
+          key.col = C,
+          label.row = R * 4 - 1,
+          label.col = C
+        )
       },
       "left" = {
-        kl_widths <- utils::head(interleave(label_widths, hgap/2, key_widths, hgap/2), -1)
-        kl_heights <- utils::head(interleave(pmax(label_heights, key_heights), vgap/2), -1)
-        vps <- transform(vps, key.row = R * 2 - 1, key.col = C * 4 - 1, label.row = R * 2 - 1, label.col = C * 4 - 3)
+        kl_widths <- utils::head(
+          interleave(label_widths, hgap / 2, key_widths, hgap / 2),
+          -1
+        )
+        kl_heights <- utils::head(
+          interleave(pmax(label_heights, key_heights), vgap / 2),
+          -1
+        )
+        vps <- transform(
+          vps,
+          key.row = R * 2 - 1,
+          key.col = C * 4 - 1,
+          label.row = R * 2 - 1,
+          label.col = C * 4 - 3
+        )
       },
       "right" = {
-        kl_widths <- utils::head(interleave(key_widths, hgap/2, label_widths, hgap/2), -1)
-        kl_heights <- utils::head(interleave(pmax(label_heights, key_heights), vgap/2), -1)
-        vps <- transform(vps, key.row = R * 2 - 1, key.col = C * 4 - 3, label.row = R * 2 - 1, label.col = C * 4 - 1)
-        })
+        kl_widths <- utils::head(
+          interleave(key_widths, hgap / 2, label_widths, hgap / 2),
+          -1
+        )
+        kl_heights <- utils::head(
+          interleave(pmax(label_heights, key_heights), vgap / 2),
+          -1
+        )
+        vps <- transform(
+          vps,
+          key.row = R * 2 - 1,
+          key.col = C * 4 - 3,
+          label.row = R * 2 - 1,
+          label.col = C * 4 - 1
+        )
+      })
   } else {
-    switch(label.position,
+    switch(
+      label.position,
       "top" = {
-        kl_widths <- utils::head(interleave(pmax(label_widths, key_widths), hgap/2), -1)
-        kl_heights <- utils::head(interleave(label_heights, vgap/2, key_heights, vgap/2), -1)
-        vps <- transform(vps, key.row = R * 4 - 1, key.col = C * 2 - 1, label.row = R * 4 - 3, label.col = C * 2 - 1)
+        kl_widths <- utils::head(
+          interleave(pmax(label_widths, key_widths), hgap/2),
+          -1
+        )
+        kl_heights <- utils::head(
+          interleave(label_heights, vgap / 2, key_heights, vgap / 2),
+          -1
+        )
+        vps <- transform(
+          vps,
+          key.row = R * 4 - 1,
+          key.col = C * 2 - 1,
+          label.row = R * 4 - 3,
+          label.col = C * 2 - 1
+        )
       },
       "bottom" = {
-        kl_widths <- utils::head(interleave(pmax(label_widths, key_widths), hgap/2), -1)
-        kl_heights <- utils::head(interleave(key_heights, vgap/2, label_heights, vgap/2), -1)
-        vps <- transform(vps, key.row = R * 4 - 3, key.col = C * 2 - 1, label.row = R * 4 - 1, label.col = C * 2 - 1)
+        kl_widths <- utils::head(
+          interleave(pmax(label_widths, key_widths), hgap / 2),
+          -1
+        )
+        kl_heights <- utils::head(
+          interleave(key_heights, vgap / 2, label_heights, vgap / 2),
+          -1
+        )
+        vps <- transform(
+          vps,
+          key.row = R * 4 - 3,
+          key.col = C * 2 - 1,
+          label.row = R * 4 - 1,
+          label.col = C * 2 - 1
+        )
       },
       "left" = {
-        kl_widths <- utils::head(interleave(label_widths, hgap/2, key_widths, hgap/2), -1)
+        kl_widths <- utils::head(
+          interleave(label_widths, hgap / 2, key_widths, hgap / 2),
+          -1
+        )
         kl_heights <- pmax(key_heights, label_heights)
-        vps <- transform(vps, key.row = R, key.col = C * 4 - 1, label.row = R, label.col = C * 4 - 3)
+        vps <- transform(
+          vps,
+          key.row = R,
+          key.col = C * 4 - 1,
+          label.row = R,
+          label.col = C * 4 - 3
+        )
       },
       "right" = {
-        kl_widths <- utils::head(interleave(key_widths, hgap/2, label_widths, hgap/2), -1)
+        kl_widths <- utils::head(
+          interleave(key_widths, hgap / 2, label_widths, hgap / 2),
+          -1
+        )
         kl_heights <- pmax(key_heights, label_heights)
-        vps <- transform(vps, key.row = R, key.col = C * 4 - 3, label.row = R, label.col = C * 4 - 1)
+        vps <- transform(
+          vps,
+          key.row = R,
+          key.col = C * 4 - 3,
+          label.row = R,
+          label.col = C * 4 - 1
+        )
       })
   }
 
   # layout the title over key-label
   switch(guide$title.position,
-    "top" = {
-      widths <- c(kl_widths, max(0, title_width - sum(kl_widths)))
-      heights <- c(title_height, vgap, kl_heights)
-      vps <- transform(vps, key.row = key.row + 2, key.col = key.col, label.row = label.row + 2, label.col = label.col)
-      vps.title.row = 1; vps.title.col = 1:length(widths)
-    },
-    "bottom" = {
-      widths <- c(kl_widths, max(0, title_width - sum(kl_widths)))
-      heights <- c(kl_heights, vgap, title_height)
-      vps <- transform(vps, key.row = key.row, key.col = key.col, label.row = label.row, label.col = label.col)
-      vps.title.row = length(heights); vps.title.col = 1:length(widths)
-    },
-    "left" = {
-      widths <- c(title_width, hgap, kl_widths)
-      heights <- c(kl_heights, max(0, title_height - sum(kl_heights)))
-      vps <- transform(vps, key.row = key.row, key.col = key.col + 2, label.row = label.row, label.col = label.col + 2)
-      vps.title.row = 1:length(heights); vps.title.col = 1
-    },
-    "right" = {
-      widths <- c(kl_widths, hgap, title_width)
-      heights <- c(kl_heights, max(0, title_height - sum(kl_heights)))
-      vps <- transform(vps, key.row = key.row, key.col = key.col, label.row = label.row, label.col = label.col)
-      vps.title.row = 1:length(heights); vps.title.col = length(widths)
-    })
+         "top" = {
+           widths <- c(kl_widths, max(0, title_width - sum(kl_widths)))
+           heights <- c(title_height, vgap, kl_heights)
+           vps <- transform(
+             vps,
+             key.row = key.row + 2,
+             key.col = key.col,
+             label.row = label.row + 2,
+             label.col = label.col
+           )
+           vps.title.row = 1; vps.title.col = 1:length(widths)
+         },
+         "bottom" = {
+           widths <- c(kl_widths, max(0, title_width - sum(kl_widths)))
+           heights <- c(kl_heights, vgap, title_height)
+           vps <- transform(
+             vps,
+             key.row = key.row,
+             key.col = key.col,
+             label.row = label.row,
+             label.col = label.col
+           )
+           vps.title.row = length(heights); vps.title.col = 1:length(widths)
+         },
+         "left" = {
+           widths <- c(title_width, hgap, kl_widths)
+           heights <- c(kl_heights, max(0, title_height - sum(kl_heights)))
+           vps <- transform(
+             vps,
+             key.row = key.row,
+             key.col = key.col + 2,
+             label.row = label.row,
+             label.col = label.col + 2
+           )
+           vps.title.row = 1:length(heights); vps.title.col = 1
+         },
+         "right" = {
+           widths <- c(kl_widths, hgap, title_width)
+           heights <- c(kl_heights, max(0, title_height - sum(kl_heights)))
+           vps <- transform(
+             vps,
+             key.row = key.row,
+             key.col = key.col,
+             label.row = label.row,
+             label.col = label.col
+           )
+           vps.title.row = 1:length(heights); vps.title.col = length(widths)
+         })
 
   # grob for key
   key_size <- c(key_width, key_height) * 10
@@ -510,20 +657,46 @@ guide_gengrob.legend <- function(guide, theme) {
 
   # Create the gtable for the legend
   gt <- gtable(widths = unit(widths, "cm"), heights = unit(heights, "cm"))
-  gt <- gtable_add_grob(gt, grob.background, name = "background", clip = "off",
-    t = 1, r = -1, b = -1, l = 1)
-  gt <- gtable_add_grob(gt, grob.title, name = "title", clip = "off",
-    t = 1 + min(vps.title.row), r = 1 + max(vps.title.col),
-    b = 1 + max(vps.title.row), l = 1 + min(vps.title.col))
-  gt <- gtable_add_grob(gt, grob.keys,
-    name = paste("key", krows, kcols, c("bg", seq(ngeom - 1)), sep = "-"), clip = "off",
-    t = 1 + krows, r = 1 + kcols,
-    b = 1 + krows, l = 1 + kcols)
-  gt <- gtable_add_grob(gt, grob.labels,
-    name = paste("label", vps$label.row, vps$label.col, sep = "-"), clip = "off",
-    t = 1 + vps$label.row, r = 1 + vps$label.col,
-    b = 1 + vps$label.row, l = 1 + vps$label.col)
-
+  gt <- gtable_add_grob(
+    gt,
+    grob.background,
+    name = "background",
+    clip = "off",
+    t = 1,
+    r = -1,
+    b = -1,
+    l = 1
+  )
+  gt <- gtable_add_grob(
+    gt,
+    grob.title,
+    name = "title",
+    clip = "off",
+    t = 1 + min(vps.title.row),
+    r = 1 + max(vps.title.col),
+    b = 1 + max(vps.title.row),
+    l = 1 + min(vps.title.col)
+  )
+  gt <- gtable_add_grob(
+    gt,
+    grob.keys,
+    name = paste("key", krows, kcols, c("bg", seq(ngeom - 1)), sep = "-"),
+    clip = "off",
+    t = 1 + krows,
+    r = 1 + kcols,
+    b = 1 + krows,
+    l = 1 + kcols
+  )
+  gt <- gtable_add_grob(
+    gt,
+    grob.labels,
+    name = paste("label", vps$label.row, vps$label.col, sep = "-"),
+    clip = "off",
+    t = 1 + vps$label.row,
+    r = 1 + vps$label.col,
+    b = 1 + vps$label.row,
+    l = 1 + vps$label.col
+  )
   gt
 }
 


### PR DESCRIPTION
When I was looking into how to add margins around legend elements I noticed that the legends code  doesn't follow tidyverse style. This just fixes the style in `guide-legend.r`.