### PR TITLE
Force arguments that are used in closures

### DIFF
--- a/R/save.r
+++ b/R/save.r
@@ -118,7 +118,10 @@ plot_dim <- function(dim = c(NA, NA), scale = 1, units = c("in", "cm", "mm"),
   dim
 }
 
-plot_dev <- function(device, filename, dpi = 300) {
+plot_dev <- function(device, filename = NULL, dpi = 300) {
+  force(filename)
+  force(dpi)
+
   if (is.function(device))
     return(device)
 

--- a/R/scale-manual.r
+++ b/R/scale-manual.r
@@ -102,6 +102,8 @@ scale_discrete_manual <- function(aesthetics, ..., values) {
 
 
 manual_scale <- function(aesthetic, values, ...) {
+  force(values)
+
   pal <- function(n) {
     if (n > length(values)) {
       stop("Insufficient values in manual scale. ", n, " needed but only ",

--- a/R/scale-size.r
+++ b/R/scale-size.r
@@ -68,6 +68,8 @@ scale_size_discrete <- function(...) {
 #' @export
 #' @usage NULL
 scale_size_ordinal <- function(..., range = c(2, 6)) {
+  force(range)
+
   discrete_scale(
     "size",
     "size_d",

--- a/R/stat-summary-bin.R
+++ b/R/stat-summary-bin.R
@@ -65,6 +65,12 @@ StatSummaryBin <- ggproto("StatSummaryBin", Stat,
 )
 
 make_summary_fun <- function(fun.data, fun.y, fun.ymax, fun.ymin, fun.args) {
+  force(fun.data)
+  force(fun.y)
+  force(fun.ymax)
+  force(fun.ymin)
+  force(fun.args)
+
   if (!is.null(fun.data)) {
     # Function that takes complete data frame as input
     fun.data <- match.fun(fun.data)


### PR DESCRIPTION
The reprex below triggered the investigation that led to possible instances where "brittle closures" are returned. I have no idea if the other instances I found have an effect, but it feels like good practice to force arguments that are used by closures.

Happy to add tests as necessary.

``` r
library(tidyverse)

scale <- c("red", "green", "blue")

p <-
  ggplot(iris, aes(Petal.Length, Petal.Width, color = Species)) +
  geom_point() +
  scale_color_manual(values = unlist(scale), labels = levels(iris$Species))

scale <- scale[-1]

p
```

![](https://i.imgur.com/ulYQCdH.png)

> Created on 2018-08-07 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).