### PR TITLE
Define non_missing_aes for GeomCol and GeomBar. Closes #2715.

### DIFF
--- a/R/geom-bar.r
+++ b/R/geom-bar.r
@@ -112,6 +112,11 @@ geom_bar <- function(mapping = NULL, data = NULL,
 GeomBar <- ggproto("GeomBar", GeomRect,
   required_aes = c("x", "y"),
 
+  # These aes columns are created by setup_data(). They need to be listed here so
+  # that GeomRect$handle_na() properly removes any bars that fall outside the defined
+  # limits, not just those for which x and y are outside the limits
+  non_missing_aes = c("xmin", "xmax", "ymin", "ymax"),
+
   setup_data = function(data, params) {
     data$width <- data$width %||%
       params$width %||% (resolution(data$x, FALSE) * 0.9)

--- a/R/geom-col.r
+++ b/R/geom-col.r
@@ -32,6 +32,11 @@ geom_col <- function(mapping = NULL, data = NULL,
 GeomCol <- ggproto("GeomCol", GeomRect,
   required_aes = c("x", "y"),
 
+  # These aes columns are created by setup_data(). They need to be listed here so
+  # that GeomRect$handle_na() properly removes any bars that fall outside the defined
+  # limits, not just those for which x and y are outside the limits
+  non_missing_aes = c("xmin", "xmax", "ymin", "ymax"),
+
   setup_data = function(data, params) {
     data$width <- data$width %||%
       params$width %||% (resolution(data$x, FALSE) * 0.9)

--- a/tests/testthat/test-geom-bar.R
+++ b/tests/testthat/test-geom-bar.R
@@ -1,0 +1,12 @@
+context("geom_bar")
+
+test_that("geom_bar removes bars with parts outside the plot limits", {
+  dat <- data.frame(x = c("a", "b", "b", "c", "c", "c"))
+
+  render_plot <- function(extra = list()) {
+    withr::with_pdf(NULL, print(ggplot(dat, aes(x)) + geom_bar() + extra))
+  }
+
+  expect_warning(render_plot(ylim(0.5, 4)), "Removed 3 rows containing missing values")
+  expect_warning(render_plot(ylim(0, 2.5)), "Removed 1 rows containing missing values")
+})

--- a/tests/testthat/test-geom-bar.R
+++ b/tests/testthat/test-geom-bar.R
@@ -3,10 +3,10 @@ context("geom_bar")
 test_that("geom_bar removes bars with parts outside the plot limits", {
   dat <- data.frame(x = c("a", "b", "b", "c", "c", "c"))
 
-  render_plot <- function(extra = list()) {
-    withr::with_pdf(NULL, print(ggplot(dat, aes(x)) + geom_bar() + extra))
-  }
+  p <- ggplot(dat, aes(x)) + geom_bar()
 
-  expect_warning(render_plot(ylim(0.5, 4)), "Removed 3 rows containing missing values")
-  expect_warning(render_plot(ylim(0, 2.5)), "Removed 1 rows containing missing values")
+  expect_warning( # warning created at render stage
+    ggplotGrob(p + ylim(0, 2.5)),
+    "Removed 1 rows containing missing values"
+  )
 })

--- a/tests/testthat/test-geom-col.R
+++ b/tests/testthat/test-geom-col.R
@@ -1,0 +1,12 @@
+context("geom_col")
+
+test_that("geom_col removes columns with parts outside the plot limits", {
+  dat <- data.frame(x = c(1, 2, 3))
+
+  render_plot <- function(extra = list()) {
+    withr::with_pdf(NULL, print(ggplot(dat, aes(x, x)) + geom_col() + extra))
+  }
+
+  expect_warning(render_plot(ylim(0.5, 4)), "Removed 3 rows containing missing values")
+  expect_warning(render_plot(ylim(0, 2.5)), "Removed 1 rows containing missing values")
+})

--- a/tests/testthat/test-geom-col.R
+++ b/tests/testthat/test-geom-col.R
@@ -3,10 +3,14 @@ context("geom_col")
 test_that("geom_col removes columns with parts outside the plot limits", {
   dat <- data.frame(x = c(1, 2, 3))
 
-  render_plot <- function(extra = list()) {
-    withr::with_pdf(NULL, print(ggplot(dat, aes(x, x)) + geom_col() + extra))
-  }
+  p <- ggplot(dat, aes(x, x)) + geom_col()
 
-  expect_warning(render_plot(ylim(0.5, 4)), "Removed 3 rows containing missing values")
-  expect_warning(render_plot(ylim(0, 2.5)), "Removed 1 rows containing missing values")
+  expect_warning( # warning created at render stage
+    ggplotGrob(p + ylim(0.5, 4)),
+    "Removed 3 rows containing missing values"
+  )
+  expect_warning( # warning created at build stage
+    ggplot_build(p + ylim(0, 2.5)),
+    "Removed 1 rows containing missing values"
+  )
 })


### PR DESCRIPTION
Define non_missing_aes for GeomCol and GeomBar. Closes #2715.