### PR TITLE
added fill to gpar in geom_curve()

### DIFF
--- a/R/geom-curve.r
+++ b/R/geom-curve.r
@@ -53,6 +53,7 @@ GeomCurve <- ggproto("GeomCurve", GeomSegment,
       square = FALSE, squareShape = 1, inflect = FALSE, open = TRUE,
       gp = gpar(
         col = alpha(trans$colour, trans$alpha),
+        fill = alpha(trans$colour, trans$alpha),
         lwd = trans$size * .pt,
         lty = trans$linetype,
         lineend = lineend),


### PR DESCRIPTION
Based on https://stackoverflow.com/questions/47878787/fill-arrow-on-geom-curve-ggplot2/47879776#47879776

this adds a missing `fill` `gpar` (i.e. back on par with `geom_segment`) and takes care of ^^ issue.