### PR TITLE
fix problems during ribbon data sort

### DIFF
--- a/R/geom-ribbon.r
+++ b/R/geom-ribbon.r
@@ -63,7 +63,12 @@ GeomRibbon <- ggproto("GeomRibbon", Geom,
   required_aes = c("x", "ymin", "ymax"),
 
   setup_data = function(data, params) {
-    transform(data[order(data$PANEL, data$group, data$x), ], y = ymin)
+    if (is.null(data$ymin) && is.null(data$ymax)) {
+      stop("Either ymin or ymax must be given as an aesthetic", call. = FALSE)
+    }
+    data <- data[order(data$PANEL, data$group, data$x), , drop = FALSE]
+    data$y <- data$ymin %||% data$ymax
+    data
   },
 
   draw_key = draw_key_polygon,

--- a/R/geom-ribbon.r
+++ b/R/geom-ribbon.r
@@ -64,7 +64,7 @@ GeomRibbon <- ggproto("GeomRibbon", Geom,
 
   setup_data = function(data, params) {
     if (is.null(data$ymin) && is.null(data$ymax)) {
-      stop("Either ymin or ymax must be given as an aesthetic", call. = FALSE)
+      stop("Either ymin or ymax must be given as an aesthetic.", call. = FALSE)
     }
     data <- data[order(data$PANEL, data$group, data$x), , drop = FALSE]
     data$y <- data$ymin %||% data$ymax


### PR DESCRIPTION
reverse dependency check picked up an issue with the new sorting of `geom_ribbon()` in `setup_data()`. When `ymin` is set outside `aes()` it would fail as it wouldn't have access to the variable at setup time. This PR mitigates that.