### PR TITLE
Fix documentation for coord_cartesian()

### DIFF
--- a/R/coord-cartesian-.r
+++ b/R/coord-cartesian-.r
@@ -9,7 +9,10 @@
 #' @param expand If `TRUE`, the default, adds a small expansion factor to
 #'   the limits to ensure that data and axes don't overlap. If `FALSE`,
 #'   limits are taken exactly from the data or `xlim`/`ylim`.
-#' @param default Is this the default coordinate system? If `FALSE`
+#' @param default Is this the default coordinate system? If `FALSE` (the default),
+#'   then replacing this coordinate system with another one creates a message alerting
+#'   the user that the coordinate system is being replaced. If `TRUE`, that warning
+#'   is suppressed.
 #' @param clip Should drawing be clipped to the extent of the plot panel? A
 #'   setting of `"on"` (the default) means yes, and a setting of `"off"`
 #'   means no. In most cases, the default of `"on"` should not be changed,

--- a/man/coord_cartesian.Rd
+++ b/man/coord_cartesian.Rd
@@ -14,7 +14,10 @@ coord_cartesian(xlim = NULL, ylim = NULL, expand = TRUE,
 the limits to ensure that data and axes don't overlap. If \code{FALSE},
 limits are taken exactly from the data or \code{xlim}/\code{ylim}.}
 
-\item{default}{Is this the default coordinate system? If \code{FALSE}}
+\item{default}{Is this the default coordinate system? If \code{FALSE} (the default),
+then replacing this coordinate system with another one creates a message alerting
+the user that the coordinate system is being replaced. If \code{TRUE}, that warning
+is suppressed.}
 
 \item{clip}{Should drawing be clipped to the extent of the plot panel? A
 setting of \code{"on"} (the default) means yes, and a setting of \code{"off"}

--- a/man/ggsf.Rd
+++ b/man/ggsf.Rd
@@ -86,7 +86,10 @@ use the CRS defined in the first layer.}
 \item{ndiscr}{number of segments to use for discretizing graticule lines;
 try increasing this when graticules look unexpected}
 
-\item{default}{Is this the default coordinate system? If \code{FALSE}}
+\item{default}{Is this the default coordinate system? If \code{FALSE} (the default),
+then replacing this coordinate system with another one creates a message alerting
+the user that the coordinate system is being replaced. If \code{TRUE}, that warning
+is suppressed.}
 }
 \description{
 This set of geom, stat, and coord are used to visualise simple feature (sf)


### PR DESCRIPTION
The current documentation for `coord_cartesian()` has an incomplete sentence in the description of the parameter `default`. This PR fixes that.