### PR TITLE
Fix breaks for bin & bin2d stats for trans scales

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -207,6 +207,9 @@ up correct aspect ratio, and draws a graticule.
 
 * Restored correct scaling for computed variable `ndensity` when binning (@timgoodman, #2324)
 
+* `stat_bin()` and `stat_bin_2d()` now properly handle the `breaks` parameter when
+  the scales are transformed (@has2k1, #2366).
+
 ### Coords
 
 * Like scales, coordinate systems now give you a message when you're 

--- a/R/stat-bin.r
+++ b/R/stat-bin.r
@@ -121,12 +121,16 @@ StatBin <- ggproto("StatBin", Stat,
   compute_group = function(data, scales, binwidth = NULL, bins = NULL,
                            center = NULL, boundary = NULL,
                            closed = c("right", "left"), pad = FALSE,
+                           breaks = NULL,
                            # The following arguments are not used, but must
                            # be listed so parameters are computed correctly
-                           breaks = NULL, origin = NULL, right = NULL,
-                           drop = NULL, width = NULL) {
+                           origin = NULL, right = NULL, drop = NULL,
+                           width = NULL) {
 
     if (!is.null(breaks)) {
+      if (!scales$x$is_discrete()){
+         breaks <- scales$x$transform(breaks)
+      }
       bins <- bin_breaks(breaks, closed)
     } else if (!is.null(binwidth)) {
       if (is.function(binwidth)) {

--- a/R/stat-bin2d.r
+++ b/R/stat-bin2d.r
@@ -101,6 +101,10 @@ bin2d_breaks <- function(scale, breaks = NULL, origin = NULL, binwidth = NULL,
   if (scale$is_discrete()) {
     breaks <- scale$get_breaks()
     return(-0.5 + seq_len(length(breaks) + 1))
+  } else {
+    if (!is.null(breaks)) {
+      breaks <- scale$transform(breaks)
+    }
   }
 
   if (!is.null(breaks))

--- a/tests/testthat/test-stat-bin.R
+++ b/tests/testthat/test-stat-bin.R
@@ -60,6 +60,16 @@ test_that("fuzzy breaks used when cutting", {
   expect_equal(bins$count, c(1, 1, 1, 1))
 })
 
+test_that("breaks are transformed by the scale", {
+   df <- data.frame(x = rep(1:4, 1:4))
+   base <- ggplot(df, aes(x)) + geom_histogram(breaks = c(1, 2.5, 4))
+
+   out1 <- layer_data(base)
+   out2 <- layer_data(base + scale_x_sqrt())
+   expect_equal(out1$xmin, c(1, 2.5))
+   expect_equal(out2$xmin, sqrt(c(1, 2.5)))
+})
+
 # Underlying binning algorithm --------------------------------------------
 
 comp_bin <- function(df, ...) {

--- a/tests/testthat/test-stat-bin2d.R
+++ b/tests/testthat/test-stat-bin2d.R
@@ -29,3 +29,15 @@ test_that("breaks override binwidth", {
   expect_equal(out$xbin, cut(df$x, adjust_breaks(integer_breaks), include.lowest = TRUE, labels = FALSE))
   expect_equal(out$ybin, cut(df$y, adjust_breaks(half_breaks), include.lowest = TRUE, labels = FALSE))
 })
+
+test_that("breaks are transformed by the scale", {
+  df <- data.frame(x = c(1, 10, 100, 1000), y = 0:3)
+  base <- ggplot(df, aes(x, y)) +
+    stat_bin_2d(
+      breaks = list(x = c(5, 50, 500), y = c(0.5, 1.5, 2.5)))
+
+  out1 <- layer_data(base)
+  out2 <- layer_data(base + scale_x_log10())
+  expect_equal(out1$x, c(27.5, 275))
+  expect_equal(out2$x, c(1.19897, 2.19897))
+})


### PR DESCRIPTION
The issue only was only about `stat_bin_2d`, but `stat_bin`
suffered the same slight.

Fixes #2366