### PR TITLE
[PoC] Combine POINTs before st_as_grob()

### DIFF
--- a/R/sf.R
+++ b/R/sf.R
@@ -158,9 +158,22 @@ GeomSf <- ggproto("GeomSf", Geom,
 
     # Need to refactor this to generate one grob per geometry type
     coord <- coord$transform(data, panel_params)
-    grobs <- lapply(1:nrow(data), function(i) {
-      sf_grob(coord[i, , drop = FALSE])
-    })
+    if (inherits(data$geometry, "sfc_POINT")) {
+      coord <- utils::modifyList(default_aesthetics("point"), coord)
+      gp <- gpar(
+        col = alpha(coord$colour, coord$alpha),
+        fill = alpha(coord$fill, coord$alpha),
+        # Stroke is added around the outside of the point
+        fontsize = coord$size * .pt + coord$stroke * .stroke / 2,
+        lwd = coord$stroke * .stroke / 2
+      )
+      geometry <- sf::st_combine(coord$geometry)[[1]]
+      grobs <- list(sf::st_as_grob(geometry, gp = gp, pch = coord$shape))
+    } else {
+      grobs <- lapply(1:nrow(data), function(i) {
+        sf_grob(coord[i, , drop = FALSE])
+      })
+    }
     do.call("gList", grobs)
   },
 


### PR DESCRIPTION
(Originally reported on #2718 )

`geom_sf()` converts an `sf` object by `lapply()`ing `st_as_grob()` on its features one by one because `st_as_grob()` accepts only one `sfg`. While this approach seems simple and clean, it is considerably slow (e.g. it takes about 10 seconds for 1000 `POINT`s). 

In this PR, I use `st_combine()` to combine `POINT`s into one `MULTIPOINT` so that `st_as_grob()` is needed only once per panel.