### PR TITLE
Avoid indexing error when adding an empty guides() specification

### DIFF
--- a/R/guides-.r
+++ b/R/guides-.r
@@ -59,8 +59,10 @@
 #' }
 guides <- function(...) {
   args <- list(...)
-  if (is.list(args[[1]]) && !inherits(args[[1]], "guide")) args <- args[[1]]
-  args <- rename_aes(args)
+  if (length(args) > 0) {
+    if (is.list(args[[1]]) && !inherits(args[[1]], "guide")) args <- args[[1]]
+    args <- rename_aes(args)
+  }
   structure(args, class = "guides")
 }
 


### PR DESCRIPTION
Fixes #2914 

This PR makes adding an empty `guides()` a no-op (from the outside look)