### PR TITLE
Add tag label for adding identifier to plot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -80,7 +80,8 @@
 * Added `tag` label for adding identification tags to the plot. A tag is added 
   with the `labs()` function and styling is handled through the `plot.tag` theme 
   element. Position is specified with the `plot.tag.position` theme setting and
-  defauls to `"topleft"` (@thomasp85).
+  defauls to `"topleft"`. Tags are useful for identifying subplots in a 
+  multiplot figure and often used in the scientific literature (@thomasp85).
 
 ### Scales
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -77,9 +77,10 @@
   line makes it easier to judge the fit of the theoretical distribution 
   (@nicksolomon).
   
-* Added `tag` label for adding identification tags to the upper left corner of 
-  the plot. A tag is added with the `labs()` function and styling is handled 
-  through the `plot.tag` theme element (@thomasp85).
+* Added `tag` label for adding identification tags to the plot. A tag is added 
+  with the `labs()` function and styling is handled through the `plot.tag` theme 
+  element. Position is specified with the `plot.tag.position` theme setting and
+  defauls to `"topleft"` (@thomasp85).
 
 ### Scales
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -76,6 +76,10 @@
 * Added `stat_qq_line()` to make it easy to add a simple line to a Q-Q plot. This
   line makes it easier to judge the fit of the theoretical distribution 
   (@nicksolomon).
