### PR TITLE
Scaled densities/counts in 2d density/bins plots (#2679)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -167,6 +167,17 @@
 
 ### Layers: geoms, stats, and position adjustments
 
+* `stat_contour()`, `stat_density2d()`, `stat_bin2d()`,  `stat_binhex()` now
+  include  a normalized version the `level`, `density`, and `count` parameters, 
+  named `nlevel`, `ndensity`, and `ncount`. This mirrors the use of `ndensity`
+  in `stat_density()` and `ncount`/`ndensity` in `stat_bin()`. These stats
+  should be useful for faceted 2D density plots and bin plots in cases where
+  the distribution of density within a facet is more relevant than the absolute
+  density or count across facets. (@bjreisman, #2680)
+
+* `stat_density()` now includes the calculated statistic `nlevel`, an alias 
+  for `scaled`, to better match the syntax of `stat_bin` (@bjreisman, #2680)
+
 * `geom_segment()` and `geom_curve()` have a new `arrow.fill` parameter which 
   allows you to specify a separate fill colour for closed arrowheads 
   (@hrbrmstr and @clauswilke, #2375).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # ggplot2 3.0.0.9000
 
+*   `stat_contour()`, `stat_density2d()`, `stat_bin2d()`,  `stat_binhex()`
+    now calculate normalized statistics including `nlevel`, `ndensity`, and
+    `ncount`. Also, `stat_density()` now includes the calculated statistic 
+    `nlevel`, an aliasfor `scaled`, to better match the syntax of `stat_bin()`
+    (@bjreisman, #2679).
+
 *  `geom_hex()` now understands the `size` and `linetype` aesthetics
    (@mikmart, #2488).
   
@@ -166,17 +172,6 @@
   `plot.tag.position` theme setting (@thomasp85).
 
 ### Layers: geoms, stats, and position adjustments
-
-* `stat_contour()`, `stat_density2d()`, `stat_bin2d()`,  `stat_binhex()` now
-  include  a normalized version the `level`, `density`, and `count` parameters, 
-  named `nlevel`, `ndensity`, and `ncount`. This mirrors the use of `ndensity`
-  in `stat_density()` and `ncount`/`ndensity` in `stat_bin()`. These stats
-  should be useful for faceted 2D density plots and bin plots in cases where
-  the distribution of density within a facet is more relevant than the absolute
-  density or count across facets. (@bjreisman, #2680)
-
-* `stat_density()` now includes the calculated statistic `nlevel`, an alias 
-  for `scaled`, to better match the syntax of `stat_bin` (@bjreisman, #2680)
 
 * `geom_segment()` and `geom_curve()` have a new `arrow.fill` parameter which 
   allows you to specify a separate fill colour for closed arrowheads 

--- a/R/geom-density2d.r
+++ b/R/geom-density2d.r
@@ -30,6 +30,17 @@
 #' # set of contours for each value of that variable
 #' d + geom_density_2d(aes(colour = cut))
 #'
+#' # Similarly, if you apply faceting to the plot,  contours will be
+#' # drawn for each facet, but the levels will calculated across all facets
+#' d + stat_density_2d(aes(fill = stat(level)), geom = "polygon") +
+#'   facet_grid(.~cut) +
+#'   scale_fill_viridis()
+#' # To override this behavior (for instace, to better visualize the density
+#' # within each facet), use stat(nlevel)
+#' d + stat_density_2d(aes(fill = stat(nlevel)), geom = "polygon") +
+#'   facet_grid(.~cut) +
+#'   scale_fill_viridis()
+#'
 #' # If we turn contouring off, we can use use geoms like tiles:
 #' d + stat_density_2d(geom = "raster", aes(fill = stat(density)), contour = FALSE)
 #' # Or points:

--- a/R/geom-density2d.r
+++ b/R/geom-density2d.r
@@ -30,16 +30,14 @@
 #' # set of contours for each value of that variable
 #' d + geom_density_2d(aes(colour = cut))
 #'
-#' # Similarly, if you apply faceting to the plot,  contours will be
+#' # Similarly, if you apply faceting to the plot, contours will be
 #' # drawn for each facet, but the levels will calculated across all facets
 #' d + stat_density_2d(aes(fill = stat(level)), geom = "polygon") +
-#'   facet_grid(.~cut) +
-#'   scale_fill_viridis()
+#'   facet_grid(. ~ cut) + scale_fill_viridis_c()
 #' # To override this behavior (for instace, to better visualize the density
 #' # within each facet), use stat(nlevel)
 #' d + stat_density_2d(aes(fill = stat(nlevel)), geom = "polygon") +
-#'   facet_grid(.~cut) +
-#'   scale_fill_viridis()
+#'   facet_grid(. ~ cut) + scale_fill_viridis_c()
 #'
 #' # If we turn contouring off, we can use use geoms like tiles:
 #' d + stat_density_2d(geom = "raster", aes(fill = stat(density)), contour = FALSE)

--- a/R/stat-bin2d.r
+++ b/R/stat-bin2d.r
@@ -5,6 +5,13 @@
 #' @param drop if `TRUE` removes all cells with 0 counts.
 #' @export
 #' @rdname geom_bin2d
+#' @section Computed variables:
+#' \describe{
+#'   \item{count}{number of points in bin}
+#'   \item{density}{density of points in bin, scaled to integrate to 1}
+#'   \item{ncount}{count, scaled to maximum of 1}
+#'   \item{ndensity}{density, scaled to maximum of 1}
+#' }
 stat_bin_2d <- function(mapping = NULL, data = NULL,
                         geom = "tile", position = "identity",
                         ...,
@@ -74,9 +81,9 @@ StatBin2d <- ggproto("StatBin2d", Stat,
     out$height <- ydim$length
 
     out$count <- out$value
-    out$ncount <- out$count/max(out$count, na.rm = TRUE)
+    out$ncount <- out$count / max(out$count, na.rm = TRUE)
     out$density <- out$count / sum(out$count, na.rm = TRUE)
-    out$ndensity <- out$density/max(out$density, na.rm = TRUE)
+    out$ndensity <- out$density / max(out$density, na.rm = TRUE)
     out
   }
 )

--- a/R/stat-bin2d.r
+++ b/R/stat-bin2d.r
@@ -74,7 +74,9 @@ StatBin2d <- ggproto("StatBin2d", Stat,
     out$height <- ydim$length
 
     out$count <- out$value
+    out$ncount <- out$count/max(out$count, na.rm = TRUE)
     out$density <- out$count / sum(out$count, na.rm = TRUE)
+    out$ndensity <- out$density/max(out$density, na.rm = TRUE)
     out
   }
 )

--- a/R/stat-binhex.r
+++ b/R/stat-binhex.r
@@ -48,7 +48,9 @@ StatBinhex <- ggproto("StatBinhex", Stat,
     wt <- data$weight %||% rep(1L, nrow(data))
     out <- hexBinSummarise(data$x, data$y, wt, binwidth, sum)
     out$density <- as.vector(out$value / sum(out$value, na.rm = TRUE))
+    out$ndensity <- out$density/max(out$density, na.rm = TRUE)
     out$count <- out$value
+    out$ncount <- out$count/max(out$count, na.rm = TRUE)
     out$value <- NULL
 
     out

--- a/R/stat-binhex.r
+++ b/R/stat-binhex.r
@@ -1,6 +1,13 @@
 #' @export
 #' @rdname geom_hex
 #' @inheritParams stat_bin_2d
+#' @section Computed variables:
+#' \describe{
+#'   \item{count}{number of points in bin}
+#'   \item{density}{density of points in bin, scaled to integrate to 1}
+#'   \item{ncount}{count, scaled to maximum of 1}
+#'   \item{ndensity}{density, scaled to maximum of 1}
+#' }
 stat_bin_hex <- function(mapping = NULL, data = NULL,
                          geom = "hex", position = "identity",
                          ...,
@@ -48,9 +55,9 @@ StatBinhex <- ggproto("StatBinhex", Stat,
     wt <- data$weight %||% rep(1L, nrow(data))
     out <- hexBinSummarise(data$x, data$y, wt, binwidth, sum)
     out$density <- as.vector(out$value / sum(out$value, na.rm = TRUE))
-    out$ndensity <- out$density/max(out$density, na.rm = TRUE)
+    out$ndensity <- out$density / max(out$density, na.rm = TRUE)
     out$count <- out$value
-    out$ncount <- out$count/max(out$count, na.rm = TRUE)
+    out$ncount <- out$count / max(out$count, na.rm = TRUE)
     out$value <- NULL
 
     out

--- a/R/stat-contour.r
+++ b/R/stat-contour.r
@@ -91,6 +91,7 @@ contour_lines <- function(data, breaks, complete = FALSE) {
 
   data.frame(
     level = rep(levels, lengths),
+    nlevel = rep(levels, lengths)/max(rep(levels, lengths), na.rm = TRUE),
     x = xs,
     y = ys,
     piece = pieces,

--- a/R/stat-contour.r
+++ b/R/stat-contour.r
@@ -3,6 +3,8 @@
 #' @section Computed variables:
 #' \describe{
 #'  \item{level}{height of contour}
+#'  \item{nlevel}{height of contour, scaled to maximum of 1}
+#'  \item{piece}{contour piece (an integer)}
 #' }
 #' @rdname geom_contour
 stat_contour <- function(mapping = NULL, data = NULL,
@@ -91,7 +93,7 @@ contour_lines <- function(data, breaks, complete = FALSE) {
 
   data.frame(
     level = rep(levels, lengths),
-    nlevel = rep(levels, lengths)/max(rep(levels, lengths), na.rm = TRUE),
+    nlevel = rep(levels, lengths) / max(rep(levels, lengths), na.rm = TRUE),
     x = xs,
     y = ys,
     piece = pieces,

--- a/R/stat-density-2d.r
+++ b/R/stat-density-2d.r
@@ -60,12 +60,13 @@ StatDensity2d <- ggproto("StatDensity2d", Stat,
       lims = c(scales$x$dimension(), scales$y$dimension())
     )
     df <- data.frame(expand.grid(x = dens$x, y = dens$y), z = as.vector(dens$z))
+    df$nz <- df$z/max(df$z)
     df$group <- data$group[1]
 
     if (contour) {
       StatContour$compute_panel(df, scales, bins, binwidth)
     } else {
-      names(df) <- c("x", "y", "density", "group")
+      names(df) <- c("x", "y", "density", "scaled", "group")
       df$level <- 1
       df$piece <- 1
       df

--- a/R/stat-density-2d.r
+++ b/R/stat-density-2d.r
@@ -7,6 +7,11 @@
 #'   using [MASS::bandwidth.nrd()].
 #' @section Computed variables:
 #' Same as [stat_contour()]
+#'
+#' With the addition of:
+#'  \item{density}{the density estimate}
+#'  \item{scaled}{density estimate, scaled to maximum of 1}
+
 stat_density_2d <- function(mapping = NULL, data = NULL,
                             geom = "density_2d", position = "identity",
                             ...,
@@ -60,7 +65,7 @@ StatDensity2d <- ggproto("StatDensity2d", Stat,
       lims = c(scales$x$dimension(), scales$y$dimension())
     )
     df <- data.frame(expand.grid(x = dens$x, y = dens$y), z = as.vector(dens$z))
-    df$nz <- df$z/max(df$z)
+    df$nz <- df$z / max(df$z)
     df$group <- data$group[1]
 
     if (contour) {

--- a/R/stat-density-2d.r
+++ b/R/stat-density-2d.r
@@ -9,9 +9,10 @@
 #' Same as [stat_contour()]
 #'
 #' With the addition of:
-#'  \item{density}{the density estimate}
-#'  \item{scaled}{density estimate, scaled to maximum of 1}
-
+#' \describe{
+#'   \item{density}{the density estimate}
+#'   \item{ndensity}{density estimate, scaled to maximum of 1}
+#' }
 stat_density_2d <- function(mapping = NULL, data = NULL,
                             geom = "density_2d", position = "identity",
                             ...,
@@ -68,10 +69,10 @@ StatDensity2d <- ggproto("StatDensity2d", Stat,
     df$group <- data$group[1]
 
     if (contour) {
-      StatContour$compute_panel(df, scales, bins, binwidth)
+        StatContour$compute_panel(df, scales, bins, binwidth)
     } else {
       names(df) <- c("x", "y", "density", "group")
-      df$scaled <- df$density / max(df$density)
+      df$ndensity <- df$density / max(df$density, na.rm = TRUE)
       df$level <- 1
       df$piece <- 1
       df

--- a/R/stat-density-2d.r
+++ b/R/stat-density-2d.r
@@ -65,13 +65,13 @@ StatDensity2d <- ggproto("StatDensity2d", Stat,
       lims = c(scales$x$dimension(), scales$y$dimension())
     )
     df <- data.frame(expand.grid(x = dens$x, y = dens$y), z = as.vector(dens$z))
-    df$nz <- df$z / max(df$z)
     df$group <- data$group[1]
 
     if (contour) {
       StatContour$compute_panel(df, scales, bins, binwidth)
     } else {
-      names(df) <- c("x", "y", "density", "scaled", "group")
+      names(df) <- c("x", "y", "density", "group")
+      df$scaled <- df$density / max(df$density)
       df$level <- 1
       df$piece <- 1
       df

--- a/R/stat-density.r
+++ b/R/stat-density.r
@@ -22,7 +22,7 @@
 #'      plots}
 #'   \item{scaled}{density estimate, scaled to maximum of 1}
 #'   \item{ndensity}{alias for `scaled`, to mirror the syntax of
-#'    `geom_bin()`}
+#'    [`stat_bin()`]}
 #' }
 #' @export
 #' @rdname geom_density

--- a/R/stat-density.r
+++ b/R/stat-density.r
@@ -21,6 +21,8 @@
 #'   \item{count}{density * number of points - useful for stacked density
 #'      plots}
 #'   \item{scaled}{density estimate, scaled to maximum of 1}
+#'   \item{ndensity}{alias for stat(scaled), to mirror the syntax of
+#'    geom_bin}
 #' }
 #' @export
 #' @rdname geom_density
@@ -92,6 +94,7 @@ compute_density <- function(x, w, from, to, bw = "nrd0", adjust = 1,
       x = NA_real_,
       density = NA_real_,
       scaled = NA_real_,
+      ndensity = NA_real_,
       count = NA_real_,
       n = NA_integer_
     ))
@@ -104,6 +107,7 @@ compute_density <- function(x, w, from, to, bw = "nrd0", adjust = 1,
     x = dens$x,
     density = dens$y,
     scaled =  dens$y / max(dens$y, na.rm = TRUE),
+    ndensity = dens$y / max(dens$y, na.rm = TRUE),
     count =   dens$y * nx,
     n = nx
   )

--- a/R/stat-density.r
+++ b/R/stat-density.r
@@ -21,7 +21,7 @@
 #'   \item{count}{density * number of points - useful for stacked density
 #'      plots}
 #'   \item{scaled}{density estimate, scaled to maximum of 1}
-#'   \item{ndensity}{alias for `stat(scaled)`, to mirror the syntax of
+#'   \item{ndensity}{alias for `scaled`, to mirror the syntax of
 #'    `geom_bin()`}
 #' }
 #' @export

--- a/R/stat-density.r
+++ b/R/stat-density.r
@@ -21,8 +21,8 @@
 #'   \item{count}{density * number of points - useful for stacked density
 #'      plots}
 #'   \item{scaled}{density estimate, scaled to maximum of 1}
-#'   \item{ndensity}{alias for stat(scaled), to mirror the syntax of
-#'    geom_bin}
+#'   \item{ndensity}{alias for `stat(scaled)`, to mirror the syntax of
+#'    `geom_bin()`}
 #' }
 #' @export
 #' @rdname geom_density

--- a/man/geom_bin2d.Rd
+++ b/man/geom_bin2d.Rd
@@ -85,6 +85,16 @@ in the presence of overplotting.
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 }
 
+\section{Computed variables}{
+
+\describe{
+\item{count}{number of points in bin}
+\item{density}{density of points in bin, scaled to integrate to 1}
+\item{ncount}{count, scaled to maximum of 1}
+\item{ndensity}{density, scaled to maximum of 1}
+}
+}
+
 \examples{
 d <- ggplot(diamonds, aes(x, y)) + xlim(4, 10) + ylim(4, 10)
 d + geom_bin2d()

--- a/man/geom_contour.Rd
+++ b/man/geom_contour.Rd
@@ -95,6 +95,8 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \describe{
 \item{level}{height of contour}
+\item{nlevel}{height of contour, scaled to maximum of 1}
+\item{piece}{contour piece (an integer)}
 }
 }
 

--- a/man/geom_density.Rd
+++ b/man/geom_density.Rd
@@ -111,7 +111,7 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 plots}
 \item{scaled}{density estimate, scaled to maximum of 1}
 \item{ndensity}{alias for \code{scaled}, to mirror the syntax of
-\code{geom_bin()}}
+\code{\link[=stat_bin]{stat_bin()}}}
 }
 }
 

--- a/man/geom_density.Rd
+++ b/man/geom_density.Rd
@@ -110,6 +110,8 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 \item{count}{density * number of points - useful for stacked density
 plots}
 \item{scaled}{density estimate, scaled to maximum of 1}
+\item{ndensity}{alias for \code{scaled}, to mirror the syntax of
+\code{geom_bin()}}
 }
 }
 

--- a/man/geom_density_2d.Rd
+++ b/man/geom_density_2d.Rd
@@ -121,16 +121,14 @@ d <- ggplot(dsmall, aes(x, y))
 # set of contours for each value of that variable
 d + geom_density_2d(aes(colour = cut))
 
-# Similarly, if you apply faceting to the plot,  contours will be
+# Similarly, if you apply faceting to the plot, contours will be
 # drawn for each facet, but the levels will calculated across all facets
 d + stat_density_2d(aes(fill = stat(level)), geom = "polygon") +
-  facet_grid(.~cut) +
-  scale_fill_viridis()
+  facet_grid(. ~ cut) + scale_fill_viridis_c()
 # To override this behavior (for instace, to better visualize the density
 # within each facet), use stat(nlevel)
 d + stat_density_2d(aes(fill = stat(nlevel)), geom = "polygon") +
-  facet_grid(.~cut) +
-  scale_fill_viridis()
+  facet_grid(. ~ cut) + scale_fill_viridis_c()
 
 # If we turn contouring off, we can use use geoms like tiles:
 d + stat_density_2d(geom = "raster", aes(fill = stat(density)), contour = FALSE)

--- a/man/geom_density_2d.Rd
+++ b/man/geom_density_2d.Rd
@@ -97,6 +97,12 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 \section{Computed variables}{
 
 Same as \code{\link[=stat_contour]{stat_contour()}}
+
+With the addition of:
+\describe{
+\item{density}{the density estimate}
+\item{ndensity}{density estimate, scaled to maximum of 1}
+}
 }
 
 \examples{
@@ -114,6 +120,17 @@ d <- ggplot(dsmall, aes(x, y))
 # If you map an aesthetic to a categorical variable, you will get a
 # set of contours for each value of that variable
 d + geom_density_2d(aes(colour = cut))
+
+# Similarly, if you apply faceting to the plot,  contours will be
+# drawn for each facet, but the levels will calculated across all facets
+d + stat_density_2d(aes(fill = stat(level)), geom = "polygon") +
+  facet_grid(.~cut) +
+  scale_fill_viridis()
+# To override this behavior (for instace, to better visualize the density
+# within each facet), use stat(nlevel)
+d + stat_density_2d(aes(fill = stat(nlevel)), geom = "polygon") +
+  facet_grid(.~cut) +
+  scale_fill_viridis()
 
 # If we turn contouring off, we can use use geoms like tiles:
 d + stat_density_2d(geom = "raster", aes(fill = stat(density)), contour = FALSE)

--- a/man/geom_hex.Rd
+++ b/man/geom_hex.Rd
@@ -87,6 +87,16 @@ the very regular alignment of \code{\link[=geom_bin2d]{geom_bin2d()}}.
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 }
 
+\section{Computed variables}{
+
+\describe{
+\item{count}{number of points in bin}
+\item{density}{density of points in bin, scaled to integrate to 1}
+\item{ncount}{count, scaled to maximum of 1}
+\item{ndensity}{density, scaled to maximum of 1}
+}
+}
+
 \examples{
 d <- ggplot(diamonds, aes(carat, price))
 d + geom_hex()

--- a/man/ggtheme.Rd
+++ b/man/ggtheme.Rd
@@ -97,14 +97,43 @@ for new features.}
 }
 }
 \examples{
-p <- ggplot(mtcars) + geom_point(aes(x = wt, y = mpg,
-     colour = factor(gear))) + facet_wrap(~am)
-p + theme_gray() # the default
-p + theme_bw()
-p + theme_linedraw()
-p + theme_light()
-p + theme_dark()
-p + theme_minimal()
-p + theme_classic()
-p + theme_void()
+mtcars2 <- within(mtcars, {
+  vs <- factor(vs, labels = c("V-shaped", "Straight"))
+  am <- factor(am, labels = c("Automatic", "Manual"))
+  cyl  <- factor(cyl)
+  gear <- factor(gear)
+})
+
+p1 <- ggplot(mtcars2) +
+  geom_point(aes(x = wt, y = mpg, colour = gear)) +
+  labs(title = "Fuel economy declines as weight increases",
+       subtitle = "(1973-74)",
+       caption = "Data from the 1974 Motor Trend US magazine.",
+       tag = "Figure 1",
+       x = "Weight (1000 lbs)",
+       y = "Fuel economy (mpg)",
+       colour = "Gears")
+
+p1 + theme_gray() # the default
+p1 + theme_bw()
+p1 + theme_linedraw()
+p1 + theme_light()
+p1 + theme_dark()
+p1 + theme_minimal()
+p1 + theme_classic()
+p1 + theme_void()
+
+# Theme examples with panels
+\donttest{
+p2 <- p1 + facet_grid(vs ~ am)
+
+p2 + theme_gray() # the default
+p2 + theme_bw()
+p2 + theme_linedraw()
+p2 + theme_light()
+p2 + theme_dark()
+p2 + theme_minimal()
+p2 + theme_classic()
+p2 + theme_void()
+}
 }

--- a/man/scale_viridis.Rd
+++ b/man/scale_viridis.Rd
@@ -50,7 +50,7 @@ same time, via \code{aesthetics = c("colour", "fill")}.}
 
 \item{values}{if colours should not be evenly positioned along the gradient
 this vector gives the position (between 0 and 1) for each colour in the
-\code{colours} vector. See \code{\link{rescale}} for a convience function
+\code{colours} vector. See \code{\link[=rescale]{rescale()}} for a convience function
 to map an arbitrary range to between 0 and 1.}
 
 \item{space}{colour space in which to calculate gradient. Must be "Lab" -

--- a/tests/testthat/test-stat-density.R
+++ b/tests/testthat/test-stat-density.R
@@ -9,6 +9,6 @@ test_that("compute_density returns useful df and throws warning when <2 values",
   expect_warning(dens <- compute_density(1, NULL, from = 0, to = 0))
 
   expect_equal(nrow(dens), 1)
-  expect_equal(names(dens), c("x", "density", "scaled", "count", "n"))
+  expect_equal(names(dens), c("x", "density", "scaled", "ndensity", "count", "n"))
   expect_type(dens$x, "double")
 })


### PR DESCRIPTION
I added 'scaled' statistics to the `stat_bin2d`, `stat_binhex`, ` stat_density_2d`, and  `stat_contour` functions for plotting 2d distributions normalized to a common height. This would be very useful for faceted 2d plots, where the maximum density/count can vary greatly between panels. 

(This is my attempt to add the feature I had requested in issue #2679.)

---
I tried my best to mirror the corresponding statistics from the 1d functions:

stat_bin | stat_bin2d | stat_binhex |  stat_bin2d (updated) | stat_binhex (updated) 
--- | --- | --- | ---| ---
`count `| `count` | `count` | `count` | `count` 
`ncount` | | | `ncount` | `ncount`
`density`|  `density` | `density` | `density` | `density`
`ndensity`|   | | `ndensity` | `ndensity`


It was a little bit harder to get things to match-up one-to-one for the density based function, so some adjustment to the syntax may be needed. 

stat_density| stat__contour | stat_density2d  | stat__contour (updated) | stat_density2d (updated)
--- | --- | --- | ---| ---
`count` | - | - | - |
`density` | - | `density` | - | `density`
`scaled` | - | - | - | `scaled`
-|`pieces`| - |`pieces`| -
 -|`level`| - |`level`| -
 -| - | - | `nlevel` | -  

---

Here is an example of the revised functions in action:
```{r}
library(ggplot2)
library(dplyr)
library(viridis)

ggplot(diamonds, aes(x=x, y= depth)) +
  stat_density_2d(aes(fill = stat(level)),
                  geom = "polygon",
                  n = 100,
                  bins = 10,
    contour = T) +
  facet_wrap(clarity~.) +
  scale_fill_viridis(option = "A")
```
![plot6](https://user-images.githubusercontent.com/22528952/40850126-6af9ee1a-6589-11e8-90d0-d1e95b430cee.png)

```{r}
ggplot(diamonds, aes(x=x, y= depth)) +
  stat_density_2d(aes(fill = stat(nlevel)),
                  geom = "polygon",
                  n = 100,
                  bins = 10,
    contour = T) +
  facet_wrap(clarity~.) +
  scale_fill_viridis(option = "A")
```
![plot7](https://user-images.githubusercontent.com/22528952/40850196-a202172a-6589-11e8-81dc-5677d51a9467.png)
