### PR TITLE
Fix grid errors when quantiles falls outside of violin

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -91,6 +91,9 @@ core developer team.
 
 * `geom_rug()` now works with `coord_flip()` (@has2k1, #2987).
 
+* `geom_violin()` no longer throws an error when quantile lines falls outside 
+  the violin polygon (@thomasp85, #3254)
+
 * Default labels are now generated more consistently; e.g., symbols no longer
   get backticks, and long expressions are abbreviated with `...`
   (@yutannihilation, #2981).

--- a/NEWS.md
+++ b/NEWS.md
@@ -91,8 +91,8 @@ core developer team.
 
 * `geom_rug()` now works with `coord_flip()` (@has2k1, #2987).
 
-* `geom_violin()` no longer throws an error when quantile lines falls outside 
-  the violin polygon (@thomasp85, #3254)
+* `geom_violin()` no longer throws an error when quantile lines fall outside 
+  the violin polygon (@thomasp85, #3254).
 
 * Default labels are now generated more consistently; e.g., symbols no longer
   get backticks, and long expressions are abbreviated with `...`

--- a/R/geom-violin.r
+++ b/R/geom-violin.r
@@ -136,12 +136,17 @@ GeomViolin <- ggproto("GeomViolin", Geom,
       quantiles <- create_quantile_segment_frame(data, draw_quantiles)
       aesthetics <- data[
         rep(1, nrow(quantiles)),
-        setdiff(names(data), c("x", "y")),
+        setdiff(names(data), c("x", "y", "group")),
         drop = FALSE
       ]
       aesthetics$alpha <- rep(1, nrow(quantiles))
       both <- cbind(quantiles, aesthetics)
-      quantile_grob <- GeomPath$draw_panel(both, ...)
+      both <- both[!is.na(both$group), , drop = FALSE]
+      quantile_grob <- if (nrow(both) == 0) {
+        zeroGrob()
+      } else {
+        GeomPath$draw_panel(both, ...)
+      }
 
       ggname("geom_violin", grobTree(
         GeomPolygon$draw_panel(newdata, ...),


### PR DESCRIPTION
Fixes #2885 

In certain instances quantiles will have `NA` coordinates and the computed aesthetics will not match the number of lines to draw, leading to grid errors