### PR TITLE
Swap order of preserve arguments in position_dodge2()

### DIFF
--- a/R/position-dodge2.r
+++ b/R/position-dodge2.r
@@ -4,7 +4,7 @@
 #'   shrunk by this proportion to allow space between them. Defaults to 0.1.
 #' @param reverse If `TRUE`, will reverse the default stacking order.
 #'   This is useful if you're rotating both the plot and legend.
-position_dodge2 <- function(width = NULL, preserve = c("single", "total"),
+position_dodge2 <- function(width = NULL, preserve = c("total", "single"),
                             padding = 0.1, reverse = FALSE) {
   ggproto(NULL, PositionDodge2,
     width = width,

--- a/man/position_dodge.Rd
+++ b/man/position_dodge.Rd
@@ -7,7 +7,7 @@
 \usage{
 position_dodge(width = NULL, preserve = c("total", "single"))
 
-position_dodge2(width = NULL, preserve = c("single", "total"),
+position_dodge2(width = NULL, preserve = c("total", "single"),
   padding = 0.1, reverse = FALSE)
 }
 \arguments{


### PR DESCRIPTION
#2386 made `preserve = "total"` the default for `PositionDodge2`, but didn't swap the order of the defaults in `position_dodge2()`. This fixes it.