### PR TITLE
fix bad default for legend spacing variables. closes #2943.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -105,6 +105,9 @@ core developer team.
 * `geom_violin()` no longer throws an error when quantile lines fall outside 
   the violin polygon (@thomasp85, #3254).
 
+* `guide_legend()` and `guide_colorbar()` now use appropriate spacing between legend
+  key glyphs and legend text even if the legend title is missing (@clauswilke, #2943).
+
 * Default labels are now generated more consistently; e.g., symbols no longer
   get backticks, and long expressions are abbreviated with `...`
   (@yutannihilation, #2981).

--- a/R/guide-colorbar.r
+++ b/R/guide-colorbar.r
@@ -342,7 +342,8 @@ guide_gengrob.colorbar <- function(guide, theme) {
 
   title_width <- width_cm(grob.title)
   title_height <- height_cm(grob.title)
-  title_fontsize <- title.theme$size %||% calc_element("legend.title", theme)$size %||% 0
+  title_fontsize <- title.theme$size %||% calc_element("legend.title", theme)$size %||%
+    calc_element("text", theme)$size %||% 11
 
   # gap between keys etc
   # the default horizontal and vertical gap need to be the same to avoid strange

--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -327,7 +327,8 @@ guide_gengrob.legend <- function(guide, theme) {
 
   title_width <- width_cm(grob.title)
   title_height <- height_cm(grob.title)
-  title_fontsize <- title.theme$size %||% calc_element("legend.title", theme)$size %||% 0
+  title_fontsize <- title.theme$size %||% calc_element("legend.title", theme)$size %||%
+    calc_element("text", theme)$size %||% 11
 
   # gap between keys etc
   # the default horizontal and vertical gap need to be the same to avoid strange


### PR DESCRIPTION
This is a minimal fix for #2943. It guarantees that plot legends look fine when `legend.title = element_blank()`, but otherwise doesn't change the appearance of the legend. In the future, this should be refactored, because the same variables control the overall spacing between the legend title and the legend keys and the spacing between individual legend items. There should be two separate variables for that.

``` r
library(ggplot2)

df <- reshape2::melt(outer(1:4, 1:4), varnames = c("X1", "X2"))
p1 <- ggplot(df, aes(X1, X2)) + geom_tile(aes(fill = value))

p1 + scale_fill_continuous(guide = guide_legend())
```

![](https://i.imgur.com/ANFu1EI.png)

``` r
p1 + scale_fill_continuous(guide = guide_legend()) +
  theme(legend.title=element_blank())
```

![](https://i.imgur.com/XGKAEmE.png)

``` r

p1
```

![](https://i.imgur.com/BTg25pQ.png)

``` r
p1 + theme(legend.title=element_blank())
```

![](https://i.imgur.com/FKuM31k.png)

<sup>Created on 2019-04-26 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>