### PR TITLE
Remove warning when guide functions are used in identity scales

### DIFF
--- a/R/scale-identity.r
+++ b/R/scale-identity.r
@@ -146,7 +146,7 @@ ScaleDiscreteIdentity <- ggproto("ScaleDiscreteIdentity", ScaleDiscrete,
 
   train = function(self, x) {
     # do nothing if no guide, otherwise train so we know what breaks to use
-    if (isTRUE(self$guide == "none")) return()
+    if (identical(self$guide, "none")) return()
     ggproto_parent(ScaleDiscrete, self)$train(x)
   }
 )
@@ -167,7 +167,7 @@ ScaleContinuousIdentity <- ggproto("ScaleContinuousIdentity", ScaleContinuous,
 
   train = function(self, x) {
     # do nothing if no guide, otherwise train so we know what breaks to use
-    if (isTRUE(self$guide == "none")) return()
+    if (identical(self$guide, "none")) return()
     ggproto_parent(ScaleContinuous, self)$train(x)
   }
 )

--- a/R/scale-identity.r
+++ b/R/scale-identity.r
@@ -146,7 +146,7 @@ ScaleDiscreteIdentity <- ggproto("ScaleDiscreteIdentity", ScaleDiscrete,
 
   train = function(self, x) {
     # do nothing if no guide, otherwise train so we know what breaks to use
-    if (self$guide == "none") return()
+    if (isTRUE(self$guide == "none")) return()
     ggproto_parent(ScaleDiscrete, self)$train(x)
   }
 )
@@ -167,7 +167,7 @@ ScaleContinuousIdentity <- ggproto("ScaleContinuousIdentity", ScaleContinuous,
 
   train = function(self, x) {
     # do nothing if no guide, otherwise train so we know what breaks to use
-    if (self$guide == "none") return()
+    if (isTRUE(self$guide == "none")) return()
     ggproto_parent(ScaleContinuous, self)$train(x)
   }
 )


### PR DESCRIPTION
This PR closes #3127 by adding a proper check for the presence or absence of a guide in the identity scales.

``` r
devtools::load_all("~/github/ggplot2")
#> Loading ggplot2

d <- base::data.frame(
  week = seq(1, 52, 1), 
  revenue = round(runif(52, 0, 100))
)

# discrete identity scale
ggplot(data = d, aes(x = week, y = revenue, fill = 'lightskyblue')) + 
  geom_col() + 
  scale_fill_identity(guide = guide_legend())
```

![](https://i.imgur.com/KfRsCCF.png)

``` r

# continuous identity scale
ggplot(data = d, aes(x = week, y = 1, size = revenue/20)) + 
  geom_point() + 
  scale_size_identity(guide = guide_legend())
```

![](https://i.imgur.com/O0L9Qd6.png)

<sup>Created on 2019-02-11 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>