### PR TITLE
Fix limits on `scale_colour_gradient2()` 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,8 @@
   warnings when mapped to size or alpha (unordered factors do). Viridis used as
   default colour and fill scale for ordered factors (@karawoo, #1526).
 
+* Fix bug in `scale_*_gradient2()` where points outside limits can sometimes reappear due to rescaling. Now, any rescaling is performed after the limits are enforced (@foo-bar-baz-qux, #2230).
+
 ### Margins
 
 * Strips gain margins on all sides by default. This means that to fully justify

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -215,7 +215,7 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
   },
 
   map = function(self, x, limits = self$get_limits()) {
-    x <- self$oob(self$rescaler(x, from = limits))
+    x <- self$rescaler(self$oob(x, range = limits), from = limits)
 
     uniq <- unique(x)
     pal <- self$palette(uniq)
@@ -598,7 +598,7 @@ continuous_scale <- function(aesthetics, scale_name, palette, name = waiver(),
 #'
 #' @export
 #' @inheritParams continuous_scale
-#' @param breaks One of: 
+#' @param breaks One of:
 #'   - `NULL` for no breaks
 #'   - `waiver()` for the default breaks computed by the
 #'     transformation object

--- a/tests/testthat/test-scale-gradient.R
+++ b/tests/testthat/test-scale-gradient.R
@@ -3,16 +3,11 @@ context("scale_gradient")
 # Limits ------------------------------------------------------------------
 
 test_that("points outside the limits are plotted as NA", {
-  p <- ggplot(iris, aes(x = Sepal.Length, y = Sepal.Width, color = Petal.Length) ) +
-          geom_point() +
-          scale_color_gradient2(low = muted("green"), high = muted("navy"),
-                                mid = "gray80",
-                                midpoint = 3, limits = c(2, 6),
-                                na.value = "orange")
-  p_data <- ggplot_build(p)$data[[1]]
+  df <- data.frame(x = c(0, 1, 2))
+  p <- ggplot(df, aes(x, 1, fill = x)) +
+    geom_col() +
+    scale_fill_gradient2(limits = c(-1, 1), midpoint = 2, na.value = "orange")
 
-  p_cand <- p_data[p_data$colour == 'orange', c('x', 'y')]  # NA values are orange
-  p_correct <- iris[iris$Petal.Length > 6 | iris$Petal.Length < 2, c('Sepal.Length', 'Sepal.Width')]
-
-  expect_equivalent(p_cand, p_correct)
+  correct_fill <- c("#B26D65", "#DCB4AF", "orange")
+  expect_equivalent(layer_data(p)$fill, correct_fill)
 })

--- a/tests/testthat/test-scale-gradient.R
+++ b/tests/testthat/test-scale-gradient.R
@@ -1,0 +1,18 @@
+context("scale_gradient")
+
+# Limits ------------------------------------------------------------------
+
+test_that("points outside the limits are plotted as NA", {
+  p <- ggplot(iris, aes(x = Sepal.Length, y = Sepal.Width, color = Petal.Length) ) +
+          geom_point() +
+          scale_color_gradient2(low = muted("green"), high = muted("navy"),
+                                mid = "gray80",
+                                midpoint = 3, limits = c(2, 6),
+                                na.value = "orange")
+  p_data <- ggplot_build(p)$data[[1]]
+
+  p_cand <- p_data[p_data$colour == 'orange', c('x', 'y')]  # NA values are orange
+  p_correct <- iris[iris$Petal.Length > 6 | iris$Petal.Length < 2, c('Sepal.Length', 'Sepal.Width')]
+
+  expect_equivalent(p_cand, p_correct)
+})


### PR DESCRIPTION
Fixes #2230. 

Limits are now imposed before rescaling so points outside the limits don't reappear.