### PR TITLE
Remove duplicated grDevices in Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,8 +33,7 @@ Imports:
     stats,
     tibble,
     viridisLite,
-    withr (>= 2.0.0),
-    grDevices
+    withr (>= 2.0.0)
 Suggests:
     covr,
     dplyr,


### PR DESCRIPTION
To fix this NOTE:

```
* checking DESCRIPTION meta-information ... NOTE
Package listed in more than one of Depends, Imports, Suggests, Enhances:
  ‘grDevices’
A package should be listed in only one of these fields.
```
https://travis-ci.org/tidyverse/ggplot2/jobs/455860461#L2326