### PR TITLE
Clarify geom_label documentation

### DIFF
--- a/R/geom-text.r
+++ b/R/geom-text.r
@@ -18,7 +18,7 @@
 #'
 #' @eval rd_aesthetics("geom", "text")
 #' @section `geom_label`:
-#' Currently `geom_label` does not support the `rot` parameter and
+#' Currently `geom_label` does not support the `angle` aesthetic and
 #' is considerably slower than `geom_text`. The `fill` aesthetic
 #' controls the background colour of the label.
 #'

--- a/man/geom_text.Rd
+++ b/man/geom_text.Rd
@@ -117,7 +117,7 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{\code{geom_label}}{
 
-Currently \code{geom_label} does not support the \code{rot} parameter and
+Currently \code{geom_label} does not support the \code{angle} aesthetic and
 is considerably slower than \code{geom_text}. The \code{fill} aesthetic
 controls the background colour of the label.
 }


### PR DESCRIPTION
Specify non-support of '`angle` aesthetic' rather than '`rot` parameter', as this is clearer.

It is indeed the case that the `angle` aesthetic isn't supported. You can see below that `geom_text` is rotated but `geom_label` isn't, despite the same aesthetics. Perhaps it's worth adding a warning if you try to use the `angle` aesthetic with `geom_label`, although I'm less sure how you'd go about this.

Do I need to render the file for the `man/` directory?

``` r
library(tidyverse)
#> Warning: package 'dplyr' was built under R version 3.5.1

data <- tibble(
  text = c('one', 'two', 'three'),
  angle = c(0, 45, 90),
  x = c(1, 2, 3)
)

ggplot(data, aes(x)) +
  geom_text(aes(y = 2, label = text, angle = angle)) +
  geom_label(aes(y = 1, label = text, angle = angle))
```

![](https://i.imgur.com/S5nlxRI.png)

Created on 2018-07-27 by the [reprex
package](http://reprex.tidyverse.org) (v0.2.0).