### PR TITLE
fixed `@seealso` link in `ggplot_gtable`

### DIFF
--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -137,7 +137,7 @@ layer_grob <- function(plot, i = 1L) {
 #' to (e.g.) make the legend box 2 cm wide, or combine multiple plots into
 #' a single display, preserving aspect ratios across the plots.
 #'
-#' @seealso [print.ggplot()] and \code{link{benchplot}} for
+#' @seealso [print.ggplot()] and [benchplot()] for
 #'  for functions that contain the complete set of steps for generating
 #'  a ggplot2 plot.
 #' @return a [gtable()] object


### PR DESCRIPTION
small typo in the documentation for `ggplot_gtable`:  had a straggling `link{}`