### PR TITLE
prefix s with mgcv:: in stat-smooth.r; closes #2535

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -202,6 +202,9 @@ up correct aspect ratio, and draws a graticule.
 
 ### Layers
 
+* In `stat-smooth.r`, the `s` in `y ~ s(x, bs = "cs")` is now `mgcv::s`, which
+  eliminates naming conflicts (@bfgray3, #2535).
+
 * In most cases, using `%>%` instead of `+` should generate an informative
   error (#2400).
   

--- a/R/stat-smooth.r
+++ b/R/stat-smooth.r
@@ -4,7 +4,7 @@
 #'   For `method = "auto"` the smoothing method is chosen based on the
 #'   size of the largest group (across all panels). [loess()] is
 #'   used for less than 1,000 observations; otherwise [mgcv::gam()] is
-#'   used with `formula = y ~ s(x, bs = "cs")`. Somewhat anecdotally,
+#'   used with `formula = y ~ mgcv::s(x, bs = "cs")`. Somewhat anecdotally,
 #'   `loess` gives a better appearance, but is O(n^2) in memory, so does
 #'   not work for larger datasets.
 #' @param formula Formula to use in smoothing function, eg. `y ~ x`,
@@ -83,7 +83,7 @@ StatSmooth <- ggproto("StatSmooth", Stat,
         params$method <- "loess"
       } else {
         params$method <- "gam"
-        params$formula <- y ~ s(x, bs = "cs")
+        params$formula <- y ~ mgcv::s(x, bs = "cs")
       }
       message("`geom_smooth()` using method = '", params$method, 
               "' and formula '", deparse(params$formula), "'")


### PR DESCRIPTION
I've specified the namespace for `s` as described in #2535.