### PR TITLE
Skip picking a scale when the layer data is Inf

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -74,6 +74,8 @@
   columns (especially in `psavert`), but more importantly, strips the grouping
   attributes from `economics_long`.
 
+* All-`Inf` layers are now ignored for picking the scale (@yutannihilation, #3184).
+
 # ggplot2 3.1.0
 
 ## Breaking changes

--- a/R/scale-type.R
+++ b/R/scale-type.R
@@ -1,5 +1,8 @@
 find_scale <- function(aes, x, env = parent.frame()) {
-  if (is.null(x)) {
+  # Inf is ambiguous; it can be used either with continuous scales or with
+  # discrete scales, so just skip in the hope that we will have a better guess
+  # with the other layers
+  if (is.null(x) || all(is.infinite(x))) {
     return(NULL)
   }
 

--- a/R/scale-type.R
+++ b/R/scale-type.R
@@ -2,7 +2,7 @@ find_scale <- function(aes, x, env = parent.frame()) {
   # Inf is ambiguous; it can be used either with continuous scales or with
   # discrete scales, so just skip in the hope that we will have a better guess
   # with the other layers
-  if (is.null(x) || all(is.infinite(x))) {
+  if (is.null(x) || (rlang::is_atomic(x) && all(is.infinite(x)))) {
     return(NULL)
   }
 

--- a/tests/testthat/test-scale-type.R
+++ b/tests/testthat/test-scale-type.R
@@ -4,6 +4,10 @@ test_that("no scale for NULL aesthetic", {
   expect_equal(find_scale("colour", NULL), NULL)
 })
 
+test_that("no scale for Inf aesthetic", {
+  expect_equal(find_scale("colour", Inf), NULL)
+})
+
 test_that("message + continuous for unknown type", {
   x <- structure(1:10, class = "ggplot2_foo")
 

--- a/tests/testthat/test-scales.r
+++ b/tests/testthat/test-scales.r
@@ -134,6 +134,17 @@ test_that("oob affects position values", {
   expect_equal(mid_squish[[1]]$y, c(0, 0.5, 1))
 })
 
+test_that("all-Inf layers are not used for determining the type of scale", {
+  d <- data_frame(x = c("a", "b"))
+  p <- ggplot(d, aes(x, x)) +
+    # Inf is numeric, but means discrete values in this case
+    annotate("rect", xmin = -Inf, xmax = Inf, ymin = -Inf, ymax = Inf, fill = "black") +
+    geom_point()
+
+  b <- ggplot_build(p)
+  expect_s3_class(b$layout$panel_scales_x[[1]], "ScaleDiscretePosition")
+})
+
 test_that("scales are looked for in appropriate place", {
   xlabel <- function(x) ggplot_build(x)$layout$panel_scales_x[[1]]$name
   p0 <- qplot(mpg, wt, data = mtcars) + scale_x_continuous("0")

--- a/tests/testthat/test-scales.r
+++ b/tests/testthat/test-scales.r
@@ -135,14 +135,21 @@ test_that("oob affects position values", {
 })
 
 test_that("all-Inf layers are not used for determining the type of scale", {
-  d <- data_frame(x = c("a", "b"))
-  p <- ggplot(d, aes(x, x)) +
+  d1 <- data_frame(x = c("a", "b"))
+  p1 <- ggplot(d1, aes(x, x)) +
     # Inf is numeric, but means discrete values in this case
     annotate("rect", xmin = -Inf, xmax = Inf, ymin = -Inf, ymax = Inf, fill = "black") +
     geom_point()
 
-  b <- ggplot_build(p)
-  expect_s3_class(b$layout$panel_scales_x[[1]], "ScaleDiscretePosition")
+  b1 <- ggplot_build(p1)
+  expect_s3_class(b1$layout$panel_scales_x[[1]], "ScaleDiscretePosition")
+
+  p2 <- ggplot() +
+    # If the layer non-Inf value, it's considered
+    annotate("rect", xmin = -Inf, xmax = 0, ymin = -Inf, ymax = Inf, fill = "black")
+
+  b2 <- ggplot_build(p2)
+  expect_s3_class(b2$layout$panel_scales_x[[1]], "ScaleContinuousPosition")
 })
 
 test_that("scales are looked for in appropriate place", {


### PR DESCRIPTION
Fix #3184 

In ggplot2, `Inf` might mean continuous value or discrete value. But, currently, the plot fails in the following case

* the first layer's data is all `Inf`
* the second layer's data is discrete

It seems better to skip picking a scale for the layer that has only infinite values. Note that, if all layers are such ones, the plot fails no matter we ignore them or not, because we cannot get a range for plots. So, I think this change is fine.