### PR TITLE
Fix colorbar to show all colors of the scale

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -71,6 +71,8 @@
 
 * Fix bug in `scale_*_gradient2()` where points outside limits can sometimes reappear due to rescaling. Now, any rescaling is performed after the limits are enforced (@foo-bar-baz-qux, #2230).
 
+* The colorbar shows all colours of the scale (@has2k1, 2343).
+
 ### Margins
 
 * Strips gain margins on all sides by default. This means that to fully justify

--- a/R/guide-colorbar.r
+++ b/R/guide-colorbar.r
@@ -190,7 +190,7 @@ guide_train.colorbar <- function(guide, scale) {
 
   # bar specification (number of divs etc)
   .limits <- scale$get_limits()
-  .bar <- discard(pretty(.limits, n = guide$nbin), scale$get_limits())
+  .bar <- seq(.limits[1], .limits[2], length = guide$nbin)
   if (length(.bar) == 0) {
     .bar = unique(.limits)
   }


### PR DESCRIPTION
Previously it showed an approximation where the colours
at the scale limits were not guaranteed to be included.

``` r
library(ggplot2)

ggplot(faithful, aes(x = eruptions, y = waiting)) +
  geom_point()  +
  stat_density_2d(aes(fill=..level..), geom='polygon') +
  xlim(0.5, 6) +
  ylim(40, 110) +
  scale_fill_viridis_c() +
  guides(fill=guide_colorbar(nbin=7))
```

![](https://i.imgur.com/2rOHqir.png)

*Before*
![](https://i.imgur.com/9NkqiQ0.png)

fixes #2343