+  
+* Added `tag` label for adding identification tags to the upper left corner of 
+  the plot. A tag is added with the `labs()` function and styling is handled 
+  through the `plot.tag` theme element (@thomasp85).
 
 ### Scales
 

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -279,9 +279,12 @@ ggplot_gtable.ggplot_built <- function(data) {
   if (tag_pos == "manual") {
     xpos <- theme$plot.tag.position[1]
     ypos <- theme$plot.tag.position[2]
-
-    tag <- editGrob(tag, vp = viewport(x = xpos, y = ypos))
-    plot_table <- gtable_add_grob(plot_table, tag, name = "tag", t = 1,
+    tag_parent  <- gTree(
+      children = gList(tag),
+      vp = viewport(x = xpos, y = ypos, width = tag_width, height = tag_height,
+                    just = c(theme$plot.tag$hjust, theme$plot.tag$vjust))
+    )
+    plot_table <- gtable_add_grob(plot_table, tag_parent, name = "tag", t = 1,
                                   b = nrow(plot_table), l = 1,
                                   r = ncol(plot_table), clip = "off")
   } else {

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -262,14 +262,70 @@ ggplot_gtable.ggplot_built <- function(data) {
   plot_table <- gtable_add_grob(plot_table, title, name = "title",
     t = 1, b = 1, l = min(pans$l), r = max(pans$r), clip = "off")
 
-  plot_table <- gtable_add_rows(plot_table, tag_height, pos = 0)
-  plot_table <- gtable_add_cols(plot_table, tag_width, pos = 0)
-  plot_table <- gtable_add_grob(plot_table, tag, name = "tag",
-    t = 1, b = 1, l = 1, r = 1, clip = "off")
-
   plot_table <- gtable_add_rows(plot_table, caption_height, pos = -1)
   plot_table <- gtable_add_grob(plot_table, caption, name = "caption",
     t = -1, b = -1, l = min(pans$l), r = max(pans$r), clip = "off")
+
+  plot_table <- gtable_add_rows(plot_table, unit(0, 'pt'), pos = 0)
+  plot_table <- gtable_add_cols(plot_table, unit(0, 'pt'), pos = 0)
+  plot_table <- gtable_add_rows(plot_table, unit(0, 'pt'), pos = -1)
+  plot_table <- gtable_add_cols(plot_table, unit(0, 'pt'), pos = -1)
+
+  tag_pos <- theme$plot.tag.position
+  if (length(tag_pos) == 2) tag_pos <- "manual"
+  stopifnot(tag_pos %in% c("topleft", "top", "topright", "left", "right",
+                           "bottomleft", "bottom", "bottomright", "manual"))
+
+  if (tag_pos == "manual") {
+    xpos <- theme$plot.tag.position[1]
+    ypos <- theme$plot.tag.position[2]
+
+    tag <- editGrob(tag, vp = viewport(x = xpos, y = ypos))
+    plot_table <- gtable_add_grob(plot_table, tag, name = "tag", t = 1,
+                                  b = nrow(plot_table), l = 1,
+                                  r = ncol(plot_table), clip = "off")
+  } else {
+    if (tag_pos == "topleft") {
+      plot_table$widths[1] <- tag_width
+      plot_table$heights[1] <- tag_height
+      plot_table <- gtable_add_grob(plot_table, tag, name = "tag",
+                                    t = 1, l = 1, clip = "off")
+    } else if (tag_pos == "top") {
+      plot_table$heights[1] <- tag_height
+      plot_table <- gtable_add_grob(plot_table, tag, name = "tag",
+                                    t = 1, l = 1, r = ncol(plot_table),
+                                    clip = "off")
+    } else if (tag_pos == "topright") {
+      plot_table$widths[ncol(plot_table)] <- tag_width
+      plot_table$heights[1] <- tag_height
+      plot_table <- gtable_add_grob(plot_table, tag, name = "tag",
+                                    t = 1, l = ncol(plot_table), clip = "off")
+    } else if (tag_pos == "left") {
+      plot_table$widths[1] <- tag_width
+      plot_table <- gtable_add_grob(plot_table, tag, name = "tag",
+                                    t = 1, b = nrow(plot_table), l = 1,
+                                    clip = "off")
+    } else if (tag_pos == "right") {
+      plot_table$widths[ncol(plot_table)] <- tag_width
+      plot_table <- gtable_add_grob(plot_table, tag, name = "tag",
+                                    t = 1, b = nrow(plot_table), l = ncol(plot_table),
+                                    clip = "off")
+    } else if (tag_pos == "bottomleft") {
+      plot_table$widths[1] <- tag_width
+      plot_table$heights[nrow(plot_table)] <- tag_height
+      plot_table <- gtable_add_grob(plot_table, tag, name = "tag",
+                                    t = nrow(plot_table), l = 1, clip = "off")
+    } else if (tag_pos == "bottom") {
+      plot_table$heights[nrow(plot_table)] <- tag_height
+      plot_table <- gtable_add_grob(plot_table, tag, name = "tag",
+                                    t = nrow(plot_table), l = 1, r = ncol(plot_table), clip = "off")
+    } else if (tag_pos == "bottomright") {
+      plot_table$widths[ncol(plot_table)] <- tag_width
+      plot_table$heights[nrow(plot_table)] <- tag_height
+      plot_table <- gtable_add_grob(plot_table, tag, name = "tag",
+                                    t = nrow(plot_table), l = ncol(plot_table), clip = "off")
+    }
+  }
 
   # Margins
   plot_table <- gtable_add_rows(plot_table, theme$plot.margin[1], pos = 0)

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -291,6 +291,8 @@ ggplot_gtable.ggplot_built <- function(data) {
                                   b = nrow(plot_table), l = 1,
                                   r = ncol(plot_table), clip = "off")
   } else {
+    # Widths and heights are reassembled below instead of assigning into them
+    # in order to avoid bug in grid 3.2 and below.
     if (tag_pos == "topleft") {
       plot_table$widths <- unit.c(tag_width, plot_table$widths[-1])
       plot_table$heights <- unit.c(tag_height, plot_table$heights[-1])

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -273,8 +273,12 @@ ggplot_gtable.ggplot_built <- function(data) {
 
   tag_pos <- theme$plot.tag.position
   if (length(tag_pos) == 2) tag_pos <- "manual"
-  stopifnot(tag_pos %in% c("topleft", "top", "topright", "left", "right",
-                           "bottomleft", "bottom", "bottomright", "manual"))
+  valid_pos <- c("topleft", "top", "topright", "left", "right", "bottomleft",
+                 "bottom", "bottomright")
+  if (!(tag_pos == "manual" || tag_pos %in% valid_pos)) {
+    stop("plot.tag.position should be a coordinate or one of ",
+         paste(valid_pos, collapse = ', '), call. = FALSE)
+  }
 
   if (tag_pos == "manual") {
     xpos <- theme$plot.tag.position[1]

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -292,42 +292,42 @@ ggplot_gtable.ggplot_built <- function(data) {
                                   r = ncol(plot_table), clip = "off")
   } else {
     if (tag_pos == "topleft") {
-      plot_table$widths[1] <- tag_width
-      plot_table$heights[1] <- tag_height
+      plot_table$widths <- unit.c(tag_width, plot_table$widths[-1])
+      plot_table$heights <- unit.c(tag_height, plot_table$heights[-1])
       plot_table <- gtable_add_grob(plot_table, tag, name = "tag",
                                     t = 1, l = 1, clip = "off")
     } else if (tag_pos == "top") {
-      plot_table$heights[1] <- tag_height
+      plot_table$heights <- unit.c(tag_height, plot_table$heights[-1])
       plot_table <- gtable_add_grob(plot_table, tag, name = "tag",
                                     t = 1, l = 1, r = ncol(plot_table),
                                     clip = "off")
     } else if (tag_pos == "topright") {
-      plot_table$widths[ncol(plot_table)] <- tag_width
-      plot_table$heights[1] <- tag_height
+      plot_table$widths <- unit.c(plot_table$widths[-ncol(plot_table)], tag_width)
+      plot_table$heights <- unit.c(tag_height, plot_table$heights[-1])
       plot_table <- gtable_add_grob(plot_table, tag, name = "tag",
                                     t = 1, l = ncol(plot_table), clip = "off")
     } else if (tag_pos == "left") {
-      plot_table$widths[1] <- tag_width
+      plot_table$widths <- unit.c(tag_width, plot_table$widths[-1])
       plot_table <- gtable_add_grob(plot_table, tag, name = "tag",
                                     t = 1, b = nrow(plot_table), l = 1,
                                     clip = "off")
     } else if (tag_pos == "right") {
-      plot_table$widths[ncol(plot_table)] <- tag_width
+      plot_table$widths <- unit.c(plot_table$widths[-ncol(plot_table)], tag_width)
       plot_table <- gtable_add_grob(plot_table, tag, name = "tag",
                                     t = 1, b = nrow(plot_table), l = ncol(plot_table),
                                     clip = "off")
     } else if (tag_pos == "bottomleft") {
-      plot_table$widths[1] <- tag_width
-      plot_table$heights[nrow(plot_table)] <- tag_height
+      plot_table$widths <- unit.c(tag_width, plot_table$widths[-1])
+      plot_table$heights <- unit.c(plot_table$heights[-nrow(plot_table)], tag_height)
       plot_table <- gtable_add_grob(plot_table, tag, name = "tag",
                                     t = nrow(plot_table), l = 1, clip = "off")
     } else if (tag_pos == "bottom") {
-      plot_table$heights[nrow(plot_table)] <- tag_height
+      plot_table$heights <- unit.c(plot_table$heights[-nrow(plot_table)], tag_height)
       plot_table <- gtable_add_grob(plot_table, tag, name = "tag",
                                     t = nrow(plot_table), l = 1, r = ncol(plot_table), clip = "off")
     } else if (tag_pos == "bottomright") {
-      plot_table$widths[ncol(plot_table)] <- tag_width
-      plot_table$heights[nrow(plot_table)] <- tag_height
+      plot_table$widths <- unit.c(plot_table$widths[-ncol(plot_table)], tag_width)
+      plot_table$heights <- unit.c(plot_table$heights[-nrow(plot_table)], tag_height)
       plot_table <- gtable_add_grob(plot_table, tag, name = "tag",
                                     t = nrow(plot_table), l = ncol(plot_table), clip = "off")
     }

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -283,11 +283,10 @@ ggplot_gtable.ggplot_built <- function(data) {
   if (tag_pos == "manual") {
     xpos <- theme$plot.tag.position[1]
     ypos <- theme$plot.tag.position[2]
-    tag_parent  <- gTree(
-      children = gList(tag),
-      vp = viewport(x = xpos, y = ypos, width = tag_width, height = tag_height,
-                    just = c(theme$plot.tag$hjust, theme$plot.tag$vjust))
-    )
+    tag_parent <- justify_grobs(tag, x = xpos, y = ypos,
+                                hjust = theme$plot.tag$hjust,
+                                vjust = theme$plot.tag$vjust,
+                                debug = theme$plot.tag$debug)
     plot_table <- gtable_add_grob(plot_table, tag_parent, name = "tag", t = 1,
                                   b = nrow(plot_table), l = 1,
                                   r = ncol(plot_table), clip = "off")

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -242,6 +242,11 @@ ggplot_gtable.ggplot_built <- function(data) {
   subtitle <- element_render(theme, "plot.subtitle", plot$labels$subtitle, margin_y = TRUE)
   subtitle_height <- grobHeight(subtitle)
 
+  # Tag
+  tag <- element_render(theme, "plot.tag", plot$labels$tag, margin_y = TRUE, margin_x = TRUE)
+  tag_height <- grobHeight(tag)
+  tag_width <- grobWidth(tag)
+
   # whole plot annotation
   caption <- element_render(theme, "plot.caption", plot$labels$caption, margin_y = TRUE)
   caption_height <- grobHeight(caption)
@@ -256,6 +261,11 @@ ggplot_gtable.ggplot_built <- function(data) {
   plot_table <- gtable_add_rows(plot_table, title_height, pos = 0)
   plot_table <- gtable_add_grob(plot_table, title, name = "title",
     t = 1, b = 1, l = min(pans$l), r = max(pans$r), clip = "off")
+
+  plot_table <- gtable_add_rows(plot_table, tag_height, pos = 0)
+  plot_table <- gtable_add_cols(plot_table, tag_width, pos = 0)
+  plot_table <- gtable_add_grob(plot_table, tag, name = "tag",
+    t = 1, b = 1, l = 1, r = 1, clip = "off")
 
   plot_table <- gtable_add_rows(plot_table, caption_height, pos = -1)
   plot_table <- gtable_add_grob(plot_table, caption, name = "caption",

--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -190,9 +190,9 @@ theme_grey <- function(base_size = 11, base_family = "",
                          ),
     plot.tag =           element_text(
                            size = rel(1.3),
-                           hjust = 0, vjust = 1,
-                           margin = margin(r = half_line, b = half_line * 3)
+                           hjust = 0.5, vjust = 0.5
                          ),
+    plot.tag.position =  'topleft',
     plot.margin =        margin(half_line, half_line, half_line, half_line),
 
     complete = TRUE
@@ -456,9 +456,9 @@ theme_void <- function(base_size = 11, base_family = "",
                          ),
     plot.tag =           element_text(
                            size = rel(1.3),
-                           hjust = 0, vjust = 1,
-                           margin = margin(r = half_line, b = half_line * 3)
+                           hjust = 0.5, vjust = 0.5
                          ),
+    plot.tag.position =  'topleft',
 
     complete = TRUE
   )
@@ -578,9 +578,9 @@ theme_test <- function(base_size = 11, base_family = "",
                          ),
     plot.tag =           element_text(
                            size = rel(1.3),
-                           hjust = 0, vjust = 1,
-                           margin = margin(r = half_line, b = half_line * 3)
+                           hjust = 0.5, vjust = 0.5
                          ),
+    plot.tag.position =  'topleft',
     plot.margin =        margin(half_line, half_line, half_line, half_line),
 
     complete = TRUE

--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -189,7 +189,7 @@ theme_grey <- function(base_size = 11, base_family = "",
                            margin = margin(t = half_line)
                          ),
     plot.tag =           element_text(
-                           size = rel(1.3),
+                           size = rel(1.2),
                            hjust = 0.5, vjust = 0.5
                          ),
     plot.tag.position =  'topleft',
@@ -455,7 +455,7 @@ theme_void <- function(base_size = 11, base_family = "",
                            margin = margin(t = half_line)
                          ),
     plot.tag =           element_text(
-                           size = rel(1.3),
+                           size = rel(1.2),
                            hjust = 0.5, vjust = 0.5
                          ),
     plot.tag.position =  'topleft',
@@ -577,7 +577,7 @@ theme_test <- function(base_size = 11, base_family = "",
                            margin = margin(t = half_line)
                          ),
     plot.tag =           element_text(
-                           size = rel(1.3),
+                           size = rel(1.2),
                            hjust = 0.5, vjust = 0.5
                          ),
     plot.tag.position =  'topleft',

--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -188,6 +188,11 @@ theme_grey <- function(base_size = 11, base_family = "",
                            hjust = 1, vjust = 1,
                            margin = margin(t = half_line)
                          ),
+    plot.tag =           element_text(
+                           size = rel(1.3),
+                           hjust = 0, vjust = 1,
+                           margin = margin(r = half_line, b = half_line * 3)
+                         ),
     plot.margin =        margin(half_line, half_line, half_line, half_line),
 
     complete = TRUE
@@ -449,6 +454,11 @@ theme_void <- function(base_size = 11, base_family = "",
                            hjust = 1, vjust = 1,
                            margin = margin(t = half_line)
                          ),
+    plot.tag =           element_text(
+                           size = rel(1.3),
+                           hjust = 0, vjust = 1,
+                           margin = margin(r = half_line, b = half_line * 3)
+                         ),
 
     complete = TRUE
   )
@@ -565,6 +575,11 @@ theme_test <- function(base_size = 11, base_family = "",
                            size = rel(0.8),
                            hjust = 1, vjust = 1,
                            margin = margin(t = half_line)
+                         ),
+    plot.tag =           element_text(
+                           size = rel(1.3),
+                           hjust = 0, vjust = 1,
+                           margin = margin(r = half_line, b = half_line * 3)
                          ),
     plot.margin =        margin(half_line, half_line, half_line, half_line),
 

--- a/R/theme-elements.r
+++ b/R/theme-elements.r
@@ -346,6 +346,7 @@ el_def <- function(class = NULL, inherit = NULL, description = NULL) {
   plot.subtitle       = el_def("element_text", "title"),
   plot.caption        = el_def("element_text", "title"),
   plot.tag            = el_def("element_text", "title"),
+  plot.tag.position   = el_def("character"),  # Need to also accept numbers
   plot.margin         = el_def("margin"),
 
   aspect.ratio        = el_def("character")

--- a/R/theme-elements.r
+++ b/R/theme-elements.r
@@ -345,6 +345,7 @@ el_def <- function(class = NULL, inherit = NULL, description = NULL) {
   plot.title          = el_def("element_text", "title"),
   plot.subtitle       = el_def("element_text", "title"),
   plot.caption        = el_def("element_text", "title"),
+  plot.tag            = el_def("element_text", "title"),
   plot.margin         = el_def("margin"),
 
   aspect.ratio        = el_def("character")

--- a/R/theme.r
+++ b/R/theme.r
@@ -159,6 +159,10 @@
 #'   (`element_text`; inherits from `title`) right-aligned by default
 #' @param plot.tag upper-left label to identify a plot (text appearance)
 #'   (`element_text`; inherits from `title`) left-aligned by default
+#' @param plot.tag.position The position of the tag as a string ("topleft",
+#'   "top", "topright", "left", "right", "bottomleft", "bottom", "bottomright)
+#'   or a coordinate. In the former case extra space will be added to accomodate
+#'   the tag.
 #' @param plot.margin margin around entire plot (`unit` with the sizes of
 #'   the top, right, bottom, and left margins)
 #'
@@ -354,6 +358,7 @@ theme <- function(line,
                   plot.subtitle,
                   plot.caption,
                   plot.tag,
+                  plot.tag.position,
                   plot.margin,
                   strip.background,
                   strip.background.x,

--- a/R/theme.r
+++ b/R/theme.r
@@ -157,6 +157,8 @@
 #'   inherits from `title`) left-aligned by default
 #' @param plot.caption caption below the plot (text appearance)
 #'   (`element_text`; inherits from `title`) right-aligned by default
+#' @param plot.tag upper-left label to identify a plot (text appearance)
+#'   (`element_text`; inherits from `title`) left-aligned by default
 #' @param plot.margin margin around entire plot (`unit` with the sizes of
 #'   the top, right, bottom, and left margins)
 #'
@@ -351,6 +353,7 @@ theme <- function(line,
                   plot.title,
                   plot.subtitle,
                   plot.caption,
+                  plot.tag,
                   plot.margin,
                   strip.background,
                   strip.background.x,

--- a/R/theme.r
+++ b/R/theme.r
@@ -161,8 +161,8 @@
 #'   (`element_text`; inherits from `title`) left-aligned by default
 #' @param plot.tag.position The position of the tag as a string ("topleft",
 #'   "top", "topright", "left", "right", "bottomleft", "bottom", "bottomright)
-#'   or a coordinate. In the former case extra space will be added to accomodate
-#'   the tag.
+#'   or a coordinate. If a string, extra space will be added to accomodate the
+#'   tag.
 #' @param plot.margin margin around entire plot (`unit` with the sizes of
 #'   the top, right, bottom, and left margins)
 #'

--- a/man/theme.Rd
+++ b/man/theme.Rd
@@ -243,8 +243,8 @@ inherits from \code{title}) left-aligned by default}
 
 \item{plot.tag.position}{The position of the tag as a string ("topleft",
 "top", "topright", "left", "right", "bottomleft", "bottom", "bottomright)
-or a coordinate. In the former case extra space will be added to accomodate
-the tag.}
+or a coordinate. If a string, extra space will be added to accomodate the
+tag.}
 
 \item{plot.margin}{margin around entire plot (\code{unit} with the sizes of
 the top, right, bottom, and left margins)}

--- a/man/theme.Rd
+++ b/man/theme.Rd
@@ -21,10 +21,10 @@ theme(line, rect, text, title, aspect.ratio, axis.title, axis.title.x,
   panel.spacing.y, panel.grid, panel.grid.major, panel.grid.minor,
   panel.grid.major.x, panel.grid.major.y, panel.grid.minor.x,
   panel.grid.minor.y, panel.ontop, plot.background, plot.title, plot.subtitle,
-  plot.caption, plot.margin, strip.background, strip.background.x,
-  strip.background.y, strip.placement, strip.text, strip.text.x, strip.text.y,
-  strip.switch.pad.grid, strip.switch.pad.wrap, ..., complete = FALSE,
-  validate = TRUE)
+  plot.caption, plot.tag, plot.tag.position, plot.margin, strip.background,
+  strip.background.x, strip.background.y, strip.placement, strip.text,
+  strip.text.x, strip.text.y, strip.switch.pad.grid, strip.switch.pad.wrap, ...,
+  complete = FALSE, validate = TRUE)
 }
 \arguments{
 \item{line}{all line elements (\code{element_line})}
@@ -237,6 +237,14 @@ inherits from \code{title}) left-aligned by default}
 
 \item{plot.caption}{caption below the plot (text appearance)
 (\code{element_text}; inherits from \code{title}) right-aligned by default}
+
+\item{plot.tag}{upper-left label to identify a plot (text appearance)
+(\code{element_text}; inherits from \code{title}) left-aligned by default}
+
+\item{plot.tag.position}{The position of the tag as a string ("topleft",
+"top", "topright", "left", "right", "bottomleft", "bottom", "bottomright)
+or a coordinate. In the former case extra space will be added to accomodate
+the tag.}
 
 \item{plot.margin}{margin around entire plot (\code{unit} with the sizes of
 the top, right, bottom, and left margins)}

--- a/tests/figs/labels/defaults.svg
+++ b/tests/figs/labels/defaults.svg
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpODEuMTR8NzE0LjUyfDU0MS41M3wzNS4xOA=='>
+    <rect x='81.14' y='35.18' width='633.38' height='506.35' />
+  </clipPath>
+</defs>
+<rect x='81.14' y='35.18' width='633.38' height='506.35' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpODEuMTR8NzE0LjUyfDU0MS41M3wzNS4xOA==)' />
+<circle cx='109.93' cy='58.20' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpODEuMTR8NzE0LjUyfDU0MS41M3wzNS4xOA==)' />
+<circle cx='173.91' cy='109.34' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpODEuMTR8NzE0LjUyfDU0MS41M3wzNS4xOA==)' />
+<circle cx='237.89' cy='160.49' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpODEuMTR8NzE0LjUyfDU0MS41M3wzNS4xOA==)' />
+<circle cx='301.86' cy='211.64' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpODEuMTR8NzE0LjUyfDU0MS41M3wzNS4xOA==)' />
+<circle cx='365.84' cy='262.78' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpODEuMTR8NzE0LjUyfDU0MS41M3wzNS4xOA==)' />
+<circle cx='429.82' cy='313.93' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpODEuMTR8NzE0LjUyfDU0MS41M3wzNS4xOA==)' />
+<circle cx='493.80' cy='365.08' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpODEuMTR8NzE0LjUyfDU0MS41M3wzNS4xOA==)' />
+<circle cx='557.77' cy='416.22' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpODEuMTR8NzE0LjUyfDU0MS41M3wzNS4xOA==)' />
+<circle cx='621.75' cy='467.37' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpODEuMTR8NzE0LjUyfDU0MS41M3wzNS4xOA==)' />
+<circle cx='685.73' cy='518.52' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpODEuMTR8NzE0LjUyfDU0MS41M3wzNS4xOA==)' />
+<rect x='81.14' y='35.18' width='633.38' height='506.35' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpODEuMTR8NzE0LjUyfDU0MS41M3wzNS4xOA==)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='63.99' y='444.82' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='63.99' y='316.95' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>5.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='63.99' y='189.09' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>7.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='59.10' y='61.22' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>10.0</text></g>
+<polyline points='78.40,441.80 81.14,441.80 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='78.40,313.93 81.14,313.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='78.40,186.06 81.14,186.06 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='78.40,58.20 81.14,58.20 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='205.90,544.27 205.90,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='365.84,544.27 365.84,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='525.79,544.27 525.79,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='685.73,544.27 685.73,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='199.79' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='359.73' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>5.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='519.68' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>7.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='677.18' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>10.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='395.08' y='568.04' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(51.14,291.11) rotate(-90)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='81.14' y='26.12' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='46.16px' lengthAdjust='spacingAndGlyphs'>defaults</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='5.48' y='15.80' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='38.09px' lengthAdjust='spacingAndGlyphs'>Fig. A)</text></g>
+</svg>

