### PR TITLE
Restored correct scaling for `ndensity` when binning (#2324)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -194,6 +194,8 @@ up correct aspect ratio, and draws a graticule.
 
 * Layers no longer warn about unknown aesthetics with value `NULL` (#1909).
 
+* Restored correct scaling for computed variable `ndensity` when binning (@timgoodman, #2324)
+
 ### Coords
 
 * Like scales, coordinate systems now give you a message when you're 

--- a/R/bin.R
+++ b/R/bin.R
@@ -165,7 +165,7 @@ bin_out <- function(count = integer(0), x = numeric(0), width = numeric(0),
     width = width,
     density = density,
     ncount = count / max(abs(count)),
-    ndensity = count / max(abs(density)),
+    ndensity = density / max(abs(density)),
     stringsAsFactors = FALSE
   )
 }


### PR DESCRIPTION
At some point during a refactoring, `ndensity` was changed from `density/max(density)` to `count/max(density)` -- I believe by mistake.  This changes it back.  See issue [#2324](https://github.com/tidyverse/ggplot2/issues/2324) for details.