### PR TITLE
Fix missing references on the pkgdown site

### DIFF
--- a/R/summarise-plot.R
+++ b/R/summarise-plot.R
@@ -51,6 +51,8 @@
 #' summarise_coord(b)
 #' summarise_layers(b)
 #'
+#' @keywords internal
+#'
 #' @name summarise_plot
 NULL
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -40,7 +40,7 @@ reference:
   desc: >
     A handful of layers are more easily specified with a `stat_` function,
     drawing attention to the statistical transformation rather than the visual
-    appearance.
+    appearance. The computed variables can be mapped using `stat()`.
   contents:
   - stat_ecdf
   - stat_ellipse
@@ -49,6 +49,8 @@ reference:
   - stat_summary_2d
   - stat_summary_bin
   - stat_unique
+  - stat_sf_coordinates
+  - stat
 
 - title: "Layer: position adjustment"
   desc: >
@@ -92,6 +94,7 @@ reference:
   - labs
   - lims
   - expand_limits
+  - expand_scale
   - starts_with("scale_")
 
 - title: "Guides: axes and legends"
@@ -115,6 +118,7 @@ reference:
   contents:
   - facet_grid
   - facet_wrap
+  - vars
 
 - title: "Facetting: labels"
   desc: >

--- a/man/summarise_plot.Rd
+++ b/man/summarise_plot.Rd
@@ -74,3 +74,4 @@ summarise_coord(b)
 summarise_layers(b)
 
 }
+\keyword{internal}


### PR DESCRIPTION
Fixes #3219

* Add missing topics (c.f. https://travis-ci.org/tidyverse/ggplot2/jobs/512667960#L2175)
    * `expand_scale`
    * `stat`
    * `stat_sf_coordinates`
    * `vars`
* Mark `summarise_plot` as internal