--- a/tests/figs/labels/manual.svg
+++ b/tests/figs/labels/manual.svg
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg=='>
+    <rect x='40.31' y='22.52' width='674.21' height='521.75' />
+  </clipPath>
+</defs>
+<rect x='40.31' y='22.52' width='674.21' height='521.75' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<polyline points='40.31,507.38 714.52,507.38 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<polyline points='40.31,375.62 714.52,375.62 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<polyline points='40.31,243.87 714.52,243.87 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<polyline points='40.31,112.11 714.52,112.11 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<polyline points='87.98,544.27 87.98,22.52 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<polyline points='258.23,544.27 258.23,22.52 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<polyline points='428.49,544.27 428.49,22.52 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<polyline points='598.75,544.27 598.75,22.52 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<polyline points='40.31,441.50 714.52,441.50 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<polyline points='40.31,309.75 714.52,309.75 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<polyline points='40.31,177.99 714.52,177.99 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<polyline points='40.31,46.24 714.52,46.24 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<polyline points='173.11,544.27 173.11,22.52 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<polyline points='343.36,544.27 343.36,22.52 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<polyline points='513.62,544.27 513.62,22.52 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<polyline points='683.87,544.27 683.87,22.52 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<circle cx='70.95' cy='46.24' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<circle cx='139.06' cy='98.94' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<circle cx='207.16' cy='151.64' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<circle cx='275.26' cy='204.34' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<circle cx='343.36' cy='257.05' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<circle cx='411.46' cy='309.75' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<circle cx='479.57' cy='362.45' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<circle cx='547.67' cy='415.15' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<circle cx='615.77' cy='467.85' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<circle cx='683.87' cy='520.56' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDU0NC4yN3wyMi41Mg==)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='23.16' y='444.53' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='23.16' y='312.77' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>5.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='23.16' y='181.02' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>7.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.27' y='49.26' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>10.0</text></g>
+<polyline points='37.57,441.50 40.31,441.50 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='37.57,309.75 40.31,309.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='37.57,177.99 40.31,177.99 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='37.57,46.24 40.31,46.24 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='173.11,547.01 173.11,544.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='343.36,547.01 343.36,544.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='513.62,547.01 513.62,544.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='683.87,547.01 683.87,544.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='167.00' y='555.25' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='337.25' y='555.25' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>5.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='507.51' y='555.25' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>7.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='675.32' y='555.25' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>10.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='374.66' y='568.04' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(13.04,286.15) rotate(-90)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='40.31' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='43.23px' lengthAdjust='spacingAndGlyphs'>Manual</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='21.88' y='546.81' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='38.09px' lengthAdjust='spacingAndGlyphs'>Fig. A)</text></g>
+</svg>

