### PR TITLE
Change all default_aes alpha from NA to 1

### DIFF
--- a/R/geom-abline.r
+++ b/R/geom-abline.r
@@ -121,7 +121,7 @@ GeomAbline <- ggproto("GeomAbline", Geom,
     GeomSegment$draw_panel(unique(data), panel_params, coord)
   },
 
-  default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = NA),
+  default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = 1),
   required_aes = c("slope", "intercept"),
 
   draw_key = draw_key_abline

--- a/R/geom-boxplot.r
+++ b/R/geom-boxplot.r
@@ -247,7 +247,7 @@ GeomBoxplot <- ggproto("GeomBoxplot", Geom,
   draw_key = draw_key_boxplot,
 
   default_aes = aes(weight = 1, colour = "grey20", fill = "white", size = 0.5,
-    alpha = NA, shape = 19, linetype = "solid"),
+    alpha = 1, shape = 19, linetype = "solid"),
 
   required_aes = c("x", "lower", "upper", "middle", "ymin", "ymax")
 )

--- a/R/geom-contour.r
+++ b/R/geom-contour.r
@@ -74,5 +74,5 @@ geom_contour <- function(mapping = NULL, data = NULL,
 #' @include geom-path.r
 GeomContour <- ggproto("GeomContour", GeomPath,
   default_aes = aes(weight = 1, colour = "#3366FF", size = 0.5, linetype = 1,
-    alpha = NA)
+    alpha = 1)
 )

--- a/R/geom-crossbar.r
+++ b/R/geom-crossbar.r
@@ -33,7 +33,7 @@ GeomCrossbar <- ggproto("GeomCrossbar", Geom,
   },
 
   default_aes = aes(colour = "black", fill = NA, size = 0.5, linetype = 1,
-    alpha = NA),
+    alpha = 1),
 
   required_aes = c("x", "y", "ymin", "ymax"),
 

