### PR TITLE
fix rd_aesthetics for clarity

### DIFF
--- a/R/utilities-help.r
+++ b/R/utilities-help.r
@@ -10,7 +10,7 @@ rd_aesthetics <- function(type, name) {
     "@section Aesthetics:",
     paste0(
       "\\code{", type, "_", name, "} ",
-      "understands the following aesthetics (required aesthetics are in bold):"
+      "understands the following aesthetics (required and computed aesthetics are in bold):"
     ),
     "\\itemize{",
     paste0("  \\item ", aes),


### PR DESCRIPTION
document that bolded aesthetics can be either required *or* computed. I was confused when reading the documentation for geom_boxplot, it seemed to claim that the computed attributes were required arguments, so I added a note indicating the bolded attributes may be computed as well.