### PR TITLE
Enable manual setting of axis tick labels with coord_sf. Closes #2857

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 *   The error message in `compute_aesthetics()` now provides the names of only
     aesthetics with mismatched lengths, rather than all aesthetics (@karawoo,
     #2853).
+    
+*   `coord_sf()` now respects manual setting of axis tick labels (@clauswilke,
+    #2857).
 
 *   `geom_sf()` now respects `lineend`, `linejoin`, and `linemitre` parameters 
     for lines and polygons (@alistaire47, #2826)


### PR DESCRIPTION
This PR closes #2857. It enables most ways in which axis tick labels can normally be set for `coord_sf()`. The main limitation is that it can only accept character vectors. Parsed expressions will not work. (However, strings that contain the degree symbol will automatically be parsed into expressions.)

``` r
library(sf)
#> Linking to GEOS 3.6.1, GDAL 2.1.3, proj.4 4.9.3
library(ggplot2) 

nc <- st_read(system.file("gpkg/nc.gpkg", package="sf"))
#> Reading layer `nc.gpkg' from data source `/Library/Frameworks/R.framework/Versions/3.5/Resources/library/sf/gpkg/nc.gpkg' using driver `GPKG'
#> Simple feature collection with 100 features and 14 fields
#> geometry type:  MULTIPOLYGON
#> dimension:      XY
#> bbox:           xmin: -84.32385 ymin: 33.88199 xmax: -75.45698 ymax: 36.58965
#> epsg (SRID):    4267
#> proj4string:    +proj=longlat +datum=NAD27 +no_defs

# explicitly supply label values
ggplot() + 
  geom_sf(aes(fill = AREA), data=nc) + 
  coord_sf() +
  scale_x_continuous(labels = letters[1:5]) +
  scale_y_continuous(
    breaks = c(34, 34.5, 35.7),
    labels = c("A", "B", "C")
  )
```

![](https://i.imgur.com/mU8fmPa.png)

``` r

# set to NULL to remove labels
ggplot() + 
  geom_sf(aes(fill = AREA), data=nc) + 
  coord_sf() +
  scale_x_continuous(labels = NULL) +
  scale_y_continuous(
    breaks = c(34, 34.5, 35.7),
    labels = NULL
  )
```

![](https://i.imgur.com/cXEjVQL.png)

``` r

# format via function
ggplot() + 
  geom_sf(aes(fill = AREA), data=nc) + 
  coord_sf() +
  scale_x_continuous(
    breaks = c(-84, -80, -76),
    labels = function(x) paste0(x, "*degree*East")
  ) +
  scale_y_continuous(
    breaks = c(34, 34.5, 35.7),
    labels = function(x) paste0(x, "*degree*North")
  )
```

![](https://i.imgur.com/krbIuqp.png)

``` r

# error if length mismatch
ggplot() + 
  geom_sf(aes(fill = AREA), data=nc) + 
  coord_sf() +
  scale_x_continuous(labels = letters[1:4])
#> Error: Breaks and labels along x direction are different lengths
```
Created on 2018-08-25 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).

