### PR TITLE
Fix Travis failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,14 @@ matrix:
   - r: devel
   - r: release
     env: USE_VDIFFR=true
+    r_github_packages: lionel-/vdiffr
   - r: oldrel
   - r: 3.2
+    # TODO: devtools 2.0 raises warnings if some packages are not available
+    r_github_packages: "r-lib/devtools@v1.13.5"
   - r: 3.1
-
-# work around temporary travis + R 3.5 bug
-r_packages: devtools
-
-# Install manually because dev vdiffr is not compatible with Appveyor yet
-r_github_packages: lionel-/vdiffr
+    # TODO: devtools 2.0 raises warnings if some packages are not available
+    r_github_packages: "r-lib/devtools@v1.13.5"
 
 # environment variables set for all builds
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,9 @@ matrix:
     r_github_packages: lionel-/vdiffr
   - r: oldrel
   - r: 3.2
-    # TODO: devtools 2.0 raises warnings if some packages are not available
-    r_github_packages: "r-lib/devtools@v1.13.5"
+    env: R_REMOTES_NO_ERRORS_FROM_WARNINGS=true
   - r: 3.1
-    # TODO: devtools 2.0 raises warnings if some packages are not available
-    r_github_packages: "r-lib/devtools@v1.13.5"
+    env: R_REMOTES_NO_ERRORS_FROM_WARNINGS=true
 
 # environment variables set for all builds
 env:


### PR DESCRIPTION
Fixes #2956 

This PR provides two workarounds:

1. Install dev version of `vdiffr` only when `USE_VDIFFR=true` since vdiffr now requires R >= 3.2.0, which means builds with R 3.1 fails.
2. Use `R_REMOTES_NO_ERRORS_FROM_WARNINGS=true` to avoid errors converted from warnings raised by `devtools::install_deps()`, which didn't seem to exist before devtools 2.0.