### PR TITLE
Fix check as a result of f61bfd62

### DIFF
--- a/tests/testthat/test-fortify.r
+++ b/tests/testthat/test-fortify.r
@@ -41,8 +41,9 @@ test_that("fortify.default proves a helpful error with class uneval", {
   expect_error(
     ggplot(aes(x = x)),
     regex = paste0(
-      "ggplot2 doesn't know how to deal with data of class uneval. ",
-      "Did you accidentally provide the results of `aes\\(\\)` to the `data` argument?"
+      "`data` must be a data frame, or other object coercible by `fortify\\(\\)`, ",
+      "not an object of class uneval",
+      "\nDid you accidentally pass `aes\\(\\)` to the `data` argument?"
     )
   )
 })


### PR DESCRIPTION
New `fortify.default` error message is misaligned with the `expect_error` msg

See changes in f61bfd620037b7e1c816129469b106443651a4dc