### PR TITLE
enable legend drawing for list data columns

### DIFF
--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -202,10 +202,12 @@ guide_train.legend <- function(guide, scale, aesthetic = NULL) {
     return()
   }
 
-  key <- as.data.frame(
-    setNames(list(scale$map(breaks)), aesthetic %||% scale$aesthetics[1]),
-    stringsAsFactors = FALSE
-  )
+  # in the key data frame, use either the aesthetic provided as
+  # argument to this function or, as a fall back, the first in the vector
+  # of possible aesthetics handled by the scale
+  aes_column_name <- aesthetic %||% scale$aesthetics[1]
+  # need to make a tibble here in case the scale returns a list column
+  key <- tibble(!!aes_column_name := scale$map(breaks))
   key$.label <- scale$get_labels(breaks)
 
   # Drop out-of-range values for continuous scale


### PR DESCRIPTION
For after the 3.1.0 release: This small change enables legend drawing for scales that take lists of complex objects.

Example:

``` r
library(ggplot2)
library(ggtextures)
library(magick)
#> Linking to ImageMagick 6.9.9.39
#> Enabled features: cairo, fontconfig, freetype, lcms, pango, rsvg, webp
#> Disabled features: fftw, ghostscript, x11

images <- list(
  giraffe = image_read_svg("http://steveharoz.com/research/isotype/icons/giraffe.svg"),
  elephant = image_read_svg("http://steveharoz.com/research/isotype/icons/elephant.svg"),
  horse = image_read_svg("http://steveharoz.com/research/isotype/icons/horse.svg")
)

data <- data.frame(
  count = c(5, 3, 6),
  animal = c("giraffe", "elephant", "horse")
)

ggplot(data, aes(animal, count, image = animal)) +
  geom_isotype_col() +
  scale_image_manual(values = images) +
  theme_minimal()
```

![](https://i.imgur.com/irIblyq.png)

<sup>Created on 2018-09-30 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>