### PR TITLE
Copyedit testthat tests

### DIFF
--- a/tests/testthat/test-add.R
+++ b/tests/testthat/test-add.R
@@ -1,6 +1,6 @@
 context("Adding plot elements")
 
-test_that("Mapping class is preserved when adding uneval objects", {
+test_that("mapping class is preserved when adding uneval objects", {
   p <- ggplot(mtcars) + aes(wt, mpg)
   expect_identical(class(p$mapping), "uneval")
 })

--- a/tests/testthat/test-aes-grouping.r
+++ b/tests/testthat/test-aes-grouping.r
@@ -9,6 +9,7 @@ df <- data.frame(
 group <- function(x) as.vector(layer_data(x, 1)$group)
 groups <- function(x) length(unique(group(x)))
 
+
 test_that("one group per combination of discrete vars", {
   plot <- ggplot(df, aes(x, x)) + geom_point()
   expect_equal(group(plot), rep(NO_GROUP, 4))

--- a/tests/testthat/test-aes-setting.r
+++ b/tests/testthat/test-aes-setting.r
@@ -1,6 +1,6 @@
 context("Aes - setting values")
 
-test_that("Aesthetic parameters must match length of data", {
+test_that("aesthetic parameters match length of data", {
   df <- data.frame(x = 1:5, y = 1:5)
   p <- ggplot(df, aes(x, y))
 
@@ -13,7 +13,6 @@ test_that("Aesthetic parameters must match length of data", {
   expect_error(set_colours(rep("red", 3)), "must be either length 1")
   expect_error(set_colours(rep("red", 4)), "must be either length 1")
   set_colours(rep("red", 5))
-
 })
 
 test_that("legend filters out aesthetics not of length 1", {
@@ -24,7 +23,6 @@ test_that("legend filters out aesthetics not of length 1", {
   # Ideally would test something in the legend data structure, but
   # that's not easily accessible currently.
   expect_error(ggplot_gtable(ggplot_build(p)), NA)
-
 })
 
 test_that("alpha affects only fill colour of solid geoms", {

--- a/tests/testthat/test-aes.r
+++ b/tests/testthat/test-aes.r
@@ -23,7 +23,7 @@ test_that("aes_string() doesn't parse non-strings", {
   expect_identical(aes_string(0.4)$x, 0.4)
 })
 
-test_that("aes_q() & aes_string() preserves explicit NULLs", {
+test_that("aes_q() & aes_string() preserve explicit NULLs", {
   expect_equal(aes_q(NULL), aes(NULL))
   expect_equal(aes_q(x = NULL), aes(NULL))
   expect_equal(aes_q(colour = NULL), aes(colour = NULL))

--- a/tests/testthat/test-build.r
+++ b/tests/testthat/test-build.r
@@ -15,7 +15,7 @@ test_that("there is one data frame for each layer", {
   expect_equal(nlayers(l3), 3)
 })
 
-test_that("position aesthetics coerced to correct type", {
+test_that("position aesthetics are coerced to correct type", {
   l1 <- ggplot(df, aes(x, y)) + geom_point()
   d1 <- layer_data(l1, 1)
 

--- a/tests/testthat/test-coord-polar.r
+++ b/tests/testthat/test-coord-polar.r
@@ -1,6 +1,6 @@
 context("coord_polar")
 
-test_that("Polar distance calculation", {
+test_that("polar distance is calculated correctly", {
   dat <- data.frame(
     theta = c(0, 2*pi,   2,   6, 6, 1,    1,  0),
     r     = c(0,    0, 0.5, 0.5, 1, 1, 0.75, .5))
@@ -26,9 +26,7 @@ test_that("Polar distance calculation", {
   #   geom_point(alpha=0.3) + coord_polar()
 })
 
-
-
-test_that("Polar distance calculation ignores NA's", {
+test_that("polar distance calculation ignores NA's", {
 
   # These are r and theta values; we'll swap them around for testing
   x1 <- c(0, 0.5, 0.5, NA, 1)
@@ -39,7 +37,6 @@ test_that("Polar distance calculation ignores NA's", {
   dists <- dist_polar(x2, x1)
   expect_equal(is.na(dists), c(FALSE, FALSE, TRUE, TRUE))
 
-
   # NA on the end
   x1 <- c(0, 0.5, 0.5, 1, NA)
   x2 <- c(0,   1,   2, 0,  1)
@@ -47,7 +44,6 @@ test_that("Polar distance calculation ignores NA's", {
   expect_equal(is.na(dists), c(FALSE, FALSE, FALSE, TRUE))
   dists <- dist_polar(x2, x1)
   expect_equal(is.na(dists), c(FALSE, FALSE, FALSE, TRUE))
-
 
   # NAs in each vector - also have NaN
   x1 <- c(0, 0.5, 0.5,  1, NA)
@@ -57,7 +53,6 @@ test_that("Polar distance calculation ignores NA's", {
   dists <- dist_polar(x2, x1)
   expect_equal(is.na(dists), c(TRUE, FALSE, TRUE, TRUE))
 })
-
 
 test_that("clipping can be turned off and on", {
   # clip can be turned on and off
@@ -73,7 +68,7 @@ test_that("clipping can be turned off and on", {
 
 # Visual tests ------------------------------------------------------------
 
-test_that("Polar coordinates draws correctly", {
+test_that("polar coordinates draw correctly", {
   theme <- theme_test() +
     theme(
       axis.text.y = element_blank(),

--- a/tests/testthat/test-empty-data.r
+++ b/tests/testthat/test-empty-data.r
@@ -20,7 +20,6 @@ test_that("layers with empty data are silently omitted", {
   expect_equal(nrow(layer_data(d, 1)), 0)
 })
 
-
 test_that("plots with empty data and vectors for aesthetics work", {
   d <- ggplot(NULL, aes(1:5, 1:5)) + geom_point()
   expect_equal(nrow(layer_data(d)), 5)
@@ -31,7 +30,6 @@ test_that("plots with empty data and vectors for aesthetics work", {
   d <- ggplot() + geom_point(aes(1:5, 1:5))
   expect_equal(nrow(layer_data(d)), 5)
 })
-
 
 test_that("layers with empty data are silently omitted with facet_wrap", {
   # Empty data, facet_wrap, throws error
@@ -55,7 +53,6 @@ test_that("layers with empty data are silently omitted with facet_grid", {
   expect_equal(nrow(layer_data(d, 1)), 0)
   expect_equal(nrow(layer_data(d, 2)), nrow(mtcars))
 })
-
 
 test_that("empty data overrides plot defaults", {
   # Should error when totally empty data frame because there's no x and y

--- a/tests/testthat/test-facet-.r
+++ b/tests/testthat/test-facet-.r
@@ -64,7 +64,7 @@ test_that("facets split up the data", {
   expect_equal(d1$PANEL, factor(1:3))
 })
 
-test_that("facet_wrap() accept vars()", {
+test_that("facet_wrap() accepts vars()", {
   p <- ggplot(df, aes(x, y)) + geom_point()
   p2 <- p + facet_wrap(vars(z))
 
@@ -130,7 +130,6 @@ test_that("facets with free scales scale independently", {
   expect_true(sd(d3$y) < 1e-10)
 })
 
-
 test_that("shrink parameter affects scaling", {
   l1 <- ggplot(df, aes(1, y)) + geom_point()
   r1 <- pranges(l1)
@@ -148,8 +147,7 @@ test_that("shrink parameter affects scaling", {
   expect_equal(r3$y[[1]], c(1, 3))
 })
 
-
-test_that("Facet variables", {
+test_that("facet variables", {
   expect_identical(facet_null()$vars(), character(0))
   expect_identical(facet_wrap(~ a)$vars(), "a")
   expect_identical(facet_grid(a ~ b)$vars(), c("a", "b"))
@@ -163,9 +161,10 @@ test_that("facet gives clear error if ", {
   )
 })
 
+
 # Visual tests ------------------------------------------------------------
 
-test_that("Facet labels can respect both justification and margin arguments", {
+test_that("facet labels respect both justification and margin arguments", {
 
   df <- data.frame(
     x = 1:2,

--- a/tests/testthat/test-facet-layout.r
+++ b/tests/testthat/test-facet-layout.r
@@ -11,7 +11,7 @@ panel_layout <- function(facet, data) {
   layout$layout
 }
 
-test_that("grid: single row and single col equivalent", {
+test_that("grid: single row and single col are equivalent", {
   row <- panel_layout(facet_grid(a~.), list(a))
   col <- panel_layout(facet_grid(.~a), list(a))
 
@@ -34,7 +34,7 @@ test_that("grid: includes all combinations", {
   expect_equal(nrow(all), 4)
 })
 
-test_that("wrap and grid equivalent for 1d data", {
+test_that("wrap and grid are equivalent for 1d data", {
   rowg <- panel_layout(facet_grid(a~.), list(a))
   roww <- panel_layout(facet_wrap(~a, ncol = 1), list(a))
   expect_equal(roww, rowg)
@@ -105,7 +105,6 @@ test_that("wrap: drop = FALSE preserves unused levels", {
   wrap_b <- panel_layout(facet_wrap(~b, drop = FALSE), list(a2))
   expect_equal(nrow(wrap_b), 4)
   expect_equal(as.character(wrap_b$b), as.character(4:1))
-
 })
 
 test_that("grid: drop = FALSE preserves unused levels", {
@@ -121,7 +120,6 @@ test_that("grid: drop = FALSE preserves unused levels", {
   expect_equal(nrow(grid_ab), 16)
   expect_equal(as.character(grid_ab$a), as.character(rep(1:4, each = 4)))
   expect_equal(as.character(grid_ab$b), as.character(rep(4:1, 4)))
-
 })
 
 # Missing behaviour ----------------------------------------------------------

--- a/tests/testthat/test-facet-map.r
+++ b/tests/testthat/test-facet-map.r
@@ -10,8 +10,7 @@ panel_map_one <- function(facet, data, plot_data = data) {
   layout$setup(list(data), plot_data)[[1]]
 }
 
-
-test_that("two col cases with no missings adds single extra column", {
+test_that("two col cases with no missings adds a single extra column", {
   loc <- panel_map_one(facet_grid(cyl~vs), mtcars)
 
   expect_equal(nrow(loc), nrow(mtcars))
@@ -19,7 +18,6 @@ test_that("two col cases with no missings adds single extra column", {
 
   match <- unique(loc[c("cyl", "vs", "PANEL")])
   expect_equal(nrow(match), 5)
-
 })
 
 test_that("margins add extra data", {
@@ -27,7 +25,6 @@ test_that("margins add extra data", {
 
   expect_equal(nrow(loc), nrow(df) * 2)
 })
-
 
 test_that("grid: missing facet columns are duplicated", {
   facet <- facet_grid(a~b)
@@ -60,7 +57,6 @@ test_that("wrap: missing facet columns are duplicated", {
   loc_c <- panel_map_one(facet, df_c, plot_data = df)
   expect_equal(nrow(loc_c), 4)
   expect_equal(loc_c$PANEL, factor(1:4))
-
 })
 
 # Missing behaviour ----------------------------------------------------------
@@ -71,7 +67,7 @@ a3 <- data.frame(
   c = factor(c(1:3, NA), exclude = NULL)
 )
 
-test_that("wrap: missing values located correctly", {
+test_that("wrap: missing values are located correctly", {
   facet <- facet_wrap(~b, ncol = 1)
   loc_b <- panel_map_one(facet, data.frame(b = NA), plot_data = a3)
   expect_equal(as.character(loc_b$PANEL), "4")
@@ -81,7 +77,7 @@ test_that("wrap: missing values located correctly", {
   expect_equal(as.character(loc_c$PANEL), "4")
 })
 
-test_that("grid: missing values located correctly", {
+test_that("grid: missing values are located correctly", {
   facet <- facet_grid(b~.)
   loc_b <- panel_map_one(facet, data.frame(b = NA), plot_data = a3)
   expect_equal(as.character(loc_b$PANEL), "4")
@@ -160,5 +156,4 @@ test_that("wrap: facet order follows default data frame order", {
   lay <- get_layout(ggplot(mapping = aes(x, y)) + facet_wrap(~fx) +
     geom_point(data = d) + geom_blank(data = d2))
   expect_equal(as.character(lay$fx), c("c","b","a")[lay$PANEL])
-
 })

--- a/tests/testthat/test-fortify.r
+++ b/tests/testthat/test-fortify.r
@@ -1,6 +1,6 @@
 context("Fortify")
 
-test_that("Spatial polygons have correct ordering", {
+test_that("spatial polygons have correct ordering", {
   skip_if_not_installed("sp")
 
   make_square <- function(x = 0, y = 0, height = 1, width = 1){
@@ -24,7 +24,6 @@ test_that("Spatial polygons have correct ordering", {
                 sp::Polygons(list(make_square(0,1)), 4),
                 sp::Polygons(list(make_square(0,3)), 5))
 
-
   polys_sp <- sp::SpatialPolygons(polys)
   fake_sp <- sp::SpatialPolygonsDataFrame(polys_sp, fake_data)
 
@@ -34,7 +33,6 @@ test_that("Spatial polygons have correct ordering", {
   fake_sp2 <- sp::SpatialPolygonsDataFrame(polys2_sp, fake_data)
 
   expect_equivalent(fortify(fake_sp), plyr::arrange(fortify(fake_sp2), id, order))
-
 })
 
 test_that("fortify.default proves a helpful error with class uneval", {

--- a/tests/testthat/test-function-args.r
+++ b/tests/testthat/test-function-args.r
@@ -42,7 +42,6 @@ test_that("geom_xxx and GeomXxx$draw arg defaults match", {
   })
 })
 
-
 test_that("stat_xxx and StatXxx$compute_panel arg defaults match", {
   ggplot2_ns <- asNamespace("ggplot2")
   objs <- ls(ggplot2_ns)

--- a/tests/testthat/test-geom-dotplot.R
+++ b/tests/testthat/test-geom-dotplot.R
@@ -3,7 +3,7 @@ context("geom_dotplot")
 set.seed(111)
 dat <- data.frame(x = LETTERS[1:2], y = rnorm(30), g = LETTERS[3:5])
 
-test_that("Dodging works", {
+test_that("dodging works", {
   p <- ggplot(dat, aes(x = x, y = y, fill = g)) +
     geom_dotplot(
       binwidth = 0.2,
@@ -34,8 +34,7 @@ test_that("Dodging works", {
   expect_true(all(abs(df$x - df$xmin - dwidth/2) < 1e-6))
 })
 
-
-test_that("Binning works", {
+test_that("binning works", {
   bp <- ggplot(dat, aes(y)) +
     geom_dotplot(binwidth = .4, method = "histodot")
   x <- layer_data(bp)$x
@@ -53,7 +52,6 @@ test_that("Binning works", {
   expect_false(all(abs((x - min(x) + 1e-7) %% .4) < 1e-6))
 })
 
-
 test_that("NA's result in warning from stat_bindot", {
   set.seed(122)
   dat <- data.frame(x = rnorm(20))
@@ -64,7 +62,7 @@ test_that("NA's result in warning from stat_bindot", {
     "Removed 2 rows.*stat_bindot")
 })
 
-test_that("When binning on y-axis, limits depend on the panel", {
+test_that("when binning on y-axis, limits depend on the panel", {
    p <- ggplot(mtcars, aes(factor(cyl), mpg)) +
         geom_dotplot(binaxis='y')
 
@@ -77,6 +75,7 @@ test_that("When binning on y-axis, limits depend on the panel", {
    expect_true(all(equal_limits1))
    expect_false(all(equal_limits2))
 })
+
 
 # Visual tests ------------------------------------------------------------
 

--- a/tests/testthat/test-geom-hex.R
+++ b/tests/testthat/test-geom-hex.R
@@ -1,6 +1,6 @@
 context("geom_hex")
 
-test_that("density and value summaries available", {
+test_that("density and value summaries are available", {
   df <- data.frame(x = c(1, 1, 1, 2), y = c(1, 1, 1, 2))
   base <- ggplot(df, aes(x, y)) +
     geom_hex()

--- a/tests/testthat/test-geom-path.R
+++ b/tests/testthat/test-geom-path.R
@@ -7,6 +7,7 @@ test_that("keep_mid_true drops leading/trailing FALSE", {
   expect_equal(keep_mid_true(c(F, T, F, T, T)), c(F, T, T, T, T))
 })
 
+
 # Visual tests ------------------------------------------------------------
 
 test_that("geom_path draws correctly", {

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -1,5 +1,6 @@
 context("geom-sf")
 
+
 # Visual tests ------------------------------------------------------------
 
 test_that("geom_sf draws correctly", {

--- a/tests/testthat/test-geom-smooth.R
+++ b/tests/testthat/test-geom-smooth.R
@@ -1,6 +1,6 @@
 context("geom_smooth")
 
-test_that("Data is ordered by x", {
+test_that("data is ordered by x", {
   df <- data.frame(x = c(1, 5, 2, 3, 4), y = 1:5)
 
   ps <- ggplot(df, aes(x, y))+
@@ -9,7 +9,7 @@ test_that("Data is ordered by x", {
   expect_equal(layer_data(ps)[c("x", "y")], df[order(df$x), ])
 })
 
-test_that("Default smoothing methods for small and large data sets work", {
+test_that("default smoothing methods for small and large data sets work", {
   # test small data set
   set.seed(6531)
   x <- rnorm(10)
@@ -48,8 +48,8 @@ test_that("Default smoothing methods for small and large data sets work", {
     "method = 'gam' and formula 'y ~ s\\(x, bs = \"cs\"\\)"
   )
   expect_equal(plot_data$y, as.numeric(out))
-
 })
+
 
 # Visual tests ------------------------------------------------------------
 

--- a/tests/testthat/test-geom-text.R
+++ b/tests/testthat/test-geom-text.R
@@ -16,7 +16,7 @@ test_that("inward moves text towards center", {
   )
 })
 
-test_that("outwards moves text away from center", {
+test_that("outward moves text away from center", {
   expect_equal(
     compute_just(c("outward", "outward", "outward"), c(0, 0.5, 1)),
     c(1.0, 0.5, 0)
@@ -28,6 +28,4 @@ test_that("inward points close to center are centered", {
     compute_just(c("inward", "inward", "inward"), c(0.5 - 1e-3, 0.5, 0.5 + 1e-3)),
     c(0.5, 0.5, 0.5)
   )
-
 })
-

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -28,7 +28,6 @@ test_that("ggsave restores previous graphics device", {
   expect_identical(old_dev, dev.cur())
 })
 
-
 # plot_dim ---------------------------------------------------------------
 
 test_that("guesses and informs if dim not specified", {
@@ -53,10 +52,9 @@ test_that("scale multiplies height & width", {
   expect_equal(plot_dim(c(5, 5), scale = 2), c(10, 10))
 })
 
-
 # plot_dev ---------------------------------------------------------------------
 
-test_that("function passed back unchanged", {
+test_that("function is passed back unchanged", {
   expect_equal(plot_dev(png), png)
 })
 
@@ -74,7 +72,6 @@ test_that("text converted to function", {
 test_that("if device is NULL, guess from extension", {
   expect_identical(body(plot_dev(NULL, "test.png"))[[1]], quote(grDevices::png))
 })
-
 
 # parse_dpi ---------------------------------------------------------------
 

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -209,7 +209,6 @@ test_that("guides title and text are positioned correctly", {
     )
 
   expect_doppelganger("rotated guide titles and labels", p )
-
 })
 
 test_that("colorbar can be styled", {

--- a/tests/testthat/test-labels.r
+++ b/tests/testthat/test-labels.r
@@ -1,6 +1,6 @@
 context("Labels")
 
-test_that("Setting guide labels", {
+test_that("setting guide labels works", {
 
     expect_identical(xlab("my label")$x, "my label")
     expect_identical(labs(x = "my label")$x, "my label")
@@ -26,6 +26,7 @@ test_that("Setting guide labels", {
     # American spelling
     expect_identical(labs(color = "my label")$colour, "my label")
 })
+
 
 # Visual tests ------------------------------------------------------------
 

--- a/tests/testthat/test-layer.r
+++ b/tests/testthat/test-layer.r
@@ -1,6 +1,5 @@
 context("Layer")
 
-
 # Parameters --------------------------------------------------------------
 
 test_that("aesthetics go in aes_params", {

--- a/tests/testthat/test-plot-summary-api.R
+++ b/tests/testthat/test-plot-summary-api.R
@@ -25,7 +25,6 @@ test_that("layout summary - basic plot", {
   expect_equal(l$yscale[[1]]$range$range, c(12, 44))
 })
 
-
 test_that("layout summary - facet_wrap", {
   lw <- summarise_layout(ggplot_build(pw))
 
@@ -44,7 +43,6 @@ test_that("layout summary - facet_wrap", {
   expect_identical(lw$yscale[[1]], lw$yscale[[2]])
   expect_identical(lw$yscale[[1]], lw$yscale[[3]])
 })
-
 
 test_that("layout summary - facet_grid", {
   lg <- summarise_layout(ggplot_build(pg))
@@ -88,7 +86,6 @@ test_that("layout summary - reversed scales", {
   expect_equal(lr$xscale[[1]]$trans$transform(5), -5)
 })
 
-
 test_that("layout summary - log scales", {
   pl <- p + scale_x_log10() + scale_y_continuous(trans = "log2")
   ll <- summarise_layout(ggplot_build(pl))
@@ -97,7 +94,6 @@ test_that("layout summary - log scales", {
   expect_equal(ll$yscale[[1]]$trans$name, "log-2")
   expect_equal(ll$yscale[[1]]$trans$transform(16), 4)
 })
-
 
 test_that("coord summary - basic", {
   l <- summarise_coord(ggplot_build(p))
@@ -116,7 +112,6 @@ test_that("coord summary - coord_flip", {
   lf <- summarise_coord(ggplot_build(pf))
   expect_identical(lf, list(xlog = NA_real_, ylog = NA_real_, flip = TRUE))
 })
-
 
 test_that("summarise_layers", {
   l <- summarise_layers(ggplot_build(p))

--- a/tests/testthat/test-position-dodge2.R
+++ b/tests/testthat/test-position-dodge2.R
@@ -80,10 +80,9 @@ test_that("boxes in facetted plots keep the correct width", {
   d <- layer_data(p)
 
   expect_true(all(d$xmax - d$xmin == 0.75))
-
 })
 
-test_that("width of groups computed per facet", {
+test_that("width of groups is computed per facet", {
   df <- tibble::tribble(
     ~g1, ~g2,  ~y,
     "x", "a",  1,

--- a/tests/testthat/test-qplot.r
+++ b/tests/testthat/test-qplot.r
@@ -36,5 +36,4 @@ test_that("qplot() evaluates layers in package environment", {
   }
 
   expect_error(p <- qplot(1, 1, geom = "line"), NA)
-
 })

--- a/tests/testthat/test-range.r
+++ b/tests/testthat/test-range.r
@@ -1,6 +1,6 @@
 context("range")
 
-test_that("continuous ranges expands as expected", {
+test_that("continuous ranges expand as expected", {
   r <- continuous_range()
 
   r$train(1)
@@ -10,7 +10,7 @@ test_that("continuous ranges expands as expected", {
   expect_equal(r$range, c(1, 10))
 })
 
-test_that("discrete ranges expands as expected", {
+test_that("discrete ranges expand as expected", {
   r <- discrete_range()
 
   r$train("a")

--- a/tests/testthat/test-scale-discrete.R
+++ b/tests/testthat/test-scale-discrete.R
@@ -10,7 +10,7 @@ df <- tibble::tibble(
   y = 1:3
 )
 
-test_that("NAs translated/preserved for position scales", {
+test_that("NAs are translated/preserved for position scales", {
   p1a <- ggplot(df, aes(x1, y)) + geom_point()
   p2a <- ggplot(df, aes(x2, y)) + geom_point()
   p3a <- ggplot(df, aes(x3, y)) + geom_point()
@@ -29,7 +29,7 @@ test_that("NAs translated/preserved for position scales", {
   expect_equal(layer_data(p3b)$x, c(1, 2, NA))
 })
 
-test_that("NAs translated/preserved for non-position scales", {
+test_that("NAs are translated/preserved for non-position scales", {
   p1a <- ggplot(df, aes(y, y, colour = x1)) + geom_point()
   p2a <- ggplot(df, aes(y, y, colour = x2)) + geom_point()
   p3a <- ggplot(df, aes(y, y, colour = x3)) + geom_point()

--- a/tests/testthat/test-scale-manual.r
+++ b/tests/testthat/test-scale-manual.r
@@ -1,6 +1,5 @@
 context("scale_manual")
 
-
 test_that("names of values used in manual scales", {
    s <- scale_colour_manual(values = c("8" = "c","4" = "a","6" = "b"))
    s$train(c("4", "6", "8"))
@@ -27,7 +26,7 @@ test_that("named values work regardless of order", {
   expect_equal(cols(p + fill_scale(c(1, 3, 2))), c("red", "green"))
 })
 
-test_that("missing values replaced with na.value", {
+test_that("missing values are replaced with na.value", {
   df <- data.frame(x = 1, y = 1:3, z = factor(c(1:2, NA), exclude = NULL))
   p <- ggplot(df, aes(x, y, colour = z)) +
     geom_point() +
@@ -45,7 +44,6 @@ test_that("insufficient values raise an error", {
 
   # Should be sufficient
   ggplot_build(p + scale_colour_manual(values = c("black", "black")))
-
 })
 
 test_that("values are matched when scale contains more unique values than are in the data", {
@@ -54,7 +52,6 @@ test_that("values are matched when scale contains more unique values than are in
   s$train(c("4", "6", "8"))
   expect_equal(s$map(c("4", "6", "8")), c("a", "b", "c"))
 })
-
 
 test_that("generic scale can be used in place of aesthetic-specific scales", {
   df <- data.frame(x = letters[1:3], y = LETTERS[1:3], z = factor(c(1, 2, 3)))

--- a/tests/testthat/test-scales-breaks-labels.r
+++ b/tests/testthat/test-scales-breaks-labels.r
@@ -8,7 +8,7 @@ test_that("labels match breaks, even when outside limits", {
   expect_equal(sc$get_breaks_minor(), c(1, 1.5, 2, 2.5, 3))
 })
 
-test_that("labels must match breaks", {
+test_that("labels match breaks", {
   expect_error(scale_x_discrete(breaks = 1:3, labels = 1:2),
     "must have the same length")
   expect_error(scale_x_continuous(breaks = 1:3, labels = 1:2),
@@ -20,7 +20,6 @@ test_that("labels don't have to match null breaks", {
   expect_true(check_breaks_labels(breaks = NULL, labels = 1:2))
 })
 
-
 test_that("labels don't have extra spaces", {
   labels <- c("a", "abc", "abcdef")
 
@@ -29,18 +28,16 @@ test_that("labels don't have extra spaces", {
 
   expect_equal(sc1$get_labels(), labels)
   expect_equal(sc2$get_labels(), labels)
-
 })
 
-
 test_that("out-of-range breaks are dropped", {
+
   # Limits are explicitly specified, automatic labels
   sc <- scale_x_continuous(breaks = 1:5, limits = c(2, 4))
   bi <- sc$break_info()
   expect_equal(bi$labels, as.character(2:4))
   expect_equal(bi$major, c(0, 0.5, 1))
   expect_equal(bi$major_source, 2:4)
-
 
   # Limits and labels are explicitly specified
   sc <- scale_x_continuous(breaks = 1:5, labels = letters[1:5], limits = c(2, 4))
@@ -49,14 +46,12 @@ test_that("out-of-range breaks are dropped", {
   expect_equal(bi$major, c(0, 0.5, 1))
   expect_equal(bi$major_source, 2:4)
 
-
   # Limits are specified, and all breaks are out of range
   sc <- scale_x_continuous(breaks = c(1,5), labels = letters[c(1,5)], limits = c(2, 4))
   bi <- sc$break_info()
   expect_equal(length(bi$labels), 0)
   expect_equal(length(bi$major), 0)
   expect_equal(length(bi$major_source), 0)
-
 
   # limits aren't specified, automatic labels
   # limits are set by the data
@@ -67,7 +62,6 @@ test_that("out-of-range breaks are dropped", {
   expect_equal(bi$major_source, 2:4)
   expect_equal(bi$major, c(0, 0.5, 1))
 
-
   # Limits and labels are specified
   sc <- scale_x_continuous(breaks = 1:5, labels = letters[1:5])
   sc$train_df(data.frame(x = 2:4))
@@ -75,7 +69,6 @@ test_that("out-of-range breaks are dropped", {
   expect_equal(bi$labels, letters[2:4])
   expect_equal(bi$major_source, 2:4)
   expect_equal(bi$major, c(0, 0.5, 1))
-
 
   # Limits aren't specified, and all breaks are out of range of data
   sc <- scale_x_continuous(breaks = c(1,5), labels = letters[c(1,5)])
@@ -86,14 +79,12 @@ test_that("out-of-range breaks are dropped", {
   expect_equal(length(bi$major_source), 0)
 })
 
-
 test_that("no minor breaks when only one break", {
   sc1 <- scale_x_discrete(limits = "a")
   sc2 <- scale_x_continuous(limits = 1)
 
   expect_equal(length(sc1$get_breaks_minor()), 0)
   expect_equal(length(sc2$get_breaks_minor()), 0)
-
 })
 
 init_scale <- function(...) {
@@ -123,11 +114,9 @@ test_that("discrete labels match breaks", {
   sc <- init_scale(breaks = pick_5)
   expect_equal(length(sc$get_breaks()), 5)
   expect_equal(length(sc$get_labels()), 5)
-
 })
 
-
-test_that("scale breaks with numeric log transformation", {
+test_that("scale breaks work with numeric log transformation", {
   sc <- scale_x_continuous(limits = c(1, 1e5), trans = log10_trans())
   expect_equal(sc$get_breaks(), c(0, 2, 4)) # 1, 100, 10000
   expect_equal(sc$get_breaks_minor(), c(0, 1, 2, 3, 4, 5))
@@ -139,7 +128,6 @@ test_that("continuous scales with no data have no breaks or labels", {
   expect_equal(sc$get_breaks(), numeric())
   expect_equal(sc$get_labels(), character())
   expect_equal(sc$get_limits(), c(0, 1))
-
 })
 
 test_that("discrete scales with no data have no breaks or labels", {
@@ -150,7 +138,7 @@ test_that("discrete scales with no data have no breaks or labels", {
   expect_equal(sc$get_limits(), c(0, 1))
 })
 
-test_that("suppressing breaks, minor_breask, and labels", {
+test_that("suppressing breaks, minor_breask, and labels works", {
   expect_equal(scale_x_continuous(breaks = NULL, limits = c(1, 3))$get_breaks(), NULL)
   expect_equal(scale_x_discrete(breaks = NULL, limits = c(1, 3))$get_breaks(), NULL)
   expect_equal(scale_x_continuous(minor_breaks = NULL, limits = c(1, 3))$get_breaks_minor(), NULL)
@@ -176,7 +164,6 @@ test_that("suppressing breaks, minor_breask, and labels", {
   expect_error(scale_x_datetime(labels = NA, limits = lims)$get_labels())
   expect_equal(scale_x_datetime(minor_breaks = NULL, limits = lims)$get_breaks_minor(), NULL)
   expect_error(scale_x_datetime(minor_breaks = NA, limits = lims)$get_breaks_minor())
-
 })
 
 test_that("scale_breaks with explicit NA options (deprecated)", {
@@ -213,7 +200,6 @@ test_that("scale_breaks with explicit NA options (deprecated)", {
   scc <- scale_colour_continuous(breaks = NA)
   scc$train(1:3)
   expect_error(scc$get_breaks())
-
 })
 
 
@@ -239,7 +225,6 @@ test_that("breaks can be specified by names of labels", {
   s <- scale_x_discrete(limits = letters[1:3], labels = labels)
   expect_equal(as.vector(s$get_breaks()), letters[1:3])
   expect_equal(as.vector(s$get_labels()), LETTERS[1:3])
-
 })
 
 test_that("only finite or NA values for breaks for transformed scales (#871)", {
@@ -259,7 +244,7 @@ test_that("minor breaks are transformed by scales", {
 
 # Visual tests ------------------------------------------------------------
 
-test_that("minor breaks draws correctly", {
+test_that("minor breaks draw correctly", {
   df <- data.frame(
     x_num = c(1, 3),
     x_chr = c("a", "b"),

--- a/tests/testthat/test-scales.r
+++ b/tests/testthat/test-scales.r
@@ -24,7 +24,6 @@ test_that("ranges update only for variables listed in aesthetics", {
 
   sc$train_df(data.frame())
   expect_equal(sc$range$range, c(1, 50))
-
 })
 
 test_that("mapping works", {
@@ -74,7 +73,7 @@ test_that("identity scale preserves input values", {
   expect_equal(d1, d2)
 })
 
-test_that("position scales updated by all position aesthetics", {
+test_that("position scales are updated by all position aesthetics", {
   df <- data.frame(x = 1:3, y = 1:3)
 
   aesthetics <- list(
@@ -92,7 +91,6 @@ test_that("position scales updated by all position aesthetics", {
     expect_equal(range$x[[1]], c(1, 3))
     expect_equal(range$y[[1]], c(1, 3))
   })
-
 })
 
 test_that("position scales generate after stats", {
@@ -102,7 +100,6 @@ test_that("position scales generate after stats", {
 
   expect_equal(ranges$x[[1]], c("1"))
   expect_equal(ranges$y[[1]], c(0, 3))
-
 })
 
 test_that("oob affects position values", {
@@ -135,11 +132,9 @@ test_that("oob affects position values", {
   expect_equal(mid_censor[[1]]$y, c(0.5))
   expect_equal(low_squish[[1]]$y, c(0.2, 1, 1))
   expect_equal(mid_squish[[1]]$y, c(0, 0.5, 1))
-
-
 })
 
-test_that("scales looked for in appropriate place", {
+test_that("scales are looked for in appropriate place", {
   xlabel <- function(x) ggplot_build(x)$layout$panel_scales_x[[1]]$name
   p0 <- qplot(mpg, wt, data = mtcars) + scale_x_continuous("0")
   expect_equal(xlabel(p0), "0")
@@ -179,7 +174,7 @@ test_that("find_global searches in the right places", {
     ggplot2::scale_colour_hue)
 })
 
-test_that("Scales warn when transforms introduces non-finite values", {
+test_that("scales warn when transforms introduces non-finite values", {
   df <- data.frame(x = c(1e1, 1e5), y = c(0, 100))
 
   p <- ggplot(df, aes(x, y)) +
@@ -189,7 +184,7 @@ test_that("Scales warn when transforms introduces non-finite values", {
   expect_warning(ggplot_build(p), "Transformation introduced infinite values")
 })
 
-test_that("Scales get their correct titles through layout", {
+test_that("scales get their correct titles through layout", {
   df <- data.frame(x = c(1e1, 1e5), y = c(0, 100))
 
   p <- ggplot(df, aes(x, y)) +
@@ -200,7 +195,7 @@ test_that("Scales get their correct titles through layout", {
   expect_identical(p$layout$ylabel(p$plot$labels)$primary, "y")
 })
 
-test_that("Size and alpha scales throw appropriate warnings for factors", {
+test_that("size and alpha scales throw appropriate warnings for factors", {
   df <- data.frame(
     x = 1:3,
     y = 1:3,
@@ -223,7 +218,7 @@ test_that("Size and alpha scales throw appropriate warnings for factors", {
   expect_warning(ggplot_build(p + geom_point(aes(alpha = o))), NA)
 })
 
-test_that("Shape scale throws appropriate warnings for factors", {
+test_that("shape scale throws appropriate warnings for factors", {
   df <- data.frame(
     x = 1:3,
     y = 1:3,
@@ -242,7 +237,7 @@ test_that("Shape scale throws appropriate warnings for factors", {
   )
 })
 
-test_that("Aesthetics can be set independently of scale name", {
+test_that("aesthetics can be set independently of scale name", {
   df <- data.frame(
     x = LETTERS[1:3],
     y = LETTERS[4:6]
@@ -253,7 +248,7 @@ test_that("Aesthetics can be set independently of scale name", {
   expect_equal(layer_data(p)$fill, c("red", "green", "blue"))
 })
 
-test_that("Multiple aesthetics can be set with one function call", {
+test_that("multiple aesthetics can be set with one function call", {
   df <- data.frame(
     x = LETTERS[1:3],
     y = LETTERS[4:6]
@@ -281,4 +276,3 @@ test_that("Multiple aesthetics can be set with one function call", {
   expect_equal(layer_data(p)$colour, c("cyan", "red", "green"))
   expect_equal(layer_data(p)$fill, c("red", "green", "blue"))
 })
-

--- a/tests/testthat/test-sec-axis.R
+++ b/tests/testthat/test-sec-axis.R
@@ -18,7 +18,7 @@ test_that("dup_axis() works", {
   expect_equal(breaks$major_source, breaks$sec.major_source)
 })
 
-test_that("custom breaks works", {
+test_that("custom breaks work", {
   custom_breaks <- c(0.01, 0.1, 1, 10, 100)
   p <- ggplot(foo, aes(x, y)) +
     geom_point() +

--- a/tests/testthat/test-stat-bin.R
+++ b/tests/testthat/test-stat-bin.R
@@ -1,6 +1,6 @@
 context("stat_bin/stat_count")
 
-test_that("stat_bin throws error when y aesthetic present", {
+test_that("stat_bin throws error when y aesthetic is present", {
   dat <- data.frame(x = c("a", "b", "c"), y = c(1, 5, 10))
 
   expect_error(ggplot_build(ggplot(dat, aes(x, y)) + stat_bin()),
@@ -25,7 +25,7 @@ test_that("bins specifies the number of bins", {
 test_that("binwidth computes widths for function input", {
   df <- data.frame(x = 1:100)
   out <- layer_data(ggplot(df, aes(x)) + geom_histogram(binwidth = function(x) 5))
-  
+
   expect_equal(nrow(out), 21)
 })
 
@@ -50,8 +50,7 @@ test_that("can use breaks argument", {
   expect_equal(out$count, c(1, 2))
 })
 
-
-test_that("fuzzy breaks used when cutting", {
+test_that("fuzzy breaks are used when cutting", {
   df <- data.frame(x = c(-1, -0.5, -0.4, 0))
   p <- ggplot(df, aes(x)) +
     geom_histogram(binwidth = 0.1, boundary = 0.1, closed = "left")
@@ -77,7 +76,7 @@ comp_bin <- function(df, ...) {
   layer_data(plot)
 }
 
-test_that("Closed left or right", {
+test_that("closed left or right", {
   dat <- data.frame(x = c(0, 10))
 
   res <- comp_bin(dat, binwidth = 10, pad = FALSE)
@@ -99,8 +98,7 @@ test_that("Closed left or right", {
   expect_identical(res$count, c(1, 1))
 })
 
-
-test_that("Setting boundary and center", {
+test_that("setting boundary and center", {
   # numeric
   df <- data.frame(x = c(0, 30))
 
@@ -125,7 +123,6 @@ test_that("weights are added", {
 
   expect_equal(out$count, df$y)
 })
-
 
 # stat_count --------------------------------------------------------------
 

--- a/tests/testthat/test-stat-boxplot.R
+++ b/tests/testthat/test-stat-boxplot.R
@@ -18,5 +18,4 @@ test_that("stat_boxplot drops missing rows with a warning", {
     ggplot_build(p2),
     "Removed 10 rows containing missing values \\(stat_boxplot\\)\\."
   )
-
 })

--- a/tests/testthat/test-theme.r
+++ b/tests/testthat/test-theme.r
@@ -1,6 +1,6 @@
 context("Themes")
 
-test_that("Modifying theme element properties with + operator", {
+test_that("modifying theme element properties with + operator works", {
 
   # Changing a "leaf node" works
   t <- theme_grey() + theme(axis.title.x = element_text(colour = 'red', margin = margin()))
@@ -39,8 +39,7 @@ test_that("Modifying theme element properties with + operator", {
   expect_error(theme_grey() + "asdf")
 })
 
-
-test_that("Adding theme object to ggplot object with + operator", {
+test_that("adding theme object to ggplot object with + operator works", {
 
   p <- qplot(1:3, 1:3)
   p <- p + theme(axis.title = element_text(size = 20))
@@ -54,11 +53,9 @@ test_that("Adding theme object to ggplot object with + operator", {
   expect_true(tt$inherit.blank)
   tt$inherit.blank <- FALSE
   expect_identical(p$theme$text, tt)
-
 })
 
-
-test_that("Replacing theme elements with %+replace% operator", {
+test_that("replacing theme elements with %+replace% operator works", {
   # Changing a "leaf node" works
   t <- theme_grey() %+replace% theme(axis.title.x = element_text(colour = 'red'))
   expect_identical(t$axis.title.x, element_text(colour = 'red'))
@@ -78,8 +75,7 @@ test_that("Replacing theme elements with %+replace% operator", {
   expect_error(theme_grey() + "asdf")
 })
 
-
-test_that("Calculating theme element inheritance", {
+test_that("calculating theme element inheritance works", {
   t <- theme_grey() + theme(axis.title = element_text(colour = 'red'))
 
   # Check that properties are passed along from axis.title to axis.title.x
@@ -88,7 +84,6 @@ test_that("Calculating theme element inheritance", {
   expect_false(is.null(e$family))
   expect_false(is.null(e$face))
   expect_false(is.null(e$size))
-
 
   # Check that rel() works for relative sizing, and is applied at each level
   t <- theme_grey(base_size = 12) +
@@ -99,14 +94,12 @@ test_that("Calculating theme element inheritance", {
   ex <- calc_element('axis.title.x', t)
   expect_identical(ex$size, 3)
 
-
   # Check that a theme_blank in a parent node gets passed along to children
   t <- theme_grey() + theme(text = element_blank())
   expect_identical(calc_element('axis.title.x', t), element_blank())
 })
 
-
-test_that("Complete and non-complete themes interact correctly with each other", {
+test_that("complete and non-complete themes interact correctly with each other", {
   # The 'complete' attribute of t1 + t2 is the OR of their 'complete' attributes.
 
   # But for _element properties_, the one on the right modifies the one on the left.
@@ -126,8 +119,7 @@ test_that("Complete and non-complete themes interact correctly with each other",
   expect_equal(t$text$colour, 'red')
 })
 
-
-test_that("Complete and non-complete themes interact correctly with ggplot objects", {
+test_that("complete and non-complete themes interact correctly with ggplot objects", {
   # Check that adding two theme successive theme objects to a ggplot object
   # works like adding the two theme object to each other
   p <- ggplot_build(qplot(1:3, 1:3) + theme_bw() + theme(text = element_text(colour = 'red')))
@@ -140,7 +132,6 @@ test_that("Complete and non-complete themes interact correctly with ggplot objec
   tt <- tt[order(names(tt))]
   expect_identical(pt, tt)
 
-
   p <- ggplot_build(qplot(1:3, 1:3) + theme(text = element_text(colour = 'red')) + theme_bw())
   expect_true(attr(p$plot$theme, "complete"))
   # Compare the theme objects, after sorting the items, because item order can differ
@@ -150,12 +141,10 @@ test_that("Complete and non-complete themes interact correctly with ggplot objec
   tt <- tt[order(names(tt))]
   expect_identical(pt, tt)
 
-
   p <- ggplot_build(qplot(1:3, 1:3) + theme(text = element_text(colour = 'red', face = 'italic')))
   expect_false(attr(p$plot$theme, "complete"))
   expect_equal(p$plot$theme$text$colour, "red")
   expect_equal(p$plot$theme$text$face, "italic")
-
 
   p <- ggplot_build(qplot(1:3, 1:3) +
     theme(text = element_text(colour = 'red')) +
@@ -182,7 +171,7 @@ test_that("theme(validate=FALSE) means do not validate_element", {
   expect_equal(red.before$theme$animint.width, 500)
 })
 
-test_that("All elements in complete themes have inherit.blank=TRUE", {
+test_that("all elements in complete themes have inherit.blank=TRUE", {
   inherit_blanks <- function(theme) {
     all(vapply(theme, function(el) {
       if (inherits(el, "element") && !inherits(el, "element_blank")) {
@@ -202,7 +191,7 @@ test_that("All elements in complete themes have inherit.blank=TRUE", {
   expect_true(inherit_blanks(theme_void()))
 })
 
-test_that("Elements can be merged", {
+test_that("elements can be merged", {
   text_base <- element_text(colour = "red", size = 10)
   expect_equal(
     merge_element(element_text(colour = "blue"), text_base),
@@ -270,8 +259,8 @@ test_that("titleGrob() and margins() work correctly", {
   expect_equal(g9$widths, grid::unit(1, "null"))
   expect_equal(g10$heights, grid::unit(1, "null"))
   expect_equal(width_cm(g10), width_cm(g1) + 2)
-
 })
+
 
 # Visual tests ------------------------------------------------------------
 

--- a/tests/testthat/test-viridis.R
+++ b/tests/testthat/test-viridis.R
@@ -2,7 +2,7 @@ context("Viridis")
 
 df <- data.frame(x = 1, y = 1, z = "a", tier = factor("low", ordered = TRUE))
 
-test_that("Viridis scale changes point color", {
+test_that("viridis scale changes point color", {
   p1 <- ggplot(df, aes(x, y, colour = z)) +
     geom_point()
   p2 <- p1 + scale_colour_viridis_d()
@@ -11,7 +11,7 @@ test_that("Viridis scale changes point color", {
   expect_equal(layer_data(p2)$colour, "#440154FF")
 })
 
-test_that("Viridis scale is used by default for ordered factors", {
+test_that("viridis scale is used by default for ordered factors", {
   p <- ggplot(df, aes(x, y, colour = tier)) + geom_point()
   
   expect_equal(layer_data(p)$colour, "#440154FF")


### PR DESCRIPTION
I'm not sure how useful or important this is, but I went ahead and edited the testthat tests to consistently use lower case to name tests, make test names grammatically correct, and apply consistent whitespace rules. Happy to make further revisions as needed.