### PR TITLE
Fix unit-to-numeric coercion assumptions

### DIFF
--- a/R/facet-.r
+++ b/R/facet-.r
@@ -467,13 +467,17 @@ check_layout <- function(x) {
 #'
 #' @keywords internal
 #' @export
-max_height <- function(grobs) {
-  unit(max(unlist(lapply(grobs, height_cm))), "cm")
+max_height <- function(grobs, value_only = FALSE) {
+  height <- max(unlist(lapply(grobs, height_cm)))
+  if (!value_only) height <- unit(height, "cm")
+  height
 }
 #' @rdname max_height
 #' @export
-max_width <- function(grobs) {
-  unit(max(unlist(lapply(grobs, width_cm))), "cm")
+max_width <- function(grobs, value_only = FALSE) {
+  width <- max(unlist(lapply(grobs, width_cm)))
+  if (!value_only) width <- unit(width, "cm")
+  width
 }
 #' Find panels in a gtable
 #'

--- a/R/facet-.r
+++ b/R/facet-.r
@@ -462,8 +462,11 @@ check_layout <- function(x) {
 #' Get the maximal width/length of a list of grobs
 #'
 #' @param grobs A list of grobs
+#' @param value_only Should the return value be a simple numeric vector giving
+#' the maximum in cm
 #'
-#' @return The largest value. measured in cm as a unit object
+#' @return The largest value. measured in cm as a unit object or a numeric
+#' vector depending on `value_only`
 #'
 #' @keywords internal
 #' @export

--- a/R/facet-wrap.r
+++ b/R/facet-wrap.r
@@ -281,10 +281,10 @@ FacetWrap <- ggproto("FacetWrap", Facet,
       axis_mat_y_left[, -1] <- list(zeroGrob())
       axis_mat_y_right[, -ncol] <- list(zeroGrob())
     }
-    axis_height_top <- unit(apply(axis_mat_x_top, 1, max_height), "cm")
-    axis_height_bottom <- unit(apply(axis_mat_x_bottom, 1, max_height), "cm")
-    axis_width_left <- unit(apply(axis_mat_y_left, 2, max_width), "cm")
-    axis_width_right <- unit(apply(axis_mat_y_right, 2, max_width), "cm")
+    axis_height_top <- unit(apply(axis_mat_x_top, 1, max_height, value_only = TRUE), "cm")
+    axis_height_bottom <- unit(apply(axis_mat_x_bottom, 1, max_height, value_only = TRUE), "cm")
+    axis_width_left <- unit(apply(axis_mat_y_left, 2, max_width, value_only = TRUE), "cm")
+    axis_width_right <- unit(apply(axis_mat_y_right, 2, max_width, value_only = TRUE), "cm")
     # Add back missing axes
     if (any(empties)) {
       first_row <- which(apply(empties, 1, any))[1] - 1
@@ -330,10 +330,10 @@ FacetWrap <- ggproto("FacetWrap", Facet,
         placement <- if (inside) 0 else 1
         strip_pad <- axis_height_bottom
       }
-      strip_height <- unit(apply(strip_mat, 1, max_height), "cm")
+      strip_height <- unit(apply(strip_mat, 1, max_height, value_only = TRUE), "cm")
       panel_table <- weave_tables_row(panel_table, strip_mat, placement, strip_height, strip_name, 2, coord$clip)
       if (!inside) {
-        strip_pad[unclass(strip_pad) != 0] <- strip_padding
+        strip_pad[as.numeric(strip_pad) != 0] <- strip_padding
         panel_table <- weave_tables_row(panel_table, row_shift = placement, row_height = strip_pad)
       }
     } else {
@@ -345,11 +345,11 @@ FacetWrap <- ggproto("FacetWrap", Facet,
         placement <- if (inside) 0 else 1
         strip_pad <- axis_width_right
       }
-      strip_pad[unclass(strip_pad) != 0] <- strip_padding
-      strip_width <- unit(apply(strip_mat, 2, max_width), "cm")
+      strip_pad[as.numeric(strip_pad) != 0] <- strip_padding
+      strip_width <- unit(apply(strip_mat, 2, max_width, value_only = TRUE), "cm")
       panel_table <- weave_tables_col(panel_table, strip_mat, placement, strip_width, strip_name, 2, coord$clip)
       if (!inside) {
-        strip_pad[unclass(strip_pad) != 0] <- strip_padding
+        strip_pad[as.numeric(strip_pad) != 0] <- strip_padding
         panel_table <- weave_tables_col(panel_table, col_shift = placement, col_width = strip_pad)
       }
     }

--- a/R/facet-wrap.r
+++ b/R/facet-wrap.r
@@ -281,10 +281,22 @@ FacetWrap <- ggproto("FacetWrap", Facet,
       axis_mat_y_left[, -1] <- list(zeroGrob())
       axis_mat_y_right[, -ncol] <- list(zeroGrob())
     }
-    axis_height_top <- unit(apply(axis_mat_x_top, 1, max_height, value_only = TRUE), "cm")
-    axis_height_bottom <- unit(apply(axis_mat_x_bottom, 1, max_height, value_only = TRUE), "cm")
-    axis_width_left <- unit(apply(axis_mat_y_left, 2, max_width, value_only = TRUE), "cm")
-    axis_width_right <- unit(apply(axis_mat_y_right, 2, max_width, value_only = TRUE), "cm")
+    axis_height_top <- unit(
+      apply(axis_mat_x_top, 1, max_height, value_only = TRUE),
+      "cm"
+    )
+    axis_height_bottom <- unit(
+      apply(axis_mat_x_bottom, 1, max_height, value_only = TRUE),
+      "cm"
+    )
+    axis_width_left <- unit(
+      apply(axis_mat_y_left, 2, max_width, value_only = TRUE),
+      "cm"
+    )
+    axis_width_right <- unit(
+      apply(axis_mat_y_right, 2, max_width, value_only = TRUE),
+      "cm"
+    )
     # Add back missing axes
     if (any(empties)) {
       first_row <- which(apply(empties, 1, any))[1] - 1

--- a/R/grob-dotstack.r
+++ b/R/grob-dotstack.r
@@ -13,14 +13,14 @@ dotstackGrob <- function(
         y <- unit(y, default.units)
     if (!is.unit(dotdia))
         dotdia <- unit(dotdia, default.units)
-    if (!is_npc(dotdia)) # Only cross-version reliable way to check the unit of a unit object
+    if (!is_npc(dotdia))
         warning("Unit type of dotdia should be 'npc'")
 
     grob(x = x, y = y, stackaxis = stackaxis, dotdia = dotdia,
          stackposition = stackposition, stackratio = stackratio,
          name = name, gp = gp, vp = vp, cl = "dotstackGrob")
 }
-
+# Only cross-version reliable way to check the unit of a unit object
 is_npc <- function(x) isTRUE(grepl('npc', as.character(x)))
 
 #' @export

--- a/R/grob-dotstack.r
+++ b/R/grob-dotstack.r
@@ -13,13 +13,15 @@ dotstackGrob <- function(
         y <- unit(y, default.units)
     if (!is.unit(dotdia))
         dotdia <- unit(dotdia, default.units)
-    if (!grepl('npc', as.character(dotdia))) # Only cross-version reliable way to check the unit of a unit object
+    if (!is_npc(dotdia)) # Only cross-version reliable way to check the unit of a unit object
         warning("Unit type of dotdia should be 'npc'")
 
     grob(x = x, y = y, stackaxis = stackaxis, dotdia = dotdia,
          stackposition = stackposition, stackratio = stackratio,
          name = name, gp = gp, vp = vp, cl = "dotstackGrob")
 }
+
+is_npc <- function(x) isTRUE(grepl('npc', as.character(x)))
 
 #' @export
 makeContext.dotstackGrob <- function(x, recording = TRUE) {

--- a/R/grob-dotstack.r
+++ b/R/grob-dotstack.r
@@ -13,7 +13,7 @@ dotstackGrob <- function(
         y <- unit(y, default.units)
     if (!is.unit(dotdia))
         dotdia <- unit(dotdia, default.units)
-    if (attr(dotdia,"unit") != "npc")
+    if (!grepl('npc', as.character(dotdia))) # Only cross-version reliable way to check the unit of a unit object
         warning("Unit type of dotdia should be 'npc'")
 
     grob(x = x, y = y, stackaxis = stackaxis, dotdia = dotdia,

--- a/R/grob-dotstack.r
+++ b/R/grob-dotstack.r
@@ -21,7 +21,7 @@ dotstackGrob <- function(
          name = name, gp = gp, vp = vp, cl = "dotstackGrob")
 }
 # Only cross-version reliable way to check the unit of a unit object
-is_npc <- function(x) isTRUE(grepl('npc', as.character(x)))
+is_npc <- function(x) isTRUE(grepl('^[^+^-^\\*]*[^s]npc$', as.character(x)))
 
 #' @export
 makeContext.dotstackGrob <- function(x, recording = TRUE) {

--- a/R/theme.r
+++ b/R/theme.r
@@ -424,7 +424,7 @@ add_theme <- function(t1, t2, t2name) {
     if (is.null(x) || inherits(x, "element_blank")) {
       # If x is NULL or element_blank, then just assign it y
       x <- y
-    } else if (is.null(y) || is.character(y) || is.numeric(y) ||
+    } else if (is.null(y) || is.character(y) || is.numeric(y) || is.unit(y) ||
                is.logical(y) || inherits(y, "element_blank")) {
       # If y is NULL, or a string or numeric vector, or is element_blank, just replace x
       x <- y

--- a/man/borders.Rd
+++ b/man/borders.Rd
@@ -67,7 +67,7 @@ if (require("maps")) {
 ia <- map_data("county", "iowa")
 mid_range <- function(x) mean(range(x))
 seats <- do.call(rbind, lapply(split(ia, ia$subregion), function(d) {
- data.frame(lat = mid_range(d$lat), long = mid_range(d$long), subregion = unique(d$subregion))
+  data.frame(lat = mid_range(d$lat), long = mid_range(d$long), subregion = unique(d$subregion))
 }))
 
 ggplot(ia, aes(long, lat)) +

--- a/man/map_data.Rd
+++ b/man/map_data.Rd
@@ -44,6 +44,6 @@ if (require("maps")) {
 ggplot(choro, aes(long, lat)) +
   geom_polygon(aes(group = group, fill = assault / murder)) +
   coord_map("albers",  at0 = 45.5, lat1 = 29.5)
- }
+}
 }
 \keyword{internal}

--- a/man/max_height.Rd
+++ b/man/max_height.Rd
@@ -5,15 +5,19 @@
 \alias{max_width}
 \title{Get the maximal width/length of a list of grobs}
 \usage{
-max_height(grobs)
+max_height(grobs, value_only = FALSE)
 
-max_width(grobs)
+max_width(grobs, value_only = FALSE)
 }
 \arguments{
 \item{grobs}{A list of grobs}
+
+\item{value_only}{Should the return value be a simple numeric vector giving
+the maximum in cm}
 }
 \value{
-The largest value. measured in cm as a unit object
+The largest value. measured in cm as a unit object or a numeric
+vector depending on \code{value_only}
 }
 \description{
 Get the maximal width/length of a list of grobs


### PR DESCRIPTION
This PR addresses several small problems with how ggplot2 treats units that have come up during my rewrite of the unit object. They all centre around the assumptions that units are a numeric vector with attributes, which are only true for freshly created unit objects.

These changes makes ggplot2 work with the new unit spec without breaking backward compatibility with old grid versions.