### PR TITLE
Move build-time calculations to .onLoad()

### DIFF
--- a/R/grob-null.r
+++ b/R/grob-null.r
@@ -4,7 +4,9 @@
 #' @export
 zeroGrob <- function() .zeroGrob
 
-.zeroGrob <- grob(cl = "zeroGrob", name = "NULL")
+# Will get assigned in .onLoad()
+.zeroGrob <- NULL
+
 #' @export
 #' @method widthDetails zeroGrob
 widthDetails.zeroGrob <- function(x) unit(0, "cm")

--- a/R/theme-current.R
+++ b/R/theme-current.R
@@ -1,6 +1,6 @@
 #' @include theme-defaults.r
 #' @include theme-elements.r
-ggplot_global$theme_current <- theme_gray()
+NULL
 
 #' Get, set, and modify the active theme
 #'

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -19,6 +19,10 @@
 .onLoad <- function(...) {
   backport_unit_methods()
 
+  .zeroGrob <<- grob(cl = "zeroGrob", name = "NULL")
+
+  ggplot_global$theme_current <- theme_gray()
+
   # To avoid namespace clash with dplyr.
   # It seems surprising that this hack works
   if (requireNamespace("dplyr", quietly = TRUE)) {


### PR DESCRIPTION
Fixes #3233

Two instances were observed and moved too `.onLoad()` after going through the full source code