### PR TITLE
edit geom_tile aesthetics and fix docs

### DIFF
--- a/R/geom-tile.r
+++ b/R/geom-tile.r
@@ -34,7 +34,7 @@
 #' ggplot(df, aes(x, y)) +
 #'   geom_tile(aes(fill = z, width = w), colour = "grey50")
 #' ggplot(df, aes(xmin = x - w / 2, xmax = x + w / 2, ymin = y, ymax = y + 1)) +
-#'   geom_rect(aes(fill = z, width = w), colour = "grey50")
+#'   geom_rect(aes(fill = z), colour = "grey50")
 #'
 #' \donttest{
 #' # Justification controls where the cells are anchored
@@ -81,7 +81,7 @@ geom_tile <- function(mapping = NULL, data = NULL,
 #' @export
 #' @include geom-rect.r
 GeomTile <- ggproto("GeomTile", GeomRect,
-  extra_params = c("na.rm", "width", "height"),
+  extra_params = c("na.rm"),
 
   setup_data = function(data, params) {
     data$width <- data$width %||% params$width %||% resolution(data$x, FALSE)
@@ -94,7 +94,7 @@ GeomTile <- ggproto("GeomTile", GeomRect,
   },
 
   default_aes = aes(fill = "grey20", colour = NA, size = 0.1, linetype = 1,
-    alpha = NA),
+    alpha = NA, width = NA, height = NA),
 
   required_aes = c("x", "y"),
 

--- a/man/geom_tile.Rd
+++ b/man/geom_tile.Rd
@@ -89,8 +89,10 @@ performance special case for when all the tiles are the same size.
 \item \code{colour}
 \item \code{fill}
 \item \code{group}
+\item \code{height}
 \item \code{linetype}
 \item \code{size}
+\item \code{width}
 }
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}
 }
@@ -118,7 +120,7 @@ ggplot(df, aes(x, y)) +
 ggplot(df, aes(x, y)) +
   geom_tile(aes(fill = z, width = w), colour = "grey50")
 ggplot(df, aes(xmin = x - w / 2, xmax = x + w / 2, ymin = y, ymax = y + 1)) +
-  geom_rect(aes(fill = z, width = w), colour = "grey50")
+  geom_rect(aes(fill = z), colour = "grey50")
 
 \donttest{
 # Justification controls where the cells are anchored

--- a/man/scale_viridis.Rd
+++ b/man/scale_viridis.Rd
@@ -41,7 +41,7 @@ are ordered from darkest to lightest. If -1, the order of colors is reversed.}
 
 \item{option}{A character string indicating the colormap option to use. Four
 options are available: "magma" (or "A"), "inferno" (or "B"), "plasma" (or "C"),
-and "viridis" (or "D", the default option).}
+"viridis" (or "D", the default option) and "cividis" (or "E").}
 
 \item{values}{if colours should not be evenly positioned along the gradient
 this vector gives the position (between 0 and 1) for each colour in the


### PR DESCRIPTION
The `geom_rect` and `geom_tile` doc examples include an aesthetic parameter for width, but neither geom has that, so the examples produce this warning:

``` r
ggplot(df, aes(x, y)) +
  geom_tile(aes(fill = z, width = w), colour = "grey50")

# > Warning: Ignoring unknown parameters: width
```
For `geom_tile`, I moved height and width over to `default_aes`. For `geom_rect`, though, I just removed `width = w` from the example in the docs because it seemed like a mistake (since `geom_rect` calculates width from `xmin` and `xmax`).

Thanks!
Malcolm
