### PR TITLE
Add protocol to pkgdown website url

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: ggplot2.tidyverse.org
+url: https://ggplot2.tidyverse.org
 
 template:
   package: tidytemplate


### PR DESCRIPTION
The current sitemap of ggplot docs website (https://ggplot2.tidyverse.org/sitemap.xml) is not valid because URLs must begin with a protocol, as stated in the description of the standard (https://www.sitemaps.org/protocol.html).