### PR TITLE
Aes format ticks are not formatted properly

### DIFF
--- a/R/aes.r
+++ b/R/aes.r
@@ -128,7 +128,7 @@ print.uneval <- function(x, ...) {
     cat("<empty>\n")
   } else {
     values <- vapply(x, rlang::quo_label, character(1))
-    bullets <- paste0("* `", format(names(x)), "` -> ", values, "\n")
+    bullets <- paste0("* ", format(paste0("`", names(x), "`")), " -> ", values, "\n")
 
     cat(bullets, sep = "")
   }

--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -745,4 +745,4 @@ label_just_defaults.legend <- function(direction, position) {
 }
 
 
-globalVariables(c("C", "R", "key.row", "key.col", "label.row", "label.col"))
+utils::globalVariables(c("C", "R", "key.row", "key.col", "label.row", "label.col"))

--- a/R/labeller.r
+++ b/R/labeller.r
@@ -230,7 +230,7 @@ label_bquote <- function(rows = NULL, cols = NULL,
 
   structure(fun, class = "labeller")
 }
-globalVariables(c("x", "."))
+utils::globalVariables(c("x", "."))
 
 #' @rdname labellers
 #' @export


### PR DESCRIPTION
current:
```r
aes(short = 1, veryveryverylong = 2)
# Aesthetic mapping: 
# * `short           ` -> 1
# * `veryveryverylong` -> 2
```

PR
```r
aes(short = 1, veryveryverylong = 2)
# Aesthetic mapping: 
# * `short`            -> 1
# * `veryveryverylong` -> 2
```

The back ticks should not contain the white space around the variable names.  This change keeps the spacing, just moves the back ticks to be directly around the name.