### PR TITLE
Better sf support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,7 @@ Suggests:
     rgeos,
     rmarkdown,
     rpart,
-    sf (>= 0.3-4),
+    sf (>= 0.7-3),
     svglite (>= 1.2.0.9001),
     testthat (>= 0.11.0),
     vdiffr (>= 0.3.0)

--- a/R/coord-sf.R
+++ b/R/coord-sf.R
@@ -365,10 +365,7 @@ sf_rescale01 <- function(x, x_range, y_range) {
     return(x)
   }
 
-  # Shift + affine transformation to rescale to [0, 1] x [0, 1]
-  # Contributed by @edzer
-  (x - c(x_range[1], y_range[1])) *
-    diag(1 / c(diff(x_range), diff(y_range)))
+  sf::st_normalize(x, c(x_range[1], y_range[1], x_range[2], y_range[2]))
 }
 sf_rescale01_x <- function(x, range) {
   (x - range[1]) / diff(range)

--- a/R/geom-sf.R
+++ b/R/geom-sf.R
@@ -134,8 +134,8 @@ sf_grob <- function(x, lineend = "butt", linejoin = "round", linemitre = 10) {
   # Need to extract geometry out of corresponding list column
   geometry <- x$geometry
   type <- sf_types[sf::st_geometry_type(geometry)]
-  is_point <- type %in% 'point'
-  type_ind <- match(type, c('point', 'line', 'other'))
+  is_point <- type %in% "point"
+  type_ind <- match(type, c("point", "line", "other"))
   defaults <- list(
     GeomPoint$default_aes,
     GeomLine$default_aes,


### PR DESCRIPTION
This PR adapts `geom_sf` and `coord_sf` to make use of the improvements in performance introduced in sf v0.7-3. The changes are as follows:

- Use `st_normalize` during rescaling to greatly speed up `coord_sf
- Construct a single grob from the geometry and let `sf` decide on how/if to split it up to multiple grobs

This PR introduces a new version dependency on sf as it does not make much sense to support both implementations simultaneously