### PR TITLE
Update READMEs to reflect 2nd edition cookbook

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -80,7 +80,7 @@ If you are new to ggplot2 you are better off starting with a systematic introduc
 1.  If you want to dive into making common graphics as quickly 
     as possible, I recommend [The R Graphics Cookbook][cookbook] 
     by Winston Chang. It provides a set of recipes to solve common
-    graphics problems. A 2nd edition is due out in 2018.
+    graphics problems.
     
 If you've mastered the basics and want to learn more, read [ggplot2: Elegant Graphics for Data Analysis][ggplot2-book]. It describes the theoretical underpinnings of ggplot2 and shows you how all the pieces fit together. This book helps you understand the theory that underpins ggplot2, and will help you create new types of graphics specifically tailored to your needs. The book is not available for free, but you can find the complete source for the book at <https://github.com/hadley/ggplot2-book>.
 
@@ -99,7 +99,7 @@ There are two main places to get help with ggplot2:
 [ggplot2-book]: http://amzn.to/2fncG50
 [gg-book]: http://amzn.to/2ef1eWp
 [so]: http://stackoverflow.com/questions/tagged/ggplot2?sort=frequent&pageSize=50
-[cookbook]: http://amzn.to/2dVfMfn
+[cookbook]: https://www.amazon.com/Graphics-Cookbook-Practical-Recipes-Visualizing/dp/1491978600/ref=dp_ob_title_bk 
 [r4ds]: http://r4ds.had.co.nz
 [r4ds-vis]: http://r4ds.had.co.nz/data-visualisation.html
 [r4ds-comm]: http://r4ds.had.co.nz/graphics-for-communication.html

--- a/README.Rmd
+++ b/README.Rmd
@@ -99,7 +99,7 @@ There are two main places to get help with ggplot2:
 [ggplot2-book]: http://amzn.to/2fncG50
 [gg-book]: http://amzn.to/2ef1eWp
 [so]: http://stackoverflow.com/questions/tagged/ggplot2?sort=frequent&pageSize=50
-[cookbook]: https://www.amazon.com/Graphics-Cookbook-Practical-Recipes-Visualizing/dp/1491978600/ref=dp_ob_title_bk 
+[cookbook]: https://amzn.to/2TU78ip 
 [r4ds]: http://r4ds.had.co.nz
 [r4ds-vis]: http://r4ds.had.co.nz/data-visualisation.html
 [r4ds-comm]: http://r4ds.had.co.nz/graphics-for-communication.html

--- a/README.md
+++ b/README.md
@@ -92,9 +92,8 @@ documentation pages. Currently, there are three good places to start:
 
 3.  If you want to dive into making common graphics as quickly as
     possible, I recommend [The R Graphics
-    Cookbook](http://amzn.to/2dVfMfn) by Winston Chang. It provides a
-    set of recipes to solve common graphics problems. A 2nd edition is
-    due out in 2018.
+    Cookbook](https://www.amazon.com/Graphics-Cookbook-Practical-Recipes-Visualizing/dp/1491978600/ref=dp_ob_title_bk) by Winston Chang. It provides a
+    set of recipes to solve common graphics problems.
 
 If you’ve mastered the basics and want to learn more, read [ggplot2:
 Elegant Graphics for Data Analysis](http://amzn.to/2fncG50). It

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ documentation pages. Currently, there are three good places to start:
 
 3.  If you want to dive into making common graphics as quickly as
     possible, I recommend [The R Graphics
-    Cookbook](https://www.amazon.com/Graphics-Cookbook-Practical-Recipes-Visualizing/dp/1491978600/ref=dp_ob_title_bk) by Winston Chang. It provides a
+    Cookbook](https://amzn.to/2TU78ip) by Winston Chang. It provides a
     set of recipes to solve common graphics problems.
 
 If you’ve mastered the basics and want to learn more, read [ggplot2:


### PR DESCRIPTION
The second edition of the The R Graphics Cookbook has been released, but the READMEs links to the first edition. This pull request should fix this and remove the text stating that a new version is due in 2018.

I have no experience with the amzn.to URL shortener so the link is the full URL obtained by following the current link and then the link to the updated version. 