### PR TITLE
add 'interval' argument to stat_smooth. addresses #3214

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+* `stat_smooth()` and `geom_smooth()` now supports prediction intervals using 
+  the `interval` argument when method = lm (@baderstine, #3214)
+
 # ggplot2 3.1.1.9000
 
 This is a minor release with an emphasis on internal changes to make ggplot2 

--- a/R/stat-smooth-methods.r
+++ b/R/stat-smooth-methods.r
@@ -6,12 +6,12 @@
 # @alias predictdf.glm
 # @alias predictdf.loess
 # @alias predictdf.locfit
-predictdf <- function(model, xseq, se, level) UseMethod("predictdf")
+predictdf <- function(model, xseq, se, level, interval) UseMethod("predictdf")
 
 #' @export
-predictdf.default <- function(model, xseq, se, level) {
+predictdf.default <- function(model, xseq, se, level, interval) {
   pred <- stats::predict(model, newdata = new_data_frame(list(x = xseq)), se.fit = se,
-    level = level, interval = if (se) "confidence" else "none")
+    level = level, interval = interval)
 
   if (se) {
     fit <- as.data.frame(pred$fit)
@@ -23,7 +23,10 @@ predictdf.default <- function(model, xseq, se, level) {
 }
 
 #' @export
-predictdf.glm <- function(model, xseq, se, level) {
+predictdf.glm <- function(model, xseq, se, level, interval) {
+  if(se & interval == "prediction")
+    message("interval = '", interval, "' not supported, using interval = 'confidence'")
+
   pred <- stats::predict(model, newdata = data_frame(x = xseq), se.fit = se,
     type = "link")
 
@@ -42,7 +45,10 @@ predictdf.glm <- function(model, xseq, se, level) {
 }
 
 #' @export
-predictdf.loess <- function(model, xseq, se, level) {
+predictdf.loess <- function(model, xseq, se, level, interval) {
+  if(se & interval == "prediction")
+    message("interval = '", interval, "' not supported, using interval = 'confidence'")
+
   pred <- stats::predict(model, newdata = data_frame(x = xseq), se = se)
 
   if (se) {
@@ -57,7 +63,10 @@ predictdf.loess <- function(model, xseq, se, level) {
 }
 
 #' @export
-predictdf.locfit <- function(model, xseq, se, level) {
+predictdf.locfit <- function(model, xseq, se, level, interval) {
+  if(se & interval == "prediction")
+    message("interval = '", interval, "' not supported, using interval = 'confidence'")
+
   pred <- stats::predict(model, newdata = data_frame(x = xseq), se.fit = se)
 
   if (se) {

--- a/man/draw_key.Rd
+++ b/man/draw_key.Rd
@@ -65,7 +65,7 @@ A grid grob.
 }
 \description{
 Each geom has an associated function that draws the key when the geom needs
-to be displayed in a legend. These functions are called \code{draw_key_*}, where
+to be displayed in a legend. These functions are called \code{draw_key_*()}, where
 \code{*} stands for the name of the respective key glyph. The key glyphs can be
 customized for individual geoms by providing a geom with the \code{key_glyph}
 argument (see \code{\link[=layer]{layer()}} or examples below.)

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -12,8 +12,8 @@ geom_smooth(mapping = NULL, data = NULL, stat = "smooth",
 stat_smooth(mapping = NULL, data = NULL, geom = "smooth",
   position = "identity", ..., method = "auto", formula = y ~ x,
   se = TRUE, n = 80, span = 0.75, fullrange = FALSE,
-  level = 0.95, method.args = list(), na.rm = FALSE,
-  show.legend = NA, inherit.aes = TRUE)
+  level = 0.95, interval = "confidence", method.args = list(),
+  na.rm = FALSE, show.legend = NA, inherit.aes = TRUE)
 }
 \arguments{
 \item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
@@ -62,8 +62,8 @@ model that \code{method = "auto"} would use, then set
 \item{formula}{Formula to use in smoothing function, eg. \code{y ~ x},
 \code{y ~ poly(x, 2)}, \code{y ~ log(x)}}
 
-\item{se}{Display confidence interval around smooth? (\code{TRUE} by default, see
-\code{level} to control.)}
+\item{se}{Display interval around smooth? (\code{TRUE} by default, see
+\code{level} to control, \code{interval} for type.)}
 
 \item{na.rm}{If \code{FALSE}, the default, missing values are removed with
 a warning. If \code{TRUE}, missing values are silently removed.}
@@ -91,7 +91,12 @@ lines.}
 \item{fullrange}{Should the fit span the full range of the plot, or just
 the data?}
 
-\item{level}{Level of confidence interval to use (0.95 by default).}
+\item{level}{Confidence/tolerance level to use (0.95 by default).}
+
+\item{interval}{Type of interval calculation (\code{confidence} by default).
+\code{confidence} produces pointwise confidence intervals for the mean. For
+linear models, (e.g., method = \code{lm}) \code{prediction} produces pointwise
+prediction intervals for new response observations.}
 
 \item{method.args}{List of additional arguments passed on to the modelling
 function defined by \code{method}.}
@@ -133,8 +138,8 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \describe{
 \item{y}{predicted value}
-\item{ymin}{lower pointwise confidence interval around the mean}
-\item{ymax}{upper pointwise confidence interval around the mean}
+\item{ymin}{lower interval value}
+\item{ymax}{upper interval value}
 \item{se}{standard error}
 }
 }


### PR DESCRIPTION
This is an initial attempt to address #3214 
Only applies to `predict.lm` calls.

Example usage where 'prediction' interval is used:
```
ggplot(mtcars, aes(x=hp, y=disp)) + 
  geom_point() + 
  geom_smooth(formula = y ~ poly(x,2), method="lm", se=T, interval="p") 
```
![image](https://user-images.githubusercontent.com/2738299/56855498-94982100-690d-11e9-91e3-b02e74fa06c7.png)

A potentially unfortunate side effect is that the following warning is always printed:

> Warning message:
> In predict.lm(model, newdata = new_data_frame(list(x = xseq)), se.fit = se,  :
>   Assuming constant prediction variance even though model fit is weighted

From the predict.lm documentation: "If the fit was weighted and newdata is given, the default is to assume constant prediction variance, with a warning."  
This warning _always_ displays because both `weights` and `newdata` are always provided:

https://github.com/tidyverse/ggplot2/blob/cd6f7cac7b1e27341cf2d08791f9c2e8bca90437/R/stat-smooth.r#L137

 https://github.com/tidyverse/ggplot2/blob/cd6f7cac7b1e27341cf2d08791f9c2e8bca90437/R/stat-smooth-methods.r#L13 

I could remove the warning message by conditionally passing a weight argument, however, it is not entirely clear what the weight values would be except in the simple case when all the weights were set to 1 by stat-smooth.r:
https://github.com/tidyverse/ggplot2/blob/cd6f7cac7b1e27341cf2d08791f9c2e8bca90437/R/stat-smooth.r#L112
It think it makes sense to address this specific case but I haven't done so yet:

For non-predict.lm models, I added a warning message to let the user know that `interval="prediction"` isn't supported and fall back on the default confidence interval:

> interval = 'prediction' not supported, using interval = 'confidence'


