### PR TITLE
Remove smart quotes

### DIFF
--- a/R/utilities.r
+++ b/R/utilities.r
@@ -227,7 +227,7 @@ expand_range4 <- function(limits, expand) {
 #'   scale_x_discrete(expand = expand_scale(add = 2))
 #'
 #' # Reproduce the default range expansion used
-#' # when the ‘expand’ argument is not specified
+#' # when the 'expand' argument is not specified
 #' ggplot(subset(diamonds, carat > 2), aes(cut, price)) +
 #'   geom_jitter() +
 #'   scale_x_discrete(expand = expand_scale(add = .6)) +

--- a/man/expand_scale.Rd
+++ b/man/expand_scale.Rd
@@ -38,7 +38,7 @@ ggplot(subset(diamonds, carat > 2), aes(cut, clarity)) +
   scale_x_discrete(expand = expand_scale(add = 2))
 
 # Reproduce the default range expansion used
-# when the ‘expand’ argument is not specified
+# when the 'expand' argument is not specified
 ggplot(subset(diamonds, carat > 2), aes(cut, price)) +
   geom_jitter() +
   scale_x_discrete(expand = expand_scale(add = .6)) +


### PR DESCRIPTION
For so so long, I've been wondering why `devtools::document()` fails on my Windows if I don't change my locale to `C`:

```
==> devtools::document(roclets = c('rd', 'collate', 'namespace'))

Updating ggplot2 documentation
Writing NAMESPACE
Loading ggplot2
Writing aes_group_order.Rd
Error in gsub("\n", "\r\n", contents, fixed = TRUE) : 
  input string 1 is invalid in this locale
Calls: suppressPackageStartupMessages ... roclet_output.roclet_rd -> mapply -> <Anonymous> -> same_contents -> gsub
Execution halted

Exited with status 1.
```

But, at last, I found the cause! Let's say goodbye to LEFT SINGLE QUOTATION MARK (U+2018) and RIGHT SINGLE QUOTATION MARK (U+2019).