### PR TITLE
add `rlang` dependency to `Imports`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Imports:
     MASS,
     plyr (>= 1.7.1),
     reshape2,
+    rlang (>=0.1.7),
     scales (>= 0.4.1.9002),
     stats,
     tibble,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     MASS,
     plyr (>= 1.7.1),
     reshape2,
-    rlang (>=0.1.7),
+    rlang (>= 0.1.7),
     scales (>= 0.4.1.9002),
     stats,
     tibble,


### PR DESCRIPTION
Hi @hadley ,

 in d69762269787ed0799ab4fb1f35638cc46b5b7e6 you added
https://github.com/tidyverse/ggplot2/blob/d69762269787ed0799ab4fb1f35638cc46b5b7e6/R/aes.r#L61
which makes `ggplot2` dependent on `rlang`. This dependency is not reflected in `gglpot2`'s `DESCRIPTION`. I added `rlang` to `Imports` but `enexprs` is not yet available in a released version of `rlang` hence the requirement for unreleased `0.1.7`. 

best, Jan


Reproduce the resulting problem:
````
remove.packages("rlang")
remove.packages("ggplot2")
devtools::install_github("tidyverse/ggplot2") # fails with:
# Error in loadNamespace [...] there is no package called 'rlang'
devtools::install_github("jan-glx/ggplot2", ref = "patch-2") # until release of rlang 0.1.7 fails with: 
# Error : 'enexprs' is not an exported object from 'namespace:rlang'
devtools::install_github("tidyverse/rlang")
devtools::install_github("tidyverse/ggplot2") # works
````
