### PR TITLE
Extend the range of recognised positional aesthetics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,6 +62,9 @@
 * `geom_polygon()` can now draw polygons with holes using the new `subgroup` 
   aesthetic. This functionality requires R 3.6 (@thomasp85, #3128)
 
+* `x0` and `y0` is now recognized positional aesthetics so they will get scaled 
+  if used in extension geoms and stats (@thomasp85, #3168)
+
 # ggplot2 3.1.0
 
 ## Breaking changes

--- a/R/scale-continuous.r
+++ b/R/scale-continuous.r
@@ -80,7 +80,7 @@ scale_x_continuous <- function(name = waiver(), breaks = waiver(),
                                na.value = NA_real_, trans = "identity",
                                position = "bottom", sec.axis = waiver()) {
   sc <- continuous_scale(
-    c("x", "xmin", "xmax", "xend", "xintercept", "xmin_final", "xmax_final", "xlower", "xmiddle", "xupper"),
+    c("x", "xmin", "xmax", "xend", "xintercept", "xmin_final", "xmax_final", "xlower", "xmiddle", "xupper", "x0"),
     "position_c", identity, name = name, breaks = breaks,
     minor_breaks = minor_breaks, labels = labels, limits = limits,
     expand = expand, oob = oob, na.value = na.value, trans = trans,
@@ -99,7 +99,7 @@ scale_y_continuous <- function(name = waiver(), breaks = waiver(),
                                na.value = NA_real_, trans = "identity",
                                position = "left", sec.axis = waiver()) {
   sc <- continuous_scale(
-    c("y", "ymin", "ymax", "yend", "yintercept", "ymin_final", "ymax_final", "lower", "middle", "upper"),
+    c("y", "ymin", "ymax", "yend", "yintercept", "ymin_final", "ymax_final", "lower", "middle", "upper", "y0"),
     "position_c", identity, name = name, breaks = breaks,
     minor_breaks = minor_breaks, labels = labels, limits = limits,
     expand = expand, oob = oob, na.value = na.value, trans = trans,


### PR DESCRIPTION
This PR extends the recognised positional aesthetics to include `x0` and `y0`. This is needed for a range of geoms/stats in ggforce to make sure they play nice with scale transformations. `x0` and `y0` are traditionally used to denote center values and a natural fit for many parametrised geometries...

Such a change has happened before in c9f276b60c so it should be fairly safe