### PR TITLE
Fix #2839: 'continuous_scale' palette param docs

### DIFF
--- a/R/scale-.r
+++ b/R/scale-.r
@@ -500,8 +500,8 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
 #' @param aesthetics The names of the aesthetics that this scale works with
 #' @param scale_name The name of the scale
 #' @param palette A palette function that when called with a numeric vector with
-#'   values in [0,1] returns the corresponding values in the range the scale
-#'   maps to.
+#'   values between 0 and 1 returns the corresponding values in the range the
+#'   scale maps to.
 #' @param name The name of the scale. Used as the axis or legend title. If
 #'   `waiver()`, the default, the name of the scale is taken from the first
 #'   mapping used for that aesthetic. If `NULL`, the legend title will be

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -499,9 +499,9 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
 #' @export
 #' @param aesthetics The names of the aesthetics that this scale works with
 #' @param scale_name The name of the scale
-#' @param palette A palette function that when called with a single integer
-#'   argument (the number of levels in the scale) returns the values that
-#'   they should take
+#' @param palette A palette function that when called with a numeric vector with
+#'   values in [0,1] returns the corresponding values in the range the scale
+#'   maps to.
 #' @param name The name of the scale. Used as the axis or legend title. If
 #'   `waiver()`, the default, the name of the scale is taken from the first
 #'   mapping used for that aesthetic. If `NULL`, the legend title will be
