### PR TITLE
Allow using functions that return NULL in aes()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
   get backticks, and long expressions are abbreviated with `...`
   (@yutannihilation, #2981).
 
+* Aesthetic mappings now accept functions that return `NULL` (@yutannihilation,
+  #2997)
+
 # ggplot2 3.1.0
 
 ## Breaking changes

--- a/R/layer.r
+++ b/R/layer.r
@@ -218,8 +218,8 @@ Layer <- ggproto("Layer", NULL,
     scales_add_defaults(plot$scales, data, aesthetics, plot$plot_env)
 
     # Evaluate and check aesthetics
-    aesthetics <- compact(aesthetics)
     evaled <- lapply(aesthetics, rlang::eval_tidy, data = data)
+    evaled <- compact(evaled)
 
     n <- nrow(data)
     if (n == 0) {

--- a/tests/testthat/test-layer.r
+++ b/tests/testthat/test-layer.r
@@ -40,8 +40,8 @@ test_that("missing aesthetics trigger informative error", {
 
 test_that("if an aes is mapped to a function that returns NULL, it is removed", {
   df <- data.frame(x = 1:10)
-  wrap <- function(...) tryCatch(..., error = function(e) NULL)
-  p <- cdata(ggplot(df, aes(x, wrap(no_such_column))))
+  null <- function(...) NULL
+  p <- cdata(ggplot(df, aes(x, null())))
   expect_identical(names(p[[1]]), c("x", "PANEL", "group"))
 })
 

--- a/tests/testthat/test-layer.r
+++ b/tests/testthat/test-layer.r
@@ -38,6 +38,13 @@ test_that("missing aesthetics trigger informative error", {
   )
 })
 
+test_that("if an aes is mapped to a function that returns NULL, it is removed", {
+  df <- data.frame(x = 1:10)
+  wrap <- function(...) tryCatch(..., error = function(e) NULL)
+  p <- cdata(ggplot(df, aes(x, wrap(no_such_column))))
+  expect_identical(names(p[[1]]), c("x", "PANEL", "group"))
+})
+
 # Data extraction ---------------------------------------------------------
 
 test_that("layer_data returns a data.frame", {


### PR DESCRIPTION
It's common practice to wrap unsafe calculations with `tryCatch()` and return `NULL`, which allows us to use the result when available and skip when unavailable. But, currently, ggplot2 doesn't accept this in `aes()`:

``` r
library(ggplot2)

df <- data.frame(x = 1:10, y = 1:10)
wrap <- function(...) tryCatch(..., error = function(e) NULL)

ggplot(df, aes(x, y, colour = wrap(no_such_column))) +
  geom_point()
#> Error: Aesthetics must be either length 1 or the same as the data (10): colour
```

This is because `Layer$compute_aesthetics()` removes `NULL` aes here BEFORE evaluation:

https://github.com/tidyverse/ggplot2/blob/f5a88a71e7b60b6531ef6c4a936370b5e3c4ef92/R/layer.r#L221-L223

Considering the following facts, I think it's safe to move `compact()` after evaluation

- `ggplot2::compact()` removes only `NULL`
- `NULL` will be still `NULL` after evaluation