### PR TITLE
Correct url link in citation

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -6,6 +6,6 @@ citEntry(entry = "book",
   publisher = "Springer-Verlag New York",
   year = "2016",
   isbn = "978-3-319-24277-4",
-  url = "https://ggplot2.tidyverse.org/",
+  url = "https://ggplot2.tidyverse.org",
   textVersion = "H. Wickham. ggplot2: Elegant Graphics for Data Analysis. Springer-Verlag New York, 2016."
 )

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -6,6 +6,6 @@ citEntry(entry = "book",
   publisher = "Springer-Verlag New York",
   year = "2016",
   isbn = "978-3-319-24277-4",
-  url = "http://ggplot2.org",
+  url = "https://ggplot2.tidyverse.org/",
   textVersion = "H. Wickham. ggplot2: Elegant Graphics for Data Analysis. Springer-Verlag New York, 2016."
 )


### PR DESCRIPTION
Closes #3071 

citation url is now the current ggplot2 webpage.