### PR TITLE
Correct documentation for default name parameter in scales.

### DIFF
--- a/R/scale-.r
+++ b/R/scale-.r
@@ -504,7 +504,8 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
 #'   they should take
 #' @param name The name of the scale. Used as axis or legend title. If
 #'   `waiver()`, the default, the name of the scale is taken from the first
-#'   mapping used for that aesthetic.
+#'   mapping used for that aesthetic. If `NULL`, the legend title will be
+#'   omitted.
 #' @param breaks One of:
 #'   - `NULL` for no breaks
 #'   - `waiver()` for the default breaks computed by the

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -503,7 +503,7 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
 #'   argument (the number of levels in the scale) returns the values that
 #'   they should take
 #' @param name The name of the scale. Used as axis or legend title. If
-#'   `NULL`, the default, the name of the scale is taken from the first
+#'   `waiver()`, the default, the name of the scale is taken from the first
 #'   mapping used for that aesthetic.
 #' @param breaks One of:
 #'   - `NULL` for no breaks

--- a/man/continuous_scale.Rd
+++ b/man/continuous_scale.Rd
@@ -20,7 +20,7 @@ argument (the number of levels in the scale) returns the values that
 they should take}
 
 \item{name}{The name of the scale. Used as axis or legend title. If
-\code{NULL}, the default, the name of the scale is taken from the first
+\code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic.}
 
 \item{breaks}{One of:

--- a/man/continuous_scale.Rd
+++ b/man/continuous_scale.Rd
@@ -21,7 +21,8 @@ they should take}
 
 \item{name}{The name of the scale. Used as axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic.}
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
 
 \item{breaks}{One of:
 \itemize{

--- a/man/discrete_scale.Rd
+++ b/man/discrete_scale.Rd
@@ -19,7 +19,7 @@ argument (the number of levels in the scale) returns the values that
 they should take}
 
 \item{name}{The name of the scale. Used as axis or legend title. If
-\code{NULL}, the default, the name of the scale is taken from the first
+\code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic.}
 
 \item{breaks}{One of:

--- a/man/discrete_scale.Rd
+++ b/man/discrete_scale.Rd
@@ -20,7 +20,8 @@ they should take}
 
 \item{name}{The name of the scale. Used as axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic.}
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
 
 \item{breaks}{One of:
 \itemize{

--- a/man/scale_continuous.Rd
+++ b/man/scale_continuous.Rd
@@ -35,7 +35,7 @@ scale_y_sqrt(...)
 }
 \arguments{
 \item{name}{The name of the scale. Used as axis or legend title. If
-\code{NULL}, the default, the name of the scale is taken from the first
+\code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic.}
 
 \item{breaks}{One of:

--- a/man/scale_continuous.Rd
+++ b/man/scale_continuous.Rd
@@ -36,7 +36,8 @@ scale_y_sqrt(...)
 \arguments{
 \item{name}{The name of the scale. Used as axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic.}
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
 
 \item{breaks}{One of:
 \itemize{

--- a/man/scale_date.Rd
+++ b/man/scale_date.Rd
@@ -39,7 +39,7 @@ scale_y_time(name = waiver(), breaks = waiver(), minor_breaks = waiver(),
 }
 \arguments{
 \item{name}{The name of the scale. Used as axis or legend title. If
-\code{NULL}, the default, the name of the scale is taken from the first
+\code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic.}
 
 \item{breaks}{One of:

--- a/man/scale_date.Rd
+++ b/man/scale_date.Rd
@@ -40,7 +40,8 @@ scale_y_time(name = waiver(), breaks = waiver(), minor_breaks = waiver(),
 \arguments{
 \item{name}{The name of the scale. Used as axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic.}
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
 
 \item{breaks}{One of:
 \itemize{

--- a/man/scale_discrete.Rd
+++ b/man/scale_discrete.Rd
@@ -38,7 +38,7 @@ where \code{NA} is always placed at the far right.}
 argument (the number of levels in the scale) returns the values that
 they should take}
   \item{name}{The name of the scale. Used as axis or legend title. If
-\code{NULL}, the default, the name of the scale is taken from the first
+\code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic.}
   \item{labels}{One of:
 \itemize{

--- a/man/scale_discrete.Rd
+++ b/man/scale_discrete.Rd
@@ -39,7 +39,8 @@ argument (the number of levels in the scale) returns the values that
 they should take}
   \item{name}{The name of the scale. Used as axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic.}
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
   \item{labels}{One of:
 \itemize{
 \item \code{NULL} for no labels

--- a/man/scale_gradient.Rd
+++ b/man/scale_gradient.Rd
@@ -47,7 +47,8 @@ argument (the number of levels in the scale) returns the values that
 they should take}
   \item{name}{The name of the scale. Used as axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic.}
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
   \item{breaks}{One of:
 \itemize{
 \item \code{NULL} for no breaks

--- a/man/scale_gradient.Rd
+++ b/man/scale_gradient.Rd
@@ -46,7 +46,7 @@ scale_fill_gradientn(..., colours, values = NULL, space = "Lab",
 argument (the number of levels in the scale) returns the values that
 they should take}
   \item{name}{The name of the scale. Used as axis or legend title. If
-\code{NULL}, the default, the name of the scale is taken from the first
+\code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic.}
   \item{breaks}{One of:
 \itemize{

--- a/man/scale_grey.Rd
+++ b/man/scale_grey.Rd
@@ -40,7 +40,8 @@ argument (the number of levels in the scale) returns the values that
 they should take}
   \item{name}{The name of the scale. Used as axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic.}
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
   \item{labels}{One of:
 \itemize{
 \item \code{NULL} for no labels

--- a/man/scale_grey.Rd
+++ b/man/scale_grey.Rd
@@ -39,7 +39,7 @@ where \code{NA} is always placed at the far right.}
 argument (the number of levels in the scale) returns the values that
 they should take}
   \item{name}{The name of the scale. Used as axis or legend title. If
-\code{NULL}, the default, the name of the scale is taken from the first
+\code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic.}
   \item{labels}{One of:
 \itemize{

--- a/man/scale_hue.Rd
+++ b/man/scale_hue.Rd
@@ -44,7 +44,7 @@ where \code{NA} is always placed at the far right.}
 argument (the number of levels in the scale) returns the values that
 they should take}
   \item{name}{The name of the scale. Used as axis or legend title. If
-\code{NULL}, the default, the name of the scale is taken from the first
+\code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic.}
   \item{labels}{One of:
 \itemize{

--- a/man/scale_hue.Rd
+++ b/man/scale_hue.Rd
@@ -45,7 +45,8 @@ argument (the number of levels in the scale) returns the values that
 they should take}
   \item{name}{The name of the scale. Used as axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic.}
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
   \item{labels}{One of:
 \itemize{
 \item \code{NULL} for no labels

--- a/man/scale_linetype.Rd
+++ b/man/scale_linetype.Rd
@@ -38,7 +38,7 @@ from a discrete scale, specify \code{na.translate = FALSE}.}
 argument (the number of levels in the scale) returns the values that
 they should take}
   \item{name}{The name of the scale. Used as axis or legend title. If
-\code{NULL}, the default, the name of the scale is taken from the first
+\code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic.}
   \item{labels}{One of:
 \itemize{

--- a/man/scale_linetype.Rd
+++ b/man/scale_linetype.Rd
@@ -39,7 +39,8 @@ argument (the number of levels in the scale) returns the values that
 they should take}
   \item{name}{The name of the scale. Used as axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic.}
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
   \item{labels}{One of:
 \itemize{
 \item \code{NULL} for no labels

--- a/man/scale_manual.Rd
+++ b/man/scale_manual.Rd
@@ -52,7 +52,8 @@ argument (the number of levels in the scale) returns the values that
 they should take}
   \item{name}{The name of the scale. Used as axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic.}
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
   \item{labels}{One of:
 \itemize{
 \item \code{NULL} for no labels

--- a/man/scale_manual.Rd
+++ b/man/scale_manual.Rd
@@ -51,7 +51,7 @@ where \code{NA} is always placed at the far right.}
 argument (the number of levels in the scale) returns the values that
 they should take}
   \item{name}{The name of the scale. Used as axis or legend title. If
-\code{NULL}, the default, the name of the scale is taken from the first
+\code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic.}
   \item{labels}{One of:
 \itemize{

--- a/man/scale_shape.Rd
+++ b/man/scale_shape.Rd
@@ -38,7 +38,7 @@ where \code{NA} is always placed at the far right.}
 argument (the number of levels in the scale) returns the values that
 they should take}
   \item{name}{The name of the scale. Used as axis or legend title. If
-\code{NULL}, the default, the name of the scale is taken from the first
+\code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic.}
   \item{labels}{One of:
 \itemize{

--- a/man/scale_shape.Rd
+++ b/man/scale_shape.Rd
@@ -39,7 +39,8 @@ argument (the number of levels in the scale) returns the values that
 they should take}
   \item{name}{The name of the scale. Used as axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic.}
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
   \item{labels}{One of:
 \itemize{
 \item \code{NULL} for no labels

--- a/man/scale_size.Rd
+++ b/man/scale_size.Rd
@@ -23,7 +23,8 @@ scale_size_area(..., max_size = 6)
 \arguments{
 \item{name}{The name of the scale. Used as axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic.}
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
 
 \item{breaks}{One of:
 \itemize{
@@ -69,7 +70,8 @@ transformation with \code{\link[scales:trans_new]{scales::trans_new()}}.}
 \describe{
   \item{name}{The name of the scale. Used as axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic.}
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
   \item{breaks}{One of:
 \itemize{
 \item \code{NULL} for no breaks

--- a/man/scale_size.Rd
+++ b/man/scale_size.Rd
@@ -22,7 +22,7 @@ scale_size_area(..., max_size = 6)
 }
 \arguments{
 \item{name}{The name of the scale. Used as axis or legend title. If
-\code{NULL}, the default, the name of the scale is taken from the first
+\code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic.}
 
 \item{breaks}{One of:
@@ -68,7 +68,7 @@ transformation with \code{\link[scales:trans_new]{scales::trans_new()}}.}
 \item{...}{Arguments passed on to \code{continuous_scale}
 \describe{
   \item{name}{The name of the scale. Used as axis or legend title. If
-\code{NULL}, the default, the name of the scale is taken from the first
+\code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic.}
   \item{breaks}{One of:
 \itemize{


### PR DESCRIPTION
This corrects the documentation issue raised in #2296.