### PR TITLE
vectorise the font_descent function to allow multiple input

### DIFF
--- a/R/margins.R
+++ b/R/margins.R
@@ -334,20 +334,26 @@ descent_cache <- new.env(parent = emptyenv())
 font_descent <- function(family = "", face = "plain", size = 12, cex = 1) {
   cur_dev <- names(grDevices::dev.cur())
   key <- paste0(cur_dev, ':', family, ':', face, ":", size, ":", cex)
+  descents <- lapply(key, function(k) {
+    descent <- descent_cache[[k]]
 
-  descent <- descent_cache[[key]]
-
-  if (is.null(descent)) {
-    descent <- convertHeight(grobDescent(textGrob(
-      label = "gjpqyQ",
-      gp = gpar(
-        fontsize = size,
-        cex = cex,
-        fontfamily = family,
-        fontface = face
-      )
-    )), 'inches')
-    descent_cache[[key]] <- descent
+    if (is.null(descent)) {
+      descent <- convertHeight(grobDescent(textGrob(
+        label = "gjpqyQ",
+        gp = gpar(
+          fontsize = size,
+          cex = cex,
+          fontfamily = family,
+          fontface = face
+        )
+      )), 'inches')
+      descent_cache[[k]] <- descent
+    }
+    descent
+  })
+  if (length(descents) == 1) {
+    descents[[1]]
+  } else {
+    do.call(unit.c, descents)
   }
-  descent
 }


### PR DESCRIPTION
reverse dependency check catched an instance of an extension storing multiple font settings in a title element, which broke the `font_descent()` assumption about only being provided a single setting to calculate descent on. This PR vectorises the function and mitigate the revdep break