### PR TITLE
Added documentation for the stat/geom_contour.

### DIFF
--- a/R/geom-contour.r
+++ b/R/geom-contour.r
@@ -12,6 +12,12 @@
 #' @inheritParams layer
 #' @inheritParams geom_point
 #' @inheritParams geom_path
+#' @param bins Setting this creates that number of evenly space contours in
+#'  the range of the data.
+#' @param binwidth Setting this creates bins in the range of the data spaced
+#'  by binwidth.
+#' @param breaks Setting this will manually create contours in at the
+#'  specified values.
 #' @seealso [geom_density_2d()]: 2d density contours
 #' @export
 #' @export
@@ -43,6 +49,9 @@
 geom_contour <- function(mapping = NULL, data = NULL,
                          stat = "contour", position = "identity",
                          ...,
+                         bins = NULL,
+                         binwidth = NULL,
+                         breaks = NULL,
                          lineend = "butt",
                          linejoin = "round",
                          linemitre = 10,
@@ -58,6 +67,9 @@ geom_contour <- function(mapping = NULL, data = NULL,
     show.legend = show.legend,
     inherit.aes = inherit.aes,
     params = list(
+      bins = NULL,
+      binwidth = NULL,
+      breaks = NULL,
       lineend = lineend,
       linejoin = linejoin,
       linemitre = linemitre,

--- a/R/stat-contour.r
+++ b/R/stat-contour.r
@@ -10,6 +10,9 @@
 stat_contour <- function(mapping = NULL, data = NULL,
                          geom = "contour", position = "identity",
                          ...,
+                         bins = NULL,
+                         binwidth = NULL,
+                         breaks = NULL,
                          na.rm = FALSE,
                          show.legend = NA,
                          inherit.aes = TRUE) {
@@ -22,6 +25,9 @@ stat_contour <- function(mapping = NULL, data = NULL,
     show.legend = show.legend,
     inherit.aes = inherit.aes,
     params = list(
+      bins = bins,
+      binwidth = binwidth,
+      breaks = breaks,
       na.rm = na.rm,
       ...
     )
@@ -37,7 +43,7 @@ StatContour <- ggproto("StatContour", Stat,
   default_aes = aes(order = stat(level)),
 
   compute_group = function(data, scales, bins = NULL, binwidth = NULL,
-                           breaks = NULL, complete = FALSE, na.rm = FALSE) {
+                           breaks = NULL, na.rm = FALSE) {
     # If no parameters set, use pretty bins
     if (is.null(bins) && is.null(binwidth) && is.null(breaks)) {
       breaks <- pretty(range(data$z), 10)
@@ -51,7 +57,7 @@ StatContour <- ggproto("StatContour", Stat,
       breaks <- fullseq(range(data$z), binwidth)
     }
 
-    contour_lines(data, breaks, complete = complete)
+    contour_lines(data, breaks)
   }
 
 )
@@ -65,7 +71,7 @@ StatContour <- ggproto("StatContour", Stat,
 # ggplot(contours, aes(x, y)) +
 #   geom_path() +
 #   facet_wrap(~piece)
-contour_lines <- function(data, breaks, complete = FALSE) {
+contour_lines <- function(data, breaks) {
   z <- tapply(data$z, data[c("x", "y")], identity)
 
   if (is.list(z)) {


### PR DESCRIPTION
Referencing #2472, I added the parameters bins, binwidth, and breaks to the stat_contour and geom_contour parameter lists. For some reason they were undocumented (except in the examples), but still available for use.

There was also an unused parameter "complete." I couldn't find any reference to it in either function, so I removed it as well. If there's a reason that it shouldn't be removed, like a future feature, I can revert it.