### PR TITLE
Fix incorrect monotonicity test failure in sec.axis

### DIFF
--- a/R/axis-secondary.R
+++ b/R/axis-secondary.R
@@ -113,10 +113,10 @@ AxisSecondary <- ggproto("AxisSecondary", NULL,
     if (self$empty()) return()
 
     # Get original range before transformation
-    along_range <- seq(range[1], range[2], length.out = self$detail)
-    old_range <- scale$trans$inverse(along_range)
+    inv_range <- scale$trans$inverse(range)
 
     # Create mapping between primary and secondary range
+    old_range <- seq(inv_range[1], inv_range[2], length.out = self$detail)
     full_range <- self$transform_range(old_range)
 
     # Test for monotonicity

--- a/tests/testthat/test-sec-axis.R
+++ b/tests/testthat/test-sec-axis.R
@@ -115,3 +115,29 @@ test_that("sec axis works with tidy eval", {
 
   expect_equal(breaks$major_source / 10, breaks$sec.major_source)
 })
+
+test_that("sec_axis() works for power transformations (monotonicity test doesn't fail)", {
+  p <- ggplot(foo, aes(x, y)) +
+    geom_point() +
+    scale_x_sqrt(sec.axis = dup_axis())
+  scale <- layer_scales(p)$x
+  breaks <- scale$break_info()
+  expect_equal(breaks$major, breaks$sec.major, tolerance = .001)
+
+  p <- ggplot(foo, aes(x, y)) +
+    geom_point() +
+    scale_x_sqrt(sec.axis = sec_axis(~. * 100))
+  scale <- layer_scales(p)$x
+  breaks <- scale$break_info()
+  expect_equal(breaks$major, breaks$sec.major, tolerance = .001)
+
+  p <- ggplot(foo, aes(x, y)) +
+    geom_point() +
+    scale_x_continuous(
+      trans = scales::boxcox_trans(.25),
+      sec.axis = sec_axis(~. / 10)
+    )
+  scale <- layer_scales(p)$x
+  breaks <- scale$break_info()
+  expect_equal(breaks$major, breaks$sec.major, tolerance = .001)
+})

--- a/tests/testthat/test-sec-axis.R
+++ b/tests/testthat/test-sec-axis.R
@@ -130,14 +130,4 @@ test_that("sec_axis() works for power transformations (monotonicity test doesn't
   scale <- layer_scales(p)$x
   breaks <- scale$break_info()
   expect_equal(breaks$major, breaks$sec.major, tolerance = .001)
-
-  p <- ggplot(foo, aes(x, y)) +
-    geom_point() +
-    scale_x_continuous(
-      trans = scales::boxcox_trans(.25),
-      sec.axis = sec_axis(~. / 10)
-    )
-  scale <- layer_scales(p)$x
-  breaks <- scale$break_info()
-  expect_equal(breaks$major, breaks$sec.major, tolerance = .001)
 })


### PR DESCRIPTION
PR #2095 changed the order in which the range a secondary axis was transformed, sampled, and tested for monotonicity. Sampling over the transformed space rather than the original scale caused the monotonicity test on the secondary axis to fail for certain transformations. This PR fixes those failures by sampling on the original scale rather than the transformed scale, effectively a partial reversal of PR #2095 whose motivating problem was fixed in an alternative way by #2796. 