### PR TITLE
Added `exclude` argument to `stat_contour()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -407,6 +407,9 @@ There were a number of tweaks to the theme elements that control legends:
 
 * `Scale` extensions can now override the `make_title` and `make_sec_title` 
   methods to let the scale modify the axis/legend titles.
+  
+* `stat_contour` gains new argument `exclude` to remove specific levels. 
+  (@eliocamp)
 
 # ggplot2 2.1.0
 

--- a/R/geom-contour.r
+++ b/R/geom-contour.r
@@ -36,6 +36,9 @@
 #' v + geom_contour(binwidth = 0.01)
 #' v + geom_contour(binwidth = 0.001)
 #'
+#' # Setting exclude removes specific contours
+#' v + geom_contour(binwidth = 0.001, exclude = c(0.002, 0.004))
+#'
 #' # Other parameters
 #' v + geom_contour(aes(colour = ..level..))
 #' v + geom_contour(colour = "red")

--- a/R/stat-contour.r
+++ b/R/stat-contour.r
@@ -35,7 +35,8 @@ StatContour <- ggproto("StatContour", Stat,
   default_aes = aes(order = ..level..),
 
   compute_group = function(data, scales, bins = NULL, binwidth = NULL,
-                           breaks = NULL, complete = FALSE, na.rm = FALSE) {
+                           breaks = NULL, complete = FALSE, na.rm = FALSE,
+                           exclude = NULL) {
     # If no parameters set, use pretty bins
     if (is.null(bins) && is.null(binwidth) && is.null(breaks)) {
       breaks <- pretty(range(data$z), 10)
@@ -48,6 +49,8 @@ StatContour <- ggproto("StatContour", Stat,
     if (is.null(breaks)) {
       breaks <- fullseq(range(data$z), binwidth)
     }
+    # Remove excluded breaks
+    breaks <- breaks[!(breaks %in% exclude)]
 
     contour_lines(data, breaks, complete = complete)
   }

--- a/man/geom_contour.Rd
+++ b/man/geom_contour.Rd
@@ -106,6 +106,9 @@ v + geom_contour(bins = 10)
 v + geom_contour(binwidth = 0.01)
 v + geom_contour(binwidth = 0.001)
 
+# Setting exclude removes specific contours
+v + geom_contour(binwidth = 0.001, exclude = c(0.002, 0.004))
+
 # Other parameters
 v + geom_contour(aes(colour = ..level..))
 v + geom_contour(colour = "red")


### PR DESCRIPTION
I added an argument to `stat_contour()` to remove specific levels. The motivation behind this comes from my field (atmospheric science) in which we often plot, for example, pressure anomalies and are more interested in areas of high or low pressure and less interested on where exactly the zero line is. 
 
Example:
``` r
library(ggplot2)
field <- expand.grid(x = 0:360, y = -90:90)
field$z <- with(field, cos(x*pi/180*3) + sin(y*pi/180*4))

ggplot(field, aes(x, y, z = z)) +
  geom_contour(aes(color = ..level..))
```
![](https://i.imgur.com/1HQvB5f.png)

``` r
ggplot(field, aes(x, y, z = z)) +
  geom_contour(aes(color = ..level..), exclude = 0) 
```

![](https://i.imgur.com/gbJIurm.png)

Right now this can be achieved by setting the breaks parameter explicitly, but it requires to know the range of the data and it's a lot more typing. 