### PR TITLE
return a tibble with `ggplot_build()` and `layer_data()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,7 +56,7 @@ core developer team.
 
 ## Minor improvements and bug fixes
 
-* `ggplot_build()` and `layer_data()` now return data as `tibble`s (@malcolmbarrett, #)
+* `ggplot_build()` and `layer_data()` now return data as `tibble`s (@malcolmbarrett, #3264)
 
 * `cut_width()` now accepts `...` to pass further arguments to `base::cut.default()`
    like `cut_number()` and `cut_interval()` already did (@cderv, #3055)

--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,8 @@ core developer team.
 
 ## Minor improvements and bug fixes
 
+* `ggplot_build()` and `layer_data()` now return data as `tibble`s (@malcolmbarrett, #)
+
 * `cut_width()` now accepts `...` to pass further arguments to `base::cut.default()`
    like `cut_number()` and `cut_interval()` already did (@cderv, #3055)
 

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -105,6 +105,9 @@ ggplot_build.ggplot <- function(plot) {
   # Let Layout modify data before rendering
   data <- layout$finish_data(data)
 
+  # Convert to tibble
+  data <- lapply(data, tibble::as_tibble)
+
   structure(
     list(data = data, layout = layout, plot = plot),
     class = "ggplot_built"
@@ -114,7 +117,7 @@ ggplot_build.ggplot <- function(plot) {
 #' @export
 #' @rdname ggplot_build
 layer_data <- function(plot, i = 1L) {
-  ggplot_build(plot)$data[[i]]
+  tibble::as_tibble(ggplot_build(plot)$data[[i]])
 }
 
 #' @export

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -117,7 +117,7 @@ ggplot_build.ggplot <- function(plot) {
 #' @export
 #' @rdname ggplot_build
 layer_data <- function(plot, i = 1L) {
-  tibble::as_tibble(ggplot_build(plot)$data[[i]])
+  ggplot_build(plot)$data[[i]]
 }
 
 #' @export

--- a/tests/testthat/test-geom-smooth.R
+++ b/tests/testthat/test-geom-smooth.R
@@ -1,7 +1,7 @@
 context("geom_smooth")
 
 test_that("data is ordered by x", {
-  df <- data_frame(x = c(1, 5, 2, 3, 4), y = 1:5)
+  df <- data_frame(x = c(1, 5, 2, 3, 4), y = as.numeric(1:5))
 
   ps <- ggplot(df, aes(x, y))+
     geom_smooth(stat = "identity", se = FALSE)

--- a/tests/testthat/test-scale-manual.r
+++ b/tests/testthat/test-scale-manual.r
@@ -11,7 +11,7 @@ dat <- data_frame(g = c("B","A","A"))
 p <- ggplot(dat, aes(g, fill = g)) + geom_bar()
 col <- c("A" = "red", "B" = "green", "C" = "blue")
 
-cols <- function(x) ggplot_build(x)$data[[1]][, "fill"]
+cols <- function(x) ggplot_build(x)$data[[1]][["fill"]]
 
 test_that("named values work regardless of order", {
   fill_scale <- function(order) scale_fill_manual(values = col[order],

--- a/tests/testthat/test-stat-sf-coordinates.R
+++ b/tests/testthat/test-stat-sf-coordinates.R
@@ -10,12 +10,12 @@ test_that("stat_sf_coordinates() retrieves coordinates from sf objects", {
 
   # point
   df_point <- sf::st_sf(geometry = sf::st_sfc(sf::st_point(c(0, 0))))
-  expect_identical(comp_sf_coord(df_point)[, c("x", "y")], data_frame(x = 0, y = 0))
+  expect_equal(comp_sf_coord(df_point)[, c("x", "y")], data_frame(x = 0, y = 0))
 
   # line
   c_line <- rbind(c(-1, -1), c(1, 1))
   df_line <- sf::st_sf(geometry = sf::st_sfc(sf::st_linestring(c_line)))
-  expect_identical(
+  expect_equal(
     # Note that st_point_on_surface() does not return the centroid for
     # `df_line`, which may be a bit confusing. So, use st_centroid() here.
     comp_sf_coord(df_line, fun.geometry = sf::st_centroid)[, c("x", "y")],
@@ -25,11 +25,11 @@ test_that("stat_sf_coordinates() retrieves coordinates from sf objects", {
   # polygon
   c_polygon <- list(rbind(c(-1, -1), c(-1, 1), c(1, 1), c(1, -1), c(-1, -1)))
   df_polygon <- sf::st_sf(geometry = sf::st_sfc(sf::st_polygon(c_polygon)))
-  expect_identical(comp_sf_coord(df_point)[, c("x", "y")], data_frame(x = 0, y = 0))
+  expect_equal(comp_sf_coord(df_point)[, c("x", "y")], data_frame(x = 0, y = 0))
 
   # computed variables (x and y)
   df_point <- sf::st_sf(geometry = sf::st_sfc(sf::st_point(c(1, 2))))
-  expect_identical(
+  expect_equal(
     comp_sf_coord(df_point, aes(x = stat(x) + 10, y = stat(y) * 10))[, c("x", "y")],
     data_frame(x = 11, y = 20)
   )
@@ -43,5 +43,5 @@ test_that("stat_sf_coordinates() ignores Z and M coordinates", {
   df_xym <- sf::st_sf(geometry = sf::st_sfc(sf::st_polygon(c_polygon, dim = "XYM")))
   # Note that st_centroid() and st_point_on_surface() cannot handle M dimension since
   # GEOS does not support it. The default fun.geometry should drop M.
-  expect_identical(comp_sf_coord(df_xym)[, c("x", "y")], data_frame(x = 0, y = 0))
+  expect_equal(comp_sf_coord(df_xym)[, c("x", "y")], data_frame(x = 0, y = 0))
 })


### PR DESCRIPTION
Currently, `ggplot_build()` and `layer_data()` return a `data.frame`. This seems a little inconsistent with the rest of the tidyverse. This is little PR (motivated by some recent work with `layer_data()` that filled up my console) changes `ggplot_build()` to convert the data for the layers to `tibble`s., which is also reflected in `layer_data()`. 

I also had to make a few tweaks to the tests due to some subtle differences with using a `tibble`. However, I think these are mostly technical and that the spirit of each test is unchanged.

