### PR TITLE
Modified line glyph as used in the fable package

### DIFF
--- a/R/legend-draw.r
+++ b/R/legend-draw.r
@@ -112,7 +112,14 @@ draw_key_crossbar <- function(data, params, size) {
 draw_key_path <- function(data, params, size) {
   data$linetype[is.na(data$linetype)] <- 0
 
-  segmentsGrob(0.1, 0.5, 0.9, 0.5,
+  # Scale the arrow to fit within the draw key
+  if(!is.null(params$arrow)){
+    params$arrow$length <- unit(0.3, "npc")
+  }
+
+  linesGrob(
+    x = c(0, 0.4, 0.6, 1),
+    y = c(0.1, 0.6, 0.4, 0.9),
     gp = gpar(
       col = alpha(data$colour, data$alpha),
       lwd = data$size * .pt,


### PR DESCRIPTION
As requested from @earowang 's rstudioconf19 talk: https://slides.earo.me/rstudioconf19/#26

Background shade is not included because it is representative of the associated interval.

``` r
library(ggplot2)
ggplot(economics_long, aes(date, value01, colour = variable)) +
  geom_line()
```

![](https://i.imgur.com/pfTt3a9.png)

``` r

devtools::load_all("~/github/ggplot2")
#> Loading ggplot2
ggplot(economics_long, aes(date, value01, colour = variable)) +
  geom_line()
```

![](https://i.imgur.com/wfssrrP.png)

<sup>Created on 2019-02-11 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>