--- a/tests/figs/labels/other-position.svg
+++ b/tests/figs/labels/other-position.svg
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg=='>
+    <rect x='40.31' y='22.52' width='674.21' height='510.19' />
+  </clipPath>
+</defs>
+<rect x='40.31' y='22.52' width='674.21' height='510.19' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<polyline points='40.31,496.63 714.52,496.63 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<polyline points='40.31,367.80 714.52,367.80 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<polyline points='40.31,238.96 714.52,238.96 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<polyline points='40.31,110.13 714.52,110.13 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<polyline points='87.98,532.71 87.98,22.52 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<polyline points='258.23,532.71 258.23,22.52 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<polyline points='428.49,532.71 428.49,22.52 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<polyline points='598.75,532.71 598.75,22.52 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<polyline points='40.31,432.22 714.52,432.22 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<polyline points='40.31,303.38 714.52,303.38 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<polyline points='40.31,174.55 714.52,174.55 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<polyline points='40.31,45.71 714.52,45.71 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<polyline points='173.11,532.71 173.11,22.52 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<polyline points='343.36,532.71 343.36,22.52 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<polyline points='513.62,532.71 513.62,22.52 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<polyline points='683.87,532.71 683.87,22.52 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<circle cx='70.95' cy='45.71' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<circle cx='139.06' cy='97.25' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<circle cx='207.16' cy='148.78' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<circle cx='275.26' cy='200.31' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<circle cx='343.36' cy='251.85' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<circle cx='411.46' cy='303.38' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<circle cx='479.57' cy='354.92' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<circle cx='547.67' cy='406.45' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<circle cx='615.77' cy='457.98' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<circle cx='683.87' cy='509.52' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNDAuMzF8NzE0LjUyfDUzMi43MXwyMi41Mg==)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='23.16' y='435.24' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='23.16' y='306.41' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>5.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='23.16' y='177.57' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>7.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.27' y='48.74' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>10.0</text></g>
+<polyline points='37.57,432.22 40.31,432.22 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='37.57,303.38 40.31,303.38 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='37.57,174.55 40.31,174.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='37.57,45.71 40.31,45.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='173.11,535.45 173.11,532.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='343.36,535.45 343.36,532.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='513.62,535.45 513.62,532.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='683.87,535.45 683.87,532.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='167.00' y='543.69' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='337.25' y='543.69' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>5.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='507.51' y='543.69' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>7.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='675.32' y='543.69' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>10.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='374.66' y='556.47' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(13.04,280.37) rotate(-90)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='40.31' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='82.05px' lengthAdjust='spacingAndGlyphs'>Other position</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='340.95' y='569.28' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='38.09px' lengthAdjust='spacingAndGlyphs'>Fig. A)</text></g>
+</svg>

