### PR TITLE
remove unwanted annotation border from saved PDFs; closes #2407

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -202,6 +202,9 @@ up correct aspect ratio, and draws a graticule.
 
 ### Layers
 
+* `annotate` no longer produces an undesired border around annotations when
+  `label.size` is 0, even when saving to PDF (@bfgray3, #2407).
+
 * In most cases, using `%>%` instead of `+` should generate an informative
   error (#2400).
   

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -90,7 +90,7 @@ GeomLabel <- ggproto("GeomLabel", Geom,
           lineheight = row$lineheight
         ),
         rect.gp = gpar(
-          col = row$colour,
+          col = if (label.size != 0) row$colour else NA,
           fill = alpha(row$fill, row$alpha),
           lwd = label.size * .pt
         )


### PR DESCRIPTION
I have tried to implement the fix suggested by Winston in the comments on this issue.