### PR TITLE
Fix `update_geom_defaults()` and `update_stat_defaults()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 2.2.1.9000
 
+* Fix `update_geom_defaults()` and `update_stat_defaults()` to allow American spelling of aesthetic parameters (@foo-bar-baz-qux, #2299).
+
 * Fixed bug when setting strips to `element_blank()` (@thomasp85). 
 
 * Strips gain margins on all sides by default. This means that to fully justify

--- a/R/geom-defaults.r
+++ b/R/geom-defaults.r
@@ -22,7 +22,7 @@ update_geom_defaults <- function(geom, new) {
   }
 
   old <- g$default_aes
-  g$default_aes <- defaults(new, old)
+  g$default_aes <- defaults(rename_aes(new), old)
 }
 
 #' @rdname update_defaults
@@ -38,5 +38,5 @@ update_stat_defaults <- function(stat, new) {
   }
 
   old <- g$default_aes
-  g$default_aes <- defaults(new, old)
+  g$default_aes <- defaults(rename_aes(new), old)
 }


### PR DESCRIPTION
Fixes #2299.

Fix `update_geom_defaults()` and `update_stat_defaults()` to allow American spelling of aesthetic parameters