### PR TITLE
Fix behaviour of combine_vars() with more than one facet variable

### DIFF
--- a/R/facet-.r
+++ b/R/facet-.r
@@ -563,7 +563,7 @@ combine_vars <- function(data, env = emptyenv(), vars = NULL, drop = TRUE) {
     if (drop) {
       new <- unique_combs(new)
     }
-    base <- rbind(base, df.grid(old, new))
+    base <- unique(rbind(base, df.grid(old, new)))
   }
 
   if (empty(base)) {

--- a/tests/testthat/test-facet-.r
+++ b/tests/testthat/test-facet-.r
@@ -204,6 +204,30 @@ test_that("facet gives clear error if ", {
   )
 })
 
+# Variable combinations ---------------------------------------------------
+
+test_that("combine_vars() generates the correct combinations with multiple data frames", {
+  df <- expand.grid(letter = c("a", "b"), number = c(1, 2), boolean = c(TRUE, FALSE))
+
+  vars <- vars(letter = letter, number = number)
+  expect_identical(
+    combine_vars(list(df), vars = vars),
+    combine_vars(list(df, df), vars = vars)
+  )
+  expect_identical(
+    combine_vars(list(df), vars = vars),
+    combine_vars(list(df, df[character(0)]), vars = vars)
+  )
+  expect_identical(
+    combine_vars(list(df), vars = vars),
+    combine_vars(list(df, df["letter"]), vars = vars)
+  )
+  expect_identical(
+    combine_vars(list(df), vars = vars),
+    combine_vars(list(df, df[c("letter", "number")]), vars = vars)
+  )
+})
+
 
 # Visual tests ------------------------------------------------------------
 

--- a/tests/testthat/test-facet-.r
+++ b/tests/testthat/test-facet-.r
@@ -206,6 +206,80 @@ test_that("facet gives clear error if ", {
 
 # Variable combinations ---------------------------------------------------
 
+test_that("zero-length vars in combine_vars() generates zero combinations", {
+  df <- data_frame(letter = c("a", "b"))
+  expect_equal(nrow(combine_vars(list(df), vars = vars())), 0)
+  expect_equal(ncol(combine_vars(list(df), vars = vars())), 0)
+})
+
+test_that("at least one layer must contain all facet variables in combine_vars()", {
+  df <- data_frame(letter = c("a", "b"))
+  expect_silent(combine_vars(list(df), vars = vars(letter = letter)))
+  expect_error(
+    combine_vars(list(df), vars = vars(letter = number)),
+    "At least one layer"
+  )
+})
+
+test_that("at least one combination must exist in combine_vars()", {
+  df <- data_frame(letter = character(0))
+  expect_error(
+    combine_vars(list(df), vars = vars(letter = letter)),
+    "Faceting variables must have at least one value"
+  )
+})
+
+test_that("combine_vars() generates the correct combinations", {
+  df_one <- data_frame(
+    letter = c("a", "b"),
+    number = c(1, 2),
+    boolean = c(TRUE, FALSE),
+    factor = factor(c("level1", "level2"))
+  )
+
+  df_all <- expand.grid(
+    letter = c("a", "b"),
+    number = c(1, 2),
+    boolean = c(TRUE, FALSE),
+    factor = factor(c("level1", "level2")),
+    stringsAsFactors = FALSE
+  )
+
+  vars_all <- vars(letter = letter, number =  number, boolean = boolean, factor = factor)
+
+  expect_equivalent(
+    combine_vars(list(df_one), vars = vars_all),
+    df_one
+  )
+
+  expect_equivalent(
+    combine_vars(list(df_all), vars = vars_all),
+    df_all
+  )
+
+  # with drop = FALSE the rows are ordered in the opposite order
+  # NAs are dropped with drop = FALSE (except for NA factor values);
+  # NAs are kept with with drop = TRUE
+  # drop keeps all combinations of data, regardless of the combinations in which
+  # they appear in the data (in addition to keeping unused factor levels)
+  expect_equivalent(
+    combine_vars(list(df_one), vars = vars_all, drop = FALSE),
+    df_all[order(df_all$letter, df_all$number, df_all$boolean, df_all$factor), ]
+  )
+})
+
+test_that("drop = FALSE in combine_vars() keeps unused factor levels", {
+  df <- data_frame(x = factor("a", levels = c("a", "b")))
+  expect_equivalent(
+    combine_vars(list(df), vars = vars(x = x), drop = TRUE),
+    data_frame(x = factor("a"))
+  )
+  expect_equivalent(
+    combine_vars(list(df), vars = vars(x = x), drop = FALSE),
+    data_frame(x = factor(c("a", "b")))
+  )
+})
+
 test_that("combine_vars() generates the correct combinations with multiple data frames", {
   df <- expand.grid(letter = c("a", "b"), number = c(1, 2), boolean = c(TRUE, FALSE))
 
@@ -227,7 +301,6 @@ test_that("combine_vars() generates the correct combinations with multiple data 
     combine_vars(list(df, df[c("letter", "number")]), vars = vars)
   )
 })
-
 
 # Visual tests ------------------------------------------------------------
 


### PR DESCRIPTION
This PR fixes #2810, which describes the unusual failure of `facet_wrap()` when used with layers containing different numbers of facet variables.

``` r
library(ggplot2)

df_all_vars <- expand.grid(letter = c("a", "b"), number = c(1, 2), x = 1, y = 1)
df_some_vars <- data.frame(letter = c("a", "b"), x = 2, y = 2)

ggplot() +
  geom_point(aes(x, y), data = df_all_vars) +
  geom_point(aes(x, y), data = df_some_vars) +
  facet_wrap(vars(letter, number))
#> Error in gList(structure(list(x = structure(0.5, class = "unit", valid.unit = 0L, unit = "npc"), : only 'grobs' allowed in "gList"
```

This took a very long time to track down. In the end, `FacetWrap$compute_layout()` was generating a layout with 12 rows, when there are only four panels computed by `FacetWrap$map_data()`. This resulted in some `NULL` grobs due to index recycling, which are not valid but don't generate errors until render time (r-lib/gtable#80). This layout is computed by `combine_vars()`, which has incorrect handling when there are different numbers of facet variables in each layer's data.

``` r
library(ggplot2)
df <- expand.grid(letter = c("a", "b"), number = c(1, 2))
combine_vars(list(df, df["letter"]), vars = vars(letter = letter, number = number))
#>    letter number
#> 1       a      1
#> 2       b      1
#> 3       a      2
#> 4       b      2
#> 5       a      1
#> 6       a      1
#> 7       a      2
#> 8       a      2
#> 9       b      1
#> 10      b      1
#> 11      b      2
#> 12      b      2
```

This PR fixes this behaviour (by wrapping the line that generates too many combinations with `unique()`) and adds tests to verify the existing behaviour of `combine_vars()`. There some odd behaviour when using the `drop = FALSE` argument, notably that NAs are dropped (unless they are factor values), and that missing combinations of multiple facet variables are included (in addition to missing factor levels). 

This function could probably be rewritten to be clearer, but I didn't do this because I didn't want to break the existing behaviour.