### PR TITLE
prevent margin from changing the unit class when subclassing

### DIFF
--- a/R/margins.R
+++ b/R/margins.R
@@ -4,7 +4,9 @@
 #' @rdname element
 #' @export
 margin <- function(t = 0, r = 0, b = 0, l = 0, unit = "pt") {
-  structure(unit(c(t, r, b, l), unit), class = c("margin", "unit"))
+  u <- unit(c(t, r, b, l), unit)
+  class(u) <- c("margin", class(u))
+  u
 }
 is.margin <- function(x) {
   inherits(x, "margin")


### PR DESCRIPTION
I've uncovered another "bad" assumption in ggplot2's handling of units. The margin constructor will drop any unit subclasses when subclassing the unit it creates. This PR fixes it and makes it work with the experimental unit implementation in https://github.com/thomasp85/grid/pull/1 in a back-compatible way