### PR TITLE
Improve error messages about conflicted parameters

### DIFF
--- a/R/geom-jitter.r
+++ b/R/geom-jitter.r
@@ -39,7 +39,7 @@ geom_jitter <- function(mapping = NULL, data = NULL,
                         inherit.aes = TRUE) {
   if (!missing(width) || !missing(height)) {
     if (!missing(position)) {
-      stop("You must specify one of `position` and `width`/`height`.", call. = FALSE)
+      stop("You must specify either `position` or `width`/`height`.", call. = FALSE)
     }
 
     position <- position_jitter(width = width, height = height)

--- a/R/geom-jitter.r
+++ b/R/geom-jitter.r
@@ -39,7 +39,7 @@ geom_jitter <- function(mapping = NULL, data = NULL,
                         inherit.aes = TRUE) {
   if (!missing(width) || !missing(height)) {
     if (!missing(position)) {
-      stop("Specify either `position` or `width`/`height`", call. = FALSE)
+      stop("`position` and `width`/`height` cannot both be specified. Please specify only one.", call. = FALSE)
     }
 
     position <- position_jitter(width = width, height = height)

--- a/R/geom-jitter.r
+++ b/R/geom-jitter.r
@@ -39,7 +39,7 @@ geom_jitter <- function(mapping = NULL, data = NULL,
                         inherit.aes = TRUE) {
   if (!missing(width) || !missing(height)) {
     if (!missing(position)) {
-      stop("`position` and `width`/`height` cannot both be specified. Please specify only one.", call. = FALSE)
+      stop("You must specify one of `position` and `width`/`height`", call. = FALSE)
     }
 
     position <- position_jitter(width = width, height = height)

--- a/R/geom-jitter.r
+++ b/R/geom-jitter.r
@@ -39,7 +39,7 @@ geom_jitter <- function(mapping = NULL, data = NULL,
                         inherit.aes = TRUE) {
   if (!missing(width) || !missing(height)) {
     if (!missing(position)) {
-      stop("You must specify one of `position` and `width`/`height`", call. = FALSE)
+      stop("You must specify one of `position` and `width`/`height`.", call. = FALSE)
     }
 
     position <- position_jitter(width = width, height = height)

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -17,7 +17,7 @@ geom_label <- function(mapping = NULL, data = NULL,
                        inherit.aes = TRUE) {
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
-      stop("Specify either `position` or `nudge_x`/`nudge_y`", call. = FALSE)
+      stop("`position` and `nudge_x`/`nudge_y` cannot both be specified. Please specify only one.", call. = FALSE)
     }
 
     position <- position_nudge(nudge_x, nudge_y)

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -17,7 +17,7 @@ geom_label <- function(mapping = NULL, data = NULL,
                        inherit.aes = TRUE) {
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
-      stop("`position` and `nudge_x`/`nudge_y` cannot both be specified. Please specify only one.", call. = FALSE)
+      stop("You must specify one of `position` and `nudge_x`/`nudge_y`", call. = FALSE)
     }
 
     position <- position_nudge(nudge_x, nudge_y)

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -17,7 +17,7 @@ geom_label <- function(mapping = NULL, data = NULL,
                        inherit.aes = TRUE) {
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
-      stop("You must specify one of `position` and `nudge_x`/`nudge_y`.", call. = FALSE)
+      stop("You must specify either `position` or `nudge_x`/`nudge_y`", call. = FALSE)
     }
 
     position <- position_nudge(nudge_x, nudge_y)

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -17,7 +17,7 @@ geom_label <- function(mapping = NULL, data = NULL,
                        inherit.aes = TRUE) {
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
-      stop("You must specify one of `position` and `nudge_x`/`nudge_y`", call. = FALSE)
+      stop("You must specify one of `position` and `nudge_x`/`nudge_y`.", call. = FALSE)
     }
 
     position <- position_nudge(nudge_x, nudge_y)

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -17,7 +17,7 @@ geom_label <- function(mapping = NULL, data = NULL,
                        inherit.aes = TRUE) {
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
-      stop("You must specify either `position` or `nudge_x`/`nudge_y`", call. = FALSE)
+      stop("You must specify either `position` or `nudge_x`/`nudge_y`.", call. = FALSE)
     }
 
     position <- position_nudge(nudge_x, nudge_y)

--- a/R/geom-text.r
+++ b/R/geom-text.r
@@ -136,7 +136,7 @@ geom_text <- function(mapping = NULL, data = NULL,
 {
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
-      stop("Specify either `position` or `nudge_x`/`nudge_y`", call. = FALSE)
+      stop("`position` and `nudge_x`/`nudge_y` cannot both be specified. Please specify only one.", call. = FALSE)
     }
 
     position <- position_nudge(nudge_x, nudge_y)

--- a/R/geom-text.r
+++ b/R/geom-text.r
@@ -136,7 +136,7 @@ geom_text <- function(mapping = NULL, data = NULL,
 {
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
-      stop("`position` and `nudge_x`/`nudge_y` cannot both be specified. Please specify only one.", call. = FALSE)
+      stop("You must specify one of `position` and `nudge_x`/`nudge_y`.", call. = FALSE)
     }
 
     position <- position_nudge(nudge_x, nudge_y)

--- a/R/geom-text.r
+++ b/R/geom-text.r
@@ -136,7 +136,7 @@ geom_text <- function(mapping = NULL, data = NULL,
 {
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
-      stop("You must specify one of `position` and `nudge_x`/`nudge_y`.", call. = FALSE)
+      stop("You must specify either `position` or `nudge_x`/`nudge_y`.", call. = FALSE)
     }
 
     position <- position_nudge(nudge_x, nudge_y)

--- a/R/sf.R
+++ b/R/sf.R
@@ -294,7 +294,7 @@ geom_sf_label <- function(mapping = aes(), data = NULL,
 
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
-      stop("Specify either `position` or `nudge_x`/`nudge_y`", call. = FALSE)
+      stop("`position` and `nudge_x`/`nudge_y` cannot both be specified. Please specify only one.", call. = FALSE)
     }
 
     position <- position_nudge(nudge_x, nudge_y)
@@ -347,7 +347,7 @@ geom_sf_text <- function(mapping = aes(), data = NULL,
 
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
-      stop("Specify either `position` or `nudge_x`/`nudge_y`", call. = FALSE)
+      stop("`position` and `nudge_x`/`nudge_y` cannot both be specified. Please specify only one.", call. = FALSE)
     }
 
     position <- position_nudge(nudge_x, nudge_y)

--- a/R/sf.R
+++ b/R/sf.R
@@ -347,7 +347,7 @@ geom_sf_text <- function(mapping = aes(), data = NULL,
 
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
-      stop("You must specify one of `position` and `nudge_x`/`nudge_y`.", call. = FALSE)
+      stop("You must specify either `position` or `nudge_x`/`nudge_y`.", call. = FALSE)
     }
 
     position <- position_nudge(nudge_x, nudge_y)

--- a/R/sf.R
+++ b/R/sf.R
@@ -294,7 +294,7 @@ geom_sf_label <- function(mapping = aes(), data = NULL,
 
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
-      stop("`position` and `nudge_x`/`nudge_y` cannot both be specified. Please specify only one.", call. = FALSE)
+      stop("Specify either `position` or `nudge_x`/`nudge_y`", call. = FALSE)
     }
 
     position <- position_nudge(nudge_x, nudge_y)
@@ -347,7 +347,7 @@ geom_sf_text <- function(mapping = aes(), data = NULL,
 
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
-      stop("`position` and `nudge_x`/`nudge_y` cannot both be specified. Please specify only one.", call. = FALSE)
+      stop("You must specify one of `position` and `nudge_x`/`nudge_y`", call. = FALSE)
     }
 
     position <- position_nudge(nudge_x, nudge_y)

--- a/R/sf.R
+++ b/R/sf.R
@@ -347,7 +347,7 @@ geom_sf_text <- function(mapping = aes(), data = NULL,
 
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
-      stop("You must specify one of `position` and `nudge_x`/`nudge_y`", call. = FALSE)
+      stop("You must specify one of `position` and `nudge_x`/`nudge_y`.", call. = FALSE)
     }
 
     position <- position_nudge(nudge_x, nudge_y)


### PR DESCRIPTION
This is suggested in https://github.com/tidyverse/ggplot2/pull/2761#discussion_r211114877.

The current error messages are like:

> Specify either `position` or `nudge_x`/`nudge_y`

@clauswilke's suggestion is:

> `position` and `width`/`height` cannot both be specified. Please specify only one

I feel the latter follows [the tidyverse style](http://style.tidyverse.org/error-messages.html) of error messages; it consists of "problem statement" + "hint".