### PR TITLE
add i and j args documention to layer_* functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # ggplot2 3.1.0.9000
 
-* `layer_data()`, `layer_grob()`, and `layer_scales()` now have documentation for `i` and `j` arguments (@malcolmbarrett, #3074).
+* `layer_data()`, `layer_grob()`, and `layer_scales()` now have documentation for `i` and `j` arguments (@malcolmbarrett, #2818).
 
 * `geom_rug()` now works with `coord_flip()` (@has2k1, #2987).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 3.1.0.9000
 
+* `layer_data()`, `layer_grob()`, and `layer_scales()` now have documentation for `i` and `j` arguments (@malcolmbarrett, #3074).
+
 * `geom_rug()` now works with `coord_flip()` (@has2k1, #2987).
 
 * Layers now have a new member function `setup_layer()` which is called at the

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,5 @@
 # ggplot2 3.1.0.9000
 
-* `layer_data()`, `layer_grob()`, and `layer_scales()` now have documentation for `i` and `j` arguments (@malcolmbarrett, #2818).
-
 * `geom_rug()` now works with `coord_flip()` (@has2k1, #2987).
 
 * Layers now have a new member function `setup_layer()` which is called at the

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -10,6 +10,11 @@
 #' layer. These are useful for tests.
 #'
 #' @param plot ggplot object
+#' @param i An integer. In `layer_data`, the data to return (in the order added to the
+#'   plot). In `layer_grob`, the grob to return (in the order added to the
+#'   plot). In `layer_scales`, the row of a facet to return scales for.
+#' @param j An integer. In `layer_scales`, the column of a facet to return
+#'   scales for.
 #' @seealso [print.ggplot()] and [benchplot()] for
 #'  functions that contain the complete set of steps for generating
 #'  a ggplot2 plot.

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -10,10 +10,10 @@
 #' layer. These are useful for tests.
 #'
 #' @param plot ggplot object
-#' @param i An integer. In `layer_data`, the data to return (in the order added to the
-#'   plot). In `layer_grob`, the grob to return (in the order added to the
-#'   plot). In `layer_scales`, the row of a facet to return scales for.
-#' @param j An integer. In `layer_scales`, the column of a facet to return
+#' @param i An integer. In `layer_data()`, the data to return (in the order added to the
+#'   plot). In `layer_grob()`, the grob to return (in the order added to the
+#'   plot). In `layer_scales()`, the row of a facet to return scales for.
+#' @param j An integer. In `layer_scales()`, the column of a facet to return
 #'   scales for.
 #' @seealso [print.ggplot()] and [benchplot()] for
 #'  functions that contain the complete set of steps for generating

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -1,11 +1,11 @@
 #' Build ggplot for rendering.
 #'
-#' `ggplot_build` takes the plot object, and performs all steps necessary
+#' `ggplot_build()` takes the plot object, and performs all steps necessary
 #' to produce an object that can be rendered.  This function outputs two pieces:
 #' a list of data frames (one for each layer), and a panel object, which
 #' contain all information about axis limits, breaks etc.
 #'
-#' `layer_data`, `layer_grob`, and `layer_scales` are helper
+#' `layer_data()`, `layer_grob()`, and `layer_scales()` are helper
 #' functions that returns the data, grob, or scales associated with a given
 #' layer. These are useful for tests.
 #'

--- a/man/ggplot_build.Rd
+++ b/man/ggplot_build.Rd
@@ -17,6 +17,13 @@ layer_grob(plot, i = 1L)
 }
 \arguments{
 \item{plot}{ggplot object}
+
+\item{i}{An integer. In \code{layer_data}, the data to return (in the order added to the
+plot). In \code{layer_grob}, the grob to return (in the order added to the
+plot). In \code{layer_scales}, the row of a facet to return scales for.}
+
+\item{j}{An integer. In \code{layer_scales}, the column of a facet to return
+scales for.}
 }
 \description{
 \code{ggplot_build} takes the plot object, and performs all steps necessary

--- a/man/ggplot_build.Rd
+++ b/man/ggplot_build.Rd
@@ -18,21 +18,21 @@ layer_grob(plot, i = 1L)
 \arguments{
 \item{plot}{ggplot object}
 
-\item{i}{An integer. In \code{layer_data}, the data to return (in the order added to the
-plot). In \code{layer_grob}, the grob to return (in the order added to the
-plot). In \code{layer_scales}, the row of a facet to return scales for.}
+\item{i}{An integer. In \code{layer_data()}, the data to return (in the order added to the
+plot). In \code{layer_grob()}, the grob to return (in the order added to the
+plot). In \code{layer_scales()}, the row of a facet to return scales for.}
 
-\item{j}{An integer. In \code{layer_scales}, the column of a facet to return
+\item{j}{An integer. In \code{layer_scales()}, the column of a facet to return
 scales for.}
 }
 \description{
-\code{ggplot_build} takes the plot object, and performs all steps necessary
+\code{ggplot_build()} takes the plot object, and performs all steps necessary
 to produce an object that can be rendered.  This function outputs two pieces:
 a list of data frames (one for each layer), and a panel object, which
 contain all information about axis limits, breaks etc.
 }
 \details{
-\code{layer_data}, \code{layer_grob}, and \code{layer_scales} are helper
+\code{layer_data()}, \code{layer_grob()}, and \code{layer_scales()} are helper
 functions that returns the data, grob, or scales associated with a given
 layer. These are useful for tests.
 }


### PR DESCRIPTION
Closes #2818.

This PR adds documentation for the `i` and `j` arguments in `layer_scales`, `layer_data`, and `layer_grob`.