### PR TITLE
Close issues #2573 & #2576

### DIFF
--- a/R/guide-colorbar.r
+++ b/R/guide-colorbar.r
@@ -526,8 +526,13 @@ guide_gengrob.colorbar <- function(guide, theme) {
     b = 1 + max(vps$label.row), l = 1 + min(vps$label.col))
   gt <- gtable_add_grob(
     gt,
-    justify_grobs(grob.title, hjust = title.hjust, vjust = title.vjust,
-                  int_angle = title.theme$angle, debug = title.theme$debug),
+    justify_grobs(
+      grob.title,
+      hjust = title.hjust,
+      vjust = title.vjust,
+      int_angle = title.theme$angle,
+      debug = title.theme$debug
+    ),
     name = "title",
     clip = "off",
     t = 1 + min(vps$title.row), r = 1 + max(vps$title.col),

--- a/R/guide-colorbar.r
+++ b/R/guide-colorbar.r
@@ -526,7 +526,8 @@ guide_gengrob.colorbar <- function(guide, theme) {
     b = 1 + max(vps$label.row), l = 1 + min(vps$label.col))
   gt <- gtable_add_grob(
     gt,
-    justify_grobs(grob.title, hjust = title.hjust, vjust = title.vjust, debug = title.theme$debug),
+    justify_grobs(grob.title, hjust = title.hjust, vjust = title.vjust,
+                  int_angle = title.theme$angle, debug = title.theme$debug),
     name = "title",
     clip = "off",
     t = 1 + min(vps$title.row), r = 1 + max(vps$title.col),

--- a/R/guide-colorbar.r
+++ b/R/guide-colorbar.r
@@ -342,8 +342,7 @@ guide_gengrob.colorbar <- function(guide, theme) {
 
   title_width <- width_cm(grob.title)
   title_height <- height_cm(grob.title)
-  title_fontsize <- title.theme$size
-  if (is.null(title_fontsize)) title_fontsize <- 0
+  title_fontsize <- title.theme$size %||% calc_element("legend.title", theme)$size %||% 0
 
   # gap between keys etc
   # the default horizontal and vertical gap need to be the same to avoid strange

--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -336,7 +336,7 @@ guide_gengrob.legend <- function(guide, theme) {
     element_grob(
       title.theme,
       label = guide$title,
-      hjust = title.hjust, #hjust and #vjust are set below via justify_grobs()
+      hjust = title.hjust,
       vjust = title.vjust,
       margin_x = TRUE,
       margin_y = TRUE
@@ -383,8 +383,8 @@ guide_gengrob.legend <- function(guide, theme) {
       g <- element_grob(
         element = label.theme,
         label = label,
-        hjust = 0.5,  #hjust and #vjust are set below via justify_grobs()
-        vjust = 0.5,
+        hjust = hjust,
+        vjust = vjust,
         margin_x = TRUE,
         margin_y = TRUE
       )
@@ -691,7 +691,8 @@ guide_gengrob.legend <- function(guide, theme) {
   )
   gt <- gtable_add_grob(
     gt,
-    justify_grobs(grob.title, hjust = title.hjust, vjust = title.vjust, debug = title.theme$debug),
+    justify_grobs(grob.title, hjust = title.hjust, vjust = title.vjust,
+                  int_angle = title.theme$angle, debug = title.theme$debug),
     name = "title",
     clip = "off",
     t = 1 + min(vps.title.row),
@@ -711,7 +712,8 @@ guide_gengrob.legend <- function(guide, theme) {
   )
   gt <- gtable_add_grob(
     gt,
-    justify_grobs(grob.labels, hjust = hjust, vjust = vjust, debug = label.theme$debug),
+    justify_grobs(grob.labels, hjust = hjust, vjust = vjust,
+                  int_angle = label.theme$angle, debug = label.theme$debug),
     name = paste("label", vps$label.row, vps$label.col, sep = "-"),
     clip = "off",
     t = 1 + vps$label.row,

--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -691,8 +691,13 @@ guide_gengrob.legend <- function(guide, theme) {
   )
   gt <- gtable_add_grob(
     gt,
-    justify_grobs(grob.title, hjust = title.hjust, vjust = title.vjust,
-                  int_angle = title.theme$angle, debug = title.theme$debug),
+    justify_grobs(
+      grob.title,
+      hjust = title.hjust,
+      vjust = title.vjust,
+      int_angle = title.theme$angle,
+      debug = title.theme$debug
+    ),
     name = "title",
     clip = "off",
     t = 1 + min(vps.title.row),
@@ -712,8 +717,13 @@ guide_gengrob.legend <- function(guide, theme) {
   )
   gt <- gtable_add_grob(
     gt,
-    justify_grobs(grob.labels, hjust = hjust, vjust = vjust,
-                  int_angle = label.theme$angle, debug = label.theme$debug),
+    justify_grobs(
+      grob.labels,
+      hjust = hjust,
+      vjust = vjust,
+      int_angle = label.theme$angle,
+      debug = label.theme$debug
+    ),
     name = paste("label", vps$label.row, vps$label.col, sep = "-"),
     clip = "off",
     t = 1 + vps$label.row,

--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -336,7 +336,7 @@ guide_gengrob.legend <- function(guide, theme) {
     element_grob(
       title.theme,
       label = guide$title,
-      hjust = title.hjust,
+      hjust = title.hjust, #hjust and #vjust are set below via justify_grobs()
       vjust = title.vjust,
       margin_x = TRUE,
       margin_y = TRUE
@@ -375,19 +375,17 @@ guide_gengrob.legend <- function(guide, theme) {
     if (is.null(guide$label.theme$vjust) && is.null(theme$legend.text$vjust)) label.theme$vjust <- NULL
 
     # label.theme in param of guide_legend() > theme$legend.text.align > default
-    hjust <- x <- guide$label.hjust %||% theme$legend.text.align %||% label.theme$hjust %||%
+    hjust <- guide$label.hjust %||% theme$legend.text.align %||% label.theme$hjust %||%
       just_defaults$hjust
-    vjust <- y <- guide$label.vjust %||% label.theme$vjust %||%
+    vjust <- guide$label.vjust %||% label.theme$vjust %||%
       just_defaults$vjust
 
     grob.labels <- lapply(guide$key$.label, function(label, ...) {
       g <- element_grob(
         element = label.theme,
         label = label,
-        x = x,
-        y = y,
-        hjust = hjust,
-        vjust = vjust,
+        hjust = 0.5,  #hjust and #vjust are set below via justify_grobs()
+        vjust = 0.5,
         margin_x = TRUE,
         margin_y = TRUE
       )

--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -345,8 +345,7 @@ guide_gengrob.legend <- function(guide, theme) {
 
   title_width <- width_cm(grob.title)
   title_height <- height_cm(grob.title)
-  title_fontsize <- title.theme$size
-  if (is.null(title_fontsize)) title_fontsize <- 0
+  title_fontsize <- title.theme$size %||% calc_element("legend.title", theme)$size %||% 0
 
   # gap between keys etc
   # the default horizontal and vertical gap need to be the same to avoid strange

--- a/R/margins.R
+++ b/R/margins.R
@@ -265,7 +265,7 @@ justify_grobs <- function(grobs, x = NULL, y = NULL, hjust = 0.5, vjust = 0.5, d
     children = gList(grobs)
   }
 
-  gTree(
+  result_grob <- gTree(
     children = children,
     vp = viewport(
       x = x,
@@ -275,4 +275,13 @@ justify_grobs <- function(grobs, x = NULL, y = NULL, hjust = 0.5, vjust = 0.5, d
       just = c(hjust, vjust)
     )
   )
+
+  if (isTRUE(debug)) {
+    grobTree(
+      result_grob,
+      pointsGrob(x, y, pch = 20, gp = gpar(col = "mediumturquoise"))
+    )
+  } else {
+    result_grob
+  }
 }

--- a/R/margins.R
+++ b/R/margins.R
@@ -41,11 +41,11 @@ title_spec <- function(label, x, y, hjust, vjust, angle, gp = gpar(),
 
   # We rotate the justifiation values to obtain the correct x and y reference point,
   # since hjust and vjust are applied relative to the rotated text frame in textGrob
-  xy <- rotate_just(angle, hjust, vjust)
+  just <- rotate_just(angle, hjust, vjust)
 
   n <- max(length(x), length(y), 1)
-  x <- x %||% unit(rep(xy[1], n), "npc")
-  y <- y %||% unit(rep(xy[2], n), "npc")
+  x <- x %||% unit(rep(just$hjust, n), "npc")
+  y <- y %||% unit(rep(just$vjust, n), "npc")
 
   text_grob <- textGrob(
     label,
@@ -246,12 +246,10 @@ justify_grobs <- function(grobs, x = NULL, y = NULL, hjust = 0.5, vjust = 0.5,
   }
 
   # adjust hjust and vjust according to internal angle
-  rjust <- rotate_just(int_angle, hjust, vjust)
-  hjust <- rjust[1]
-  vjust <- rjust[2]
+  just <- rotate_just(int_angle, hjust, vjust)
 
-  x <- x %||% unit(hjust, "npc")
-  y <- y %||% unit(vjust, "npc")
+  x <- x %||% unit(just$hjust, "npc")
+  y <- y %||% unit(just$vjust, "npc")
 
 
   if (isTRUE(debug)) {
@@ -272,7 +270,7 @@ justify_grobs <- function(grobs, x = NULL, y = NULL, hjust = 0.5, vjust = 0.5,
       y = y,
       width = grobWidth(grobs),
       height = grobHeight(grobs),
-      just = c(hjust, vjust)
+      just = unlist(just)
     )
   )
 
@@ -295,7 +293,7 @@ justify_grobs <- function(grobs, x = NULL, y = NULL, hjust = 0.5, vjust = 0.5,
 #' @param angle angle of rotation, in degrees
 #' @param hjust horizontal justification
 #' @param vjust vertical justification
-#' @return A vector with two components, containing the rotated hjust and vjust values
+#' @return A list with two components, `hjust` and `vjust`, containing the rotated hjust and vjust values
 #'
 #' @noRd
 rotate_just <- function(angle, hjust, vjust) {
@@ -305,5 +303,5 @@ rotate_just <- function(angle, hjust, vjust) {
   hnew <- cos(rad) * hjust - sin(rad) * vjust + (1 - cos(rad) + sin(rad)) / 2
   vnew <- sin(rad) * hjust + cos(rad) * vjust + (1 - cos(rad) - sin(rad)) / 2
 
-  c(hnew, vnew)
+  list(hjust = hnew, vjust = vnew)
 }

--- a/R/margins.R
+++ b/R/margins.R
@@ -54,6 +54,11 @@ title_spec <- function(label, x, y, hjust, vjust, angle, gp = gpar(),
     yp <- 1 - hjust
   }
 
+  # Should the above if statements be replaced by this?
+  #rad <- angle * 2 * pi / 360
+  #xp <- cos(rad) * hjust - sin(rad) * vjust + (1 - cos(rad) + sin(rad)) / 2
+  #yp <- sin(rad) * hjust + cos(rad) * vjust + (1 - cos(rad) - sin(rad)) / 2
+
   n <- max(length(x), length(y), 1)
   x <- x %||% unit(rep(xp, n), "npc")
   y <- y %||% unit(rep(yp, n), "npc")
@@ -256,20 +261,11 @@ justify_grobs <- function(grobs, x = NULL, y = NULL, hjust = 0.5, vjust = 0.5,
     return(grobs)
   }
 
-  # adjust hjust, and vjust according to internal angle
-  int_angle <- (int_angle %||% 0) %% 360
-  if (90 <= int_angle & int_angle < 180) {
-    htmp <- hjust
-    hjust <- 1 - vjust
-    vjust <- htmp
-  } else if (180 <= int_angle & int_angle < 270) {
-    hjust <- 1 - hjust
-    vjust <- 1 - vjust
-  } else if (270 <= int_angle & int_angle < 360) {
-    htmp <- hjust
-    hjust <- vjust
-    vjust <- 1 - htmp
-  }
+  # adjust hjust and vjust according to internal angle
+  rad <- (int_angle %||% 0) * 2 * pi / 360
+  htmp <- hjust
+  hjust <- cos(rad) * htmp - sin(rad) * vjust + (1 - cos(rad) + sin(rad)) / 2
+  vjust <- sin(rad) * htmp + cos(rad) * vjust + (1 - cos(rad) - sin(rad)) / 2
 
   x <- x %||% unit(hjust, "npc")
   y <- y %||% unit(vjust, "npc")

--- a/R/margins.R
+++ b/R/margins.R
@@ -257,7 +257,7 @@ justify_grobs <- function(grobs, x = NULL, y = NULL, hjust = 0.5, vjust = 0.5,
   }
 
   # adjust hjust, and vjust according to internal angle
-  int_angle <- int_angle %% 360
+  int_angle <- (int_angle %||% 0) %% 360
   if (90 <= int_angle & int_angle < 180) {
     htmp <- hjust
     hjust <- 1 - vjust

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -287,6 +287,7 @@ ggplot_gtable.ggplot_built <- function(data) {
     tag_parent <- justify_grobs(tag, x = xpos, y = ypos,
                                 hjust = theme$plot.tag$hjust,
                                 vjust = theme$plot.tag$vjust,
+                                int_angle = theme$plot.tag$angle,
                                 debug = theme$plot.tag$debug)
     plot_table <- gtable_add_grob(plot_table, tag_parent, name = "tag", t = 1,
                                   b = nrow(plot_table), l = 1,

--- a/tests/figs/coord-polar/secondary-axis-ticks-and-labels.svg
+++ b/tests/figs/coord-polar/secondary-axis-ticks-and-labels.svg
@@ -57,6 +57,6 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='628.72' y='78.79' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>0.30</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='354.80' y='568.04' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(68.94,291.51) rotate(-90)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(648.57,275.91) rotate(-270)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='25.69px' lengthAdjust='spacingAndGlyphs'>sec y</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(648.57,275.91) rotate(90)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='25.69px' lengthAdjust='spacingAndGlyphs'>sec y</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='91.32' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='181.70px' lengthAdjust='spacingAndGlyphs'>secondary axis ticks and labels</text></g>
 </svg>

--- a/tests/figs/facetting/left-justified-facet-labels-with-margins.svg
+++ b/tests/figs/facetting/left-justified-facet-labels-with-margins.svg
@@ -93,7 +93,7 @@
   </clipPath>
 </defs>
 <rect x='696.03' y='41.02' width='18.49' height='248.89' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpNjk2LjAzfDcxNC41MnwyODkuOTB8NDEuMDI=)' />
-<g clip-path='url(#cpNjk2LjAzfDcxNC41MnwyODkuOTB8NDEuMDI=)'><text transform='translate(702.25,46.00) rotate(-270)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text></g>
+<g clip-path='url(#cpNjk2LjAzfDcxNC41MnwyODkuOTB8NDEuMDI=)'><text transform='translate(702.25,46.00) rotate(90)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text></g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />
@@ -105,7 +105,7 @@
   </clipPath>
 </defs>
 <rect x='696.03' y='295.38' width='18.49' height='248.89' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpNjk2LjAzfDcxNC41Mnw1NDQuMjd8Mjk1LjM4)' />
-<g clip-path='url(#cpNjk2LjAzfDcxNC41Mnw1NDQuMjd8Mjk1LjM4)'><text transform='translate(702.25,300.36) rotate(-270)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='43.53px' lengthAdjust='spacingAndGlyphs'>bbbbbbbcd</text></g>
+<g clip-path='url(#cpNjk2LjAzfDcxNC41Mnw1NDQuMjd8Mjk1LjM4)'><text transform='translate(702.25,300.36) rotate(90)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='43.53px' lengthAdjust='spacingAndGlyphs'>bbbbbbbcd</text></g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />

--- a/tests/figs/geom-dotplot/facets-3-groups-histodot-stackgroups.svg
+++ b/tests/figs/geom-dotplot/facets-3-groups-histodot-stackgroups.svg
@@ -145,7 +145,7 @@
   </clipPath>
 </defs>
 <rect x='655.06' y='23.62' width='19.49' height='168.99' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpNjU1LjA2fDY3NC41NXwxOTIuNjB8MjMuNjI=)' />
-<g clip-path='url(#cpNjU1LjA2fDY3NC41NXwxOTIuNjB8MjMuNjI=)'><text transform='translate(661.78,105.17) rotate(-270)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='5.88px' lengthAdjust='spacingAndGlyphs'>A</text></g>
+<g clip-path='url(#cpNjU1LjA2fDY3NC41NXwxOTIuNjB8MjMuNjI=)'><text transform='translate(661.78,105.17) rotate(90)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='5.88px' lengthAdjust='spacingAndGlyphs'>A</text></g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />
@@ -157,7 +157,7 @@
   </clipPath>
 </defs>
 <rect x='655.06' y='198.08' width='19.49' height='168.99' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpNjU1LjA2fDY3NC41NXwzNjcuMDd8MTk4LjA4)' />
-<g clip-path='url(#cpNjU1LjA2fDY3NC41NXwzNjcuMDd8MTk4LjA4)'><text transform='translate(661.78,279.64) rotate(-270)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='5.88px' lengthAdjust='spacingAndGlyphs'>B</text></g>
+<g clip-path='url(#cpNjU1LjA2fDY3NC41NXwzNjcuMDd8MTk4LjA4)'><text transform='translate(661.78,279.64) rotate(90)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='5.88px' lengthAdjust='spacingAndGlyphs'>B</text></g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />
@@ -169,7 +169,7 @@
   </clipPath>
 </defs>
 <rect x='655.06' y='372.55' width='19.49' height='168.99' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpNjU1LjA2fDY3NC41NXw1NDEuNTN8MzcyLjU1)' />
-<g clip-path='url(#cpNjU1LjA2fDY3NC41NXw1NDEuNTN8MzcyLjU1)'><text transform='translate(661.78,453.86) rotate(-270)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text></g>
+<g clip-path='url(#cpNjU1LjA2fDY3NC41NXw1NDEuNTN8MzcyLjU1)'><text transform='translate(661.78,453.86) rotate(90)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text></g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />

--- a/tests/figs/guides/facet-grid-legend-on-bottom.svg
+++ b/tests/figs/guides/facet-grid-legend-on-bottom.svg
@@ -44,7 +44,7 @@
   </clipPath>
 </defs>
 <rect x='697.22' y='39.82' width='17.30' height='409.95' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpNjk3LjIyfDcxNC41Mnw0NDkuNzd8MzkuODI=)' />
-<g clip-path='url(#cpNjk3LjIyfDcxNC41Mnw0NDkuNzd8MzkuODI=)'><text transform='translate(702.85,242.35) rotate(-270)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpNjk3LjIyfDcxNC41Mnw0NDkuNzd8MzkuODI=)'><text transform='translate(702.85,242.35) rotate(90)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />

--- a/tests/figs/guides/facet-grid-legend-on-left.svg
+++ b/tests/figs/guides/facet-grid-legend-on-left.svg
@@ -44,7 +44,7 @@
   </clipPath>
 </defs>
 <rect x='697.22' y='39.82' width='17.30' height='438.19' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpNjk3LjIyfDcxNC41Mnw0NzguMDF8MzkuODI=)' />
-<g clip-path='url(#cpNjk3LjIyfDcxNC41Mnw0NzguMDF8MzkuODI=)'><text transform='translate(702.85,256.47) rotate(-270)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpNjk3LjIyfDcxNC41Mnw0NzguMDF8MzkuODI=)'><text transform='translate(702.85,256.47) rotate(90)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />

--- a/tests/figs/guides/facet-grid-legend-on-right.svg
+++ b/tests/figs/guides/facet-grid-legend-on-right.svg
@@ -44,7 +44,7 @@
   </clipPath>
 </defs>
 <rect x='658.61' y='39.82' width='17.30' height='438.19' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpNjU4LjYxfDY3NS45MXw0NzguMDF8MzkuODI=)' />
-<g clip-path='url(#cpNjU4LjYxfDY3NS45MXw0NzguMDF8MzkuODI=)'><text transform='translate(664.24,256.47) rotate(-270)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpNjU4LjYxfDY3NS45MXw0NzguMDF8MzkuODI=)'><text transform='translate(664.24,256.47) rotate(90)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />

--- a/tests/figs/guides/facet-grid-legend-on-top.svg
+++ b/tests/figs/guides/facet-grid-legend-on-top.svg
@@ -44,7 +44,7 @@
   </clipPath>
 </defs>
 <rect x='697.22' y='68.06' width='17.30' height='409.95' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpNjk3LjIyfDcxNC41Mnw0NzguMDF8NjguMDY=)' />
-<g clip-path='url(#cpNjk3LjIyfDcxNC41Mnw0NzguMDF8NjguMDY=)'><text transform='translate(702.85,270.59) rotate(-270)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpNjk3LjIyfDcxNC41Mnw0NzguMDF8NjguMDY=)'><text transform='translate(702.85,270.59) rotate(90)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />

--- a/tests/figs/guides/rotated-guide-titles-and-labels.svg
+++ b/tests/figs/guides/rotated-guide-titles-and-labels.svg
@@ -1,0 +1,83 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpNDMuMDV8NjQwLjM4fDU0MS41M3wyMy42Mg=='>
+    <rect x='43.05' y='23.62' width='597.34' height='517.91' />
+  </clipPath>
+</defs>
+<rect x='43.05' y='23.62' width='597.34' height='517.91' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpNDMuMDV8NjQwLjM4fDU0MS41M3wyMy42Mg==)' />
+<circle cx='70.20' cy='517.99' r='7.46pt' style='stroke-width: 4.25; stroke: #132B43; fill: #336A98;' clip-path='url(#cpNDMuMDV8NjQwLjM4fDU0MS41M3wyMy42Mg==)' />
+<circle cx='341.71' cy='282.57' r='7.46pt' style='stroke-width: 4.25; stroke: #336A98; fill: #132B43;' clip-path='url(#cpNDMuMDV8NjQwLjM4fDU0MS41M3wyMy42Mg==)' />
+<circle cx='613.23' cy='47.16' r='7.46pt' style='stroke-width: 4.25; stroke: #56B1F7; fill: #7F7F7F;' clip-path='url(#cpNDMuMDV8NjQwLjM4fDU0MS41M3wyMy42Mg==)' />
+<rect x='43.05' y='23.62' width='597.34' height='517.91' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpNDMuMDV8NjQwLjM4fDU0MS41M3wyMy42Mg==)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='25.90' y='521.01' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>5.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='25.90' y='403.31' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>7.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='21.01' y='285.60' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>10.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='21.01' y='167.89' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>12.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='21.01' y='50.18' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>15.0</text></g>
+<polyline points='40.31,517.99 43.05,517.99 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='40.31,400.28 43.05,400.28 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='40.31,282.57 43.05,282.57 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='40.31,164.87 43.05,164.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='40.31,47.16 43.05,47.16 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='70.20,544.27 70.20,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='205.96,544.27 205.96,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='341.71,544.27 341.71,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='477.47,544.27 477.47,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='613.23,544.27 613.23,541.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='64.09' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>5.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='199.85' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>7.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='333.16' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>10.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='468.92' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>12.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='604.68' y='552.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>15.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='338.96' y='568.04' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(13.04,285.32) rotate(-90)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
+<rect x='651.72' y='192.38' width='31.29' height='101.93' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><image width='17.28' height='86.40' x='651.72' y='207.90' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAABXCAYAAAAJWxWIAAAABmJLR0QA/wD/AP+gvaeTAAABNklEQVRYhc2YwVkGQQxCYUxzNmAL1mcv9uJlBv6DawXzDm4B+RYCJBN/fP1Ul1/l93Vb5O+b9vqHJB9Nc+7ryJom14XOElNIiUYFClkMRypUyK6mALTEEDRD7XcL6cjWqAC0QNBkCJoKdc1U1yIK2qKgRZT7KUHKmhKCNJWQlNdoHQEcLSghvalgczUioAmCtqmuPTqC5hpi2oMKEjFtIB0Jcr9D6UjW6F8NSCpquWArRLaoPdvoMspMWgjaDjYgFwRNlPsXlEfZi9pqsWCjRrahHXJXVLAFcv+hwp8i+/eZhWQ2Ff4xFbUU2ZRFIvZRQ5w0FmRaKiFPqXEkSkfsux8hG1J2ujQKcYfcFNnUfkStx88higg26g5JnQ8fsu/bb+5WC1kkqUbEhV0Sd/O3/HlbpG/7+wX6zEQzSzM5XAAAAABJRU5ErkJggg=='/></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(672.70,286.03) rotate(-270)' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>5.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(672.70,265.51) rotate(-270)' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>7.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(672.70,242.55) rotate(-270)' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>10.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(672.70,222.03) rotate(-270)' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>12.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(672.70,201.51) rotate(-270)' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>15.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='654.21' y='199.94' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='26.31px' lengthAdjust='spacingAndGlyphs'>value</text></g>
+<line x1='651.72' y1='292.14' x2='655.18' y2='292.14' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<line x1='651.72' y1='271.62' x2='655.18' y2='271.62' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<line x1='651.72' y1='251.10' x2='655.18' y2='251.10' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<line x1='651.72' y1='230.58' x2='655.18' y2='230.58' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<line x1='651.72' y1='210.06' x2='655.18' y2='210.06' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<line x1='665.55' y1='292.14' x2='669.00' y2='292.14' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<line x1='665.55' y1='271.62' x2='669.00' y2='271.62' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<line x1='665.55' y1='251.10' x2='669.00' y2='251.10' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<line x1='665.55' y1='230.58' x2='669.00' y2='230.58' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<line x1='665.55' y1='210.06' x2='669.00' y2='210.06' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<rect x='651.72' y='305.64' width='62.80' height='67.13' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(714.52,308.13) rotate(-180)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='39.75px' lengthAdjust='spacingAndGlyphs'>fill value</text></g>
+<rect x='651.72' y='321.17' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='660.36' cy='329.81' r='7.46pt' style='stroke-width: 4.25; fill: #132B43;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<rect x='674.48' y='321.17' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='683.12' cy='329.81' r='7.46pt' style='stroke-width: 4.25; fill: #336A98;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<rect x='697.24' y='321.17' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<circle cx='705.88' cy='329.81' r='7.46pt' style='stroke-width: 4.25; fill: #56B1F7;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(663.39,367.88) rotate(-90)' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='23.95px' lengthAdjust='spacingAndGlyphs'>long 5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(686.14,372.77) rotate(-90)' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='28.84px' lengthAdjust='spacingAndGlyphs'>long 10</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(708.90,372.77) rotate(-90)' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='28.84px' lengthAdjust='spacingAndGlyphs'>long 15</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='43.05' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='171.44px' lengthAdjust='spacingAndGlyphs'>rotated guide titles and labels</text></g>
+</svg>

--- a/tests/figs/themes/axes-styling.svg
+++ b/tests/figs/themes/axes-styling.svg
@@ -89,6 +89,6 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='349.28' y='32.57' style='font-size: 11.00px; fill: #FF0000; font-family: Liberation Sans;' textLength='21.44px' lengthAdjust='spacingAndGlyphs'>1:10</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='349.28' y='568.04' style='font-size: 11.00px; fill: #00FF00; font-family: Liberation Sans;' textLength='21.44px' lengthAdjust='spacingAndGlyphs'>1:10</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(13.04,307.24) rotate(-90)' style='font-size: 11.00px; fill: #0000FF; font-family: Liberation Sans;' textLength='21.44px' lengthAdjust='spacingAndGlyphs'>1:10</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(704.47,285.80) rotate(-270)' style='font-size: 11.00px; fill: #FFFF00; font-family: Liberation Sans;' textLength='21.44px' lengthAdjust='spacingAndGlyphs'>1:10</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(704.47,285.80) rotate(90)' style='font-size: 11.00px; fill: #FFFF00; font-family: Liberation Sans;' textLength='21.44px' lengthAdjust='spacingAndGlyphs'>1:10</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='40.31' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='72.55px' lengthAdjust='spacingAndGlyphs'>axes_styling</text></g>
 </svg>

--- a/tests/figs/themes/height-is-3-times-width-2-row-facets.svg
+++ b/tests/figs/themes/height-is-3-times-width-2-row-facets.svg
@@ -61,7 +61,7 @@
   </clipPath>
 </defs>
 <rect x='400.35' y='22.52' width='17.30' height='264.53' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpNDAwLjM1fDQxNy42NXwyODcuMDV8MjIuNTI=)' />
-<g clip-path='url(#cpNDAwLjM1fDQxNy42NXwyODcuMDV8MjIuNTI=)'><text transform='translate(405.98,152.34) rotate(-270)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpNDAwLjM1fDQxNy42NXwyODcuMDV8MjIuNTI=)'><text transform='translate(405.98,152.34) rotate(90)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />
@@ -73,7 +73,7 @@
   </clipPath>
 </defs>
 <rect x='400.35' y='292.53' width='17.30' height='264.53' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpNDAwLjM1fDQxNy42NXw1NTcuMDZ8MjkyLjUz)' />
-<g clip-path='url(#cpNDAwLjM1fDQxNy42NXw1NTcuMDZ8MjkyLjUz)'><text transform='translate(405.98,422.35) rotate(-270)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<g clip-path='url(#cpNDAwLjM1fDQxNy42NXw1NTcuMDZ8MjkyLjUz)'><text transform='translate(405.98,422.35) rotate(90)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text></g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />

--- a/tests/figs/themes/height-is-3-times-width-2x2-facets.svg
+++ b/tests/figs/themes/height-is-3-times-width-2x2-facets.svg
@@ -109,7 +109,7 @@
   </clipPath>
 </defs>
 <rect x='444.29' y='39.82' width='17.30' height='255.88' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpNDQ0LjI5fDQ2MS41OXwyOTUuNzB8MzkuODI=)' />
-<g clip-path='url(#cpNDQ0LjI5fDQ2MS41OXwyOTUuNzB8MzkuODI=)'><text transform='translate(449.92,165.31) rotate(-270)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpNDQ0LjI5fDQ2MS41OXwyOTUuNzB8MzkuODI=)'><text transform='translate(449.92,165.31) rotate(90)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />
@@ -121,7 +121,7 @@
   </clipPath>
 </defs>
 <rect x='444.29' y='301.18' width='17.30' height='255.88' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' clip-path='url(#cpNDQ0LjI5fDQ2MS41OXw1NTcuMDZ8MzAxLjE4)' />
-<g clip-path='url(#cpNDQ0LjI5fDQ2MS41OXw1NTcuMDZ8MzAxLjE4)'><text transform='translate(449.92,426.67) rotate(-270)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<g clip-path='url(#cpNDQ0LjI5fDQ2MS41OXw1NTcuMDZ8MzAxLjE4)'><text transform='translate(449.92,426.67) rotate(90)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text></g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />

--- a/tests/figs/themes/strip-styling.svg
+++ b/tests/figs/themes/strip-styling.svg
@@ -159,7 +159,7 @@
   </clipPath>
 </defs>
 <rect x='697.22' y='39.82' width='17.30' height='249.49' style='stroke-width: 1.07; stroke: none; fill: #00FF00;' clip-path='url(#cpNjk3LjIyfDcxNC41MnwyODkuMzF8MzkuODI=)' />
-<g clip-path='url(#cpNjk3LjIyfDcxNC41MnwyODkuMzF8MzkuODI=)'><text transform='translate(702.85,162.12) rotate(-270)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpNjk3LjIyfDcxNC41MnwyODkuMzF8MzkuODI=)'><text transform='translate(702.85,162.12) rotate(90)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />
@@ -171,7 +171,7 @@
   </clipPath>
 </defs>
 <rect x='697.22' y='294.79' width='17.30' height='249.49' style='stroke-width: 1.07; stroke: none; fill: #00FF00;' clip-path='url(#cpNjk3LjIyfDcxNC41Mnw1NDQuMjd8Mjk0Ljc5)' />
-<g clip-path='url(#cpNjk3LjIyfDcxNC41Mnw1NDQuMjd8Mjk0Ljc5)'><text transform='translate(702.85,417.08) rotate(-270)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<g clip-path='url(#cpNjk3LjIyfDcxNC41Mnw1NDQuMjd8Mjk0Ljc5)'><text transform='translate(702.85,417.08) rotate(90)' style='font-size: 8.80px; fill: #1A1A1A; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text></g>
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -183,6 +183,33 @@ test_that("guides title and text are positioned correctly", {
     )
   )
 
+  # title and label rotation
+  df <- data.frame(x = c(5, 10, 15))
+  p <- ggplot(df, aes(x, x, color = x, fill = 15 - x)) +
+    geom_point(shape = 21, size = 5, stroke = 3) +
+    scale_colour_continuous(
+      name = "value",
+      guide = guide_colorbar(
+        title.theme = element_text(size = 11, angle = 0, hjust = 0.5, vjust = 1),
+        label.theme = element_text(size = 0.8*11, angle = 270, hjust = 0.5, vjust = 1)
+      )
+    ) +
+    scale_fill_continuous(
+      breaks = c(5, 10, 15),
+      limits = c(5, 15),
+      labels = paste("long", c(5, 10, 15)),
+      name = "fill value",
+      guide = guide_legend(
+        direction = "horizontal",
+        title.position = "top",
+        label.position = "bottom",
+        title.theme = element_text(size = 11, angle = 180, hjust = 0, vjust = 1),
+        label.theme = element_text(size = 0.8*11, angle = 90, hjust = 1, vjust = 0.5)
+      )
+    )
+
+  expect_doppelganger("rotated guide titles and labels", p )
+
 })
 
 test_that("colorbar can be styled", {


### PR DESCRIPTION
Correct text justification works now for rotated text. Do you want me to add a visual test for this?

``` r
library(ggplot2)
df <- reshape2::melt(outer(1:4, 1:4), varnames = c("X1", "X2"))

p1 <- ggplot(df, aes(X1, X2)) + geom_tile(aes(fill = value))
p1 + scale_fill_continuous(
  breaks = c(5, 10, 15),
  labels = paste("long", c(5, 10, 15)),
  guide = guide_legend(
    direction = "horizontal",
    title.position = "top",
    label.position = "bottom",
    label.theme = element_text(angle = 90, hjust = 1, vjust = 0.5)
  )
)
```

![](https://i.imgur.com/9MsgYsE.png)

Created on 2018-05-11 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).