### PR TITLE
Fix missing default setting for angles in element_grob.element_text(). Closes #2544.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -328,6 +328,8 @@ up correct aspect ratio, and draws a graticule.
   to make sure the two legend functions behave as similarly as possible.
   (@clauswilke, #2397 and #2398)
 
+* Non-angle parameters of `label.theme` or `title.theme` can now be set in `guide_legend()` and
+  `guide_colorbar()`. (@clauswilke, #2544)
 
 ### Other
 

--- a/R/theme-elements.r
+++ b/R/theme-elements.r
@@ -203,10 +203,7 @@ element_grob.element_text <- function(element, label = "", x = NULL, y = NULL,
   hj <- hjust %||% element$hjust
   margin <- margin %||% element$margin
 
-  angle <- angle %||% element$angle
-  if (is.null(angle)) {
-    stop("Text element requires non-NULL value for 'angle'.")
-  }
+  angle <- angle %||% element$angle %||% 0
 
   # The gp settings can override element_gp
   gp <- gpar(fontsize = size, col = colour,


### PR DESCRIPTION
This closes #2544.

```{r}
library(ggplot2)                                                                                                                                                       
ggplot(iris, aes(x = Sepal.Length, y = Petal.Length, color = Species)) +                                                                                               
  geom_point() +                                                                                                                                                         
  scale_color_discrete(guide = guide_legend(label.theme = element_text(face = "italic")))                                                                                
```
<img width="627" alt="screen shot 2018-05-07 at 12 12 05 pm" src="https://user-images.githubusercontent.com/4210929/39714788-c2fdea46-51f0-11e8-9cc2-e42bc4fff1c9.png">


```{r}
ggplot(iris, aes(x = Sepal.Length, y = Petal.Length, color = Species)) +                                                                                               
  geom_point() +                                                                                                                                                         
  scale_color_discrete(guide = guide_legend(title.theme = element_text(face = "italic")))     
```
<img width="627" alt="screen shot 2018-05-07 at 12 12 17 pm" src="https://user-images.githubusercontent.com/4210929/39714801-cb403eb6-51f0-11e8-8649-d6ff956b8987.png">

Both examples look a bit weird because the font size isn't specified. Once we specify font size as well, things look as expected.