### PR TITLE
Fix angle of switched y strips

### DIFF
--- a/R/labeller.r
+++ b/R/labeller.r
@@ -552,8 +552,9 @@ build_strip <- function(label_df, labeller, theme, horizontal) {
       clip = "on"
     )
 
-    if (inherits(theme$strip.text.y, "element_text")) {
-      theme$strip.text.y$angle <- adjust_angle(theme$strip.text.y$angle)
+    # Change angle of strip labels for y strips that are placed on the left side
+    if (inherits(element, "element_text")) {
+      element$angle <- adjust_angle(element$angle)
     }
 
     grobs_left <- grobs

--- a/R/labeller.r
+++ b/R/labeller.r
@@ -519,20 +519,9 @@ build_strip <- function(label_df, labeller, theme, horizontal) {
     lineheight = element$lineheight
   )
 
-  # Create text grobs, preserving array layout
-  grobs <- lapply(labels, title_spec,
-    x = NULL,
-    y = NULL,
-    hjust = element$hjust,
-    vjust = element$vjust,
-    angle = element$angle,
-    gp = gp,
-    debug = element$debug
-  )
-  dim(grobs) <- dim(labels)
-
   if (horizontal) {
 
+    grobs <- create_strip_labels(labels, element, gp)
     grobs <- ggstrip(grobs, theme, element, gp, horizontal, clip = "on")
 
     list(
@@ -541,6 +530,7 @@ build_strip <- function(label_df, labeller, theme, horizontal) {
     )
   } else {
 
+    grobs <- create_strip_labels(labels, element, gp)
     grobs_right <- grobs[, rev(seq_len(ncol(grobs))), drop = FALSE]
 
     grobs_right <- ggstrip(
@@ -557,7 +547,7 @@ build_strip <- function(label_df, labeller, theme, horizontal) {
       element$angle <- adjust_angle(element$angle)
     }
 
-    grobs_left <- grobs
+    grobs_left <- create_strip_labels(labels, element, gp)
 
     grobs_left <- ggstrip(
       grobs_left,
@@ -573,6 +563,30 @@ build_strip <- function(label_df, labeller, theme, horizontal) {
       right = grobs_right
     )
   }
+}
+
+#' Create list of strip labels
+#'
+#' Calls [title_spec()] on all the labels for a set of strips to create a list
+#' of text grobs, heights, and widths.
+#'
+#' @param labels Matrix of strip labels
+#' @param element Theme element (see [calc_element()]).
+#' @param gp Additional graphical parameters.
+#'
+#' @noRd
+create_strip_labels <- function(labels, element, gp) {
+  grobs <- lapply(labels, title_spec,
+    x = NULL,
+    y = NULL,
+    hjust = element$hjust,
+    vjust = element$vjust,
+    angle = element$angle,
+    gp = gp,
+    debug = element$debug
+  )
+  dim(grobs) <- dim(labels)
+  grobs
 }
 
 #' Grob for strip labels

--- a/tests/figs/facet-strips/switched-facet-strips.svg
+++ b/tests/figs/facet-strips/switched-facet-strips.svg
@@ -1,0 +1,247 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpNTMuMzZ8MjcwLjA5fDI3Mi4zMHwyMy40OA=='>
+    <rect x='53.36' y='23.48' width='216.73' height='248.82' />
+  </clipPath>
+</defs>
+<rect x='53.36' y='23.48' width='216.73' height='248.82' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpNTMuMzZ8MjcwLjA5fDI3Mi4zMHwyMy40OA==)' />
+<circle cx='100.37' cy='164.05' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNTMuMzZ8MjcwLjA5fDI3Mi4zMHwyMy40OA==)' />
+<circle cx='97.47' cy='140.07' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNTMuMzZ8MjcwLjA5fDI3Mi4zMHwyMy40OA==)' />
+<circle cx='87.29' cy='163.00' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNTMuMzZ8MjcwLjA5fDI3Mi4zMHwyMy40OA==)' />
+<rect x='53.36' y='23.48' width='216.73' height='248.82' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpNTMuMzZ8MjcwLjA5fDI3Mi4zMHwyMy40OA==)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpNTMuMzZ8MjcwLjA5fDUyNi42MHwyNzcuNzg='>
+    <rect x='53.36' y='277.78' width='216.73' height='248.82' />
+  </clipPath>
+</defs>
+<rect x='53.36' y='277.78' width='216.73' height='248.82' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpNTMuMzZ8MjcwLjA5fDUyNi42MHwyNzcuNzg=)' />
+<circle cx='81.35' cy='401.67' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNTMuMzZ8MjcwLjA5fDUyNi42MHwyNzcuNzg=)' />
+<circle cx='66.95' cy='377.70' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNTMuMzZ8MjcwLjA5fDUyNi42MHwyNzcuNzg=)' />
+<circle cx='65.47' cy='289.09' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNTMuMzZ8MjcwLjA5fDUyNi42MHwyNzcuNzg=)' />
+<circle cx='63.21' cy='363.10' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNTMuMzZ8MjcwLjA5fDUyNi42MHwyNzcuNzg=)' />
+<circle cx='67.09' cy='377.70' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNTMuMzZ8MjcwLjA5fDUyNi42MHwyNzcuNzg=)' />
+<circle cx='87.39' cy='341.21' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNTMuMzZ8MjcwLjA5fDUyNi42MHwyNzcuNzg=)' />
+<circle cx='75.01' cy='410.01' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNTMuMzZ8MjcwLjA5fDUyNi42MHwyNzcuNzg=)' />
+<circle cx='87.74' cy='374.57' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNTMuMzZ8MjcwLjA5fDUyNi42MHwyNzcuNzg=)' />
+<rect x='53.36' y='277.78' width='216.73' height='248.82' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpNTMuMzZ8MjcwLjA5fDUyNi42MHwyNzcuNzg=)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMjc1LjU3fDQ5Mi4zMXwyNzIuMzB8MjMuNDg='>
+    <rect x='275.57' y='23.48' width='216.73' height='248.82' />
+  </clipPath>
+</defs>
+<rect x='275.57' y='23.48' width='216.73' height='248.82' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMjc1LjU3fDQ5Mi4zMXwyNzIuMzB8MjMuNDg=)' />
+<circle cx='377.28' cy='227.63' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpMjc1LjU3fDQ5Mi4zMXwyNzIuMzB8MjMuNDg=)' />
+<circle cx='361.06' cy='260.99' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpMjc1LjU3fDQ5Mi4zMXwyNzIuMzB8MjMuNDg=)' />
+<circle cx='332.85' cy='140.07' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpMjc1LjU3fDQ5Mi4zMXwyNzIuMzB8MjMuNDg=)' />
+<circle cx='332.85' cy='140.07' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpMjc1LjU3fDQ5Mi4zMXwyNzIuMzB8MjMuNDg=)' />
+<rect x='275.57' y='23.48' width='216.73' height='248.82' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpMjc1LjU3fDQ5Mi4zMXwyNzIuMzB8MjMuNDg=)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMjc1LjU3fDQ5Mi4zMXw1MjYuNjB8Mjc3Ljc4'>
+    <rect x='275.57' y='277.78' width='216.73' height='248.82' />
+  </clipPath>
+</defs>
+<rect x='275.57' y='277.78' width='216.73' height='248.82' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMjc1LjU3fDQ5Mi4zMXw1MjYuNjB8Mjc3Ljc4)' />
+<circle cx='329.12' cy='396.46' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpMjc1LjU3fDQ5Mi4zMXw1MjYuNjB8Mjc3Ljc4)' />
+<circle cx='329.12' cy='396.46' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpMjc1LjU3fDQ5Mi4zMXw1MjYuNjB8Mjc3Ljc4)' />
+<circle cx='321.74' cy='425.65' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpMjc1LjU3fDQ5Mi4zMXw1MjYuNjB8Mjc3Ljc4)' />
+<rect x='275.57' y='277.78' width='216.73' height='248.82' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpMjc1LjU3fDQ5Mi4zMXw1MjYuNjB8Mjc3Ljc4)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpNDk3Ljc5fDcxNC41MnwyNzIuMzB8MjMuNDg='>
+    <rect x='497.79' y='23.48' width='216.73' height='248.82' />
+  </clipPath>
+</defs>
+<rect x='497.79' y='23.48' width='216.73' height='248.82' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpNDk3Ljc5fDcxNC41MnwyNzIuMzB8MjMuNDg=)' />
+<circle cx='649.62' cy='220.34' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDk3Ljc5fDcxNC41MnwyNzIuMzB8MjMuNDg=)' />
+<circle cx='649.62' cy='214.08' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDk3Ljc5fDcxNC41MnwyNzIuMzB8MjMuNDg=)' />
+<circle cx='608.24' cy='228.68' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDk3Ljc5fDcxNC41MnwyNzIuMzB8MjMuNDg=)' />
+<circle cx='608.24' cy='228.68' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDk3Ljc5fDcxNC41MnwyNzIuMzB8MjMuNDg=)' />
+<circle cx='608.24' cy='228.68' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDk3Ljc5fDcxNC41MnwyNzIuMzB8MjMuNDg=)' />
+<circle cx='704.67' cy='243.27' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDk3Ljc5fDcxNC41MnwyNzIuMzB8MjMuNDg=)' />
+<circle cx='698.77' cy='235.97' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDk3Ljc5fDcxNC41MnwyNzIuMzB8MjMuNDg=)' />
+<circle cx='688.94' cy='212.00' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDk3Ljc5fDcxNC41MnwyNzIuMzB8MjMuNDg=)' />
+<circle cx='628.98' cy='260.99' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDk3Ljc5fDcxNC41MnwyNzIuMzB8MjMuNDg=)' />
+<circle cx='622.10' cy='220.34' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDk3Ljc5fDcxNC41MnwyNzIuMzB8MjMuNDg=)' />
+<circle cx='644.71' cy='159.88' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDk3Ljc5fDcxNC41MnwyNzIuMzB8MjMuNDg=)' />
+<circle cx='669.28' cy='227.63' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDk3Ljc5fDcxNC41MnwyNzIuMzB8MjMuNDg=)' />
+<rect x='497.79' y='23.48' width='216.73' height='248.82' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpNDk3Ljc5fDcxNC41MnwyNzIuMzB8MjMuNDg=)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpNDk3Ljc5fDcxNC41Mnw1MjYuNjB8Mjc3Ljc4'>
+    <rect x='497.79' y='277.78' width='216.73' height='248.82' />
+  </clipPath>
+</defs>
+<rect x='497.79' y='277.78' width='216.73' height='248.82' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpNDk3Ljc5fDcxNC41Mnw1MjYuNjB8Mjc3Ljc4)' />
+<circle cx='645.20' cy='363.10' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDk3Ljc5fDcxNC41Mnw1MjYuNjB8Mjc3Ljc4)' />
+<circle cx='620.63' cy='433.99' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDk3Ljc5fDcxNC41Mnw1MjYuNjB8Mjc3Ljc4)' />
+<rect x='497.79' y='277.78' width='216.73' height='248.82' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpNDk3Ljc5fDcxNC41Mnw1MjYuNjB8Mjc3Ljc4)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpNTMuMzZ8MjcwLjA5fDU0My44OHw1MjYuNjA='>
+    <rect x='53.36' y='526.60' width='216.73' height='17.27' />
+  </clipPath>
+</defs>
+<rect x='53.36' y='526.60' width='216.73' height='17.27' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpNTMuMzZ8MjcwLjA5fDU0My44OHw1MjYuNjA=)' />
+<g clip-path='url(#cpNTMuMzZ8MjcwLjA5fDU0My44OHw1MjYuNjA=)'><text x='159.22' y='538.33' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>4</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMjc1LjU3fDQ5Mi4zMXw1NDMuODh8NTI2LjYw'>
+    <rect x='275.57' y='526.60' width='216.73' height='17.27' />
+  </clipPath>
+</defs>
+<rect x='275.57' y='526.60' width='216.73' height='17.27' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpMjc1LjU3fDQ5Mi4zMXw1NDMuODh8NTI2LjYw)' />
+<g clip-path='url(#cpMjc1LjU3fDQ5Mi4zMXw1NDMuODh8NTI2LjYw)'><text x='381.44' y='538.33' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>6</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpNDk3Ljc5fDcxNC41Mnw1NDMuODh8NTI2LjYw'>
+    <rect x='497.79' y='526.60' width='216.73' height='17.27' />
+  </clipPath>
+</defs>
+<rect x='497.79' y='526.60' width='216.73' height='17.27' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpNDk3Ljc5fDcxNC41Mnw1NDMuODh8NTI2LjYw)' />
+<g clip-path='url(#cpNDk3Ljc5fDcxNC41Mnw1NDMuODh8NTI2LjYw)'><text x='603.65' y='538.33' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>8</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMzYuMDl8NTMuMzZ8MjcyLjMwfDIzLjQ4'>
+    <rect x='36.09' y='23.48' width='17.27' height='248.82' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<rect x='36.09' y='23.48' width='17.27' height='248.82' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(47.82,150.39) rotate(-90)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<defs>
+  <clipPath id='cpMzYuMDl8NTMuMzZ8MjcyLjMwfDIzLjQ4'>
+    <rect x='36.09' y='23.48' width='17.27' height='248.82' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMzYuMDl8NTMuMzZ8NTI2LjYwfDI3Ny43OA=='>
+    <rect x='36.09' y='277.78' width='17.27' height='248.82' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<rect x='36.09' y='277.78' width='17.27' height='248.82' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(47.82,404.69) rotate(-90)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<defs>
+  <clipPath id='cpMzYuMDl8NTMuMzZ8NTI2LjYwfDI3Ny43OA=='>
+    <rect x='36.09' y='277.78' width='17.27' height='248.82' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<polyline points='77.42,546.61 77.42,543.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='126.56,546.61 126.56,543.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='175.71,546.61 175.71,543.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='224.86,546.61 224.86,543.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='69.91' y='554.99' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='15.02px' lengthAdjust='spacingAndGlyphs'>100</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='119.05' y='554.99' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='15.02px' lengthAdjust='spacingAndGlyphs'>200</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='168.20' y='554.99' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='15.02px' lengthAdjust='spacingAndGlyphs'>300</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='217.35' y='554.99' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='15.02px' lengthAdjust='spacingAndGlyphs'>400</text></g>
+<polyline points='299.63,546.61 299.63,543.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='348.78,546.61 348.78,543.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='397.92,546.61 397.92,543.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='447.07,546.61 447.07,543.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='292.12' y='554.99' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='15.02px' lengthAdjust='spacingAndGlyphs'>100</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='341.27' y='554.99' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='15.02px' lengthAdjust='spacingAndGlyphs'>200</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='390.41' y='554.99' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='15.02px' lengthAdjust='spacingAndGlyphs'>300</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='439.56' y='554.99' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='15.02px' lengthAdjust='spacingAndGlyphs'>400</text></g>
+<polyline points='521.84,546.61 521.84,543.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='570.99,546.61 570.99,543.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='620.14,546.61 620.14,543.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='669.28,546.61 669.28,543.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='514.33' y='554.99' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='15.02px' lengthAdjust='spacingAndGlyphs'>100</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='563.48' y='554.99' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='15.02px' lengthAdjust='spacingAndGlyphs'>200</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='612.63' y='554.99' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='15.02px' lengthAdjust='spacingAndGlyphs'>300</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='661.78' y='554.99' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='15.02px' lengthAdjust='spacingAndGlyphs'>400</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.65' y='239.07' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.65' y='186.95' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>3.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.65' y='134.82' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>4.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.65' y='82.70' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>4.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.65' y='30.58' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>5.0</text></g>
+<polyline points='33.35,235.97 36.09,235.97 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='33.35,183.85 36.09,183.85 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='33.35,131.73 36.09,131.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='33.35,79.61 36.09,79.61 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='33.35,27.49 36.09,27.49 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.65' y='493.37' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.65' y='441.25' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>3.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.65' y='389.13' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>4.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.65' y='337.01' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>4.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.65' y='284.89' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>5.0</text></g>
+<polyline points='33.35,490.28 36.09,490.28 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='33.35,438.16 36.09,438.16 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='33.35,386.03 36.09,386.03 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='33.35,333.91 36.09,333.91 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='33.35,281.79 36.09,281.79 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='373.85' y='568.04' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='20.18px' lengthAdjust='spacingAndGlyphs'>disp</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(13.04,284.52) rotate(-90)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='18.95px' lengthAdjust='spacingAndGlyphs'>drat</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='53.36' y='14.42' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='117.04px' lengthAdjust='spacingAndGlyphs'>switched facet strips</text></g>
+</svg>

--- a/tests/testthat/test-facet-strips.r
+++ b/tests/testthat/test-facet-strips.r
@@ -132,3 +132,9 @@ test_that("strips can be removed", {
   strip_grobs <- g_grobs$grobs[grepl('strip-', g_grobs$layout$name)]
   expect_true(all(sapply(strip_grobs, inherits, 'zeroGrob')))
 })
+
+test_that("y strip labels are rotated when strips are switched", {
+  switched <- p + facet_grid(am ~ cyl, switch = "both")
+  
+  vdiffr::expect_doppelganger("switched facet strips", switched)
+})


### PR DESCRIPTION
Fixes #2356. The [titleGrob() refactor](https://github.com/tidyverse/ggplot2/pull/2232/) caused a bug where strip labels on the left side weren't rotated properly. This fixes it by extracting the creation of the text grobs into a separate function (`create_strip_labels()`) that can be called after the angle has been adjusted.