### PR TITLE
`facet_grid()` supporting a different scale per each facet.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@
     feed data columns into `aes()` or into parameters of geoms or stats. However,
     doing so remains discouraged (@clauswilke).
 
+*   `facet_grid()` supports a different scale per each facet. This
+    can be used in facetting plots that share one axis but have different
+    units in the other axis (@zeehio, #1613).
 
 # ggplot2 3.0.0
 

--- a/R/facet-grid-.r
+++ b/R/facet-grid-.r
@@ -111,6 +111,7 @@ NULL
 #'            c(160, 0.71, 3.2E-4),
 #'            c(159, 0.62, 3E-4)))
 #'
+#'  library(scales)
 #'  scales_y <- list(
 #'    Percent = scale_y_continuous(labels=percent_format()),
 #'    SomeValue = scale_y_continuous(),

--- a/man/facet_grid.Rd
+++ b/man/facet_grid.Rd
@@ -20,9 +20,10 @@ the columns (of the tabular display) on the RHS; the dot in the
 formula is used to indicate there should be no faceting on this
 dimension (either row or column).}
 
-\item{scales}{Are scales shared across all facets (the default,
-\code{"fixed"}), or do they vary across rows (\code{"free_x"}),
-columns (\code{"free_y"}), or both rows and columns (\code{"free"})?}
+\item{scales}{A list of two elements (\code{x} and \code{y}). Each element can be either
+\code{"fixed"} (scale limits shared across facets), \code{"free"} (with varying limits per facet), or
+a named list, with a different scale for each facet value. Previous scale values
+(\code{"fixed"}, \code{"free_x"}, \code{"free_y"}, \code{"free"} are accepted but soft-deprecated).}
 
 \item{space}{If \code{"fixed"}, the default, all panels have the same size.
 If \code{"free_y"} their height will be proportional to the length of the
@@ -116,6 +117,25 @@ ggplot(mpg, aes(drv, model)) +
   geom_point() +
   facet_grid(manufacturer ~ ., scales = "free", space = "free") +
   theme(strip.text.y = element_text(angle = 0))
+
+# Custom scales per facet:
+ mydf <- data.frame(
+   Subject = rep(c("A", "B", "C", "D"), each = 3),
+   Magnitude = rep(c("SomeValue", "Percent", "Scientific"), times = 4),
+   Value=c(c(170,0.6,2.7E-4),
+           c(180, 0.8, 2.5E-4),
+           c(160, 0.71, 3.2E-4),
+           c(159, 0.62, 3E-4)))
+
+ scales_y <- list(
+   Percent = scale_y_continuous(labels=percent_format()),
+   SomeValue = scale_y_continuous(),
+   Scientific = scale_y_continuous(labels=scientific_format())
+ )
+
+ ggplot(mydf) +
+   geom_point(aes(x=Subject, y=Value)) +
+   facet_grid(rows = vars(Magnitude), scales = list(y = scales_y))
 
 # Margins ----------------------------------------------------------
 \donttest{

--- a/man/facet_grid.Rd
+++ b/man/facet_grid.Rd
@@ -127,6 +127,7 @@ ggplot(mpg, aes(drv, model)) +
            c(160, 0.71, 3.2E-4),
            c(159, 0.62, 3E-4)))
 
+ library(scales)
  scales_y <- list(
    Percent = scale_y_continuous(labels=percent_format()),
    SomeValue = scale_y_continuous(),

--- a/tests/testthat/test-facet-.r
+++ b/tests/testthat/test-facet-.r
@@ -96,6 +96,14 @@ test_that("facet_grid() fails if passed both a formula and a vars()", {
   expect_error(facet_grid(~foo, vars()), "`rows` must be `NULL` or a `vars\\(\\)` list if")
 })
 
+test_that("facet_grid() accepts custom scales per facet", {
+  sc_y <- list(barpercent = scale_y_continuous(labels = percent_format()),
+               barscientific = scale_y_continuous(labels = scientific_format()))
+  grid <- facet_grid(vars(foo), scales = list(x = "fixed", y = sc_y))
+  expect_identical(grid$params$scales$x, NULL)
+  expect_identical(grid$params$scales$y, sc_y)
+})
+
 test_that("can't pass formulas to `cols`", {
   expect_error(facet_grid(NULL, ~foo), "`cols` must be `NULL` or a `vars\\(\\)`")
 })


### PR DESCRIPTION
# Motivation

The ability to use different scales in different facets has been a long time feature request (e.g. two years ago in #1613) and back in 2010 [here](https://groups.google.com/forum/#!topic/ggplot2/cDzL_yHew0I).

The main reason to ask for this feature is to be able to compare different magnitudes, as would be desired for instance in this plot:

![imatge](https://user-images.githubusercontent.com/75441/42507162-76f76178-8444-11e8-9e32-4d0ccb868a53.png)

This kind of plots are usual in scientific environments (for instance for comparing concentrations, https://github.com/tidyverse/ggplot2/issues/1613#issuecomment-319985331) and currently require a lot of fine tuning, using `grid.arrange` and playing with legends to make sure each subplot is aligned.

# Example of use:

``` r
  library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
  library(scales)
  library(ggplot2)
# Simple tidy data frame, with 4 subjects. We measure three variables on each
# subject (namely: SomeValue, Percent and Scientific).
mydf <- dplyr::data_frame(Subject=rep(c("Alice", "Bob", "Charlie", "Diane"), each=3),
                          Magnitude=rep(c("SomeValue", "Percent", "Scientific"), times=4),
                          Value=c(c(170,0.6,2.7E-4),
                                  c(180, 0.8, 2.5E-4),
                                  c(160, 0.71, 3.2E-4),
                                  c(159, 0.62, 3E-4)),
                          Gender=rep(c("Female", "Male", "Male", "Female"), each=3))

# This is how the df looks like:
head(mydf)
#> # A tibble: 6 x 4
#>   Subject Magnitude      Value Gender
#>   <chr>   <chr>          <dbl> <chr> 
#> 1 Alice   SomeValue  170       Female
#> 2 Alice   Percent      0.6     Female
#> 3 Alice   Scientific   0.00027 Female
#> 4 Bob     SomeValue  180       Male  
#> 5 Bob     Percent      0.8     Male  
#> 6 Bob     Scientific   0.00025 Male
#  Subject  Magnitude   Value Gender
#1   Alice  SomeValue 1.7e+02 Female
#2   Alice    Percent 6.0e-01 Female
#3   Alice Scientific 2.7e-04 Female
#4     Bob  SomeValue 1.8e+02   Male
#5     Bob    Percent 8.0e-01   Male
#6     Bob Scientific 2.5e-04   Male

scales_y <- list(
  Percent = scale_y_continuous(labels=percent_format()),
  SomeValue = scale_y_continuous(),
  Scientific = scale_y_continuous(labels=scientific_format())
)

# Here the percent (top) is well written, the other ones don't make sense
ggplot(mydf) +
  geom_point(aes(x=Subject, y=Value, color=Gender)) +
  facet_grid(Magnitude~., scales = list(y = scales_y))
```

![](https://i.imgur.com/lOXbFmO.png)

Created on 2018-07-10 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).

# Merge vs not merge reasons:

- Merge:
    - The diff is small.
    - Backwards compatibility is preserved.
- Not merge:
    - This feature could fit in another package, providing a custom facet. There would be some code duplication, but it looks easy to do (I have a proof of concept).

