### PR TITLE
Better respect theme settings when drawing coord_sf() panel grid

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # ggplot2 3.1.0.9000
 
+* `coord_sf()` graticule lines are now drawn in the same thickness as 
+  panel grid lines in `coord_cartesian()`, and seting panel grid
+  lines to `element_blank()` now also works in `coord_sf()` 
+  (@clauswilke, #2991, #2525).
+
 * `geom_hline()`, `geom_vline()`, and `geom_abline()` now throw a warning if the user supplies both an `xintercept`, `yintercept`, or `slope` value and a mapping (@RichardJActon, #2950).
   
 * `scale_color_continuous()` now points at `scale_colour_continuos()` so that it 

--- a/R/coord-sf.R
+++ b/R/coord-sf.R
@@ -201,7 +201,11 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
     if (inherits(el, "element_blank")) {
       grobs <- list(element_render(theme, "panel.background"))
     } else {
-      line_gp <- gpar(col = el$colour, lwd = el$size*.pt, lty = el$linetype)
+      line_gp <- gpar(
+        col = el$colour,
+        lwd = len0_null(el$size*.pt),
+        lty = el$linetype
+      )
       grobs <- c(
         list(element_render(theme, "panel.background")),
         lapply(sf::st_geometry(panel_params$graticule), sf::st_as_grob, gp = line_gp)

--- a/R/coord-sf.R
+++ b/R/coord-sf.R
@@ -195,7 +195,14 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
 
   render_bg = function(self, panel_params, theme) {
     el <- calc_element("panel.grid.major", theme)
-    line_gp <- gpar(col = el$colour, lwd = el$size, lty = el$linetype)
+
+    # we don't draw the graticules if the major panel grid is
+    # turned off
+    if (inherits(el, "element_blank")) {
+      return(zeroGrob())
+    }
+
+    line_gp <- gpar(col = el$colour, lwd = el$size*.pt, lty = el$linetype)
     grobs <- c(
       list(element_render(theme, "panel.background")),
       lapply(sf::st_geometry(panel_params$graticule), sf::st_as_grob, gp = line_gp)

--- a/R/coord-sf.R
+++ b/R/coord-sf.R
@@ -199,14 +199,14 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
     # we don't draw the graticules if the major panel grid is
     # turned off
     if (inherits(el, "element_blank")) {
-      return(zeroGrob())
+      grobs <- list(element_render(theme, "panel.background"))
+    } else {
+      line_gp <- gpar(col = el$colour, lwd = el$size*.pt, lty = el$linetype)
+      grobs <- c(
+        list(element_render(theme, "panel.background")),
+        lapply(sf::st_geometry(panel_params$graticule), sf::st_as_grob, gp = line_gp)
+      )
     }
-
-    line_gp <- gpar(col = el$colour, lwd = el$size*.pt, lty = el$linetype)
-    grobs <- c(
-      list(element_render(theme, "panel.background")),
-      lapply(sf::st_geometry(panel_params$graticule), sf::st_as_grob, gp = line_gp)
-    )
     ggname("grill", do.call("grobTree", grobs))
   },
 

--- a/tests/figs/coord-sf/no-panel-grid.svg
+++ b/tests/figs/coord-sf/no-panel-grid.svg
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpNzguNDd8NjQxLjUzfDU3Ni4wMHwwLjAw'>
+    <rect x='78.47' y='0.00' width='563.05' height='576.00' />
+  </clipPath>
+</defs>
+<rect x='78.47' y='0.00' width='563.05' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' clip-path='url(#cpNzguNDd8NjQxLjUzfDU3Ni4wMHwwLjAw)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMTEzLjY5fDYzNi4wNXw1NDUuMTN8MjIuNzc='>
+    <rect x='113.69' y='22.77' width='522.36' height='522.36' />
+  </clipPath>
+</defs>
+<rect x='113.69' y='22.77' width='522.36' height='522.36' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' clip-path='url(#cpMTEzLjY5fDYzNi4wNXw1NDUuMTN8MjIuNzc=)' />
+<circle cx='137.43' cy='521.39' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpMTEzLjY5fDYzNi4wNXw1NDUuMTN8MjIuNzc=)' />
+<circle cx='374.87' cy='283.95' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpMTEzLjY5fDYzNi4wNXw1NDUuMTN8MjIuNzc=)' />
+<circle cx='612.30' cy='46.52' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpMTEzLjY5fDYzNi4wNXw1NDUuMTN8MjIuNzc=)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='96.54' y='524.41' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>1.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='96.54' y='405.69' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>1.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='96.54' y='286.97' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>2.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='96.54' y='168.26' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='96.54' y='49.54' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<polyline points='110.95,521.39 113.69,521.39 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='110.95,402.67 113.69,402.67 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='110.95,283.95 113.69,283.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='110.95,165.23 113.69,165.23 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='110.95,46.52 113.69,46.52 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='137.43,547.87 137.43,545.13 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='256.15,547.87 256.15,545.13 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='374.87,547.87 374.87,545.13 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='493.58,547.87 493.58,545.13 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='612.30,547.87 612.30,545.13 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='131.32' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>1.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='250.04' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>1.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='368.76' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>2.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='487.48' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='606.19' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>3.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='372.12' y='568.24' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(91.52,286.70) rotate(-90)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='113.69' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='76.20px' lengthAdjust='spacingAndGlyphs'>no panel grid</text></g>
+</svg>

--- a/tests/testthat/test-coord_sf.R
+++ b/tests/testthat/test-coord_sf.R
@@ -1,6 +1,6 @@
 context("coord_sf")
 
-test_that("multiplication works", {
+test_that("basic plot builds without error", {
   skip_if_not_installed("sf")
 
   nc <- sf::st_read(system.file("shape/nc.shp", package = "sf"), quiet = TRUE)
@@ -15,6 +15,18 @@ test_that("multiplication works", {
   expect_doppelganger("sf-polygons", plot)
 })
 
+test_that("graticule lines can be removed via theme", {
+  skip_if_not_installed("sf")
+
+  df <- data_frame(x = c(1, 2, 3), y = c(1, 2, 3))
+  plot <- ggplot(df, aes(x, y)) +
+    geom_point() +
+    coord_sf() +
+    theme_gray() + # to test for presence of background grob
+    theme(panel.grid = element_blank())
+
+  expect_doppelganger("no panel grid", plot)
+})
 
 test_that("axis labels can be set manually", {
   skip_if_not_installed("sf")


### PR DESCRIPTION
This PR makes `coord_sf()` behave more similarly to `coord_cartesian()` when drawing the panel grid, by applying the same line-width correction and by respecting `element_blank()`. Closes #2991 and #2525.

Reprex 1:

``` r
library(ggplot2)

df <- data.frame(x = c(1, 2, 3), y = c(1, 2, 3))
p <- ggplot(df, aes(x, y)) + geom_point()

# default grid
cowplot::plot_grid(
  p + coord_fixed() + theme(panel.grid.minor = element_blank()) +
    ggtitle("coord_fixed()"),
  p + coord_sf() +
    ggtitle("coord_sf()")
)
```

![](https://i.imgur.com/hy8fdbO.png)

``` r

# different theme
cowplot::plot_grid(
  p + coord_fixed() + theme_bw() + theme(panel.grid.minor = element_blank()) +
    ggtitle("coord_fixed()"),
  p + coord_sf() + theme_bw() + 
    ggtitle("coord_sf()")
)
```

![](https://i.imgur.com/OexJgXc.png)

``` r

# setting grid lines to element_blank()
cowplot::plot_grid(
  p + coord_fixed() + theme(panel.grid = element_blank()) +
    ggtitle("coord_fixed()"),
  p + coord_sf() + theme(panel.grid = element_blank()) +
    ggtitle("coord_sf()")
)
```

![](https://i.imgur.com/b7kluDa.png)

<sup>Created on 2019-02-01 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>


Reprex 2:

``` r
library(sf) 
#> Linking to GEOS 3.6.1, GDAL 2.1.3, PROJ 4.9.3
library(ggplot2)

nc <- st_read(system.file("gpkg/nc.gpkg", package = "sf"), quiet = TRUE) 

ggplot(nc) + 
  geom_sf(data = nc, aes(fill = AREA)) + 
  theme_void()
```

![](https://i.imgur.com/9Nz7FCR.png)

<sup>Created on 2019-02-01 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>