### PR TITLE
Add stat aesthetics to contour docs

### DIFF
--- a/R/stat-contour.r
+++ b/R/stat-contour.r
@@ -1,5 +1,6 @@
 #' @inheritParams stat_identity
 #' @export
+#' @eval rd_aesthetics("stat", "contour")
 #' @section Computed variables:
 #' \describe{
 #'  \item{level}{height of contour}

--- a/man/geom_contour.Rd
+++ b/man/geom_contour.Rd
@@ -90,6 +90,17 @@ to a grid before visualising.
 \item \code{weight}
 }
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
+
+
+\code{stat_contour()} understands the following aesthetics (required aesthetics are in bold):
+\itemize{
+\item \strong{\code{x}}
+\item \strong{\code{y}}
+\item \strong{\code{z}}
+\item \code{group}
+\item \code{order}
+}
+Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 }
 
 \section{Computed variables}{


### PR DESCRIPTION
Fixes #3095

This adds the stat aesthetics to the documentation of contour thus properly showing the required `z` aesthetic... I don't really like the look of stacking calls to `rd_aesthetics()` but this is what we got right now...