### PR TITLE
Add 3.1.0 post link to pkgdown News

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -227,6 +227,8 @@ navbar:
   - text: News
     menu:
     - text: "Release notes"
+    - text: "Version 3.1.0"
+      href: https://www.tidyverse.org/articles/2018/10/ggplot2-3-1-0/
     - text: "Version 3.0.0"
       href: https://www.tidyverse.org/articles/2018/07/ggplot2-3-0-0/
     - text: "Version 2.2.0"


### PR DESCRIPTION
Per https://github.com/tidyverse/ggplot2/issues/2890#issuecomment-445902471, adding link to the post for ggplot2 3.1.0 to News section of the pkgdown site.

@hadley, I didn't run `build_site()`, since I'm not yet clear on how the automated pkgdown build is handling this. 😬 