@@ -600,6 +600,9 @@ continuous_scale <- function(aesthetics, scale_name, palette, name = waiver(),
 #'
 #' @export
 #' @inheritParams continuous_scale
+#' @param palette A palette function that when called with a single integer
+#'   argument (the number of levels in the scale) returns the values that
+#'   they should take.
 #' @param breaks One of:
 #'   - `NULL` for no breaks
 #'   - `waiver()` for the default breaks computed by the

--- a/man/continuous_scale.Rd
+++ b/man/continuous_scale.Rd
@@ -15,9 +15,9 @@ continuous_scale(aesthetics, scale_name, palette, name = waiver(),
 
 \item{scale_name}{The name of the scale}
 
-\item{palette}{A palette function that when called with a single integer
-argument (the number of levels in the scale) returns the values that
-they should take}
+\item{palette}{A palette function that when called with a numeric vector with
+values in \link{0,1} returns the corresponding values in the range the scale
+maps to.}
 
 \item{name}{The name of the scale. Used as the axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first

--- a/man/continuous_scale.Rd
+++ b/man/continuous_scale.Rd
@@ -16,8 +16,8 @@ continuous_scale(aesthetics, scale_name, palette, name = waiver(),
 \item{scale_name}{The name of the scale}
 
 \item{palette}{A palette function that when called with a numeric vector with
-values in \link{0,1} returns the corresponding values in the range the scale
-maps to.}
+values between 0 and 1 returns the corresponding values in the range the
+scale maps to.}
 
 \item{name}{The name of the scale. Used as the axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first

--- a/man/discrete_scale.Rd
+++ b/man/discrete_scale.Rd
@@ -17,7 +17,7 @@ discrete_scale(aesthetics, scale_name, palette, name = waiver(),
 
 \item{palette}{A palette function that when called with a single integer
 argument (the number of levels in the scale) returns the values that
-they should take}
+they should take.}
 
 \item{name}{The name of the scale. Used as the axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first

--- a/man/scale_discrete.Rd
+++ b/man/scale_discrete.Rd
@@ -12,6 +12,9 @@ scale_y_discrete(..., expand = waiver(), position = "left")
 \arguments{
 \item{...}{Arguments passed on to \code{discrete_scale}
 \describe{
+  \item{palette}{A palette function that when called with a single integer
+argument (the number of levels in the scale) returns the values that
+they should take.}
   \item{breaks}{One of:
 \itemize{
 \item \code{NULL} for no breaks
@@ -34,9 +37,6 @@ value should missing be displayed as? Does not apply to position scales
 where \code{NA} is always placed at the far right.}
   \item{aesthetics}{The names of the aesthetics that this scale works with}
   \item{scale_name}{The name of the scale}
-  \item{palette}{A palette function that when called with a single integer
-argument (the number of levels in the scale) returns the values that
-they should take}
   \item{name}{The name of the scale. Used as the axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic. If \code{NULL}, the legend title will be

--- a/man/scale_gradient.Rd
+++ b/man/scale_gradient.Rd
@@ -46,8 +46,8 @@ scale_fill_gradientn(..., colours, values = NULL, space = "Lab",
 \describe{
   \item{scale_name}{The name of the scale}
   \item{palette}{A palette function that when called with a numeric vector with
-values in \link{0,1} returns the corresponding values in the range the scale
-maps to.}
+values between 0 and 1 returns the corresponding values in the range the
+scale maps to.}
   \item{name}{The name of the scale. Used as the axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic. If \code{NULL}, the legend title will be

--- a/man/scale_gradient.Rd
+++ b/man/scale_gradient.Rd
@@ -45,9 +45,9 @@ scale_fill_gradientn(..., colours, values = NULL, space = "Lab",
 \item{...}{Arguments passed on to \code{continuous_scale}
 \describe{
   \item{scale_name}{The name of the scale}
-  \item{palette}{A palette function that when called with a single integer
-argument (the number of levels in the scale) returns the values that
-they should take}
+  \item{palette}{A palette function that when called with a numeric vector with
+values in \link{0,1} returns the corresponding values in the range the scale
+maps to.}
   \item{name}{The name of the scale. Used as the axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic. If \code{NULL}, the legend title will be

--- a/man/scale_grey.Rd
+++ b/man/scale_grey.Rd
@@ -15,6 +15,9 @@ scale_fill_grey(..., start = 0.2, end = 0.8, na.value = "red",
 \arguments{
 \item{...}{Arguments passed on to \code{discrete_scale}
 \describe{
+  \item{palette}{A palette function that when called with a single integer
+argument (the number of levels in the scale) returns the values that
+they should take.}
   \item{breaks}{One of:
 \itemize{
 \item \code{NULL} for no breaks
@@ -37,9 +40,6 @@ value should missing be displayed as? Does not apply to position scales
 where \code{NA} is always placed at the far right.}
   \item{aesthetics}{The names of the aesthetics that this scale works with}
   \item{scale_name}{The name of the scale}
-  \item{palette}{A palette function that when called with a single integer
-argument (the number of levels in the scale) returns the values that
-they should take}
   \item{name}{The name of the scale. Used as the axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic. If \code{NULL}, the legend title will be

--- a/man/scale_hue.Rd
+++ b/man/scale_hue.Rd
@@ -20,6 +20,9 @@ scale_fill_hue(..., h = c(0, 360) + 15, c = 100, l = 65,
 \arguments{
 \item{...}{Arguments passed on to \code{discrete_scale}
 \describe{
+  \item{palette}{A palette function that when called with a single integer
+argument (the number of levels in the scale) returns the values that
+they should take.}
   \item{breaks}{One of:
 \itemize{
 \item \code{NULL} for no breaks
@@ -41,9 +44,6 @@ from a discrete scale, specify \code{na.translate = FALSE}.}
 value should missing be displayed as? Does not apply to position scales
 where \code{NA} is always placed at the far right.}
   \item{scale_name}{The name of the scale}
-  \item{palette}{A palette function that when called with a single integer
-argument (the number of levels in the scale) returns the values that
-they should take}
   \item{name}{The name of the scale. Used as the axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic. If \code{NULL}, the legend title will be

--- a/man/scale_linetype.Rd
+++ b/man/scale_linetype.Rd
@@ -15,6 +15,9 @@ scale_linetype_discrete(..., na.value = "blank")
 \arguments{
 \item{...}{Arguments passed on to \code{discrete_scale}
 \describe{
+  \item{palette}{A palette function that when called with a single integer
+argument (the number of levels in the scale) returns the values that
+they should take.}
   \item{breaks}{One of:
 \itemize{
 \item \code{NULL} for no breaks
@@ -34,9 +37,6 @@ missing values, and do so by default. If you want to remove missing values
 from a discrete scale, specify \code{na.translate = FALSE}.}
   \item{aesthetics}{The names of the aesthetics that this scale works with}
   \item{scale_name}{The name of the scale}
-  \item{palette}{A palette function that when called with a single integer
-argument (the number of levels in the scale) returns the values that
-they should take}
   \item{name}{The name of the scale. Used as the axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic. If \code{NULL}, the legend title will be

--- a/man/scale_manual.Rd
+++ b/man/scale_manual.Rd
@@ -28,6 +28,9 @@ scale_discrete_manual(aesthetics, ..., values)
 \arguments{
 \item{...}{Arguments passed on to \code{discrete_scale}
 \describe{
+  \item{palette}{A palette function that when called with a single integer
+argument (the number of levels in the scale) returns the values that
+they should take.}
   \item{breaks}{One of:
 \itemize{
 \item \code{NULL} for no breaks
@@ -49,9 +52,6 @@ from a discrete scale, specify \code{na.translate = FALSE}.}
 value should missing be displayed as? Does not apply to position scales
 where \code{NA} is always placed at the far right.}
   \item{scale_name}{The name of the scale}
-  \item{palette}{A palette function that when called with a single integer
-argument (the number of levels in the scale) returns the values that
-they should take}
   \item{name}{The name of the scale. Used as the axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic. If \code{NULL}, the legend title will be

--- a/man/scale_shape.Rd
+++ b/man/scale_shape.Rd
@@ -12,6 +12,9 @@ scale_shape(..., solid = TRUE)
 \arguments{
 \item{...}{Arguments passed on to \code{discrete_scale}
 \describe{
+  \item{palette}{A palette function that when called with a single integer
+argument (the number of levels in the scale) returns the values that
+they should take.}
   \item{breaks}{One of:
 \itemize{
 \item \code{NULL} for no breaks
@@ -34,9 +37,6 @@ value should missing be displayed as? Does not apply to position scales
 where \code{NA} is always placed at the far right.}
   \item{aesthetics}{The names of the aesthetics that this scale works with}
   \item{scale_name}{The name of the scale}
-  \item{palette}{A palette function that when called with a single integer
-argument (the number of levels in the scale) returns the values that
-they should take}
   \item{name}{The name of the scale. Used as the axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic. If \code{NULL}, the legend title will be


### PR DESCRIPTION
The 'palette' parameter has different usage in continuous
vs discrete scales, and the documentation described the
discrete usage.