### PR TITLE
Improve document about handling of NA in geom_path()

### DIFF
--- a/R/geom-path.r
+++ b/R/geom-path.r
@@ -20,7 +20,7 @@
 #'  [geom_polygon()]: Filled paths (polygons);
 #'  [geom_segment()]: Line segments
 #' @section Missing value handling:
-#' `geom_path()`, `geom_line()`, and `geom_step` handle `NA` in this manner:
+#' `geom_path()`, `geom_line()`, and `geom_step` handle `NA` as follows:
 #'
 #' * If an `NA` occurs in the middle of a line, it breaks the line. No warning
 #'   is shown, regardless of whether `na.rm` is `TRUE` or `FALSE`.

--- a/R/geom-path.r
+++ b/R/geom-path.r
@@ -19,6 +19,15 @@
 #' @seealso
 #'  [geom_polygon()]: Filled paths (polygons);
 #'  [geom_segment()]: Line segments
+#' @section Missing value handling:
+#' `geom_path()`, `geom_line()` and `geom_step` handle `NA` in this manner:
+#'
+#' * If `NA` is at the middle of the line, it breaks the line. It doesn't
+#'   show any warnings no matter whether `na.rm` is `TRUE` or `FALSE`.
+#' * If `NA` is at the start or the end of the line and `na.rm` is `FALSE`
+#'   (default), it removes the `NA` with a warning.
+#' * If `NA` is at the start or the end of the line and `na.rm` is `TRUE`,
+#'   it silently removes the `NA`.
 #' @export
 #' @examples
 #' # geom_line() is suitable for time series
@@ -60,17 +69,6 @@
 #' # You can use NAs to break the line.
 #' df <- data.frame(x = 1:5, y = c(1, 2, NA, 4, 5))
 #' ggplot(df, aes(x, y)) + geom_point() + geom_line()
-#'
-#' # If NAs are at the start or end of the line, they are removed with a warning.
-#' df <- data.frame(
-#'   x = 1:5,
-#'   y1 = c(1, 2, 3, 4, NA),
-#'   y2 = c(NA, 2, 3, 4, 5)
-#' )
-#' ggplot(df, aes(x, y1)) + geom_point() + geom_line()
-#' ggplot(df, aes(x, y2)) + geom_point() + geom_line()
-#' # Use na.rm = TRUE to suppress the warning message.
-#' ggplot(df, aes(x, y1)) + geom_point() + geom_line(na.rm = TRUE)
 #'
 #' \donttest{
 #' # Setting line type vs colour/size

--- a/R/geom-path.r
+++ b/R/geom-path.r
@@ -57,16 +57,20 @@
 #' base + geom_path(size = 10, lineend = "round")
 #' base + geom_path(size = 10, linejoin = "mitre", lineend = "butt")
 #'
-#' # NAs break the line. Use na.rm = T to suppress the warning message
+#' # You can use NAs to break the line.
+#' df <- data.frame(x = 1:5, y = c(1, 2, NA, 4, 5))
+#' ggplot(df, aes(x, y)) + geom_point() + geom_line()
+#'
+#' # If NAs are at the start or end of the line, they are removed with a warning.
 #' df <- data.frame(
 #'   x = 1:5,
 #'   y1 = c(1, 2, 3, 4, NA),
-#'   y2 = c(NA, 2, 3, 4, 5),
-#'   y3 = c(1, 2, NA, 4, 5)
+#'   y2 = c(NA, 2, 3, 4, 5)
 #' )
 #' ggplot(df, aes(x, y1)) + geom_point() + geom_line()
 #' ggplot(df, aes(x, y2)) + geom_point() + geom_line()
-#' ggplot(df, aes(x, y3)) + geom_point() + geom_line()
+#' # Use na.rm = TRUE to suppress the warning message.
+#' ggplot(df, aes(x, y1)) + geom_point() + geom_line(na.rm = TRUE)
 #'
 #' \donttest{
 #' # Setting line type vs colour/size

--- a/R/geom-path.r
+++ b/R/geom-path.r
@@ -20,14 +20,14 @@
 #'  [geom_polygon()]: Filled paths (polygons);
 #'  [geom_segment()]: Line segments
 #' @section Missing value handling:
-#' `geom_path()`, `geom_line()` and `geom_step` handle `NA` in this manner:
+#' `geom_path()`, `geom_line()`, and `geom_step` handle `NA` in this manner:
 #'
-#' * If `NA` is at the middle of the line, it breaks the line. It doesn't
-#'   show any warnings no matter whether `na.rm` is `TRUE` or `FALSE`.
-#' * If `NA` is at the start or the end of the line and `na.rm` is `FALSE`
-#'   (default), it removes the `NA` with a warning.
-#' * If `NA` is at the start or the end of the line and `na.rm` is `TRUE`,
-#'   it silently removes the `NA`.
+#' * If an `NA` occurs in the middle of a line, it breaks the line. No warning
+#'   is shown, regardless of whether `na.rm` is `TRUE` or `FALSE`.
+#' * If an `NA` occurs at the start or the end of the line and `na.rm` is `FALSE`
+#'   (default), the `NA` is removed with a warning.
+#' * If an `NA` occurs at the start or the end of the line and `na.rm` is `TRUE`,
+#'   the `NA` is removed silently, without warning.
 #' @export
 #' @examples
 #' # geom_line() is suitable for time series

--- a/man/geom_path.Rd
+++ b/man/geom_path.Rd
@@ -101,6 +101,19 @@ corresponds to a single case which provides the start and end coordinates.
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 }
 
