### PR TITLE
Fix Travis failures on r-devel

### DIFF
--- a/R/backports.R
+++ b/R/backports.R
@@ -14,3 +14,8 @@ if (getRversion() < 3.3) {
 } else {
   backport_unit_methods <- function() {}
 }
+
+# isFALSE() is available on R (>=3.5)
+if (getRversion() < 3.5) {
+  isFALSE <- function(x) is.logical(x) && length(x) == 1L && !is.na(x) && !x
+}

--- a/R/guide-colorbar.r
+++ b/R/guide-colorbar.r
@@ -244,7 +244,7 @@ guide_geom.colorbar <- function(guide, layers, default_mapping) {
   guide_layers <- lapply(layers, function(layer) {
     matched <- matched_aes(layer, guide, default_mapping)
 
-    if (length(matched) && (isTRUE(is.na(layer$show.legend)) || isTRUE(layer$show.legend))) {
+    if (length(matched) > 0 && (isTRUE(is.na(layer$show.legend)) || isTRUE(layer$show.legend))) {
       layer
     } else {
       # This layer does not use this guide

--- a/R/guide-colorbar.r
+++ b/R/guide-colorbar.r
@@ -244,7 +244,7 @@ guide_geom.colorbar <- function(guide, layers, default_mapping) {
   guide_layers <- lapply(layers, function(layer) {
     matched <- matched_aes(layer, guide, default_mapping)
 
-    if (length(matched) && ((is.na(layer$show.legend) || layer$show.legend))) {
+    if (length(matched) && (isTRUE(is.na(layer$show.legend) || isTRUE(layer$show.legend)))) {
       layer
     } else {
       # This layer does not use this guide

--- a/R/guide-colorbar.r
+++ b/R/guide-colorbar.r
@@ -244,7 +244,7 @@ guide_geom.colorbar <- function(guide, layers, default_mapping) {
   guide_layers <- lapply(layers, function(layer) {
     matched <- matched_aes(layer, guide, default_mapping)
 
-    if (length(matched) && (isTRUE(is.na(layer$show.legend) || isTRUE(layer$show.legend)))) {
+    if (length(matched) && (isTRUE(is.na(layer$show.legend)) || isTRUE(layer$show.legend))) {
       layer
     } else {
       # This layer does not use this guide

--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -271,7 +271,7 @@ guide_geom.legend <- function(guide, layers, default_mapping) {
       }
     } else {
       # This layer does not contribute to the legend
-      if (is.na(layer$show.legend) || !layer$show.legend) {
+      if (isTRUE(is.na(layer$show.legend)) || isFALSE(layer$show.legend)) {
         # Default is to exclude it
         return(NULL)
       } else {

--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -255,7 +255,7 @@ guide_geom.legend <- function(guide, layers, default_mapping) {
         include <- is.na(layer$show.legend[matched]) ||
           layer$show.legend[matched]
       } else {
-        include <- is.na(layer$show.legend) || layer$show.legend
+        include <- isTRUE(is.na(layer$show.legend)) || isTRUE(layer$show.legend)
       }
 
       if (include) {

--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -271,7 +271,7 @@ guide_geom.legend <- function(guide, layers, default_mapping) {
       }
     } else {
       # This layer does not contribute to the legend
-      if (isTRUE(is.na(layer$show.legend)) || isFALSE(layer$show.legend)) {
+      if (isTRUE(is.na(layer$show.legend)) || !isTRUE(layer$show.legend)) {
         # Default is to exclude it
         return(NULL)
       } else {

--- a/R/guides-.r
+++ b/R/guides-.r
@@ -180,7 +180,7 @@ guides_train <- function(scales, theme, guides, labels) {
       guide <- validate_guide(guide)
 
       # check the consistency of the guide and scale.
-      if (identical(guide$available_aes, "any") && any(!scale$aesthetics %in% guide$available_aes))
+      if (!identical(guide$available_aes, "any") && !any(scale$aesthetics %in% guide$available_aes))
         stop("Guide '", guide$name, "' cannot be used for '", scale$aesthetics, "'.")
 
       guide$title <- scale$make_title(guide$title %|W|% scale$name %|W|% labels[[output]])

--- a/R/guides-.r
+++ b/R/guides-.r
@@ -180,7 +180,7 @@ guides_train <- function(scales, theme, guides, labels) {
       guide <- validate_guide(guide)
 
       # check the consistency of the guide and scale.
-      if (guide$available_aes != "any" && !scale$aesthetics %in% guide$available_aes)
+      if (identical(guide$available_aes, "any") && any(!scale$aesthetics %in% guide$available_aes))
         stop("Guide '", guide$name, "' cannot be used for '", scale$aesthetics, "'.")
 
       guide$title <- scale$make_title(guide$title %|W|% scale$name %|W|% labels[[output]])

--- a/R/guides-.r
+++ b/R/guides-.r
@@ -173,7 +173,7 @@ guides_train <- function(scales, theme, guides, labels) {
       # this should be changed to testing guide == "none"
       # scale$legend is backward compatibility
       # if guides(XXX=FALSE), then scale_ZZZ(guides=XXX) is discarded.
-      if (guide == "none" || (is.logical(guide) && !guide)) next
+      if (identical(guide, "none") || isFALSE(guide)) next
 
       # check the validity of guide.
       # if guide is character, then find the guide object

--- a/R/position-stack.r
+++ b/R/position-stack.r
@@ -225,7 +225,7 @@ PositionFill <- ggproto("PositionFill", PositionStack,
 
 stack_var <- function(data) {
   if (!is.null(data$ymax)) {
-    if (any(data$ymin != 0 && data$ymax != 0, na.rm = TRUE)) {
+    if (any(data$ymin != 0 & data$ymax != 0, na.rm = TRUE)) {
       warning("Stacking not well defined when not anchored on the axis", call. = FALSE)
     }
     "ymax"

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -563,7 +563,8 @@ continuous_scale <- function(aesthetics, scale_name, palette, name = waiver(),
 
   position <- match.arg(position, c("left", "right", "top", "bottom"))
 
-  if (is.null(breaks) && all(is_position_aes(aesthetics)) && identical(guide, "none")) {
+  # If the scale is non-positional, break = NULL means removing the guide
+  if (is.null(breaks) && all(!is_position_aes(aesthetics))) {
     guide <- "none"
   }
 
@@ -634,7 +635,8 @@ discrete_scale <- function(aesthetics, scale_name, palette, name = waiver(),
 
   position <- match.arg(position, c("left", "right", "top", "bottom"))
 
-  if (is.null(breaks) && all(is_position_aes(aesthetics)) && identical(guide, "none")) {
+  # If the scale is non-positional, break = NULL means removing the guide
+  if (is.null(breaks) && all(!is_position_aes(aesthetics))) {
     guide <- "none"
   }
 

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -563,7 +563,7 @@ continuous_scale <- function(aesthetics, scale_name, palette, name = waiver(),
 
   position <- match.arg(position, c("left", "right", "top", "bottom"))
 
-  if (is.null(breaks) && !is_position_aes(aesthetics) && guide != "none") {
+  if (is.null(breaks) && all(is_position_aes(aesthetics)) && identical(guide, "none")) {
     guide <- "none"
   }
 
@@ -634,7 +634,7 @@ discrete_scale <- function(aesthetics, scale_name, palette, name = waiver(),
 
   position <- match.arg(position, c("left", "right", "top", "bottom"))
 
-  if (is.null(breaks) && !is_position_aes(aesthetics) && guide != "none") {
+  if (is.null(breaks) && all(is_position_aes(aesthetics)) && identical(guide, "none")) {
     guide <- "none"
   }
 

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -475,3 +475,6 @@ parse_safe <- function(text) {
   }
   out
 }
+
+# For older version of R
+isFALSE <- function(x) is.logical(x) && length(x) == 1L && !is.na(x) && !x

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -475,6 +475,3 @@ parse_safe <- function(text) {
   }
   out
 }
-
-# For older version of R
-isFALSE <- function(x) is.logical(x) && length(x) == 1L && !is.na(x) && !x


### PR DESCRIPTION
It seems the failure on r-devel is related to `R_CHECK_LENGTH_1_LOGIC2`, an option to raise error when multiple logicals are passed to `||` or `&&`.

```
 --- failure: length > 1 in coercion to logical ---
```

I'm not sure the next version of R will be released with this strict behaviour, but it's a nice chance to fix inappropriate if conditions.