### PR TITLE
Make clipping configurable in coord_sf().

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,9 @@ This is a minor release and breaking changes have been kept to a minimum. End us
     safer to feed data columns into `aes()` or into parameters of geoms or
     stats. However, doing so remains discouraged (@clauswilke, #2694).
 
+*   `coord_sf()` now also understands the `clip` argument, just like the other
+    coords (@clauswilke, #2938).
+
 *   `fortify()` now displays a more informative error message for
     `grouped_df()` objects when dplyr is not installed (@jimhester, #2822).
 

--- a/R/sf.R
+++ b/R/sf.R
@@ -789,7 +789,7 @@ coord_sf <- function(xlim = NULL, ylim = NULL, expand = TRUE,
                      crs = NULL, datum = sf::st_crs(4326),
                      label_graticule = waiver(),
                      label_axes = waiver(),
-                     ndiscr = 100, default = FALSE) {
+                     ndiscr = 100, default = FALSE, clip = "on") {
 
   if (is.waive(label_graticule) && is.waive(label_axes)) {
     # if both `label_graticule` and `label_axes` are set to waive then we
@@ -830,7 +830,8 @@ coord_sf <- function(xlim = NULL, ylim = NULL, expand = TRUE,
     label_graticule = label_graticule,
     ndiscr = ndiscr,
     expand = expand,
-    default = default
+    default = default,
+    clip = clip
   )
 }
 

--- a/man/ggsf.Rd
+++ b/man/ggsf.Rd
@@ -34,7 +34,8 @@ geom_sf_text(mapping = aes(), data = NULL, stat = "sf_coordinates",
 
 coord_sf(xlim = NULL, ylim = NULL, expand = TRUE, crs = NULL,
   datum = sf::st_crs(4326), label_graticule = waiver(),
-  label_axes = waiver(), ndiscr = 100, default = FALSE)
+  label_axes = waiver(), ndiscr = 100, default = FALSE,
+  clip = "on")
 }
 \arguments{
 \item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
@@ -151,6 +152,15 @@ try increasing this when graticules look unexpected}
 then replacing this coordinate system with another one creates a message alerting
 the user that the coordinate system is being replaced. If \code{TRUE}, that warning
 is suppressed.}
+
+\item{clip}{Should drawing be clipped to the extent of the plot panel? A
+setting of \code{"on"} (the default) means yes, and a setting of \code{"off"}
+means no. In most cases, the default of \code{"on"} should not be changed,
+as setting \code{clip = "off"} can cause unexpected results. It allows
+drawing of data points anywhere on the plot, including in the plot margins. If
+limits are set via \code{xlim} and \code{ylim} and some data points fall outside those
+limits, then those data points may show up in places such as the axes, the
+legend, the plot title, or the plot margins.}
 }
 \description{
 This set of geom, stat, and coord are used to visualise simple feature (sf)


### PR DESCRIPTION
This PR closes #2938.

Example:

``` r
library(ggplot2)

nc <- sf::st_read(system.file("shape/nc.shp", package = "sf"), quiet = TRUE)
p <- ggplot(nc) +
  geom_sf(aes(fill = AREA)) +
  geom_text(x = -80, y = 37, label = "label outside limits", inherit.aes = FALSE)

p
```

![](https://i.imgur.com/vMvICQU.png)

``` r

p + coord_sf(clip = "off")
```

![](https://i.imgur.com/RxwAu2d.png)

<sup>Created on 2018-10-15 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>