### PR TITLE
Improve error message from find_subclass() (#2065).

### DIFF
--- a/R/layer.r
+++ b/R/layer.r
@@ -325,8 +325,8 @@ find_subclass <- function(super, class, env) {
   name <- paste0(super, camelize(class, first = TRUE))
   obj <- find_global(name, env = env)
 
-  if (is.null(name)) {
-    stop("No ", tolower(super), " called ", name, ".", call. = FALSE)
+  if (is.null(obj)) {
+    stop("No ", tolower(super), " called '", class, "'.", call. = FALSE)
   } else if (!inherits(obj, super)) {
     stop("Found object is not a ", tolower(super), ".", call. = FALSE)
   }


### PR DESCRIPTION
The check for null was occurring on the wrong variable: 'name' cannot be
null, but 'obj' can. Moreover the message should report the variable as
set by the end user (such as 'identity'), rather than the internal name
constructed by the function (such as 'StatIdentity').