### PR TITLE
In qplot, don't require I() for parameters. Closes #2671

### DIFF
--- a/R/quick-plot.r
+++ b/R/quick-plot.r
@@ -73,7 +73,10 @@ qplot <- function(x, y, ..., data, facets = NULL, margins = FALSE,
 
   exprs <- rlang::enquos(x = x, y = y, ...)
   is_missing <- vapply(exprs, rlang::quo_is_missing, logical(1))
-  is_constant <- vapply(exprs, rlang::quo_is_call, logical(1), name = "I")
+  # treat arguments as regular parameters if they are wrapped into I() or
+  # if they don't have a name that is in the list of all aesthetics
+  is_constant <- (!names(exprs) %in% .all_aesthetics) |
+    vapply(exprs, rlang::quo_is_call, logical(1), name = "I")
 
   mapping <- new_aes(exprs[!is_missing & !is_constant], env = parent.frame())
 


### PR DESCRIPTION
This closes issue #2671.

I think it's sufficient to treat everything as a parameter that is not in the complete list of aesthetics. This is a heuristic that is not guaranteed to be always right, but it is going to be mostly right. And in any case, it's the heuristic that was used prior to 2.3.0.