### PR TITLE
Fix typo in position_stack documentation

### DIFF
--- a/R/position-stack.r
+++ b/R/position-stack.r
@@ -76,7 +76,7 @@
 #'   geom_area(aes(fill = type)) +
 #'   scale_fill_discrete(breaks = c('a', 'b', 'c', 'd'))
 #'
-#' # If you've flipped the plot, use reveres = TRUE so the levels
+#' # If you've flipped the plot, use reverse = TRUE so the levels
 #' # continue to match
 #' ggplot(series, aes(time, value)) +
 #'   geom_area(aes(fill = type2), position = position_stack(reverse = TRUE)) +


### PR DESCRIPTION
`reverse` is misspelled as `reveres` in the documentation.