### PR TITLE
New examples for theme_*()

### DIFF
--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -49,16 +49,45 @@
 #' }
 #'
 #' @examples
-#' p <- ggplot(mtcars) + geom_point(aes(x = wt, y = mpg,
-#'      colour = factor(gear))) + facet_wrap(~am)
-#' p + theme_gray() # the default
-#' p + theme_bw()
-#' p + theme_linedraw()
-#' p + theme_light()
-#' p + theme_dark()
-#' p + theme_minimal()
-#' p + theme_classic()
-#' p + theme_void()
+#' mtcars2 <- within(mtcars, {
+#'   vs <- factor(vs, labels = c("V-shaped", "Straight"))
+#'   am <- factor(am, labels = c("Automatic", "Manual"))
+#'   cyl  <- factor(cyl)
+#'   gear <- factor(gear)
+#' })
+#'
+#' p1 <- ggplot(mtcars2) +
+#'   geom_point(aes(x = wt, y = mpg, colour = gear)) +
+#'   labs(title = "Fuel economy declines as weight increases",
+#'        subtitle = "(1973-74)",
+#'        caption = "Data from the 1974 Motor Trend US magazine.",
+#'        tag = "Figure 1",
+#'        x = "Weight (1000 lbs)",
+#'        y = "Fuel economy (mpg)",
+#'        colour = "Gears")
+#'
+#' p1 + theme_gray() # the default
+#' p1 + theme_bw()
+#' p1 + theme_linedraw()
+#' p1 + theme_light()
+#' p1 + theme_dark()
+#' p1 + theme_minimal()
+#' p1 + theme_classic()
+#' p1 + theme_void()
+#'
+#' # Theme examples with panels
+#' \donttest{
+#' p2 <- p1 + facet_grid(vs ~ am)
+#'
+#' p2 + theme_gray() # the default
+#' p2 + theme_bw()
+#' p2 + theme_linedraw()
+#' p2 + theme_light()
+#' p2 + theme_dark()
+#' p2 + theme_minimal()
+#' p2 + theme_classic()
+#' p2 + theme_void()
+#' }
 #' @name ggtheme
 #' @aliases NULL
 NULL


### PR DESCRIPTION
Update the example used in the "complete themes" help page (`ggtheme`). I extended the current `mtcars` example to use more (all?) of the features which themes affect: title, subtitle, tag, caption, and both x- and y-facets.

There are now two plot examples. One with no facets, and one with 2x2 facets. The latter is enclosed in `\donttest{}` to keep R CMD check from complaining about the runtime.

The `mtcars` dataset may not be the best for this, but I wanted to keep it close to the orginal example, and the data isn't as important in this example.