### PR TITLE
Add `z` as required aesthetic in documentation of `geom_contour()`

### DIFF
--- a/R/geom-contour.r
+++ b/R/geom-contour.r
@@ -8,7 +8,7 @@
 #' spaced grid. If your data is not evenly spaced, you may want to interpolate
 #' to a grid before visualising.
 #'
-#' @eval rd_aesthetics("geom", "contour")
+#' @eval rd_aesthetics("stat", "contour")
 #' @inheritParams layer
 #' @inheritParams geom_point
 #' @inheritParams geom_path

--- a/man/geom_contour.Rd
+++ b/man/geom_contour.Rd
@@ -77,16 +77,13 @@ to a grid before visualising.
 }
 \section{Aesthetics}{
 
-\code{geom_contour} understands the following aesthetics (required aesthetics are in bold):
+\code{stat_contour} understands the following aesthetics (required aesthetics are in bold):
 \itemize{
 \item \strong{\code{x}}
 \item \strong{\code{y}}
-\item \code{alpha}
-\item \code{colour}
+\item \strong{\code{z}}
 \item \code{group}
-\item \code{linetype}
-\item \code{size}
-\item \code{weight}
+\item \code{order}
 }
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}
 }


### PR DESCRIPTION
Currently the only required aesthetics in the documentation are `x` and `y`. Adding `z` to `GeomContour`s `required_aes` does not work because as a geom, it actually never uses that variable. 
I guess changing the `rd_aesthetics()` call is the easiest way to fix it.