### PR TITLE
WIP: Emit warning if non-constant data columns are dropped by stat transformation.

### DIFF
--- a/R/stat-.r
+++ b/R/stat-.r
@@ -61,6 +61,10 @@ Stat <- ggproto("Stat",
 
   non_missing_aes = character(),
 
+  # aesthetics that are dropped from the data frame during the
+  # process of the statistical transformation
+  dropped_aes = character(),
+
   setup_params = function(data, params) {
     params
   },
@@ -119,7 +123,7 @@ Stat <- ggproto("Stat",
     # The above code will drop columns that are not constant within groups and not
     # carried over/recreated by the stat. This can produce unexpeted results,
     # and hence we warn about it.
-    dropped <- base::setdiff(names(data), names(data_new))
+    dropped <- base::setdiff(names(data), base::union(self$dropped_aes, names(data_new)))
     if (length(dropped) > 0) {
       warn_message <- paste0(
         length(dropped), " aesthetic(s) dropped during statistical transformation: ",

--- a/R/stat-.r
+++ b/R/stat-.r
@@ -114,7 +114,22 @@ Stat <- ggproto("Stat",
       )
     }, stats, groups, SIMPLIFY = FALSE)
 
-    rbind_dfs(stats)
+    data_new <- rbind_dfs(stats)
+
+    # The above code will drop columns that are not constant within groups and not
+    # carried over/recreated by the stat. This can produce unexpeted results,
+    # and hence we warn about it.
+    dropped <- base::setdiff(names(data), names(data_new))
+    if (length(dropped) > 0) {
+      warn_message <- paste0(
+        length(dropped), " aesthetic(s) dropped during statistical transformation: ",
+        paste0(dropped, collapse = ", "),
+        ".\nDid you forget to define a group aesthetic or to convert a numeric variable ",
+        "into a factor?"
+      )
+      warning(warn_message, call. = FALSE)
+    }
+    data_new
   },
 
   compute_group = function(self, data, scales) {

--- a/R/stat-bin.r
+++ b/R/stat-bin.r
@@ -1,8 +1,8 @@
 #' @param binwidth The width of the bins. Can be specified as a numeric value
-#'   or as a function that calculates width from unscaled x. Here, "unscaled x" 
-#'   refers to the original x values in the data, before application of any 
+#'   or as a function that calculates width from unscaled x. Here, "unscaled x"
+#'   refers to the original x values in the data, before application of any
 #'   scale transformation. When specifying a function along with a grouping
-#'   structure, the function will be called once per group. 
+#'   structure, the function will be called once per group.
 #'   The default is to use `bins`
 #'   bins that cover the range of the data. You should always override
 #'   this value, exploring multiple widths to find the best to illustrate the
@@ -147,6 +147,7 @@ StatBin <- ggproto("StatBin", Stat,
   },
 
   default_aes = aes(y = stat(count), weight = 1),
-  required_aes = c("x")
+  required_aes = c("x"),
+  dropped_aes = c("weight")
 )
 

--- a/R/stat-bindot.r
+++ b/R/stat-bindot.r
@@ -6,6 +6,7 @@ StatBindot <- ggproto("StatBindot", Stat,
   required_aes = "x",
   non_missing_aes = "weight",
   default_aes = aes(y = stat(count)),
+  dropped_aes = c("bin", "bincenter"), # these are temporary variables that are created and then removed by the stat
 
   setup_params = function(data, params) {
     if (is.null(params$binwidth)) {

--- a/R/stat-boxplot.r
+++ b/R/stat-boxplot.r
@@ -44,6 +44,7 @@ stat_boxplot <- function(mapping = NULL, data = NULL,
 StatBoxplot <- ggproto("StatBoxplot", Stat,
   required_aes = c("y"),
   non_missing_aes = "weight",
+  dropped_aes = c("y"),
   setup_data = function(data, params) {
     data$x <- data$x %||% 0
     data <- remove_missing(

--- a/R/stat-contour.r
+++ b/R/stat-contour.r
@@ -35,6 +35,7 @@ stat_contour <- function(mapping = NULL, data = NULL,
 StatContour <- ggproto("StatContour", Stat,
   required_aes = c("x", "y", "z"),
   default_aes = aes(order = stat(level)),
+  dropped_aes = c("z"),
 
   compute_group = function(data, scales, bins = NULL, binwidth = NULL,
                            breaks = NULL, complete = FALSE, na.rm = FALSE) {


### PR DESCRIPTION
Here is a first stab at fixing #3250, which is the silent dropping of mapped aesthetics. The code works in most cases, but there are false positives when the stat purposefully drops an aesthetic. For example, `stat_boxplot()` takes `y` and turns it into `ymin`, `ymax`, etc., and the current code doesn't know that.

One way to fix this would be to add a mechanism so that stats can declare aesthetics that are expected to be dropped, something like `Stat$dropped_aesthetics`, and the warning message would ignore those.

``` r
library(ggplot2)

# fill aesthetic is dropped, emit warning
ggplot(mtcars, aes(mpg, fill = am)) + geom_density(alpha = 0.5)
#> Warning: 1 aesthetic(s) dropped during statistical transformation: fill.
#> Did you forget to define a group aesthetic or to convert a numeric variable into a factor?
```

![](https://i.imgur.com/fqfuvG9.png)

``` r

# fill aesthetic is not dropped because color sets up
# a grouping, no warning
ggplot(mtcars, aes(mpg, fill = am, color = factor(am))) + geom_density(alpha = 0.5)
```

![](https://i.imgur.com/bv4SMby.png)

``` r

# false positive, y aesthetic is dropped because it is converted
# to ymin, ymax, etc.
ggplot(mtcars, aes(factor(cyl), mpg)) + geom_boxplot()
#> Warning: 1 aesthetic(s) dropped during statistical transformation: y.
#> Did you forget to define a group aesthetic or to convert a numeric variable into a factor?
```

![](https://i.imgur.com/2L8FT8g.png)

<sup>Created on 2019-04-19 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>