### PR TITLE
Add warning when raster data doesn't fall on an even grid

### DIFF
--- a/R/geom-raster.r
+++ b/R/geom-raster.r
@@ -49,18 +49,23 @@ GeomRaster <- ggproto("GeomRaster", Geom,
   required_aes = c("x", "y"),
 
   setup_data = function(data, params) {
+    precision <- sqrt(.Machine$double.eps)
     hjust <- params$hjust %||% 0.5
     vjust <- params$vjust %||% 0.5
 
-    x_diff <- diff(sort(unique(data$x)))
-    if (!length(unique(x_diff)) == 1) {
+    x_diff <- diff(sort(unique(as.numeric(data$x))))
+    if (length(x_diff) == 0) {
+      w <- 1
+    } else if (any(abs(diff(x_diff)) > precision)) {
       warning("Raster pixels are placed at uneven horizontal intervals and will be shifted. Consider using geom_tile() instead.")
       w <- min(x_diff)
     } else {
       w <- x_diff[1]
     }
-    y_diff <- diff(sort(unique(data$y)))
-    if (!length(unique(x_diff)) == 1) {
+    y_diff <- diff(sort(unique(as.numeric(data$y))))
+    if (length(y_diff) == 0) {
+      h <- 1
+    } else if (any(abs(diff(y_diff)) > precision)) {
       warning("Raster pixels are placed at uneven vertical intervals and will be shifted. Consider using geom_tile() instead.")
       h <- min(y_diff)
     } else {

--- a/R/geom-raster.r
+++ b/R/geom-raster.r
@@ -52,8 +52,20 @@ GeomRaster <- ggproto("GeomRaster", Geom,
     hjust <- params$hjust %||% 0.5
     vjust <- params$vjust %||% 0.5
 
-    w <- resolution(data$x, FALSE)
-    h <- resolution(data$y, FALSE)
+    x_diff <- diff(sort(unique(data$x)))
+    if (!length(unique(x_diff)) == 1) {
+      warning("Raster pixels are placed at uneven horizontal intervals and will be shifted. Consider using geom_tile() instead.")
+      w <- min(x_diff)
+    } else {
+      w <- x_diff[1]
+    }
+    y_diff <- diff(sort(unique(data$y)))
+    if (!length(unique(x_diff)) == 1) {
+      warning("Raster pixels are placed at uneven vertical intervals and will be shifted. Consider using geom_tile() instead.")
+      h <- min(y_diff)
+    } else {
+      h <- y_diff[1]
+    }
 
     data$xmin <- data$x - w * (1 - hjust)
     data$xmax <- data$x + w * hjust


### PR DESCRIPTION
Fixes #2932

This adds a warning when `geom_raster()` can't truthfully represent the provided data. To avoid recompilation the call to `resolution()` has been changed to direct calculation.

@batpigandme can you have a look at the wording of the warning?