### PR TITLE
Make position_dodge2 preserve total width by default

### DIFF
--- a/R/geom-boxplot.r
+++ b/R/geom-boxplot.r
@@ -111,7 +111,9 @@ geom_boxplot <- function(mapping = NULL, data = NULL,
                          inherit.aes = TRUE) {
 
   # varwidth = TRUE is not compatible with preserve = "total"
-  if (!is.character(position)) {
+  if (is.character(position)) {
+    if (varwidth == TRUE) position <- position_dodge2(preserve = "single")
+  } else {
     if (identical(position$preserve, "total") & varwidth == TRUE) {
       warning("Can't preserve total widths when varwidth = TRUE.", call. = FALSE)
       position$preserve <- "single"

--- a/R/position-dodge2.r
+++ b/R/position-dodge2.r
@@ -19,7 +19,7 @@ position_dodge2 <- function(width = NULL, preserve = c("single", "total"),
 #' @usage NULL
 #' @export
 PositionDodge2 <- ggproto("PositionDodge2", PositionDodge,
-  preserve = "single",
+  preserve = "total",
   padding = 0.1,
   reverse = FALSE,
 

--- a/tests/testthat/test-position-dodge2.R
+++ b/tests/testthat/test-position-dodge2.R
@@ -64,3 +64,15 @@ test_that("padding argument controls space between elements", {
   expect_equal(gaps(d1), 0)
   expect_equal(gaps(d2), 0.0375)  
 })
+
+test_that("boxes in facetted plots keep the correct width", {
+
+  p <- ggplot(mtcars, aes(x = factor(vs), y = mpg)) +
+    facet_wrap( ~ factor(cyl)) +
+    geom_boxplot()
+
+  d <- layer_data(p)
+
+  expect_true(all(d$xmax - d$xmin == 0.75))
+
+})


### PR DESCRIPTION
Closes #2290 by setting the default `preserve` argument in `position_dodge2()` to `"total"`. 

Before: 

``` r
ggplot(mtcars, aes(x = factor(vs), y = mpg)) +
  facet_wrap( ~ factor(cyl)) +
  geom_boxplot()
```

![](https://i.imgur.com/zr206DP.png)


After:

``` r
ggplot(mtcars, aes(x = factor(vs), y = mpg)) +
  facet_wrap( ~ factor(cyl)) +
  geom_boxplot()
```

![](https://i.imgur.com/V5JE7Qr.png)
