### PR TITLE
Add documentation about `labs(tag = )`

### DIFF
--- a/R/labels.r
+++ b/R/labels.r
@@ -22,7 +22,7 @@ update_labels <- function(p, labels) {
 #' audience. Ensure the axis and legend labels display the full variable name.
 #' Use the plot `title` and `subtitle` to explain the main findings.
 #' It's common to use the `caption` to provide information about the
-#' data source.
+#' data source. `tag` can be used for adding identification tags.
 #'
 #' You can also set axis and legend labels in the individual scales (using
 #' the first argument, the `name`. I recommend doing that if you're
@@ -32,7 +32,7 @@ update_labels <- function(p, labels) {
 #' @param subtitle the text for the subtitle for the plot which will be
 #'        displayed below the title. Leave `NULL` for no subtitle.
 #' @param ... A list of new name-value pairs. The name should either be
-#'   an aesthetic, or one of "title", "subtitle", or "caption".
+#'   an aesthetic, or one of "title", "subtitle", "caption", or "tag".
 #' @export
 #' @examples
 #' p <- ggplot(mtcars, aes(mpg, wt, colour = cyl)) + geom_point()
@@ -47,6 +47,10 @@ update_labels <- function(p, labels) {
 #' # The caption appears in the bottom-right, and is often used for
 #' # sources, notes or copyright
 #' p + labs(caption = "(based on data from ...)")
+#'
+#' # The plot tag appears at the top-left, and is typically used
+#' # for labelling a subplot with a letter.
+#' p + labs(title = "title", tag = "A")
 labs <- function(...) {
   args <- list(...)
   if (is.list(args[[1]])) args <- args[[1]]

--- a/R/labels.r
+++ b/R/labels.r
@@ -25,7 +25,7 @@ update_labels <- function(p, labels) {
 #' data source. `tag` can be used for adding identification tags.
 #'
 #' You can also set axis and legend labels in the individual scales (using
-#' the first argument, the `name`. I recommend doing that if you're
+#' the first argument, the `name`). I recommend doing that if you're
 #' changing other scale options.
 #'
 #' @param label The text for the axis, plot title or caption below the plot.

--- a/man/labs.Rd
+++ b/man/labs.Rd
@@ -17,7 +17,7 @@ ggtitle(label, subtitle = NULL)
 }
 \arguments{
 \item{...}{A list of new name-value pairs. The name should either be
-an aesthetic, or one of "title", "subtitle", or "caption".}
+an aesthetic, or one of "title", "subtitle", "caption", or "tag".}
 
 \item{label}{The text for the axis, plot title or caption below the plot.}
 
@@ -29,7 +29,7 @@ Good labels are critical for making your plots accessible to a wider
 audience. Ensure the axis and legend labels display the full variable name.
 Use the plot \code{title} and \code{subtitle} to explain the main findings.
 It's common to use the \code{caption} to provide information about the
-data source.
+data source. \code{tag} can be used for adding identification tags.
 }
 \details{
 You can also set axis and legend labels in the individual scales (using
@@ -49,4 +49,8 @@ p + labs(title = "New plot title", subtitle = "A subtitle")
 # The caption appears in the bottom-right, and is often used for
 # sources, notes or copyright
 p + labs(caption = "(based on data from ...)")
+
+# The plot tag appears at the top-left, and is typically used
+# for labelling a subplot with a letter.
+p + labs(title = "title", tag = "A")
 }

--- a/man/labs.Rd
+++ b/man/labs.Rd
@@ -33,7 +33,7 @@ data source. \code{tag} can be used for adding identification tags.
 }
 \details{
 You can also set axis and legend labels in the individual scales (using
-the first argument, the \code{name}. I recommend doing that if you're
+the first argument, the \code{name}). I recommend doing that if you're
 changing other scale options.
 }
 \examples{


### PR DESCRIPTION
`tag` argument seems not documented in `?labs` yet. Since `tag` is intended to be specified by `labs()`, I think this should be described here.