### PR TITLE
allow geom_sf to accept line parameters (#2826)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 3.0.0.9000
 
+*   `geom_sf()` now respects `lineend`, `linejoin` and `linemitre` parameters 
+    for lines and polygons (@alistaire47, #2826)
+
 *   `benchplot()` now uses tidy evaluation (@dpseidel, #2699).
     
 *   `fortify()` now displays a more informative error message for

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # ggplot2 3.0.0.9000
 
-*   `geom_sf()` now respects `lineend`, `linejoin` and `linemitre` parameters 
+*   `geom_sf()` now respects `lineend`, `linejoin`, and `linemitre` parameters 
     for lines and polygons (@alistaire47, #2826)
 
 *   `benchplot()` now uses tidy evaluation (@dpseidel, #2699).

--- a/R/sf.R
+++ b/R/sf.R
@@ -159,11 +159,13 @@ GeomSf <- ggproto("GeomSf", Geom,
 
     # Need to refactor this to generate one grob per geometry type
     coord <- coord$transform(data, panel_params)
-    coord$lineend <- lineend
-    coord$linejoin <- linejoin
-    coord$linemitre <- linemitre
     grobs <- lapply(1:nrow(data), function(i) {
-      sf_grob(coord[i, , drop = FALSE])
+      sf_grob(
+        coord[i, , drop = FALSE],
+        lineend = lineend,
+        linejoin = linejoin,
+        linemitre = linemitre
+      )
     })
     do.call("gList", grobs)
   },
@@ -190,7 +192,7 @@ default_aesthetics <- function(type) {
   }
 }
 
-sf_grob <- function(row) {
+sf_grob <- function(row, lineend, linejoin, linemitre) {
   # Need to extract geometry out of corresponding list column
   geometry <- row$geometry[[1]]
 
@@ -211,9 +213,9 @@ sf_grob <- function(row) {
       fill = alpha(row$fill, row$alpha),
       lwd = row$size * .pt,
       lty = row$linetype,
-      lineend = row$lineend,
-      linejoin = row$linejoin,
-      linemitre = row$linemitre
+      lineend = lineend,
+      linejoin = linejoin,
+      linemitre = linemitre
     )
     sf::st_as_grob(geometry, gp = gp)
   }


### PR DESCRIPTION
This closes #2826, allowing `lineend`, `linejoin`, and `linemitre` arguments to be passed through `geom_sf`. I copied the defaults directly from `geom_path`, so this shouldn't alter the results of current code.

The only change I had to make beyond what Claus mentioned on the issue was assigning the parameters to `coord` so they get passed through to `sf_grob`. There may be a simpler way to structure that. If so, let me know and I'll refactor.

For now, I decided against adding them as explicit parameters to `geom_sf`, as while it would make sense for lines, it would sound like they'd apply to polygons, too, which they wouldn't, and thus may cause more confusion than it'd remove.

This builds and performs fine. I didn't add any tests, as the `geom_sf` tests don't currently test its line behavior, but can if you like. I do get an error when checking due to the `economics_long` dataset. I didn't touch it, but it gives me a C++ error when printed, even though `str` works fine: 

```r
> economics_long
Error: Not compatible with STRSXP: [type=list].
```
I suspect this means I've got a dependency issue with tibble or something, but I can't figure out what. I presume that if it has been working in CI builds, it will continue to do so.

Apologies for the extra commits in there; I realized too late that I didn't rebase fully. They shouldn't do anything at this point, so if there's some git-fu to clean them out, I'd be happy to remove them.