--- a/tests/testthat/test-labels.r
+++ b/tests/testthat/test-labels.r
@@ -29,11 +29,11 @@ test_that("Setting guide labels", {
 
 # Visual tests ------------------------------------------------------------
 
-test_that("geom_violin draws correctly", {
+test_that("tags are drawn correctly", {
   dat <- data.frame(x = 1:10, y = 10:1)
   p <- ggplot(dat, aes(x = x, y = y)) + geom_point() + labs(tag = "Fig. A)")
 
-  vdiffr::expect_doppelganger("defaults", p)
-  vdiffr::expect_doppelganger("Other position", p + theme(plot.tag.position = 'bottom'))
-  vdiffr::expect_doppelganger("Manual", p + theme(plot.tag.position = c(0.05, 0.05)))
+  expect_doppelganger("defaults", p)
+  expect_doppelganger("Other position", p + theme(plot.tag.position = 'bottom'))
+  expect_doppelganger("Manual", p + theme(plot.tag.position = c(0.05, 0.05)))
 })

--- a/tests/testthat/test-labels.r
+++ b/tests/testthat/test-labels.r
@@ -17,6 +17,9 @@ test_that("Setting guide labels", {
     expect_identical(labs(caption = "my notice")$caption, "my notice")
     expect_identical(labs(title = "my title",
                           caption = "my notice")$caption, "my notice")
+    expect_identical(labs(tag = "A)")$tag, "A)")
+    expect_identical(labs(title = "my title",
+                          tag = "A)")$tag, "A)")
 
     # Colour
     expect_identical(labs(colour = "my label")$colour, "my label")

--- a/tests/testthat/test-labels.r
+++ b/tests/testthat/test-labels.r
@@ -26,3 +26,14 @@ test_that("Setting guide labels", {
     # American spelling
     expect_identical(labs(color = "my label")$colour, "my label")
 })
+
+# Visual tests ------------------------------------------------------------
+
+test_that("geom_violin draws correctly", {
+  dat <- data.frame(x = 1:10, y = 10:1)
+  p <- ggplot(dat, aes(x = x, y = y)) + geom_point() + labs(tag = "Fig. A)")
+
+  vdiffr::expect_doppelganger("defaults", p)
+  vdiffr::expect_doppelganger("Other position", p + theme(plot.tag.position = 'bottom'))
+  vdiffr::expect_doppelganger("Manual", p + theme(plot.tag.position = c(0.05, 0.05)))
+})


### PR DESCRIPTION
As per discussions on twitter, this PR adds a `tag` label alongside `title`, `subtitle`, and `caption`. It is placed in the upper left corner in its own row and column between the margin and the title/x-label.

The tag name is chosen over `label` as the `labs()` function indicate that “label” is a catchall term for all types of titles.

The default theming is like this:

```r
ggplot(mtcars) +
  geom_point(aes(disp, mpg)) + 
  labs(tag = 'A', title = 'test')
```

![tag](https://user-images.githubusercontent.com/1775316/35062710-5802fdde-fbc5-11e7-9387-6bac0cdd41fe.png)

The size is slightly larger than the title and the margin is chosen so that it is well separated from the main parts of the plot. In general this is based on my own taste and is up for discussion.