### PR TITLE
Validate mapping before data in layer(). Closes #2862

### DIFF
--- a/R/layer.r
+++ b/R/layer.r
@@ -81,11 +81,15 @@ layer <- function(geom = NULL, stat = NULL,
     show.legend <- FALSE
   }
 
-  data <- fortify(data)
-
+  # we validate mapping before data because in geoms and stats
+  # the mapping is listed before the data argument; this causes
+  # less confusing error messages when layers are accidentally
+  # piped into each other
   if (!is.null(mapping)) {
     mapping <- validate_mapping(mapping)
   }
+
+  data <- fortify(data)
 
   geom <- check_subclass(geom, "Geom", env = parent.frame())
   stat <- check_subclass(stat, "Stat", env = parent.frame())


### PR DESCRIPTION
Validate mapping before data in layer(). Closes #2862

``` r
library(ggplot2)
library(magrittr)

ggplot(mtcars, aes(mpg, cyl)) %>%
  geom_point()
#> Error: `mapping` must be created by `aes()`
#> Did you use %>% instead of +?

ggplot(mtcars) %>%
  geom_point(aes(mpg, cyl))
#> Error: `mapping` must be created by `aes()`
#> Did you use %>% instead of +?

ggplot(mtcars) +
  geom_point(aes(mpg, cyl), list())
#> Error: `data` must be a data frame, or other object coercible by `fortify()`, not a list
```

Created on 2018-08-29 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).