### PR TITLE
Pass `label` to `draw_key_text`

### DIFF
--- a/R/legend-draw.r
+++ b/R/legend-draw.r
@@ -169,7 +169,9 @@ draw_key_smooth <- function(data, params, size) {
 #' @export
 #' @rdname draw_key
 draw_key_text <- function(data, params, size) {
-  textGrob("a", 0.5, 0.5,
+  if(is.null(data$label)) data$label <- "a"
+  
+  textGrob(data$label, 0.5, 0.5,
     rot = data$angle,
     gp = gpar(
       col = alpha(data$colour, data$alpha),


### PR DESCRIPTION
To override the default "a" in the label of a text legend: first check if `data$label` has anything in it; if not, use "a" as before. However, if the user sets a label within `guide_legend(override.aes = list(label = "foo"))`, then use that label or vector of labels as the first arg of `textGrob`.

Motivation
----
This is a relatively common request on SO, to wit: https://stackoverflow.com/questions/48892982/change-key-letter-in-legend-of-ggplot

The problem
----
The current version of `draw_key_text` has a hardcoded "a" as the first arg of `textGrob`.

Example using the fix
----
ggplot(mtcars, aes(mpg, wt, color = factor(am), label = disp)) +
  geom_text() +
  guides(color = guide_legend(override.aes = list(label = c("a", "m"))))

![image](https://user-images.githubusercontent.com/13338560/36451656-c27908ca-165f-11e8-83b8-7e14fc51a1b2.png)
