### PR TITLE
Theme override

### DIFF
--- a/R/theme-current.R
+++ b/R/theme-current.R
@@ -64,7 +64,7 @@ theme_env$override <- FALSE
 #'
 #' theme_set(theme_dark(), override = TRUE)
 #'
-#' # Uses theme_dark()
+#' # Uses theme_dark() instead
 #' custom_plot()
 #'
 #' # Modifying theme objects -----------------------------------------

--- a/R/theme-current.R
+++ b/R/theme-current.R
@@ -2,6 +2,7 @@
 #' @include theme-elements.r
 theme_env <- new.env(parent = emptyenv())
 theme_env$current <- theme_gray()
+theme_env$override <- FALSE
 
 #' Get, set, and modify the active theme
 #'
@@ -29,6 +30,7 @@ theme_env$current <- theme_gray()
 #' the theme with `NULL`s.
 #'
 #' @param ... named list of theme settings
+#' @param override if `TRUE`, overrides all theme elements.
 #' @param e1,e2 Theme and element to combine
 #' @return `theme_set`, `theme_update`, and `theme_replace`
 #'   invisibly return the previous theme so you can easily save it, then
@@ -40,7 +42,7 @@ theme_env$current <- theme_gray()
 #'   geom_point()
 #' p
 #'
-#' # Use theme_set() to completely override the current theme.
+#' # Use theme_set() to completely replace the current theme.
 #' # Here we have the old theme so we can later restore it.
 #' # Note that the theme is applied when the plot is drawn, not
 #' # when it is created.
@@ -49,6 +51,21 @@ theme_env$current <- theme_gray()
 #' theme_set(old)
 #' p
 #'
+#' # Completely override existing theme elements with override = TRUE
+#'
+#' custom_plot <- function() {
+#'   ggplot(mtcars, aes(mpg, wt)) +
+#'     geom_point() +
+#'     theme_bw()
+#' }
+#'
+#' # Uses theme_bw()
+#' custom_plot()
+#'
+#' theme_set(theme_dark(), override = TRUE)
+#'
+#' # Uses theme_dark()
+#' custom_plot()
 #'
 #' # Modifying theme objects -----------------------------------------
 #' # You can use + and %+replace% to modify a theme object.
@@ -71,8 +88,9 @@ theme_get <- function() {
 
 #' @rdname theme_get
 #' @param new new theme (a list of theme elements)
+#'
 #' @export
-theme_set <- function(new) {
+theme_set <- function(new, override = FALSE) {
   missing <- setdiff(names(theme_gray()), names(new))
   if (length(missing) > 0) {
     warning("New theme missing the following elements: ",
@@ -81,19 +99,22 @@ theme_set <- function(new) {
 
   old <- theme_env$current
   theme_env$current <- new
+
+  theme_env$override <- override
+
   invisible(old)
 }
 
 #' @rdname theme_get
 #' @export
-theme_update <- function(...) {
-  theme_set(theme_get() + theme(...))
+theme_update <- function(..., override = FALSE) {
+  theme_set(theme_get() + theme(...), override = override)
 }
 
 #' @rdname theme_get
 #' @export
-theme_replace <- function(...) {
-  theme_set(theme_get() %+replace% theme(...))
+theme_replace <- function(..., override = FALSE) {
+  theme_set(theme_get() %+replace% theme(...), override = override)
 }
 
 #' @rdname theme_get

--- a/R/theme.r
+++ b/R/theme.r
@@ -432,6 +432,7 @@ is_theme_complete <- function(x) isTRUE(attr(x, "complete"))
 
 # Combine plot defaults with current theme to get complete theme for a plot
 plot_theme <- function(x, default = theme_get()) {
+  if (theme_env$override) return(theme_get())
   theme <- x$theme
   if (is_theme_complete(theme)) {
     theme

--- a/man/theme_get.Rd
+++ b/man/theme_get.Rd
@@ -85,7 +85,7 @@ custom_plot()
 
 theme_set(theme_dark(), override = TRUE)
 
-# Uses theme_dark()
+# Uses theme_dark() instead
 custom_plot()
 
 # Modifying theme objects -----------------------------------------

--- a/man/theme_get.Rd
+++ b/man/theme_get.Rd
@@ -10,16 +10,18 @@
 \usage{
 theme_get()
 
-theme_set(new)
+theme_set(new, override = FALSE)
 
-theme_update(...)
+theme_update(..., override = FALSE)
 
-theme_replace(...)
+theme_replace(..., override = FALSE)
 
 e1 \%+replace\% e2
 }
 \arguments{
 \item{new}{new theme (a list of theme elements)}
+
+\item{override}{if \code{TRUE}, overrides all theme elements.}
 
 \item{...}{named list of theme settings}
 
@@ -61,7 +63,7 @@ p <- ggplot(mtcars, aes(mpg, wt)) +
   geom_point()
 p
 
-# Use theme_set() to completely override the current theme.
+# Use theme_set() to completely replace the current theme.
 # Here we have the old theme so we can later restore it.
 # Note that the theme is applied when the plot is drawn, not
 # when it is created.
@@ -70,6 +72,21 @@ p
 theme_set(old)
 p
 
+# Completely override existing theme elements with override = TRUE
+
+custom_plot <- function() {
+  ggplot(mtcars, aes(mpg, wt)) +
+    geom_point() +
+    theme_bw()
+}
+
+# Uses theme_bw()
+custom_plot()
+
+theme_set(theme_dark(), override = TRUE)
+
+# Uses theme_dark()
+custom_plot()
 
 # Modifying theme objects -----------------------------------------
 # You can use + and \%+replace\% to modify a theme object.


### PR DESCRIPTION
It's common for packages to include wrapper functions for ggplots that include themes. In those cases, `theme_set()` and friends don't work, and you need to manually add a theme. This PR adds a simple, hard override option to `theme_set/replace/update()` to allow it to apply under all circumstances.

``` r
qp <- function(data = mtcars) {
  ggplot(data, aes(x = hp, y = mpg)) +
    geom_point() +
    theme_bw()
}

qp()
```

![](https://i.imgur.com/fteIDV4.png)

``` r

# nothing happens because of internal function theme
theme_set(theme_dark())
qp()
```

![](https://i.imgur.com/q9xmASU.png)

``` r

# override the theme
theme_set(theme_dark(), override = TRUE)
qp()
```

![](https://i.imgur.com/RhaP5z5.png)

``` r

# reset override to FALSE
theme_set(theme_gray()) 
# returns to normal behavior 
qp() 
```

![](https://i.imgur.com/OjDjllG.png)

``` r

# need to explicitly override to work
theme_set(theme_gray(), override = TRUE) 
qp()
```

![](https://i.imgur.com/dtfhH2a.png)

``` r

# also ignores non-complete theme elements
# it's a complete override of the theme
qp() + theme(text = element_text(size = 20))
```

![](https://i.imgur.com/dm709SA.png)

I did think to add a softer version of the override that doesn't ignore non-complete but it seemed better to not do that, because if you're adding theme elements to the call, you might as well just change the theme manually. 