### PR TITLE
Simplistic fix for #2264

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # ggplot2 2.2.1.9000
 
-<<<<<<< HEAD
+* Replacing a coordinate system (other than the default) will now give a message
+  (@Axeman, #2264).
+
 * Strips gain margins on all sides by default. This means that to fully justify
   text to the edge of a strip, you will need to also set the margins to 0
   (@karawoo).
@@ -64,8 +66,6 @@
 * Axes positioned on the top and to the right can now customize their ticks and
   lines separately (@thomasp85, #1899)
 
-=======
->>>>>>> 62207026f9d456e02d1014a664d16ea33743be13
 * `geom_segment` now also takes a `linejoin` parameter. This allows more control over the appearance of the segments, which is especially useful for plotting thick arrows (@Ax3man, #774).
 
 * Theme elements can now be subclassed. Add a `merge_element` method to control

--- a/R/plot-construction.r
+++ b/R/plot-construction.r
@@ -79,6 +79,10 @@ add_ggplot <- function(p, object, objectname) {
       names(labels) <- names(object)
       p <- update_labels(p, labels)
   } else if (is.Coord(object)) {
+      if (!is.null(attributes(p$coordinates)$default)) {
+        message("Coordinate system already present. Adding new coordinate ",
+                "system, which will replace the existing one.")
+      }
       p$coordinates <- object
       p
   } else if (is.facet(object)) {

--- a/R/plot.r
+++ b/R/plot.r
@@ -102,6 +102,8 @@ ggplot.data.frame <- function(data, mapping = aes(), ...,
     plot_env = environment
   ), class = c("gg", "ggplot"))
 
+  attr(p$coordinates, 'default') <- TRUE
+
   p$labels <- make_labels(mapping)
 
   set_last_plot(p)


### PR DESCRIPTION
This will now give a message whenever a second (or more) coordinate system is added. To avoid a message when adding one coordinate system that effectively overrides the default `coord_cartesian`, I gave the default one a `default` attribute. `add_ggplot` checks for that attribute.

If there is a preferred method of checking for the default coordinate system, I can change this.

Running e.g.

```r
qplot(1:2, 1:2) + coord_trans(y = 'log10') + coord_polar()
```

now prints: 

```r
Coordinate system already present. Adding new coordinate system, which will replace the existing one.
```