### PR TITLE
add seed argument to position_jitterdodge

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -198,6 +198,9 @@ up correct aspect ratio, and draws a graticule.
 * `position_jitter()` gains a `seed` argument that allows specifying a random 
   seed for reproducible jittering (#1996, @krlmlr).
 
+* `position_jitterdodge()` gains a `seed` argument that allows specifying
+  a random seed for reproducible jittering (#2445, @slowkow).
+
 * `stat_density()` has better behaviour if all groups are dropped because they
   are too small (#2282).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -195,11 +195,9 @@ up correct aspect ratio, and draws a graticule.
   default), or ensure that the width of a `single` element is preserved
   (what many people want) (#1935).
 
-* `position_jitter()` gains a `seed` argument that allows specifying a random 
-  seed for reproducible jittering (#1996, @krlmlr).
-
-* `position_jitterdodge()` gains a `seed` argument that allows specifying
-  a random seed for reproducible jittering (#2445, @slowkow).
+* `position_jitter()` and `position_jitterdodge()` gain a `seed` argument that
+  allows specifying a random seed for reproducible jittering (@krlmlr, #1996
+  and @slowkow, #2445).
 
 * `stat_density()` has better behaviour if all groups are dropped because they
   are too small (#2282).

--- a/R/position-jitterdodge.R
+++ b/R/position-jitterdodge.R
@@ -10,14 +10,7 @@
 #' @param jitter.height degree of jitter in y direction. Defaults to 0.
 #' @param dodge.width the amount to dodge in the x direction. Defaults to 0.75,
 #'   the default `position_dodge()` width.
-#' @param seed A random seed to make the jitter reproducible.
-#'   Useful if you need to apply the same jitter twice, e.g., for a point and
-#'   a corresponding label.
-#'   The random seed is reset after jittering.
-#'   If `NA` (the default value), the seed is initialised with a random value;
-#'   this makes sure that two subsequent calls start with a different seed.
-#'   Use `NULL` to use the current random seed and also avoid resetting
-#'   (the behavior of \pkg{ggplot} 2.2.1 and earlier).
+#' @inheritParams position_jitter
 #' @export
 #' @examples
 #' dsub <- diamonds[ sample(nrow(diamonds), 1000), ]

--- a/R/position-jitterdodge.R
+++ b/R/position-jitterdodge.R
@@ -10,6 +10,14 @@
 #' @param jitter.height degree of jitter in y direction. Defaults to 0.
 #' @param dodge.width the amount to dodge in the x direction. Defaults to 0.75,
 #'   the default `position_dodge()` width.
+#' @param seed A random seed to make the jitter reproducible.
+#'   Useful if you need to apply the same jitter twice, e.g., for a point and
+#'   a corresponding label.
+#'   The random seed is reset after jittering.
+#'   If `NA` (the default value), the seed is initialised with a random value;
+#'   this makes sure that two subsequent calls start with a different seed.
+#'   Use `NULL` to use the current random seed and also avoid resetting
+#'   (the behavior of \pkg{ggplot} 2.2.1 and earlier).
 #' @export
 #' @examples
 #' dsub <- diamonds[ sample(nrow(diamonds), 1000), ]
@@ -17,12 +25,16 @@
 #'   geom_boxplot(outlier.size = 0) +
 #'   geom_point(pch = 21, position = position_jitterdodge())
 position_jitterdodge <- function(jitter.width = NULL, jitter.height = 0,
-                                 dodge.width = 0.75) {
+                                 dodge.width = 0.75, seed = NA) {
+  if (!is.null(seed) && is.na(seed)) {
+    seed <- sample.int(.Machine$integer.max, 1L)
+  }
 
   ggproto(NULL, PositionJitterdodge,
     jitter.width = jitter.width,
     jitter.height = jitter.height,
-    dodge.width = dodge.width
+    dodge.width = dodge.width,
+    seed = seed
   )
 }
 
@@ -50,19 +62,18 @@ PositionJitterdodge <- ggproto("PositionJitterdodge", Position,
     list(
       dodge.width = self$dodge.width,
       jitter.height = self$jitter.height,
-      jitter.width = width / (ndodge + 2)
+      jitter.width = width / (ndodge + 2),
+      seed = self$seed
     )
   },
-
 
   compute_panel = function(data, params, scales) {
     data <- collide(data, params$dodge.width, "position_jitterdodge", pos_dodge,
       check.width = FALSE)
 
-    # then jitter
-    transform_position(data,
-      if (params$jitter.width > 0) function(x) jitter(x, amount = params$jitter.width),
-      if (params$jitter.height > 0) function(x) jitter(x, amount = params$jitter.height)
-    )
+    trans_x <- if (params$jitter.width > 0) function(x) jitter(x, amount = params$jitter.width)
+    trans_y <- if (params$jitter.height > 0) function(x) jitter(x, amount = params$jitter.height)
+
+    with_seed_null(params$seed, transform_position(data, trans_x, trans_y))
   }
 )

--- a/man/position_jitterdodge.Rd
+++ b/man/position_jitterdodge.Rd
@@ -5,7 +5,7 @@
 \title{Simultaneously dodge and jitter}
 \usage{
 position_jitterdodge(jitter.width = NULL, jitter.height = 0,
-  dodge.width = 0.75)
+  dodge.width = 0.75, seed = NA)
 }
 \arguments{
 \item{jitter.width}{degree of jitter in x direction. Defaults to 40\% of the
@@ -15,6 +15,15 @@ resolution of the data.}
 
 \item{dodge.width}{the amount to dodge in the x direction. Defaults to 0.75,
 the default \code{position_dodge()} width.}
+
+\item{seed}{A random seed to make the jitter reproducible.
+Useful if you need to apply the same jitter twice, e.g., for a point and
+a corresponding label.
+The random seed is reset after jittering.
+If \code{NA} (the default value), the seed is initialised with a random value;
+this makes sure that two subsequent calls start with a different seed.
+Use \code{NULL} to use the current random seed and also avoid resetting
+(the behavior of \pkg{ggplot} 2.2.1 and earlier).}
 }
 \description{
 This is primarily used for aligning points generated through


### PR DESCRIPTION
In pull #1996 position_jitter got a new argument called seed.

position_jitterdodge might also benefit from having a seed.

Below, I show an example of `position_jitterdodge` before and after my changes.

Please notice two things:

1. After my changes, the text labels are correctly centered on the points.

2. The x-axis gains 2 tick marks at 5 and 7.

    - This was unexpected, and I don't know why it happened or if it matters much. It's easy to fix by doing `dat$cyl <- factor(dat$cyl)`.

Here's the code:

```r
library(ggplot2)
dat <- mtcars
dat$name <- rownames(mtcars)
dat$name[dat$cyl != 6] <- ""

set.seed(1)
pos <- position_jitterdodge(seed = 1)
ggplot(dat, aes(cyl, mpg, color = name != "", label = name)) +
  geom_point(
    size = 0.5,
    position = pos
  ) +
  geom_text(
    size = 2,
    position = pos
  )
# ggplot2      * 2.2.1.9000 2018-02-09 Github (tidyverse/ggplot2@2b5b88d)
# ggsave("ggplot2-2b5b88d-jitterdodge.png", width = 6, height = 4)
ggsave("ggplot2-slowkow-jitterdodge.png", width = 6, height = 4)
```

# Before

This figure was made with ggplot2 2b5b88d

![ggplot2-2b5b88d-jitterdodge](https://user-images.githubusercontent.com/209714/36048547-94c67cb0-0dad-11e8-9656-e9247c73fbb1.png)


# After

This figure was made after making the changes in this pull request.

![ggplot2-slowkow-jitterdodge](https://user-images.githubusercontent.com/209714/36048551-99330eda-0dad-11e8-83b5-33b7d2ccd19c.png)
