### PR TITLE
fix #2260 for continuous color scales

### DIFF
--- a/R/guide-colorbar.r
+++ b/R/guide-colorbar.r
@@ -299,8 +299,8 @@ guide_gengrob.colorbar <- function(guide, theme) {
 
   # gap between keys etc
   hgap <- width_cm(theme$legend.spacing.x  %||% unit(0.3, "line"))
-  vgap <- height_cm(theme$legend.spacing.y %||% 0.5 * unit(title_height, "cm"))
-  
+  vgap <- height_cm(theme$legend.spacing.y %||% (0.5 * unit(title_height, "cm")))
+
   # label
   label.theme <- guide$label.theme %||% calc_element("legend.text", theme)
   grob.label <- {


### PR DESCRIPTION
This pull request fixes #2260 for continuous color scales. #2260 has been previously fixed for discrete color scales, but it still exists for continuous ones:

```
library(ggplot2)
ggplot(iris, aes(x=Sepal.Length, y=Sepal.Width, color=Petal.Width)) + 
  geom_point() +
  theme(legend.spacing.y = grid::unit(0.5, "cm"))

#  Error in Ops.unit(theme$legend.spacing.y %||% 0.5, unit(title_height,  : 
#   only one operand may be a unit 
```