--- a/R/geom-curve.r
+++ b/R/geom-curve.r
@@ -40,7 +40,7 @@ geom_curve <- function(mapping = NULL, data = NULL,
 #' @usage NULL
 #' @export
 GeomCurve <- ggproto("GeomCurve", GeomSegment,
-  default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = NA),
+  default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = 1),
   draw_panel = function(data, panel_params, coord, curvature = 0.5, angle = 90,
                         ncp = 5, arrow = NULL, arrow.fill, lineend = "butt", na.rm = FALSE) {
 

--- a/R/geom-density.r
+++ b/R/geom-density.r
@@ -74,7 +74,7 @@ geom_density <- function(mapping = NULL, data = NULL,
 #' @include geom-ribbon.r
 GeomDensity <- ggproto("GeomDensity", GeomArea,
   default_aes = defaults(
-    aes(fill = NA, weight = 1, colour = "black", alpha = NA),
+    aes(fill = NA, weight = 1, colour = "black", alpha = 1),
     GeomArea$default_aes
   )
 )

--- a/R/geom-density2d.r
+++ b/R/geom-density2d.r
@@ -73,5 +73,5 @@ geom_density2d <- geom_density_2d
 #' @usage NULL
 #' @export
 GeomDensity2d <- ggproto("GeomDensity2d", GeomPath,
-  default_aes = aes(colour = "#3366FF", size = 0.5, linetype = 1, alpha = NA)
+  default_aes = aes(colour = "#3366FF", size = 0.5, linetype = 1, alpha = 1)
 )

--- a/R/geom-dotplot.r
+++ b/R/geom-dotplot.r
@@ -175,7 +175,7 @@ GeomDotplot <- ggproto("GeomDotplot", Geom,
   required_aes = c("x", "y"),
   non_missing_aes = c("size", "shape"),
 
-  default_aes = aes(colour = "black", fill = "black", alpha = NA),
+  default_aes = aes(colour = "black", fill = "black", alpha = 1),
 
   setup_data = function(data, params) {
     data$width <- data$width %||%

--- a/R/geom-errorbar.r
+++ b/R/geom-errorbar.r
@@ -27,7 +27,7 @@ geom_errorbar <- function(mapping = NULL, data = NULL,
 #' @export
 GeomErrorbar <- ggproto("GeomErrorbar", Geom,
   default_aes = aes(colour = "black", size = 0.5, linetype = 1, width = 0.5,
-    alpha = NA),
+    alpha = 1),
 
   draw_key = draw_key_path,
 

--- a/R/geom-errorbarh.r
+++ b/R/geom-errorbarh.r
@@ -49,7 +49,7 @@ geom_errorbarh <- function(mapping = NULL, data = NULL,
 #' @export
 GeomErrorbarh <- ggproto("GeomErrorbarh", Geom,
   default_aes = aes(colour = "black", size = 0.5, linetype = 1, height = 0.5,
-    alpha = NA),
+    alpha = 1),
 
   draw_key = draw_key_path,
 

--- a/R/geom-hex.r
+++ b/R/geom-hex.r
@@ -68,7 +68,7 @@ GeomHex <- ggproto("GeomHex", Geom,
 
   required_aes = c("x", "y"),
 
-  default_aes = aes(colour = NA, fill = "grey50", size = 0.5, alpha = NA),
+  default_aes = aes(colour = NA, fill = "grey50", size = 0.5, alpha = 1),
 
   draw_key = draw_key_polygon
 )

--- a/R/geom-hline.r
+++ b/R/geom-hline.r
@@ -47,7 +47,7 @@ GeomHline <- ggproto("GeomHline", Geom,
     GeomSegment$draw_panel(unique(data), panel_params, coord)
   },
 
-  default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = NA),
+  default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = 1),
   required_aes = "yintercept",
 
   draw_key = draw_key_path

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -52,7 +52,7 @@ GeomLabel <- ggproto("GeomLabel", Geom,
 
   default_aes = aes(
     colour = "black", fill = "white", size = 3.88, angle = 0,
-    hjust = 0.5, vjust = 0.5, alpha = NA, family = "", fontface = 1,
+    hjust = 0.5, vjust = 0.5, alpha = 1, family = "", fontface = 1,
     lineheight = 1.2
   ),
 

--- a/R/geom-linerange.r
+++ b/R/geom-linerange.r
@@ -83,7 +83,7 @@ geom_linerange <- function(mapping = NULL, data = NULL,
 #' @usage NULL
 #' @export
 GeomLinerange <- ggproto("GeomLinerange", Geom,
-  default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = NA),
+  default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = 1),
 
   draw_key = draw_key_vpath,
 

--- a/R/geom-path.r
+++ b/R/geom-path.r
@@ -123,7 +123,7 @@ geom_path <- function(mapping = NULL, data = NULL,
 GeomPath <- ggproto("GeomPath", Geom,
   required_aes = c("x", "y"),
 
-  default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = NA),
+  default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = 1),
 
   handle_na = function(data, params) {
     # Drop missing values at the start or end of a line - can't drop in the

--- a/R/geom-point.r
+++ b/R/geom-point.r
@@ -122,7 +122,7 @@ GeomPoint <- ggproto("GeomPoint", Geom,
   non_missing_aes = c("size", "shape", "colour"),
   default_aes = aes(
     shape = 19, colour = "black", size = 1.5, fill = NA,
-    alpha = NA, stroke = 0.5
+    alpha = 1, stroke = 0.5
   ),
 
   draw_panel = function(data, panel_params, coord, na.rm = FALSE) {

--- a/R/geom-pointrange.r
+++ b/R/geom-pointrange.r
@@ -29,7 +29,7 @@ geom_pointrange <- function(mapping = NULL, data = NULL,
 #' @export
 GeomPointrange <- ggproto("GeomPointrange", Geom,
   default_aes = aes(colour = "black", size = 0.5, linetype = 1, shape = 19,
-    fill = NA, alpha = NA, stroke = 1),
+    fill = NA, alpha = 1, stroke = 1),
 
   draw_key = draw_key_pointrange,
 

--- a/R/geom-polygon.r
+++ b/R/geom-polygon.r
@@ -106,7 +106,7 @@ GeomPolygon <- ggproto("GeomPolygon", Geom,
   },
 
   default_aes = aes(colour = "NA", fill = "grey20", size = 0.5, linetype = 1,
-    alpha = NA),
+    alpha = 1),
 
   handle_na = function(data, params) {
     data

--- a/R/geom-raster.r
+++ b/R/geom-raster.r
@@ -44,7 +44,7 @@ geom_raster <- function(mapping = NULL, data = NULL,
 #' @usage NULL
 #' @export
 GeomRaster <- ggproto("GeomRaster", Geom,
-  default_aes = aes(fill = "grey20", alpha = NA),
+  default_aes = aes(fill = "grey20", alpha = 1),
   non_missing_aes = "fill",
   required_aes = c("x", "y"),
 

--- a/R/geom-rect.r
+++ b/R/geom-rect.r
@@ -27,7 +27,7 @@ geom_rect <- function(mapping = NULL, data = NULL,
 #' @export
 GeomRect <- ggproto("GeomRect", Geom,
   default_aes = aes(colour = NA, fill = "grey35", size = 0.5, linetype = 1,
-    alpha = NA),
+    alpha = 1),
 
   required_aes = c("xmin", "xmax", "ymin", "ymax"),
 

--- a/R/geom-ribbon.r
+++ b/R/geom-ribbon.r
@@ -58,7 +58,7 @@ geom_ribbon <- function(mapping = NULL, data = NULL,
 #' @export
 GeomRibbon <- ggproto("GeomRibbon", Geom,
   default_aes = aes(colour = NA, fill = "grey20", size = 0.5, linetype = 1,
-    alpha = NA),
+    alpha = 1),
 
   required_aes = c("x", "ymin", "ymax"),
 
@@ -132,7 +132,7 @@ geom_area <- function(mapping = NULL, data = NULL, stat = "identity",
 #' @export
 GeomArea <- ggproto("GeomArea", GeomRibbon,
   default_aes = aes(colour = NA, fill = "grey20", size = 0.5, linetype = 1,
-    alpha = NA),
+    alpha = 1),
 
   required_aes = c("x", "y"),
 

--- a/R/geom-rug.r
+++ b/R/geom-rug.r
@@ -106,7 +106,7 @@ GeomRug <- ggproto("GeomRug", Geom,
     gTree(children = do.call("gList", rugs))
   },
 
-  default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = NA),
+  default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = 1),
 
   draw_key = draw_key_path
 )

--- a/R/geom-segment.r
+++ b/R/geom-segment.r
@@ -101,7 +101,7 @@ geom_segment <- function(mapping = NULL, data = NULL,
 GeomSegment <- ggproto("GeomSegment", Geom,
   required_aes = c("x", "y", "xend", "yend"),
   non_missing_aes = c("linetype", "size", "shape"),
-  default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = NA),
+  default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = 1),
 
   draw_panel = function(data, panel_params, coord, arrow = NULL, arrow.fill = NULL,
                         lineend = "butt", linejoin = "round", na.rm = FALSE) {

--- a/R/geom-text.r
+++ b/R/geom-text.r
@@ -169,7 +169,7 @@ GeomText <- ggproto("GeomText", Geom,
 
   default_aes = aes(
     colour = "black", size = 3.88, angle = 0, hjust = 0.5,
-    vjust = 0.5, alpha = NA, family = "", fontface = 1, lineheight = 1.2
+    vjust = 0.5, alpha = 1, family = "", fontface = 1, lineheight = 1.2
   ),
 
   draw_panel = function(data, panel_params, coord, parse = FALSE,

--- a/R/geom-tile.r
+++ b/R/geom-tile.r
@@ -94,7 +94,7 @@ GeomTile <- ggproto("GeomTile", GeomRect,
   },
 
   default_aes = aes(fill = "grey20", colour = NA, size = 0.1, linetype = 1,
-    alpha = NA, width = NA, height = NA),
+    alpha = 1, width = NA, height = NA),
 
   required_aes = c("x", "y"),
 

--- a/R/geom-violin.r
+++ b/R/geom-violin.r
@@ -155,7 +155,7 @@ GeomViolin <- ggproto("GeomViolin", Geom,
   draw_key = draw_key_polygon,
 
   default_aes = aes(weight = 1, colour = "grey20", fill = "white", size = 0.5,
-    alpha = NA, linetype = "solid"),
+    alpha = 1, linetype = "solid"),
 
   required_aes = c("x", "y")
 )

--- a/R/geom-vline.r
+++ b/R/geom-vline.r
@@ -47,7 +47,7 @@ GeomVline <- ggproto("GeomVline", Geom,
     GeomSegment$draw_panel(unique(data), panel_params, coord)
   },
 
-  default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = NA),
+  default_aes = aes(colour = "black", size = 0.5, linetype = 1, alpha = 1),
   required_aes = "xintercept",
 
   draw_key = draw_key_vline

--- a/R/sf.R
+++ b/R/sf.R
@@ -147,7 +147,7 @@ GeomSf <- ggproto("GeomSf", Geom,
     fill = NULL,
     size = NULL,
     linetype = 1,
-    alpha = NA,
+    alpha = 1,
     stroke = 0.5
   ),
 


### PR DESCRIPTION
Fix #2558

This PR changes all the default values for the alpha aesthetic to 1 in the cases where it is currently set to `NA`. Any colour are currently passed through `scales::alpha()` if it should be modified with transparency and this function treats `NA` as 1, so there should be no practical effect of this change.