### PR TITLE
coord_fixed: Add example of using limits

### DIFF
--- a/R/coord-fixed.r
+++ b/R/coord-fixed.r
@@ -19,6 +19,7 @@
 #' p + coord_fixed(ratio = 1)
 #' p + coord_fixed(ratio = 5)
 #' p + coord_fixed(ratio = 1/5)
+#' p + coord_fixed(xlim = c(15, 30))
 #'
 #' # Resize the plot to see that the specified aspect ratio is maintained
 coord_fixed <- function(ratio = 1, xlim = NULL, ylim = NULL, expand = TRUE) {


### PR DESCRIPTION
It is not clear in the function documentation that the limits need to be a vector. This is clearer in the related coord_cartesian examples. Adding example may help some users.