### PR TITLE
Treat input as list

### DIFF
--- a/R/position-.r
+++ b/R/position-.r
@@ -75,6 +75,8 @@ Position <- ggproto("Position",
 #' @keywords internal
 #' @export
 transform_position <- function(df, trans_x = NULL, trans_y = NULL, ...) {
+  oldclass <- class(df)
+  df <- unclass(df)
   scales <- aes_to_scale(names(df))
 
   if (!is.null(trans_x)) {
@@ -83,6 +85,8 @@ transform_position <- function(df, trans_x = NULL, trans_y = NULL, ...) {
   if (!is.null(trans_y)) {
     df[scales == "y"] <- lapply(df[scales == "y"], trans_y, ...)
   }
+
+  class(df) <- oldclass
 
   df
 }


### PR DESCRIPTION
This PR treats the data frame in `transform_position` as a list for the duration of the call, speeding up `ggplot_build` up by some 30% for a simple faceted boxplot of mtcars