### PR TITLE
Better error message when using +.gg() as unary operator

### DIFF
--- a/R/plot-construction.r
+++ b/R/plot-construction.r
@@ -39,8 +39,8 @@
 #' base + list(subset(mpg, fl == "p"), geom_smooth())
 "+.gg" <- function(e1, e2) {
   if (missing(e2)) {
-    stop("There's nothing on the left-hand side of `+`. ",
-         "Did you forget to add this object to a ggplot object?",
+    stop("Cannot use `+.gg()` with a single argument. ",
+         "Did you accidentally put + on a new line?",
          call. = FALSE)
   }
 

--- a/R/plot-construction.r
+++ b/R/plot-construction.r
@@ -38,6 +38,12 @@
 #' # This can be useful to return from a function.
 #' base + list(subset(mpg, fl == "p"), geom_smooth())
 "+.gg" <- function(e1, e2) {
+  if (missing(e2)) {
+    stop("There's nothing on the left-hand side of `+`. ",
+         "Did you forget to add this object to a ggplot object?",
+         call. = FALSE)
+  }
+
   # Get the name of what was passed in as e2, and pass along so that it
   # can be displayed in error messages
   e2name <- deparse(substitute(e2))

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -1,0 +1,18 @@
+context("error")
+
+test_that("various misuses of +.gg (#2638)", {
+  expect_error(
+    {
+      ggplot(mtcars, aes(hwy, displ))
+      + geom_point()
+    },
+    "Cannot use `+.gg()` with a single argument. Did you accidentally put + on a new line?",
+    fixed = TRUE
+  )
+
+  expect_error(
+    geom_point() + geom_point(),
+    "Cannot add ggproto objects together. Did you forget to add this object to a ggplot object?",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
The behavior in the dev version is much better than in the CRAN version, but I think we can be even clearer here.

## With this PR

``` r
library(ggplot2)
+ geom_point()
#> Error: There's nothing on the left-hand side of `+`. Did you forget to add this object to a ggplot object?
```

> Created on 2018-05-19 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).

## With 582acfec

``` r
library(ggplot2)
+ geom_point()
#> Error: Cannot add ggproto objects together. Did you forget to add this object to a ggplot object?
```

> Created on 2018-05-19 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).