### PR TITLE
Sort ribbon/area in setup_data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,9 @@
 
 * ggplot2 now works in Turkish locale (@yutannihilation, #3011).
 
+* `GeomRibbon` and `GeomArea` now sort the data along the x-axis in the 
+  `setup_data()` method rather than as part of `draw_group()` (@thomasp85, #3023)
+
 # ggplot2 3.1.0
 
 ## Breaking changes

--- a/R/geom-ribbon.r
+++ b/R/geom-ribbon.r
@@ -62,6 +62,10 @@ GeomRibbon <- ggproto("GeomRibbon", Geom,
 
   required_aes = c("x", "ymin", "ymax"),
 
+  setup_data = function(data, params) {
+    transform(data[order(data$PANEL, data$group, data$x), ], y = ymin)
+  },
+
   draw_key = draw_key_polygon,
 
   handle_na = function(data, params) {
@@ -70,7 +74,7 @@ GeomRibbon <- ggproto("GeomRibbon", Geom,
 
   draw_group = function(data, panel_params, coord, na.rm = FALSE) {
     if (na.rm) data <- data[stats::complete.cases(data[c("x", "ymin", "ymax")]), ]
-    data <- data[order(data$group, data$x), ]
+    data <- data[order(data$group), ]
 
     # Check that aesthetics are constant
     aes <- unique(data[c("colour", "fill", "size", "linetype", "alpha")])
@@ -137,6 +141,6 @@ GeomArea <- ggproto("GeomArea", GeomRibbon,
   required_aes = c("x", "y"),
 
   setup_data = function(data, params) {
-    transform(data, ymin = 0, ymax = y)
+    transform(data[order(data$PANEL, data$group, data$x), ], ymin = 0, ymax = y)
   }
 )


### PR DESCRIPTION
This PR streamlines the handling of data in line-like gloms where an implicit sorting of data along the x-axis is happening. Previously GeomLine had the sorting happening in `setup_data` while GeomRibbon (and by extension GeomArea) had it inside `draw_group`.

The motivation is that it solves some issues in gganimate that couldn't be fixed outside of ggplot2, but I also think that conceptually this is the right approach, and we should be consistent in how we treat data operations across kindred geoms/stats