### PR TITLE
Clarifying description of facet_wrap.RD

### DIFF
--- a/man/facet_wrap.Rd
+++ b/man/facet_wrap.Rd
@@ -57,7 +57,7 @@ either of the four sides by setting \code{strip.position = c("top",
 \description{
 \code{facet_wrap} wraps a 1d sequence of panels into 2d. This is generally
 a better use of screen space than \code{\link[=facet_grid]{facet_grid()}} because most
-displays are roughly rectangular.
+displays have an aspect ratio (width\\height) lower than 2.
 }
 \examples{
 ggplot(mpg, aes(displ, hwy)) +


### PR DESCRIPTION
The previous version contained the phrase: "Most displays are roughly rectangular".
The meaning is understandable but this is confusing in a strictly mathematical sense: most display are indeed rectangular but this is not the point.
The point is that the aspect ratio (width/height) is not too high, i.e. we don't have extremely wide displays (which would be also rectangular)