### PR TITLE
Make geom_col() ignore data$width

### DIFF
--- a/R/geom-bar.r
+++ b/R/geom-bar.r
@@ -118,6 +118,10 @@ GeomBar <- ggproto("GeomBar", GeomRect,
   non_missing_aes = c("xmin", "xmax", "ymin", "ymax"),
 
   setup_data = function(data, params) {
+    # Contrary to the case of geom_col(), the `width` in `data` is very likely
+    # a calculated column by Stat. So, geom_bar() should use data$width if
+    # available. Note that StatIdentity is not the case, but, as we cannot know
+    # what Stat was used, we can do nothing here.
     data$width <- data$width %||%
       params$width %||% (resolution(data$x, FALSE) * 0.9)
     transform(data,

--- a/R/geom-col.r
+++ b/R/geom-col.r
@@ -38,8 +38,11 @@ GeomCol <- ggproto("GeomCol", GeomRect,
   non_missing_aes = c("xmin", "xmax", "ymin", "ymax"),
 
   setup_data = function(data, params) {
-    data$width <- data$width %||%
-      params$width %||% (resolution(data$x, FALSE) * 0.9)
+    # To ensure bar widths are constant within a PANEL, `width` is not allowed
+    # to be mapped to data. So, even if the `data` already contains `width`, it
+    # should be ignored except when the width is calculated by Stat. But, as
+    # geom_col() uses stat_identity() fixedly, this is not the case.
+    data$width <- params$width %||% (resolution(data$x, FALSE) * 0.9)
     transform(data,
       ymin = pmin(y, 0), ymax = pmax(y, 0),
       xmin = x - width / 2, xmax = x + width / 2, width = NULL

--- a/tests/testthat/test-geom-col.R
+++ b/tests/testthat/test-geom-col.R
@@ -14,3 +14,12 @@ test_that("geom_col removes columns with parts outside the plot limits", {
     "Removed 1 rows containing missing values"
   )
 })
+
+test_that("geom_col() ignores width", {
+  dat <- data_frame(x = c(1, 2, 3))
+
+
+  p <- ggplot(dat, aes(x, x, width = x)) + geom_col()
+  d <- layer_data(p)
+  expect_equal(d$xmax - d$xmin, c(0.9, 0.9, 0.9))
+})


### PR DESCRIPTION
Fix #3142

Currently, `geom_bar()` does ignore `width` mapping, but `geom_col()` does not. Here's my thinking:

* We want to enforce a constant bar width within a panel, so `width` cannot be an aesthetic.
* Yet, the widths can vary among panels, so we need to pass `width`s per bar via `data`, not a single value via `param`.
* `data$width` should be used only when it's a calculated value by Stat. But, as `geom_col()` is not the case, it should ignore `data$width`.

Note that, this doesn't prevent variable widths when `geom_bar()` uses such Stat as

* `StatIdentity`
* some Stat that actually returns variable widths

but I think `geom_col()` should ignore `width` for consistency at least.

### Current HEAD

``` r
library(ggplot2)
library(patchwork)

d <- data.frame(x = c(1,2,3,3,3))

p1 <- ggplot(d) + geom_bar(aes(x, width = x / 2), alpha = 0.7) + ggtitle("bar")
#> Warning: Ignoring unknown aesthetics: width
p2 <- ggplot(d) + geom_col(aes(x, x, width = x / 2), alpha = 0.7) + ggtitle("col")
#> Warning: Ignoring unknown aesthetics: width

p1 / p2
#> Warning: position_stack requires non-overlapping x intervals
```

![](https://i.imgur.com/Z03hehR.png)

<sup>Created on 2019-03-19 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>

### This PR

``` r
library(ggplot2)
library(patchwork)

d <- data.frame(x = c(1,2,3,3,3))

p1 <- ggplot(d) + geom_bar(aes(x, width = x / 2), alpha = 0.7) + ggtitle("bar")
#> Warning: Ignoring unknown aesthetics: width
p2 <- ggplot(d) + geom_col(aes(x, x, width = x / 2), alpha = 0.7) + ggtitle("col")
#> Warning: Ignoring unknown aesthetics: width

p1 / p2
```

![](https://i.imgur.com/dOtwrkN.png)

<sup>Created on 2019-03-19 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>