### PR TITLE
Fix issue 1546, fill aesthetic does not show in the legend guide for stat_summary

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -265,6 +265,9 @@ up correct aspect ratio, and draws a graticule.
   (@davharris #1951). It also orders by the `x` aesthetic, making it easier 
   to pass pre-computed values without manual ordering (@izahn, #2028).
   It also now knows it has `ymin` and `ymax` aesthetics (#1939).
+  
+* Fixed legend-drawing bug when using `geom_smooth()` with stats other than
+  `stat_smooth()` (@clauswilke, #1546).
 
 * `geom_tile()` now once again interprets `width` and `height` correctly 
   (@malcolmbarrett, #2510)

--- a/R/geom-smooth.r
+++ b/R/geom-smooth.r
@@ -87,12 +87,12 @@ geom_smooth <- function(mapping = NULL, data = NULL,
 
   params <- list(
     na.rm = na.rm,
+    se = se,
     ...
   )
   if (identical(stat, "smooth")) {
     params$method <- method
     params$formula <- formula
-    params$se <- se
   }
 
   layer(
@@ -115,11 +115,19 @@ GeomSmooth <- ggproto("GeomSmooth", Geom,
   setup_data = function(data, params) {
     GeomLine$setup_data(data, params)
   },
-  draw_group = function(data, panel_params, coord) {
+
+  # The `se` argument is set to false here to make sure drawing the
+  # geom and drawing the legend is in synch. If the geom is used by a
+  # stat that doesn't set the `se` argument then `se` will be missing
+  # and the legend key won't be drawn. With `se = FALSE` here the
+  # ribbon won't be drawn either in that case, keeping the overall
+  # behavior predictable and sensible. The user will realize that they
+  # need to set `se = TRUE` to obtain the ribbon and the legend key.
+  draw_group = function(data, panel_params, coord, se = FALSE) {
     ribbon <- transform(data, colour = NA)
     path <- transform(data, alpha = NA)
 
-    has_ribbon <- !is.null(data$ymax) && !is.null(data$ymin)
+    has_ribbon <- se && !is.null(data$ymax) && !is.null(data$ymin)
 
     gList(
       if (has_ribbon) GeomRibbon$draw_group(ribbon, panel_params, coord),

--- a/tests/figs/geom-smooth/ribbon-turned-off-in-geom-smooth.svg
+++ b/tests/figs/geom-smooth/ribbon-turned-off-in-geom-smooth.svg
@@ -1,0 +1,61 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpMzguMTZ8Njc0LjU1fDU0MS41M3wyMy42Mg=='>
+    <rect x='38.16' y='23.62' width='636.39' height='517.91' />
+  </clipPath>
+</defs>
+<rect x='38.16' y='23.62' width='636.39' height='517.91' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMzguMTZ8Njc0LjU1fDU0MS41M3wyMy42Mg==)' />
+<polyline points='67.08,400.28 645.62,164.87 ' style='stroke-width: 2.13; stroke: #F8766D; stroke-linecap: butt;' clip-path='url(#cpMzguMTZ8Njc0LjU1fDU0MS41M3wyMy42Mg==)' />
+<polyline points='67.08,164.87 645.62,400.28 ' style='stroke-width: 2.13; stroke: #00BFC4; stroke-linecap: butt;' clip-path='url(#cpMzguMTZ8Njc0LjU1fDU0MS41M3wyMy42Mg==)' />
+<rect x='38.16' y='23.62' width='636.39' height='517.91' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpMzguMTZ8Njc0LjU1fDU0MS41M3wyMy42Mg==)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='21.01' y='521.01' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>1.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='21.01' y='403.31' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>1.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='21.01' y='285.60' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>2.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='21.01' y='167.89' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='21.01' y='50.18' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<polyline points='35.42,517.99 38.16,517.99 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='35.42,400.28 38.16,400.28 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='35.42,282.57 38.16,282.57 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='35.42,164.87 38.16,164.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='35.42,47.16 38.16,47.16 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='67.08,544.27 67.08,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='211.72,544.27 211.72,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='356.35,544.27 356.35,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='500.99,544.27 500.99,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='645.62,544.27 645.62,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.53' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>1.00</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='203.16' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>1.25</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='347.80' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>1.50</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='492.43' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>1.75</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='637.07' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>2.00</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='353.60' y='568.04' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(13.04,285.32) rotate(-90)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text></g>
+<rect x='685.89' y='257.53' width='28.63' height='50.09' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='685.89' y='266.34' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='10.38px' lengthAdjust='spacingAndGlyphs'>fill</text></g>
+<rect x='685.89' y='273.06' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<line x1='687.61' y1='281.70' x2='701.44' y2='281.70' style='stroke-width: 2.13; stroke: #F8766D; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<rect x='685.89' y='290.34' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<line x1='687.61' y1='298.98' x2='701.44' y2='298.98' style='stroke-width: 2.13; stroke: #00BFC4; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='708.65' y='284.72' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='5.88px' lengthAdjust='spacingAndGlyphs'>A</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='708.65' y='302.00' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='5.88px' lengthAdjust='spacingAndGlyphs'>B</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='38.16' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='196.81px' lengthAdjust='spacingAndGlyphs'>ribbon turned off in geom_smooth</text></g>
+</svg>

--- a/tests/figs/geom-smooth/ribbon-turned-on-in-geom-smooth.svg
+++ b/tests/figs/geom-smooth/ribbon-turned-on-in-geom-smooth.svg
@@ -1,0 +1,65 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpMzguMTZ8Njc0LjU1fDU0MS41M3wyMy42Mg=='>
+    <rect x='38.16' y='23.62' width='636.39' height='517.91' />
+  </clipPath>
+</defs>
+<rect x='38.16' y='23.62' width='636.39' height='517.91' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMzguMTZ8Njc0LjU1fDU0MS41M3wyMy42Mg==)' />
+<polygon points='67.08,282.57 645.62,47.16 645.62,282.57 67.08,517.99 ' style='stroke-width: 2.13; stroke: none; fill: #F8766D; fill-opacity: 0.40;' clip-path='url(#cpMzguMTZ8Njc0LjU1fDU0MS41M3wyMy42Mg==)' />
+<polyline points='67.08,400.28 645.62,164.87 ' style='stroke-width: 2.13; stroke: #F8766D; stroke-linecap: butt;' clip-path='url(#cpMzguMTZ8Njc0LjU1fDU0MS41M3wyMy42Mg==)' />
+<polygon points='67.08,47.16 645.62,282.57 645.62,517.99 67.08,282.57 ' style='stroke-width: 2.13; stroke: none; fill: #00BFC4; fill-opacity: 0.40;' clip-path='url(#cpMzguMTZ8Njc0LjU1fDU0MS41M3wyMy42Mg==)' />
+<polyline points='67.08,164.87 645.62,400.28 ' style='stroke-width: 2.13; stroke: #00BFC4; stroke-linecap: butt;' clip-path='url(#cpMzguMTZ8Njc0LjU1fDU0MS41M3wyMy42Mg==)' />
+<rect x='38.16' y='23.62' width='636.39' height='517.91' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpMzguMTZ8Njc0LjU1fDU0MS41M3wyMy42Mg==)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='21.01' y='521.01' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>1.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='21.01' y='403.31' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>1.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='21.01' y='285.60' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>2.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='21.01' y='167.89' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='21.01' y='50.18' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<polyline points='35.42,517.99 38.16,517.99 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='35.42,400.28 38.16,400.28 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='35.42,282.57 38.16,282.57 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='35.42,164.87 38.16,164.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='35.42,47.16 38.16,47.16 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='67.08,544.27 67.08,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='211.72,544.27 211.72,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='356.35,544.27 356.35,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='500.99,544.27 500.99,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='645.62,544.27 645.62,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='58.53' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>1.00</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='203.16' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>1.25</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='347.80' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>1.50</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='492.43' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>1.75</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='637.07' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>2.00</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='353.60' y='568.04' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(13.04,285.32) rotate(-90)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text></g>
+<rect x='685.89' y='257.53' width='28.63' height='50.09' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='685.89' y='266.34' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='10.38px' lengthAdjust='spacingAndGlyphs'>fill</text></g>
+<rect x='685.89' y='273.06' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<rect x='685.89' y='273.06' width='17.28' height='17.28' style='stroke-width: 0.75; stroke: none; fill: #F8766D; fill-opacity: 0.40;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<line x1='687.61' y1='281.70' x2='701.44' y2='281.70' style='stroke-width: 2.13; stroke: #F8766D; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<rect x='685.89' y='290.34' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<rect x='685.89' y='290.34' width='17.28' height='17.28' style='stroke-width: 0.75; stroke: none; fill: #00BFC4; fill-opacity: 0.40;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<line x1='687.61' y1='298.98' x2='701.44' y2='298.98' style='stroke-width: 2.13; stroke: #00BFC4; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='708.65' y='284.72' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='5.88px' lengthAdjust='spacingAndGlyphs'>A</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='708.65' y='302.00' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='5.88px' lengthAdjust='spacingAndGlyphs'>B</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='38.16' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='197.06px' lengthAdjust='spacingAndGlyphs'>ribbon turned on in geom_smooth</text></g>
+</svg>

--- a/tests/testthat/test-function-args.r
+++ b/tests/testthat/test-function-args.r
@@ -13,7 +13,7 @@ test_that("geom_xxx and GeomXxx$draw arg defaults match", {
   # These aren't actually geoms, or need special parameters and can't be tested this way.
   geom_fun_names <- setdiff(
     geom_fun_names,
-    c("geom_map", "geom_sf", "geom_column", "annotation_custom", "annotation_map",
+    c("geom_map", "geom_sf", "geom_smooth", "geom_column", "annotation_custom", "annotation_map",
       "annotation_raster", "annotation_id")
   )
 

--- a/tests/testthat/test-geom-smooth.R
+++ b/tests/testthat/test-geom-smooth.R
@@ -8,3 +8,21 @@ test_that("Data is ordered by x", {
 
   expect_equal(layer_data(ps)[c("x", "y")], df[order(df$x), ])
 })
+
+# Visual tests ------------------------------------------------------------
+
+test_that("geom_smooth() works with alternative stats", {
+  df <- data.frame(x = c(1, 1, 2, 2, 1, 1, 2, 2),
+                   y = c(1, 2, 2, 3, 2, 3, 1, 2),
+                   fill = c(rep("A", 4), rep("B", 4)))
+
+  expect_doppelganger("ribbon turned on in geom_smooth", {
+    ggplot(df, aes(x, y, color = fill, fill = fill)) +
+      geom_smooth(stat = "summary") # ribbon on by default
+  })
+
+  expect_doppelganger("ribbon turned off in geom_smooth", {
+    ggplot(df, aes(x, y, color = fill, fill = fill)) +
+      geom_smooth(stat = "summary", se = FALSE) # ribbon is turned off via `se = FALSE`
+  })
+})


### PR DESCRIPTION
I think the way to fix this issue is to give `geom_smooth()` a first-class `se` parameter that is considered when drawing the panel. This allows the geom and the legend drawing code to always be in synch. See resulting behavior in the examples below.

One note: Currently one regression test fails because the `geom_smooth()` and `draw_group()` functions have different default arguments and the test checks for that. I think the test is wrong in this particular case, but I wanted to bring this up for discussion. Relevant lines in the code, with explanation for why it should be this way:
https://github.com/clauswilke/ggplot2/blob/ed016144c97cf67424498453a2f4e06925fdba92/R/geom-smooth.r#L119-L126

Examples of `geom_smooth()` with `stat_summary()`:
``` r
library(ggplot2)
ggplot(mtcars, aes(cyl, mpg, fill = factor(am))) +
  geom_smooth(stat = "summary")
#> No summary function supplied, defaulting to `mean_se()
```

![](https://i.imgur.com/T1NIgn7.png)

``` r

ggplot(mtcars, aes(cyl, mpg, fill = factor(am))) +
  geom_smooth(stat = "summary", se = FALSE)
#> No summary function supplied, defaulting to `mean_se()
```

![](https://i.imgur.com/q1bfbuN.png)

``` r

# stat_summary doesn't have an `se` parameter, hence
# default is `se = FALSE`
ggplot(mtcars, aes(cyl, mpg, fill = factor(am))) +
  stat_summary(geom = "smooth")
#> No summary function supplied, defaulting to `mean_se()
```

![](https://i.imgur.com/9qzn74l.png)

``` r

ggplot(mtcars, aes(cyl, mpg, fill = factor(am))) +
  stat_summary(geom = "smooth", se = TRUE)
#> No summary function supplied, defaulting to `mean_se()
```

![](https://i.imgur.com/7buwIW5.png)

And, for completeness, all combinations of `geom_smooth()` / `stat_smooth()` with `se = TRUE` / `se = FALSE` work as expected:

``` r
library(ggplot2)
ggplot(iris, aes(Sepal.Length, Sepal.Width, color = Species, fill = Species)) +
  geom_smooth()
#> `geom_smooth()` using method = 'loess' and formula 'y ~ x'
```

![](https://i.imgur.com/T0acn22.png)

``` r

ggplot(iris, aes(Sepal.Length, Sepal.Width, color = Species, fill = Species)) +
  geom_smooth(se = FALSE)
#> `geom_smooth()` using method = 'loess' and formula 'y ~ x'
```

![](https://i.imgur.com/gGn6HGV.png)

``` r

ggplot(iris, aes(Sepal.Length, Sepal.Width, color = Species, fill = Species)) +
  stat_smooth()
#> `geom_smooth()` using method = 'loess' and formula 'y ~ x'
```

![](https://i.imgur.com/RylFjCL.png)

``` r

ggplot(iris, aes(Sepal.Length, Sepal.Width, color = Species, fill = Species)) +
  stat_smooth(se = FALSE)
#> `geom_smooth()` using method = 'loess' and formula 'y ~ x'
```

![](https://i.imgur.com/RxuwOfy.png)

Created on 2018-05-10 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).