### PR TITLE
Reset the random stream after running .onAttach

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -503,6 +503,8 @@ There were a number of tweaks to the theme elements that control legends:
 * `Scale` extensions can now override the `make_title` and `make_sec_title` 
   methods to let the scale modify the axis/legend titles.
 
+* The random stream is now reset after calling `.onAttach()` (#2409).
+
 # ggplot2 2.1.0
 
 ## New features

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -1,17 +1,19 @@
 .onAttach <- function(...) {
-  if (!interactive() || stats::runif(1) > 0.1) return()
+  withr::with_preserve_seed({
+    if (!interactive() || stats::runif(1) > 0.1) return()
 
-  tips <- c(
-    "Need help? Try the ggplot2 mailing list: http://groups.google.com/group/ggplot2.",
-    "Find out what's changed in ggplot2 at http://github.com/tidyverse/ggplot2/releases.",
-    "Use suppressPackageStartupMessages() to eliminate package startup messages.",
-    "Stackoverflow is a great place to get help: http://stackoverflow.com/tags/ggplot2.",
-    "Need help getting started? Try the cookbook for R: http://www.cookbook-r.com/Graphs/",
-    "Want to understand how all the pieces fit together? Buy the ggplot2 book: http://ggplot2.org/book/"
-  )
+    tips <- c(
+      "Need help? Try the ggplot2 mailing list: http://groups.google.com/group/ggplot2.",
+      "Find out what's changed in ggplot2 at http://github.com/tidyverse/ggplot2/releases.",
+      "Use suppressPackageStartupMessages() to eliminate package startup messages.",
+      "Stackoverflow is a great place to get help: http://stackoverflow.com/tags/ggplot2.",
+      "Need help getting started? Try the cookbook for R: http://www.cookbook-r.com/Graphs/",
+      "Want to understand how all the pieces fit together? Buy the ggplot2 book: http://ggplot2.org/book/"
+      )
 
-  tip <- sample(tips, 1)
-  packageStartupMessage(paste(strwrap(tip), collapse = "\n"))
+    tip <- sample(tips, 1)
+    packageStartupMessage(paste(strwrap(tip), collapse = "\n"))
+  })
 }
 
 release_questions <- function() {

--- a/tests/testthat/test-zzz.R
+++ b/tests/testthat/test-zzz.R
@@ -1,0 +1,9 @@
+context("zzz")
+
+test_that(".onAttach does not modify the random stream", {
+  set.seed(42)
+  x <- runif(5)
+  set.seed(42)
+  .onAttach()
+  expect_equal(runif(5), x)
+})


### PR DESCRIPTION
This avoids confusion when calling `set.seed()` before attaching
ggplot2.