### PR TITLE
Fix partial argument match in guide_train.colorbar

### DIFF
--- a/R/guide-colorbar.r
+++ b/R/guide-colorbar.r
@@ -218,7 +218,7 @@ guide_train.colorbar <- function(guide, scale, aesthetic = NULL) {
 
   # bar specification (number of divs etc)
   .limits <- scale$get_limits()
-  .bar <- seq(.limits[1], .limits[2], length = guide$nbin)
+  .bar <- seq(.limits[1], .limits[2], length.out = guide$nbin)
   if (length(.bar) == 0) {
     .bar = unique(.limits)
   }


### PR DESCRIPTION
This fixes #2779.