### PR TITLE
WIP: Pass actual data to annotation_raster() and annotation_custom() instead of dummy data

### DIFF
--- a/R/annotation-custom.r
+++ b/R/annotation-custom.r
@@ -42,11 +42,11 @@ NULL
 #' base +
 #'   annotation_custom(grob = g, xmin = 1, xmax = 10, ymin = 8, ymax = 10)
 annotation_custom <- function(grob, xmin = -Inf, xmax = Inf, ymin = -Inf, ymax = Inf) {
-  data <- new_data_frame(list(x = c(xmin, xmax), y = c(ymin, ymax)), n = 2)
+  data <- new_data_frame(list(xmin = xmin, xmax = xmax, ymin = ymin, ymax = ymax), n = 1)
 
   layer(
     data = data,
-    mapping = aes(x = x, y = y),
+    mapping = aes(xmin = xmin, xmax = xmax, ymin = ymin, ymax = ymax),
     stat = StatIdentity,
     position = PositionIdentity,
     geom = GeomCustomAnn,
@@ -64,8 +64,6 @@ annotation_custom <- function(grob, xmin = -Inf, xmax = Inf, ymin = -Inf, ymax =
 GeomCustomAnn <- ggproto("GeomCustomAnn", Geom,
   extra_params = "",
 
-  required_aes = c("x", "y"),
-
   handle_na = function(data, params) {
     data
   },
@@ -75,6 +73,7 @@ GeomCustomAnn <- ggproto("GeomCustomAnn", Geom,
       stop("annotation_custom only works with Cartesian coordinates",
         call. = FALSE)
     }
+    data <- new_data_frame(list(x = c(data$xmin, data$xmax), y = c(data$ymin, data$ymax)), n = 2)
     data <- coord$transform(data, panel_params)
 
     x_rng <- range(data$x, na.rm = TRUE)
@@ -84,7 +83,9 @@ GeomCustomAnn <- ggproto("GeomCustomAnn", Geom,
                    width = diff(x_rng), height = diff(y_rng),
                    just = c("center","center"))
     editGrob(grob, vp = vp, name = paste(grob$name, annotation_id()))
-  }
+  },
+
+  required_aes = c("xmin", "xmax", "ymin", "ymax")
 )
 
 annotation_id <- local({

--- a/R/annotation-custom.r
+++ b/R/annotation-custom.r
@@ -42,18 +42,17 @@ NULL
 #' base +
 #'   annotation_custom(grob = g, xmin = 1, xmax = 10, ymin = 8, ymax = 10)
 annotation_custom <- function(grob, xmin = -Inf, xmax = Inf, ymin = -Inf, ymax = Inf) {
+  data <- new_data_frame(list(x = c(xmin, xmax), y = c(ymin, ymax)), n = 2)
+
   layer(
-    data = dummy_data(),
+    data = data,
+    mapping = aes(x = x, y = y),
     stat = StatIdentity,
     position = PositionIdentity,
     geom = GeomCustomAnn,
     inherit.aes = FALSE,
     params = list(
-      grob = grob,
-      xmin = xmin,
-      xmax = xmax,
-      ymin = ymin,
-      ymax = ymax
+      grob = grob
     )
   )
 }
@@ -64,18 +63,19 @@ annotation_custom <- function(grob, xmin = -Inf, xmax = Inf, ymin = -Inf, ymax =
 #' @export
 GeomCustomAnn <- ggproto("GeomCustomAnn", Geom,
   extra_params = "",
+
+  required_aes = c("x", "y"),
+
   handle_na = function(data, params) {
     data
   },
 
-  draw_panel = function(data, panel_params, coord, grob, xmin, xmax,
-                        ymin, ymax) {
+  draw_panel = function(data, panel_params, coord, grob) {
     if (!inherits(coord, "CoordCartesian")) {
       stop("annotation_custom only works with Cartesian coordinates",
         call. = FALSE)
     }
-    corners <- new_data_frame(list(x = c(xmin, xmax), y = c(ymin, ymax)), n = 2)
-    data <- coord$transform(corners, panel_params)
+    data <- coord$transform(data, panel_params)
 
     x_rng <- range(data$x, na.rm = TRUE)
     y_rng <- range(data$y, na.rm = TRUE)
@@ -84,9 +84,7 @@ GeomCustomAnn <- ggproto("GeomCustomAnn", Geom,
                    width = diff(x_rng), height = diff(y_rng),
                    just = c("center","center"))
     editGrob(grob, vp = vp, name = paste(grob$name, annotation_id()))
-  },
-
-  default_aes = aes_(xmin = -Inf, xmax = Inf, ymin = -Inf, ymax = Inf)
+  }
 )
 
 annotation_id <- local({

--- a/R/annotation-raster.r
+++ b/R/annotation-raster.r
@@ -40,20 +40,17 @@ NULL
 annotation_raster <- function(raster, xmin, xmax, ymin, ymax,
                               interpolate = FALSE) {
   raster <- grDevices::as.raster(raster)
+  data <- new_data_frame(list(xmin = xmin, xmax = xmax, ymin = ymin, ymax = ymax), n = 1)
 
   layer(
-    data = dummy_data(),
-    mapping = NULL,
+    data = data,
+    mapping = aes(xmin = xmin, xmax = xmax, ymin = ymin, ymax = ymax),
     stat = StatIdentity,
     position = PositionIdentity,
     geom = GeomRasterAnn,
     inherit.aes = FALSE,
     params = list(
       raster = raster,
-      xmin = xmin,
-      xmax = xmax,
-      ymin = ymin,
-      ymax = ymax,
       interpolate = interpolate
     )
   )
@@ -76,8 +73,8 @@ GeomRasterAnn <- ggproto("GeomRasterAnn", Geom,
       stop("annotation_raster only works with Cartesian coordinates",
         call. = FALSE)
     }
-    corners <- new_data_frame(list(x = c(xmin, xmax), y = c(ymin, ymax)), n = 2)
-    data <- coord$transform(corners, panel_params)
+    data <- new_data_frame(list(x = c(data$xmin, data$xmax), y = c(data$ymin, data$ymax)), n = 2)
+    data <- coord$transform(data, panel_params)
 
     x_rng <- range(data$x, na.rm = TRUE)
     y_rng <- range(data$y, na.rm = TRUE)
@@ -85,5 +82,7 @@ GeomRasterAnn <- ggproto("GeomRasterAnn", Geom,
     rasterGrob(raster, x_rng[1], y_rng[1],
       diff(x_rng), diff(y_rng), default.units = "native",
       just = c("left","bottom"), interpolate = interpolate)
-  }
+  },
+
+  required_aes = c("xmin", "xmax", "ymin", "ymax")
 )

--- a/tests/testthat/test-annotate.r
+++ b/tests/testthat/test-annotate.r
@@ -53,17 +53,15 @@ test_that("annotation_raster() has data and don't inherit aes", {
   expect_false(raster$inherit.aes)
 })
 
-test_that("annotation_map() has data and don't inherit aes", {
+test_that("annotation_map() and annotation_logstick() has dummy data assigned and don't inherit aes", {
   library(maps)
   usamap <- map_data("state")
   map <- annotation_map(usamap)
-  expect_equal(map$data, dummy_data())
-  expect_false(map$inherit.aes)
-})
-
-test_that("annotation_logstick() has dummy data assigned and don't inherit aes", {
   logtick <- annotation_logticks()
+
+  expect_equal(map$data, dummy_data())
   expect_equal(logtick$data, dummy_data())
 
+  expect_false(map$inherit.aes)
   expect_false(logtick$inherit.aes)
 })

--- a/tests/testthat/test-annotate.r
+++ b/tests/testthat/test-annotate.r
@@ -44,7 +44,12 @@ test_that("annotation_custom() has data and don't inherit aes", {
 test_that("annotation_raster() has data and don't inherit aes", {
   rainbow <- matrix(hcl(seq(0, 360, length.out = 50 * 50), 80, 70), nrow = 50)
   raster <- annotation_raster(rainbow, 15, 20, 3, 4)
-  expect_equal(raster$data, dummy_data())
+
+  expect_equal(raster$data, data_frame(xmin = 15, xmax = 20, ymin = 3, ymax = 4))
+  # can be transformed
+  expect_equal(layer_data(ggplot() + raster + scale_x_reverse() + scale_y_reverse())[, c("xmin", "xmax", "ymin", "ymax")],
+               data_frame(xmin = -15, xmax = -20, ymin = -3, ymax = -4))
+
   expect_false(raster$inherit.aes)
 })
 

--- a/tests/testthat/test-annotate.r
+++ b/tests/testthat/test-annotate.r
@@ -30,22 +30,35 @@ test_that("segment annotations transform with scales", {
   expect_doppelganger("line matches points", plot)
 })
 
-test_that("annotation_* has dummy data assigned and don't inherit aes", {
-  custom <- annotation_custom(zeroGrob())
-  logtick <- annotation_logticks()
+test_that("annotation_custom() has data and don't inherit aes", {
+  custom <- annotation_custom(zeroGrob(), xmin = -1, xmax = 1, ymin = -1, ymax = 1)
+
+  expect_equal(custom$data, data_frame(xmin = -1, xmax = 1, ymin = -1, ymax = 1))
+  # can be transformed
+  expect_equal(layer_data(ggplot() + custom + scale_x_reverse() + scale_y_reverse())[, c("xmin", "xmax", "ymin", "ymax")],
+               data_frame(xmin = 1, xmax = -1, ymin = 1, ymax = -1))
+
+  expect_false(custom$inherit.aes)
+})
+
+test_that("annotation_raster() has data and don't inherit aes", {
+  rainbow <- matrix(hcl(seq(0, 360, length.out = 50 * 50), 80, 70), nrow = 50)
+  raster <- annotation_raster(rainbow, 15, 20, 3, 4)
+  expect_equal(raster$data, dummy_data())
+  expect_false(raster$inherit.aes)
+})
+
+test_that("annotation_map() has data and don't inherit aes", {
   library(maps)
   usamap <- map_data("state")
   map <- annotation_map(usamap)
-  rainbow <- matrix(hcl(seq(0, 360, length.out = 50 * 50), 80, 70), nrow = 50)
-  raster <- annotation_raster(rainbow, 15, 20, 3, 4)
-  dummy <- dummy_data()
-  expect_equal(custom$data, dummy)
-  expect_equal(logtick$data, dummy)
-  expect_equal(map$data, dummy)
-  expect_equal(raster$data, dummy)
-
-  expect_false(custom$inherit.aes)
-  expect_false(logtick$inherit.aes)
+  expect_equal(map$data, dummy_data())
   expect_false(map$inherit.aes)
-  expect_false(raster$inherit.aes)
+})
+
+test_that("annotation_logstick() has dummy data assigned and don't inherit aes", {
+  logtick <- annotation_logticks()
+  expect_equal(logtick$data, dummy_data())
+
+  expect_false(logtick$inherit.aes)
 })


### PR DESCRIPTION
Fix  #3120

This PR does fix these two annotations to have `xmin`, `xmax`, `ymin` and `ymax` as `data` so that scale transformations takes effect (this is the same strategy as `annotate()`).

* `annotation_raster()`
* `annotation_custom()`

On the other hand, this PR doesn't modify `annotation_map()` and `annotation_logstick()` because:

* `annotation_map()`: we don't know what to do with the reversed scales for map yet (c.f. scale transformations won't work for `coord_sf()` or `coord_map()`). Besides, annotation itself should not be transformed, but I don't know how to implement this for maps.
* `annotation_logstick()`: the document says "These tick marks probably make sense only for base 10"

``` r
library(ggplot2)
library(patchwork)

data <- data.frame(x = c(20, 85, 42, 78, 33, 74),
                   y = c(43, 40, 52, 56, 44, 71))

p <- ggplot(data) +
  geom_point(aes(x = x, y = y)) +
  annotate(geom = "rect", xmin = 8, xmax = 12, ymin = 38, ymax = 42) +
  annotation_custom(
    grob = grid::circleGrob(
      r  = grid::unit(1, "npc"),
      gp = grid::gpar(col  = "black",
                      fill = "white",
                      lwd = 2)),
    xmin = 48, xmax = 52, ymin = 48, ymax = 52
  )

p * (p + scale_x_reverse())
```

![](https://i.imgur.com/GaGPj7v.png)

``` r


rainbow <- matrix(hcl(seq(0, 360, length.out = 50 * 50), 80, 70), nrow = 50)
p <- ggplot(mtcars, aes(mpg, wt)) +
  geom_point() +
  annotation_raster(rainbow, 15, 20, 3, 4)

p * (p + scale_x_reverse())
```

![](https://i.imgur.com/q7haBws.png)

<sup>Created on 2019-02-14 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>
