### PR TITLE
Standardise spelling: ‘faceting’ instead of ‘facetting’

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -544,7 +544,7 @@ SCALES
 
 * Scales now automatically shrink to what is actually displayed on the plot,
   not the underlying data used for statistical transformation. If you want the
-  old behaviour, supply `shrink = FALSE` to the facetting specification.
+  old behaviour, supply `shrink = FALSE` to the faceting specification.
   (Fixes #125)
 
 * `scale_colour_gradient` and `scale_fill_gradient` now use a colour scheme
@@ -554,7 +554,7 @@ SCALES
 FACETS
 
 * Converted from proto to S3 objects, and class methods (somewhat) documented
-  in `facet.r`. This should make it easier to develop new types of facetting
+  in `facet.r`. This should make it easier to develop new types of faceting
   specifications.
 
 * The new `facet_null` specification is applied in the default case of no
@@ -892,7 +892,7 @@ BUG FIXES
 
 * order aesthetic now correctly affects position adjustments  (Fixes #70)
 
-* qplot loads facetting variables from global environment more correctly
+* qplot loads faceting variables from global environment more correctly
 
 * scale_date and scale_date_time now work with infinite positions
 
@@ -993,7 +993,7 @@ BUG FIXES
 * facet_grid with scales = "free" and space = "free" now calculates space
   correctly if the range of the scale is < 1 (fixes #1)
 
-* facet_grid works once more when facetting with multiple variables in one
+* facet_grid works once more when faceting with multiple variables in one
   direction (fixes #11)
 
 * facet_wrap now sets aspect ratio correctly
@@ -1085,7 +1085,7 @@ New features
 
 Dealing with missing values
 
-* facet_wrap: add drop argument to control whether or not panels for non-existent combinations of facetting variables should be dropped or not.  Defaults to TRUE
+* facet_wrap: add drop argument to control whether or not panels for non-existent combinations of faceting variables should be dropped or not.  Defaults to TRUE
 
 * scale_discrete: empty factor levels will be preserved, unless drop = TRUE
 
@@ -1098,7 +1098,7 @@ Bug fixes
 
 * facet_wrap: contents guaranteed to be clipped to panel
 
-* facet_wrap: corrected labelling when facetting by multiple variables (thank
+* facet_wrap: corrected labelling when faceting by multiple variables (thank
   to Charlotte Wickham for a clear test case)
 
 * geom_histogram now works with negative weights (provided position =
@@ -1388,7 +1388,7 @@ Bug fixes
   variables ignored when generating default group value)
 
 * facet_grid: fix long standing bug when combining datasets with different
-  levels of facetting variable
+  levels of faceting variable
 
 * geom_smooth calls stat::predict explicitly to avoid conflicts with packages
   that override predict for S4 model classes

--- a/NEWS.md
+++ b/NEWS.md
@@ -313,7 +313,7 @@ The facet system, as well as the internal panel class, has been rewritten in ggp
 
 We have also added the following new fatures.
   
-* `facet_grid()` and `facet_wrap()` now allow expressions in their facetting 
+* `facet_grid()` and `facet_wrap()` now allow expressions in their faceting 
   formulas (@DanRuderman, #1596).
 
 * When `facet_wrap()` results in an uneven number of panels, axes will now be
@@ -474,7 +474,7 @@ There were a number of tweaks to the theme elements that control legends:
   range that allows the density to reach zero (by extending the range 3 
   bandwidths to either side of the data) (#1700).
 
-* `geom_dotplot()` works better when facetting and binning on the y-axis. 
+* `geom_dotplot()` works better when faceting and binning on the y-axis. 
   (#1618, @has2k1).
   
 * `geom_hexbin()` once again supports `..density..` (@mikebirdgeneau, #1688).
@@ -563,7 +563,7 @@ There were a number of tweaks to the theme elements that control legends:
 * `facet_wrap()`/`facet_grid()` works with multiple empty panels of data 
   (#1445).
 
-* `facet_wrap()` correctly swaps `nrow` and `ncol` when facetting vertically
+* `facet_wrap()` correctly swaps `nrow` and `ncol` when faceting vertically
   (#1417).
 
 * `ggsave("x.svg")` now uses svglite to produce the svg (#1432).
@@ -906,7 +906,7 @@ some new features:
   values to help identifying them.
 
 On the programming side, the labeller API has been rewritten in order
-to offer more control when facetting over multiple factors (e.g. with
+to offer more control when faceting over multiple factors (e.g. with
 formulae such as `~cyl + am`). This also means that if you have
 written custom labellers, you will need to update them for this
 version of ggplot.

--- a/R/facet-.r
+++ b/R/facet-.r
@@ -170,7 +170,7 @@ Facet <- ggproto("Facet", NULL,
 
 # Helpers -----------------------------------------------------------------
 
-#' Is this object a facetting specification?
+#' Is this object a faceting specification?
 #'
 #' @param x object to test
 #' @keywords internal
@@ -208,7 +208,7 @@ df.grid <- function(a, b) {
 # always succeed, even if the variable doesn't exist in the data frame:
 # that makes it possible to repeat data across multiple factors. But
 # when evaluating an expression, you want to see any errors. That does
-# mean you can't have background data when facetting by an expression,
+# mean you can't have background data when faceting by an expression,
 # but that seems like a reasonable tradeoff.
 eval_facet_vars <- function(vars, data, env = emptyenv()) {
   nms <- names(vars)
@@ -232,7 +232,7 @@ eval_facet_var <- function(var, data, env = emptyenv()) {
   } else if (is.call(var)) {
     eval(var, envir = data, enclos = env)
   } else {
-    stop("Must use either variable name or expression when facetting",
+    stop("Must use either variable name or expression when faceting",
       call. = FALSE)
   }
 }
@@ -308,7 +308,7 @@ panel_rows <- function(table) {
   panels <- table$layout[grepl("^panel", table$layout$name), , drop = FALSE]
   unique(panels[, c('t', 'b')])
 }
-#' Take input data and define a mapping between facetting variables and ROW,
+#' Take input data and define a mapping between faceting variables and ROW,
 #' COL and PANEL keys
 #'
 #' @param data A list of data.frames, the first being the plot data and the
@@ -317,7 +317,7 @@ panel_rows <- function(table) {
 #' @param vars A list of quoted symbols matching columns in data
 #' @param drop should missing combinations/levels be dropped
 #'
-#' @return A data.frame with columns for PANEL, ROW, COL, and facetting vars
+#' @return A data.frame with columns for PANEL, ROW, COL, and faceting vars
 #'
 #' @keywords internal
 #' @export
@@ -327,11 +327,11 @@ combine_vars <- function(data, env = emptyenv(), vars = NULL, drop = TRUE) {
   # For each layer, compute the facet values
   values <- compact(plyr::llply(data, eval_facet_vars, vars = vars, env = env))
 
-  # Form the base data frame which contains all combinations of facetting
+  # Form the base data frame which contains all combinations of faceting
   # variables that appear in the data
   has_all <- unlist(plyr::llply(values, length)) == length(vars)
   if (!any(has_all)) {
-    stop("At least one layer must contain all variables used for facetting")
+    stop("At least one layer must contain all variables used for faceting")
   }
 
   base <- unique(plyr::ldply(values[has_all]))

--- a/R/facet-grid-.r
+++ b/R/facet-grid-.r
@@ -4,7 +4,7 @@ NULL
 #' Lay out panels in a grid
 #'
 #' `facet_grid` forms a matrix of panels defined by row and column
-#' facetting variables. It is most useful when you have two discrete
+#' faceting variables. It is most useful when you have two discrete
 #' variables, and all combinations of the variables exist in the data.
 #'
 #' @param facets a formula with the rows (of the tabular display) on the LHS
@@ -62,7 +62,7 @@ NULL
 #' # change the order of variable levels with factor()
 #'
 #' # If you combine a facetted dataset with a dataset that lacks those
-#' # facetting variables, the data will be repeated across the missing
+#' # faceting variables, the data will be repeated across the missing
 #' # combinations:
 #' df <- data.frame(displ = mean(mpg$displ), cty = mean(mpg$cty))
 #' p +
@@ -238,14 +238,14 @@ FacetGrid <- ggproto("FacetGrid", Facet,
     cols <- as.quoted(params$cols)
     vars <- c(names(rows), names(cols))
 
-    # Compute facetting values and add margins
+    # Compute faceting values and add margins
     margin_vars <- list(intersect(names(rows), names(data)),
       intersect(names(cols), names(data)))
     data <- reshape2::add_margins(data, margin_vars, params$margins)
 
     facet_vals <- eval_facet_vars(c(rows, cols), data, params$plot_env)
 
-    # If any facetting variables are missing, add them in by
+    # If any faceting variables are missing, add them in by
     # duplicating the data
     missing_facets <- setdiff(vars, names(facet_vals))
     if (length(missing_facets) > 0) {
@@ -262,7 +262,7 @@ FacetGrid <- ggproto("FacetGrid", Facet,
 
     # Add PANEL variable
     if (nrow(facet_vals) == 0) {
-      # Special case of no facetting
+      # Special case of no faceting
       data$PANEL <- NO_PANEL
     } else {
       facet_vals[] <- lapply(facet_vals[], as.factor)

--- a/R/facet-null.r
+++ b/R/facet-null.r
@@ -7,7 +7,7 @@ NULL
 #' @keywords internal
 #' @export
 #' @examples
-#' # facet_null is the default facetting specification if you
+#' # facet_null is the default faceting specification if you
 #' # don't override it with facet_grid or facet_wrap
 #' ggplot(mtcars, aes(mpg, wt)) + geom_point()
 facet_null <- function(shrink = TRUE) {

--- a/R/facet-wrap.r
+++ b/R/facet-wrap.r
@@ -62,7 +62,7 @@ NULL
 #'   facet_wrap(~class, scales = "free")
 #'
 #' # To repeat the same data in every panel, simply construct a data frame
-#' # that does not contain the facetting variable.
+#' # that does not contain the faceting variable.
 #' ggplot(mpg, aes(displ, hwy)) +
 #'   geom_point(data = transform(mpg, class = NULL), colour = "grey85") +
 #'   geom_point() +

--- a/R/labeller.r
+++ b/R/labeller.r
@@ -9,7 +9,7 @@
 #' `label_value()` only displays the value of a factor while
 #' `label_both()` displays both the variable name and the factor
 #' value. `label_context()` is context-dependent and uses
-#' `label_value()` for single factor facetting and
+#' `label_value()` for single factor faceting and
 #' `label_both()` when multiple factors are
 #' involved. `label_wrap_gen()` uses [base::strwrap()]
 #' for line wrapping.
@@ -56,7 +56,7 @@
 #'   function must have the `labeller` S3 class.
 #'
 #' @param labels Data frame of labels. Usually contains only one
-#'   element, but facetting over multiple factors entails multiple
+#'   element, but faceting over multiple factors entails multiple
 #'   label variables.
 #' @param multi_line Whether to display the labels of multiple factors
 #'   on separate lines.
@@ -297,7 +297,7 @@ resolve_labeller <- function(rows, cols, labels) {
 #' appender <- function(string, suffix = "-foo") paste0(string, suffix)
 #' p + facet_wrap(~am, labeller = as_labeller(appender))
 #'
-#' # If you have more than one facetting variable, be sure to dispatch
+#' # If you have more than one faceting variable, be sure to dispatch
 #' # your labeller to the right variable with labeller()
 #' p + facet_grid(cyl ~ am, labeller = labeller(am = to_string))
 as_labeller <- function(x, default = label_value, multi_line = TRUE) {

--- a/R/layout.R
+++ b/R/layout.R
@@ -1,6 +1,6 @@
 # The job of `Layout` is to coordinate:
 # * The coordinate system
-# * The facetting specification
+# * The faceting specification
 # * The individual position scales for each panel
 #
 # This includes managing the parameters for the facet and the coord
@@ -15,7 +15,7 @@ Layout <- ggproto("Layout", NULL,
   coord = NULL,
   coord_params = list(),
 
-  # The facetting specification and its parameters
+  # The faceting specification and its parameters
   facet = NULL,
   facet_params = list(),
 

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -39,7 +39,7 @@ ggplot_build.ggplot <- function(plot) {
     out
   }
 
-  # Initialise panels, add extra data for margins & missing facetting
+  # Initialise panels, add extra data for margins & missing faceting
   # variables, and add on a PANEL variable to data
   layout <- create_layout(plot$facet, plot$coordinates)
   data <- layout$setup(layer_data, plot$data, plot$plot_env)

--- a/man/as_labeller.Rd
+++ b/man/as_labeller.Rd
@@ -36,7 +36,7 @@ p + facet_wrap(~am, labeller = to_string)
 appender <- function(string, suffix = "-foo") paste0(string, suffix)
 p + facet_wrap(~am, labeller = as_labeller(appender))
 
-# If you have more than one facetting variable, be sure to dispatch
+# If you have more than one faceting variable, be sure to dispatch
 # your labeller to the right variable with labeller()
 p + facet_grid(cyl ~ am, labeller = labeller(am = to_string))
 }

--- a/man/combine_vars.Rd
+++ b/man/combine_vars.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/facet-.r
 \name{combine_vars}
 \alias{combine_vars}
-\title{Take input data and define a mapping between facetting variables and ROW,
+\title{Take input data and define a mapping between faceting variables and ROW,
 COL and PANEL keys}
 \usage{
 combine_vars(data, env = emptyenv(), vars = NULL, drop = TRUE)
@@ -18,10 +18,10 @@ subsequent individual layer data}
 \item{drop}{should missing combinations/levels be dropped}
 }
 \value{
-A data.frame with columns for PANEL, ROW, COL, and facetting vars
+A data.frame with columns for PANEL, ROW, COL, and faceting vars
 }
 \description{
-Take input data and define a mapping between facetting variables and ROW,
+Take input data and define a mapping between faceting variables and ROW,
 COL and PANEL keys
 }
 \keyword{internal}

--- a/man/facet_grid.Rd
+++ b/man/facet_grid.Rd
@@ -63,7 +63,7 @@ will be shown, regardless of whether or not they appear in the data.}
 }
 \description{
 \code{facet_grid} forms a matrix of panels defined by row and column
-facetting variables. It is most useful when you have two discrete
+faceting variables. It is most useful when you have two discrete
 variables, and all combinations of the variables exist in the data.
 }
 \examples{
@@ -77,7 +77,7 @@ p + facet_grid(drv ~ cyl)
 # change the order of variable levels with factor()
 
 # If you combine a facetted dataset with a dataset that lacks those
-# facetting variables, the data will be repeated across the missing
+# faceting variables, the data will be repeated across the missing
 # combinations:
 df <- data.frame(displ = mean(mpg$displ), cty = mean(mpg$cty))
 p +

--- a/man/facet_null.Rd
+++ b/man/facet_null.Rd
@@ -15,7 +15,7 @@ before statistical summary.}
 Facet specification: a single panel.
 }
 \examples{
-# facet_null is the default facetting specification if you
+# facet_null is the default faceting specification if you
 # don't override it with facet_grid or facet_wrap
 ggplot(mtcars, aes(mpg, wt)) + geom_point()
 }

--- a/man/facet_wrap.Rd
+++ b/man/facet_wrap.Rd
@@ -100,7 +100,7 @@ ggplot(mpg, aes(displ, hwy)) +
   facet_wrap(~class, scales = "free")
 
 # To repeat the same data in every panel, simply construct a data frame
-# that does not contain the facetting variable.
+# that does not contain the faceting variable.
 ggplot(mpg, aes(displ, hwy)) +
   geom_point(data = transform(mpg, class = NULL), colour = "grey85") +
   geom_point() +

--- a/man/gg-add.Rd
+++ b/man/gg-add.Rd
@@ -29,7 +29,7 @@ new layer.
 \item A \code{scale} overrides the existing scale.
 \item A \code{\link[=theme]{theme()}} modifies the current theme.
 \item A \code{coord} overrides current coordinate system.
-\item A \code{facet} specificatio override current faceting.
+\item A \code{facet} specification override current faceting.
 }
 
 To replace the current default data frame, you must use \code{\%+\%},

--- a/man/is.facet.Rd
+++ b/man/is.facet.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/facet-.r
 \name{is.facet}
 \alias{is.facet}
-\title{Is this object a facetting specification?}
+\title{Is this object a faceting specification?}
 \usage{
 is.facet(x)
 }
@@ -10,6 +10,6 @@ is.facet(x)
 \item{x}{object to test}
 }
 \description{
-Is this object a facetting specification?
+Is this object a faceting specification?
 }
 \keyword{internal}

--- a/man/labellers.Rd
+++ b/man/labellers.Rd
@@ -21,7 +21,7 @@ label_wrap_gen(width = 25, multi_line = TRUE)
 }
 \arguments{
 \item{labels}{Data frame of labels. Usually contains only one
-element, but facetting over multiple factors entails multiple
+element, but faceting over multiple factors entails multiple
 label variables.}
 
 \item{multi_line}{Whether to display the labels of multiple factors
@@ -42,7 +42,7 @@ line separated with commas, or each on their own line.
 \code{label_value()} only displays the value of a factor while
 \code{label_both()} displays both the variable name and the factor
 value. \code{label_context()} is context-dependent and uses
-\code{label_value()} for single factor facetting and
+\code{label_value()} for single factor faceting and
 \code{label_both()} when multiple factors are
 involved. \code{label_wrap_gen()} uses \code{\link[base:strwrap]{base::strwrap()}}
 for line wrapping.

--- a/vignettes/extending-ggplot2.Rmd
+++ b/vignettes/extending-ggplot2.Rmd
@@ -553,9 +553,9 @@ Complete and incomplete themes behave somewhat differently when added to a ggplo
   
 * Adding a complete theme wipes away the existing theme and applies the new theme.
 
-## Creating a new facetting
+## Creating a new faceting
 
-One of the more daunting exercises in ggplot2 extensions is to create a new facetting system. The reason for this is that when creating new facettings you take on the responsibility of how (almost) everything is drawn on the screen, and many do not have experience with directly using [gtable](https://cran.r-project.org/package=gtable) and [grid](https://cran.r-project.org/package=grid) upon which the ggplot2 rendering is built. If you decide to venture into facetting extensions, it is highly recommended to gain proficiency with the above-mentioned packages.
+One of the more daunting exercises in ggplot2 extensions is to create a new faceting system. The reason for this is that when creating new facetings you take on the responsibility of how (almost) everything is drawn on the screen, and many do not have experience with directly using [gtable](https://cran.r-project.org/package=gtable) and [grid](https://cran.r-project.org/package=grid) upon which the ggplot2 rendering is built. If you decide to venture into faceting extensions, it is highly recommended to gain proficiency with the above-mentioned packages.
 
 The `Facet` class in ggplot2 is very powerful as it takes on responsibility of a wide range of tasks. The main tasks of a `Facet` object are:
 
@@ -573,11 +573,11 @@ Apart from these three tasks, for which functionality must be implemented, there
 
 * Drawing of axis labels
 
-To show how a new facetting class is created we will start simple and go through each of the required methods in turn to build up `facet_duplicate()` that simply duplicate our plot into two panels. After this we will tinker with it a bit to show some of the more powerful possibilities.
+To show how a new faceting class is created we will start simple and go through each of the required methods in turn to build up `facet_duplicate()` that simply duplicate our plot into two panels. After this we will tinker with it a bit to show some of the more powerful possibilities.
 
 ### Creating a layout specification
 
-A layout in the context of facets is a `data.frame` that defines a mapping between data and the panels it should reside in as well as which positional scales should be used. The output should at least contain the columns `PANEL`, `SCALE_X`, and `SCALE_Y`, but will often contain more to help assign data to the correct panel (`facet_grid()` will e.g. also return the facetting variables associated with each panel). Let's make a function that defines a duplicate layout:
+A layout in the context of facets is a `data.frame` that defines a mapping between data and the panels it should reside in as well as which positional scales should be used. The output should at least contain the columns `PANEL`, `SCALE_X`, and `SCALE_Y`, but will often contain more to help assign data to the correct panel (`facet_grid()` will e.g. also return the faceting variables associated with each panel). Let's make a function that defines a duplicate layout:
 
 ```{r}
 layout <- function(data, params) {
@@ -585,7 +585,7 @@ layout <- function(data, params) {
 }
 ```
 
-This is quite simple as the facetting should just define two panels irrespectively of the input data and parameters.
+This is quite simple as the faceting should just define two panels irrespectively of the input data and parameters.
 
 ### Mapping data into panels
 
@@ -715,7 +715,7 @@ p + facet_duplicate()
 
 ### Doing more with facets
 
-The example above was pretty useless and we'll now try to expand on it to add some actual usability. We are going to make a facetting that adds panels with y-transformed axes:
+The example above was pretty useless and we'll now try to expand on it to add some actual usability. We are going to make a faceting that adds panels with y-transformed axes:
 
 ```{r}
 library(scales)
@@ -903,7 +903,7 @@ FacetTrans <- ggproto("FacetTrans", Facet,
 
 As is very apparent, the `draw_panel` method can become very unwieldy once it begins to take multiple possibilities into account. The fact that we want to support both horizontal and vertical layout leads to a lot of if/else blocks in the above code. In general, this is the big challenge when writing facet extensions so be prepared to be very meticulous when writing these methods.
 
-Enough talk - lets see if our new and powerful facetting extension works:
+Enough talk - lets see if our new and powerful faceting extension works:
 
 ```{r}
 ggplot(mtcars, aes(x = hp, y = mpg)) + geom_point() + facet_trans('sqrt')
@@ -911,7 +911,7 @@ ggplot(mtcars, aes(x = hp, y = mpg)) + geom_point() + facet_trans('sqrt')
 
 ## Extending existing facet function
 
-As the rendering part of a facet class is often the difficult development step, it is possible to piggyback on the existing facetting classes to achieve a range of new facettings. Below we will subclass `facet_wrap()` to make a `facet_bootstrap()` class that splits the input data into a number of panels at random.
+As the rendering part of a facet class is often the difficult development step, it is possible to piggyback on the existing faceting classes to achieve a range of new facetings. Below we will subclass `facet_wrap()` to make a `facet_bootstrap()` class that splits the input data into a number of panels at random.
 
 ```{r}
 facet_bootstrap <- function(n = 9, prop = 0.2, nrow = NULL, ncol = NULL, 

--- a/vignettes/releases/ggplot2-2.0.0.Rmd
+++ b/vignettes/releases/ggplot2-2.0.0.Rmd
@@ -206,7 +206,7 @@ Thanks to the work of [Lionel Henry](https://github.com/lionel-), facet labels h
 
 1. `facet_wrap()` now supports custom labellers.
 
-1. You can create combined labels when facetting by multiple variables.
+1. You can create combined labels when faceting by multiple variables.
 
 ### Switching the labels
 

--- a/vignettes/releases/ggplot2-2.2.0.Rmd
+++ b/vignettes/releases/ggplot2-2.2.0.Rmd
@@ -26,7 +26,7 @@ knitr::opts_chunk$set(
 I'm very pleased to announce ggplot2 2.2.0. It includes four major new features:
 
 * Subtitles and captions.
-* A large rewrite of the facetting system.
+* A large rewrite of the faceting system.
 * Improved theme options.
 * Better stacking.
 
@@ -61,9 +61,9 @@ The plot title is now aligned to the left by default. To return to the previous 
 
 ## Facets
 
-The facet and layout implementation has been moved to ggproto and received a large rewrite and refactoring. This will allow others to create their own facetting systems, as descrbied in the `vignette("extending-ggplot2")`. Along with the rewrite a number of features and improvements has been added, most notably:
+The facet and layout implementation has been moved to ggproto and received a large rewrite and refactoring. This will allow others to create their own faceting systems, as descrbied in the `vignette("extending-ggplot2")`. Along with the rewrite a number of features and improvements has been added, most notably:
 
-*   ou can now use functions in facetting formulas, thanks to 
+*   ou can now use functions in faceting formulas, thanks to 
     [Dan Ruderman](https://github.com/DanRuderman).
   
     ```{r facet-1}


### PR DESCRIPTION
Change documentation and comments to standardise the spelling of 'faceting'. Both spellings ('faceting' and 'facetting') were previously in use. OED and https://en.oxforddictionaries.com/definition/faceting give the usual spelling as ‘faceting’.

Updated `man` directory using roxygen2