### PR TITLE
Add new parameter "preset" for ggsave() to specify width/height at once

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,15 @@
     is now always internally converted to "colour", even when part of a longer
     aesthetic name (e.g., `point_color`) (@clauswilke, #2649).
 
+*   `ggsave()` has a new parameter `preset`, which allows plot `width` and
+    `height` (and `units`) to be specified at once. It recognizes common paper
+    sizes (such as "a4" and "letter"), common screen resolutions ("4k"), or a
+    resolution specification such as "1920x1080". All presets default to
+    landscape orientation, and portrait can be specified by appending an "r"
+    (for rotated) to the end of the string. This is similar to the `paper`
+    option for `grDevices::pdf()`, but with landscape being the default as it's
+    probably a more common choice for plots (@ilarischeinin).
+
 # ggplot2 3.0.0
 
 ## Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # ggplot2 3.0.0.9000
 
+*   `ggsave()` has a new parameter `preset`, which allows plot `width` and
+    `height` (and `units`) to be specified at once. It recognizes common paper
+    sizes (such as "a4" and "letter"), common screen resolutions ("4k"), or a
+    resolution specification such as "1920x1080". All presets default to
+    landscape orientation, and portrait can be specified by appending an "r"
+    (for rotated) to the end of the string. This is similar to the `paper`
+    option for `grDevices::pdf()`, but with landscape being the default as it's
+    probably a more common choice for plots (@ilarischeinin).
+
 *   `stat_contour()`, `stat_density2d()`, `stat_bin2d()`,  `stat_binhex()`
     now calculate normalized statistics including `nlevel`, `ndensity`, and
     `ncount`. Also, `stat_density()` now includes the calculated statistic 
@@ -17,15 +26,6 @@
     `aesthetics` argument of scale functions. Also, the US spelling "color"
     is now always internally converted to "colour", even when part of a longer
     aesthetic name (e.g., `point_color`) (@clauswilke, #2649).
-
-*   `ggsave()` has a new parameter `preset`, which allows plot `width` and
-    `height` (and `units`) to be specified at once. It recognizes common paper
-    sizes (such as "a4" and "letter"), common screen resolutions ("4k"), or a
-    resolution specification such as "1920x1080". All presets default to
-    landscape orientation, and portrait can be specified by appending an "r"
-    (for rotated) to the end of the string. This is similar to the `paper`
-    option for `grDevices::pdf()`, but with landscape being the default as it's
-    probably a more common choice for plots (@ilarischeinin).
 
 # ggplot2 3.0.0
 

--- a/R/save.r
+++ b/R/save.r
@@ -61,7 +61,7 @@ ggsave <- function(filename, plot = last_plot(),
       width <- preset_values$width
       height <- preset_values$height
       units <- preset_values$units
-    } else {
+    } else {
       warning(
         "Ignoring 'preset = \"", preset, "\"', as width/height was specified."
       )

--- a/man/ggsave.Rd
+++ b/man/ggsave.Rd
@@ -6,7 +6,7 @@
 \usage{
 ggsave(filename, plot = last_plot(), device = NULL, path = NULL,
   scale = 1, width = NA, height = NA, units = c("in", "cm", "mm"),
-  dpi = 300, limitsize = TRUE, ...)
+  dpi = 300, limitsize = TRUE, preset = NULL, ...)
 }
 \arguments{
 \item{filename}{File name to create on disk.}
@@ -30,6 +30,15 @@ If not supplied, uses the size of current graphics device.}
 \item{limitsize}{When \code{TRUE} (the default), \code{ggsave} will not
 save images larger than 50x50 inches, to prevent the common error of
 specifying dimensions in pixels.}
+
+\item{preset}{A character string to specify \code{width} and \code{height} (and
+\code{units}) at once. Recognizes common paper sizes (such as "a4" and
+"letter"), common screen resolutions ("4k"), or a resolution specification
+such as "1920x1080". All presets default to landscape orientation, and
+portrait can be specified by appending an "r" (for rotated) to the end of
+the string. This is similar to the \code{paper} option for
+\code{\link[grDevices]{pdf}()}, but with landscape being the default as
+it's more common. Ignored if \code{width}/\code{height} was specified.}
 
 \item{...}{Other arguments passed on to the graphics device function,
 as specified by \code{device}.}

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -93,3 +93,46 @@ test_that("invalid non-single-string DPI values throw an error", {
   expect_error(parse_dpi(c(150, 300)), "DPI must be a single number or string")
   expect_error(parse_dpi(list(150)), "DPI must be a single number or string")
 })
+
+# parse_preset ----------------------------------------------------------------
+
+test_that("presets are formatted as expected", {
+  expect_true(all(ggsave_presets$width >= ggsave_presets$height))
+  landscape_presets <- unlist(ggsave_presets$names)
+  portrait_presets <- paste0(landscape_presets, "r")
+  expect_false(any(duplicated(c(landscape_presets, portrait_presets))))
+})
+
+test_that("invalid preset values throw an error", {
+  expect_error(parse_preset(letters), "preset must be a character string")
+  expect_error(parse_preset(1), "preset must be a character string")
+  expect_error(parse_preset(factor("a")), "preset must be a character string")
+  expect_error(parse_preset("abc"), "Unknown preset")
+})
+
+test_that("presets returned as expected", {
+  expect_equal(
+    parse_preset("a4"),
+    list(width = 297, height = 210, units = "mm")
+  )
+  expect_equal(
+    parse_preset("a4r"),
+    list(width = 210, height = 297, units = "mm")
+  )
+  expect_equal(
+    parse_preset("fhd", dpi = 300),
+    list(width = 1920 / 300, height = 1080 / 300, units = "in")
+  )
+  expect_equal(
+    parse_preset("fhdr", dpi = 300),
+    list(width = 1080 / 300, height = 1920 / 300, units = "in")
+  )
+  expect_equal(
+    parse_preset("1920x1080", dpi = 300),
+    list(width = 1920 / 300, height = 1080 / 300, units = "in")
+  )
+  expect_equal(
+    parse_preset("1920x1080r", dpi = 300),
+    list(width = 1080 / 300, height = 1920 / 300, units = "in")
+  )
+})


### PR DESCRIPTION
This PR adds a new parameter `preset` for `ggsave()` that allows plot width and height (and units) to be specified at once. It recognizes common paper sizes (such as "a4" and "letter"), common screen resolutions ("4k"), and resolution specifications such as "1920x1080".

All presets default to landscape orientation, and portrait can be specified by appending an "r" (for rotated) to the end of the string. This is similar to the `paper` option for `grDevices::pdf()`, but with landscape being the default as it's probably a more common choice for plots.

(Naturally this new parameter could also be called `paper` instead of `preset`, but 1) that felt a bit too old-fashioned, and 2) might seem odd when making a plot that is to be placed on a sheet of paper together with other elements like text. `size` is another name I considered, but as the function already has a parameter called `limitsize`, I think they would be an odd pair. Anyways, `preset` is just one suggestion and I can rename it as wished.)

For now, some selected [paper sizes](https://en.wikipedia.org/wiki/Paper_size) and [screen resolutions](https://en.wikipedia.org/wiki/Computer_display_standard) are included, but I'm happy to make the list more comprehensive if that seems reasonable.

### Example Usage

```r
library(ggplot2)
p <- ggplot(data.frame(x = rnorm(100), y = rnorm(100)), aes(x, y)) + geom_point()

ggsave("letter.pdf", p, preset = "letter")
ggsave("a4r.pdf", p, preset = "a4r")
ggsave("hd.png", p, preset = "HD")
ggsave("1920x1080.png", p, preset = "1920x1080")
```