### PR TITLE
Draw axis line when length(breaks) == 0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -107,6 +107,9 @@ core developer team.
 
 * `scale_shape_identity()` now works correctly with `guide = "legend"` 
   (@malcolmbarrett, #3029)
+  
+* `scale_continuous` will now draw axis line even if the length of breaks is 0
+  (@thomasp85, #3257)
 
 * `stat_bin()` will now error when the number of bins exceeds 1e6 to avoid 
   accidentally freezing the user session (@thomasp85).

--- a/R/guides-axis.r
+++ b/R/guides-axis.r
@@ -5,14 +5,27 @@
 # @param position of axis (top, bottom, left or right)
 # @param range of data values
 guide_axis <- function(at, labels, position = "right", theme) {
-  if (length(at) == 0)
-    return(zeroGrob())
-
-  at <- unit(at, "native")
+  line <- switch(position,
+    top =    element_render(theme, "axis.line.x.top", c(0, 1), c(0, 0), id.lengths = 2),
+    bottom = element_render(theme, "axis.line.x.bottom", c(0, 1), c(1, 1), id.lengths = 2),
+    right =  element_render(theme, "axis.line.y.right", c(0, 0), c(0, 1), id.lengths = 2),
+    left =   element_render(theme, "axis.line.y.left", c(1, 1), c(0, 1), id.lengths = 2)
+  )
   position <- match.arg(position, c("top", "bottom", "right", "left"))
 
   zero <- unit(0, "npc")
   one <- unit(1, "npc")
+
+  if (length(at) == 0) {
+    vertical <- position %in% c("left", "right")
+    return(absoluteGrob(
+      gList(line),
+      width = if (vertical) zero else one,
+      height = if (vertical) one else zero
+    ))
+  }
+
+  at <- unit(at, "native")
 
   theme$axis.ticks.length.x.bottom <- with(
     theme,
@@ -71,12 +84,7 @@ guide_axis <- function(at, labels, position = "right", theme) {
     right = ,
     left =  element_render(theme, label_render, labels, y = label_y, margin_x = TRUE))
 
-  line <- switch(position,
-    top =    element_render(theme, "axis.line.x.top", c(0, 1), c(0, 0), id.lengths = 2),
-    bottom = element_render(theme, "axis.line.x.bottom", c(0, 1), c(1, 1), id.lengths = 2),
-    right =  element_render(theme, "axis.line.y.right", c(0, 0), c(0, 1), id.lengths = 2),
-    left =   element_render(theme, "axis.line.y.left", c(1, 1), c(0, 1), id.lengths = 2)
-  )
+
 
   nticks <- length(at)
 


### PR DESCRIPTION
Fixes #2983

Prior to this, `guide_axis()` would return a `zeroGrob` when no break position where provided. This meant that axis lines were not drawn in these situations. This fix changes the behaviour so that axis lines always will be drawn (if allowed by the theme)

@hadley I've asked you to review as the old behaviour may have been deliberate