### PR TITLE
Do not check the system clock on r-devel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ dist: trusty
 matrix:
   include:
   - r: devel
+    # avoind errors due to world clock API (hopefully can be removed in future)
+    env: _R_CHECK_SYSTEM_CLOCK_=false
   - r: release
     env: VDIFFR_RUN_TESTS=true
     before_cache:


### PR DESCRIPTION
(See https://github.com/tidyverse/ggplot2/pull/3177#issuecomment-470349699)

R-devel introduced a check for future file timestamps. The check tries to verify the system click is correct by accessing world clock API, but it seems not stable enough to rely on. This PR avoid the check by setting `_R_CHECK_SYSTEM_CLOCK_` to false.

Not sure we'll need this also on the release version of R, but for now let's set only on r-devel.