### PR TITLE
fix typo in scale_shape_identity

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # ggplot2 3.1.0.9000
   
-* `scale_fill_identity()` now works correctly with `guide = "legend"` (@malcolmbarrett, #3075)
+* `scale_fill_identity()` now works correctly with `guide = "legend"` (@malcolmbarrett, #3029)
 
 * `geom_rug()` now works with `coord_flip()` (@has2k1, #2987).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@
 
 * `coord_sf()`, `coord_map()`, and `coord_polar()` now squash `-Inf` and `Inf`
   into the min and max of the plot (@yutannihilation, #2972).
+  
+* `scale_fill_identity()` now works correctly with `guide = "legend"` (@malcolmbarrett, #3075)
 
 # ggplot2 3.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 # ggplot2 3.1.0.9000
+  
+* `scale_fill_identity()` now works correctly with `guide = "legend"` (@malcolmbarrett, #3075)
 
 * `geom_rug()` now works with `coord_flip()` (@has2k1, #2987).
 
@@ -26,8 +28,6 @@
 
 * `coord_sf()`, `coord_map()`, and `coord_polar()` now squash `-Inf` and `Inf`
   into the min and max of the plot (@yutannihilation, #2972).
-  
-* `scale_fill_identity()` now works correctly with `guide = "legend"` (@malcolmbarrett, #3075)
 
 # ggplot2 3.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # ggplot2 3.1.0.9000
   
-* `scale_fill_identity()` now works correctly with `guide = "legend"` (@malcolmbarrett, #3029)
+* `scale_shape_identity()` now works correctly with `guide = "legend"` (@malcolmbarrett, #3029)
 
 * `geom_rug()` now works with `coord_flip()` (@has2k1, #2987).
 

--- a/R/scale-identity.r
+++ b/R/scale-identity.r
@@ -81,7 +81,7 @@ scale_fill_identity <- function(..., guide = "none", aesthetics = "fill") {
 #' @export
 scale_shape_identity <- function(..., guide = "none") {
   sc <- continuous_scale("shape", "identity", identity_pal(), ..., guide = guide,
-    super = ScaleDiscreteIdentity)
+    super = ScaleContinuousIdentity)
 
   sc
 }


### PR DESCRIPTION
Closes #3029

This PR fixes an issue where `scale_shape_identity` was producing an error with `guide = "legend"`

``` r
library(ggplot2)

df2 <- data.frame(x = 1:5 , y = 1:10, z = 1:10)
s <- ggplot(df2, aes(x = x, y = y))
s + 
  geom_point(aes(shape = z), size = 4) + 
  scale_shape_identity(guide = 'legend')
```

![](https://i.imgur.com/BgPThqI.png)

<sup>Created on 2019-01-19 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>