### PR TITLE
Fix geom_rug + coord_flip

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 3.1.0.9000
 
+*   `geom_rug()` now works with `coord_flip()` (@has2k1, #2987).
+
+
 # ggplot2 3.1.0
 
 ## Breaking changes

--- a/R/geom-rug.r
+++ b/R/geom-rug.r
@@ -66,6 +66,10 @@ GeomRug <- ggproto("GeomRug", Geom,
     rugs <- list()
     data <- coord$transform(data, panel_params)
 
+    if (inherits(coord, 'CoordFlip')) {
+      sides <- chartr('tblr', 'rlbt', sides)
+    }
+
     gp <- gpar(col = alpha(data$colour, data$alpha), lty = data$linetype, lwd = data$size * .pt)
     if (!is.null(data$x)) {
       if (grepl("b", sides)) {

--- a/R/geom-rug.r
+++ b/R/geom-rug.r
@@ -66,6 +66,8 @@ GeomRug <- ggproto("GeomRug", Geom,
     rugs <- list()
     data <- coord$transform(data, panel_params)
 
+    # For coord_flip, coord$tranform does not flip the sides where to
+    # draw the rugs. We have to flip them.
     if (inherits(coord, 'CoordFlip')) {
       sides <- chartr('tblr', 'rlbt', sides)
     }

--- a/tests/testthat/test-geom-rug.R
+++ b/tests/testthat/test-geom-rug.R
@@ -1,0 +1,22 @@
+context("geom_rug")
+
+n = 10
+df <- data.frame(x = 1:n, y = (1:n)^3)
+p <- ggplot(df, aes(x, y)) + geom_point() + geom_rug(sides = 'l')
+
+test_that("coord_flip flips the rugs", {
+  a <- layer_grob(p, 2)
+  b <- layer_grob(p + coord_flip(), 2)
+
+  # Rugs along y-axis, all x coordinates are the same
+  expect_equal(length(a[[1]]$children[[1]]$x0), 1)
+  expect_equal(length(a[[1]]$children[[1]]$x1), 1)
+  expect_equal(length(a[[1]]$children[[1]]$y0), n)
+  expect_equal(length(a[[1]]$children[[1]]$y1), n)
+
+  # Rugs along x-axis, all y coordinates are the same
+  expect_equal(length(b[[1]]$children[[1]]$x0), n)
+  expect_equal(length(b[[1]]$children[[1]]$x1), n)
+  expect_equal(length(b[[1]]$children[[1]]$y0), 1)
+  expect_equal(length(b[[1]]$children[[1]]$y1), 1)
+})


### PR DESCRIPTION
The rugs in `geom_rug` are drawn along an axis depending the
`sides` parameter. Since the coordinate system does not alter
the `geom` parameters, the `geom` has to alter any parameters
that determine where the geoms are plotted.

fixes #2987 

----

``` r
library(ggplot2)

df <- data.frame(x = 1:10, y = (1:10)^3)
g <- ggplot(df, aes(x, y)) + geom_point() + geom_rug(sides = 'l')

# Normal plot
g
```

![](https://i.imgur.com/332csm1.png)

``` r

# The rugs are flipped
g + coord_flip()
```

![](https://i.imgur.com/UP8i1S6.png)

<sup>Created on 2018-11-09 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>