### PR TITLE
Shorten fortify() error to conform to style guide

### DIFF
--- a/R/fortify.r
+++ b/R/fortify.r
@@ -34,9 +34,9 @@ fortify.grouped_df <- function(model, data, ...) {
 #' @export
 fortify.default <- function(model, data, ...) {
   msg <- paste0(
-    "`data` must be a data frame, or other object coercible by `fortify()`, ",
-    "not ", obj_desc(model)
+    "`data` must be a data frame, or other object coercible by `fortify()`."
   )
+
   if (inherits(model, "uneval")) {
     msg <- paste0(
       msg, "\n",


### PR DESCRIPTION
Fixes #2717 on the ggplot2 end. Will still need to be updated in tidyverse/style, original issue tidyverse/style#80