### PR TITLE
ensure scale_index matches the number of scales in length

### DIFF
--- a/R/layout.R
+++ b/R/layout.R
@@ -272,7 +272,10 @@ scale_apply <- function(data, vars, method, scale_id, scales) {
 
   if (any(is.na(scale_id))) stop()
 
-  scale_index <- unname(split(seq_along(scale_id), scale_id))
+  scale_index <- unname(split(
+    seq_along(scale_id),
+    factor(scale_id, levels = seq_along(scales))
+  ))
 
   lapply(vars, function(var) {
     pieces <- lapply(seq_along(scales), function(i) {


### PR DESCRIPTION
Fixes #3099 

Make scale_id a factor before splitting to make sure all levels are part of the output despite not being part of the data