### PR TITLE
Fix sec.axis() when used with tidyeval (#2788)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 3.0.0.9000
 
+*   `sec_axis()` now works as expected when used in combination with tidy eval
+    (@dpseidel, #2788).
+
 *   `stat_contour()`, `stat_density2d()`, `stat_bin2d()`,  `stat_binhex()`
     now calculate normalized statistics including `nlevel`, `ndensity`, and
     `ncount`. Also, `stat_density()` now includes the calculated statistic 

--- a/R/axis-secondary.R
+++ b/R/axis-secondary.R
@@ -106,7 +106,7 @@ AxisSecondary <- ggproto("AxisSecondary", NULL,
 
   transform_range = function(self, range) {
     range <- structure(data.frame(range), names = '.')
-    f_eval(self$trans, range)
+    rlang::eval_tidy(rlang::f_rhs(self$trans), data = range)
   },
 
 

--- a/tests/testthat/test-sec-axis.R
+++ b/tests/testthat/test-sec-axis.R
@@ -46,3 +46,29 @@ test_that("sec axis works with skewed transform", {
                                              breaks = derive()))
   )
 })
+
+test_that("sec axis works with tidy eval",{
+
+  f <- function(df, .x, .y, .z) {
+    x<-enquo(.x)
+    y<-enquo(.y)
+    z<-enquo(.z)
+
+    g <- ggplot(df,aes(x=!!x,y=!!y)) +
+      geom_bar(stat="identity") +
+      geom_point(aes(y=!!z)) +
+      scale_y_continuous(sec.axis = sec_axis(~./10))
+
+    g
+  }
+
+  t <- tibble(x = letters, y = seq(10,260, 10), z = 1:26)
+
+  p <- f(t, x, y, z)
+
+  scale <- layer_scales(p)$y
+  breaks <- scale$break_info()
+
+  expect_equal(breaks$major_source/10, breaks$sec.major_source)
+
+  })

--- a/tests/testthat/test-sec-axis.R
+++ b/tests/testthat/test-sec-axis.R
@@ -47,28 +47,26 @@ test_that("sec axis works with skewed transform", {
   )
 })
 
-test_that("sec axis works with tidy eval",{
-
+test_that("sec axis works with tidy eval", {
   f <- function(df, .x, .y, .z) {
-    x<-enquo(.x)
-    y<-enquo(.y)
-    z<-enquo(.z)
+    x <- enquo(.x)
+    y <- enquo(.y)
+    z <- enquo(.z)
 
-    g <- ggplot(df,aes(x=!!x,y=!!y)) +
-      geom_bar(stat="identity") +
-      geom_point(aes(y=!!z)) +
-      scale_y_continuous(sec.axis = sec_axis(~./10))
+    g <- ggplot(df, aes(x = !!x, y = !!y)) +
+      geom_bar(stat = "identity") +
+      geom_point(aes(y = !!z)) +
+      scale_y_continuous(sec.axis = sec_axis(~. / 10))
 
     g
   }
 
-  t <- tibble(x = letters, y = seq(10,260, 10), z = 1:26)
+  t <- tibble(x = letters, y = seq(10, 260, 10), z = 1:26)
 
   p <- f(t, x, y, z)
 
   scale <- layer_scales(p)$y
   breaks <- scale$break_info()
 
-  expect_equal(breaks$major_source/10, breaks$sec.major_source)
-
-  })
+  expect_equal(breaks$major_source / 10, breaks$sec.major_source)
+})


### PR DESCRIPTION
This PR make a small change to the evaluation of the transform formula of secondary axes to support plots created with tidy evaluation when calling `sec_axis()`. Fixes #2788. 

This PR solves the original issue, and does not break any other secondary axis transformations, but if there is a better way to implement this or something this might break downstream that I'm not seeing, please advise. 