### PR TITLE
Fix CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ r:
 # work around temporary travis + R 3.5 bug
 r_packages: devtools
 
+# Install manually because dev vdiffr is not compatible with Appveyor yet
+r_github_packages: lionel-/vdiffr
+
 env:
   global:
   - _R_CHECK_FORCE_SUGGESTS_=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
       - libfreetype6
 
 r:
-# - 3.1 # because of tidyr <- tidyselect
+- 3.1
 - 3.2
 - oldrel
 - release

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Suggests:
     munsell,
     nlme,
     testthat (>= 0.11.0),
-    vdiffr (>= 0.2.3.9000),
+    vdiffr,
     quantreg,
     knitr,
     rgeos,
@@ -54,7 +54,6 @@ Suggests:
     sf (>= 0.3-4),
     svglite (>= 1.2.0.9001)
 Remotes:
-    lionel-/vdiffr,
     hadley/scales,
     r-lib/rlang
 Enhances: sp

--- a/tests/testthat/helper-vdiffr.R
+++ b/tests/testthat/helper-vdiffr.R
@@ -1,6 +1,11 @@
 
 enable_vdiffr <- TRUE
 
+if (!requireNamespace("vdiffr", quietly = TRUE) ||
+      utils::packageVersion("vdiffr") < "0.2.3.9000") {
+  enable_vdiffr <- FALSE
+}
+
 expect_doppelganger <- function(title, fig,
                                path = NULL,
                                ...,


### PR DESCRIPTION
- On Travis add R 3.1 now that tidyr/tidyselect are fixed on 3.1
- On Appveyor use `ggplot_build()` instead of vdiffr until the latter is fixed on Windows platforms