### PR TITLE
Fix a broken link to CODE_OF_CONDUCT.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ quickly as possible. The guide is divided into two main pieces:
 1. Filing a bug report or feature request in an issue.
 1. Suggesting a change via a pull request.
 
-Please note that ggplot2 is released with a [Contributor Code of Conduct](.github/CODE_OF_CONDUCT.md). By contributing to this project, 
+Please note that ggplot2 is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By contributing to this project, 
 you agree to abide by its terms.
 
 ## Issues


### PR DESCRIPTION
Moving the CODE_OF_CONDUCT.md document to the main directory (https://github.com/tidyverse/ggplot2/pull/2973) has broken the link to it within the CONTRIBUTING.md document.

This PR fixes an identical issue to one of the commits in https://github.com/tidyverse/ggplot2/pull/2973 (https://github.com/tidyverse/ggplot2/pull/2973/commits/027a0ddc28f58685ecffa5464999d46b04308737) which fixed a broken link in the GOVERNANCE.md document.