### PR TITLE
Use the fully qualified forms for quos()

### DIFF
--- a/R/facet-grid-.r
+++ b/R/facet-grid-.r
@@ -150,7 +150,7 @@ facet_grid <- function(rows = NULL, cols = NULL, scales = "fixed",
     stop("A grid facet specification can't have more than two dimensions", call. = FALSE)
   }
   if (n == 1L) {
-    rows <- quos()
+    rows <- rlang::quos()
     cols <- facets_list[[1]]
   } else {
     rows <- facets_list[[1]]
@@ -182,12 +182,12 @@ grid_as_facets_list <- function(rows, cols) {
   }
 
   if (is.null(rows)) {
-    rows <- quos()
+    rows <- rlang::quos()
   } else {
     rows <- rlang::quos_auto_name(rows)
   }
   if (is.null(cols)) {
-    cols <- quos()
+    cols <- rlang::quos()
   } else {
     cols <- rlang::quos_auto_name(cols)
   }

--- a/R/ggplot2.r
+++ b/R/ggplot2.r
@@ -3,5 +3,4 @@
 
 #' @import scales grid gtable
 #' @importFrom stats setNames
-#' @importFrom rlang quo quos
 NULL


### PR DESCRIPTION
Though `quos()` are imported in `utilities-tidy-eval.R`, I think it's good practice to stick with the fully qualified forms in package code (I'm tolerant for test code). There are a few places that lacks `rlang::`, so this PR added them.

In addition, I want to remove this line to make it clear that we don't encourange the unqualified forms of `quo()` and `quos()`. I guess this was added by mistake.

https://github.com/tidyverse/ggplot2/blob/033fb521a084447c15178c591ab96a158f3b1e1e/R/ggplot2.r#L6