### PR TITLE
issue #2505, hiding boxplot outliers

### DIFF
--- a/R/geom-boxplot.r
+++ b/R/geom-boxplot.r
@@ -39,10 +39,10 @@
 #'   US spelling will take precedence.
 #'
 #'   Sometimes it can be useful to hide the outliers, for example when overlaying
-#'   the raw data points on top of the boxplot. Hiding the outliers can be achieved in numerous ways,
-#'   including by setting `outlier.colour = NA`, `outlier.colour = "transparent"`,
-#'   `outlier.shape = NA`, or `outlier.shape = ""`. All these options are equivalent and
-#'   you can choose whichever you prefer.
+#'   the raw data points on top of the boxplot. Hiding the outliers can be achieved
+#'   by setting `outlier.shape = NA`. Importantly, this does not remove the outliers,
+#'   it only hides them, so the range calculated for the y-axis will be the
+#'   same with outliers shown and outliers hidden.
 #'
 #' @param notch If `FALSE` (default) make a standard box plot. If
 #'   `TRUE`, make a notched box plot. Notches are used to compare groups;

--- a/R/geom-boxplot.r
+++ b/R/geom-boxplot.r
@@ -37,6 +37,13 @@
 #'
 #'   In the unlikely event you specify both US and UK spellings of colour, the
 #'   US spelling will take precedence.
+#'
+#'   Sometimes it can be useful to hide the outliers, for example when overlaying
+#'   the raw data points on top of the boxplot. Hiding the outliers can be achieved in numerous ways,
+#'   including by setting `outlier.colour = NA`, `outlier.colour = "transparent"`,
+#'   `outlier.shape = NA`, or `outlier.shape = ""`. All these options are equivalent and
+#'   you can choose whichever you prefer.
+#'
 #' @param notch If `FALSE` (default) make a standard box plot. If
 #'   `TRUE`, make a notched box plot. Notches are used to compare groups;
 #'   if the notches of two boxes do not overlap, this suggests that the medians

--- a/R/geom-point.r
+++ b/R/geom-point.r
@@ -146,7 +146,8 @@ GeomPoint <- ggproto("GeomPoint", Geom,
 )
 
 translate_shape_string <- function(shape_string) {
-  if (nchar(shape_string[1]) == 1) {
+  # strings of length 0 or 1 are interpreted as symbols by grid
+  if (nchar(shape_string[1]) <= 1) {
     return(shape_string)
   }
 

--- a/man/geom_boxplot.Rd
+++ b/man/geom_boxplot.Rd
@@ -51,10 +51,10 @@ In the unlikely event you specify both US and UK spellings of colour, the
 US spelling will take precedence.
 
 Sometimes it can be useful to hide the outliers, for example when overlaying
-the raw data points on top of the boxplot. Hiding the outliers can be achieved in numerous ways,
-including by setting \code{outlier.colour = NA}, \code{outlier.colour = "transparent"},
-\code{outlier.shape = NA}, or \code{outlier.shape = ""}. All these options are equivalent and
-you can choose whichever you prefer.}
+the raw data points on top of the boxplot. Hiding the outliers can be achieved
+by setting \code{outlier.shape = NA}. Importantly, this does not remove the outliers,
+it only hides them, so the range calculated for the y-axis will be the
+same with outliers shown and outliers hidden.}
 
 \item{notch}{If \code{FALSE} (default) make a standard box plot. If
 \code{TRUE}, make a notched box plot. Notches are used to compare groups;

--- a/man/geom_boxplot.Rd
+++ b/man/geom_boxplot.Rd
@@ -48,7 +48,13 @@ to the paired geom/stat.}
 aesthetics used for the box.
 
 In the unlikely event you specify both US and UK spellings of colour, the
-US spelling will take precedence.}
+US spelling will take precedence.
+
+Sometimes it can be useful to hide the outliers, for example when overlaying
+the raw data points on top of the boxplot. Hiding the outliers can be achieved in numerous ways,
+including by setting \code{outlier.colour = NA}, \code{outlier.colour = "transparent"},
+\code{outlier.shape = NA}, or \code{outlier.shape = ""}. All these options are equivalent and
+you can choose whichever you prefer.}
 
 \item{notch}{If \code{FALSE} (default) make a standard box plot. If
 \code{TRUE}, make a notched box plot. Notches are used to compare groups;


### PR DESCRIPTION
Since there are already at least 4-5 different ways of hiding  outliers, I don't see the need to add a new parameter to the API. Instead, I think updating the documentation is sufficient. I didn't list `outlier.size = -1`, because that option is only guaranteed to work if the stroke value hasn't been modified.

I also fixed the problem where `geom_point()` was trying to match an empty string against the shape names.