+\section{Missing value handling}{
+
+\code{geom_path()}, \code{geom_line()} and \code{geom_step} handle \code{NA} in this manner:
+\itemize{
+\item If \code{NA} is at the middle of the line, it breaks the line. It doesn't
+show any warnings no matter whether \code{na.rm} is \code{TRUE} or \code{FALSE}.
+\item If \code{NA} is at the start or the end of the line and \code{na.rm} is \code{FALSE}
+(default), it removes the \code{NA} with a warning.
+\item If \code{NA} is at the start or the end of the line and \code{na.rm} is \code{TRUE},
+it silently removes the \code{NA}.
+}
+}
+
 \examples{
 # geom_line() is suitable for time series
 ggplot(economics, aes(date, unemploy)) + geom_line()
@@ -141,17 +154,6 @@ base + geom_path(size = 10, linejoin = "mitre", lineend = "butt")
 # You can use NAs to break the line.
 df <- data.frame(x = 1:5, y = c(1, 2, NA, 4, 5))
 ggplot(df, aes(x, y)) + geom_point() + geom_line()
-
-# If NAs are at the start or end of the line, they are removed with a warning.
-df <- data.frame(
-  x = 1:5,
-  y1 = c(1, 2, 3, 4, NA),
-  y2 = c(NA, 2, 3, 4, 5)
-)
-ggplot(df, aes(x, y1)) + geom_point() + geom_line()
-ggplot(df, aes(x, y2)) + geom_point() + geom_line()
-# Use na.rm = TRUE to suppress the warning message.
-ggplot(df, aes(x, y1)) + geom_point() + geom_line(na.rm = TRUE)
 
 \donttest{
 # Setting line type vs colour/size

--- a/man/geom_path.Rd
+++ b/man/geom_path.Rd
@@ -103,14 +103,14 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Missing value handling}{
 
-\code{geom_path()}, \code{geom_line()} and \code{geom_step} handle \code{NA} in this manner:
+\code{geom_path()}, \code{geom_line()}, and \code{geom_step} handle \code{NA} in this manner:
 \itemize{
-\item If \code{NA} is at the middle of the line, it breaks the line. It doesn't
-show any warnings no matter whether \code{na.rm} is \code{TRUE} or \code{FALSE}.
-\item If \code{NA} is at the start or the end of the line and \code{na.rm} is \code{FALSE}
-(default), it removes the \code{NA} with a warning.
-\item If \code{NA} is at the start or the end of the line and \code{na.rm} is \code{TRUE},
-it silently removes the \code{NA}.
+\item If an \code{NA} occurs in the middle of a line, it breaks the line. No warning
+is shown, regardless of whether \code{na.rm} is \code{TRUE} or \code{FALSE}.
+\item If an \code{NA} occurs at the start or the end of the line and \code{na.rm} is \code{FALSE}
+(default), the \code{NA} is removed with a warning.
+\item If an \code{NA} occurs at the start or the end of the line and \code{na.rm} is \code{TRUE},
+the \code{NA} is removed silently, without warning.
 }
 }
 

--- a/man/geom_path.Rd
+++ b/man/geom_path.Rd
@@ -103,7 +103,7 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Missing value handling}{
 
-\code{geom_path()}, \code{geom_line()}, and \code{geom_step} handle \code{NA} in this manner:
+\code{geom_path()}, \code{geom_line()}, and \code{geom_step} handle \code{NA} as follows:
 \itemize{
 \item If an \code{NA} occurs in the middle of a line, it breaks the line. No warning
 is shown, regardless of whether \code{na.rm} is \code{TRUE} or \code{FALSE}.

--- a/man/geom_path.Rd
+++ b/man/geom_path.Rd
@@ -138,16 +138,20 @@ base + geom_path(size = 10)
 base + geom_path(size = 10, lineend = "round")
 base + geom_path(size = 10, linejoin = "mitre", lineend = "butt")
 
-# NAs break the line. Use na.rm = T to suppress the warning message
+# You can use NAs to break the line.
+df <- data.frame(x = 1:5, y = c(1, 2, NA, 4, 5))
+ggplot(df, aes(x, y)) + geom_point() + geom_line()
+
+# If NAs are at the start or end of the line, they are removed with a warning.
 df <- data.frame(
   x = 1:5,
   y1 = c(1, 2, 3, 4, NA),
-  y2 = c(NA, 2, 3, 4, 5),
-  y3 = c(1, 2, NA, 4, 5)
+  y2 = c(NA, 2, 3, 4, 5)
 )
 ggplot(df, aes(x, y1)) + geom_point() + geom_line()
 ggplot(df, aes(x, y2)) + geom_point() + geom_line()
-ggplot(df, aes(x, y3)) + geom_point() + geom_line()
+# Use na.rm = TRUE to suppress the warning message.
+ggplot(df, aes(x, y1)) + geom_point() + geom_line(na.rm = TRUE)
 
 \donttest{
 # Setting line type vs colour/size


### PR DESCRIPTION
Minor document fix. This closes #2877.

`geom_path()` (and its family functions) handles `NA` in this manner:

* If `NA` is at the middle of the line, it breaks the line and doesn't show any warnings (so, `na.rm` doesn't matter here)
* If `NA` is at the start or the end of the line and `na.rm` is `FALSE` (default), it removes the `NA` with a warning.
* If `NA` is at the start or the end of the line and `na.rm` is `TRUE`, it silently removes the `NA`.

This PR is intended to improve the document of `geom_path()` to illustrate this behaviour well.