### PR TITLE
updated revdeps

### DIFF
--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,77 +1,165 @@
 # Platform
 
-|field    |value                                              |
-|:--------|:--------------------------------------------------|
-|version  |R Under development (unstable) (2019-03-18 r76245) |
-|os       |macOS High Sierra 10.13.6                          |
-|system   |x86_64, darwin15.6.0                               |
-|ui       |X11                                                |
-|language |(EN)                                               |
-|collate  |en_US.UTF-8                                        |
-|ctype    |en_US.UTF-8                                        |
-|tz       |America/New_York                                   |
-|date     |2019-03-27                                         |
+|field    |value                        |
+|:--------|:----------------------------|
+|version  |R version 3.5.3 (2019-03-11) |
+|os       |macOS High Sierra 10.13.6    |
+|system   |x86_64, darwin15.6.0         |
+|ui       |X11                          |
+|language |(EN)                         |
+|collate  |en_US.UTF-8                  |
+|ctype    |en_US.UTF-8                  |
+|tz       |America/New_York             |
+|date     |2019-05-03                   |
 
 # Dependencies
 
 |package |old   |new        |Δ  |
 |:-------|:-----|:----------|:--|
-|ggplot2 |3.1.0 |3.1.0.9000 |*  |
+|ggplot2 |3.1.1 |3.1.1.9000 |*  |
 
 # Revdeps
 
-## Couldn't check (9)
+## Failed to check (99)
 
-|package         |version |error |warning |note |source                                                          |
-|:---------------|:-------|:-----|:-------|:----|:---------------------------------------------------------------|
-|annotatr        |?       |      |        |     |[cran/annotatr](https://github.com/cran/annotatr)               |
-|ChIPseeker      |?       |      |        |     |[cran/ChIPseeker](https://github.com/cran/ChIPseeker)           |
-|clusterProfiler |?       |      |        |     |[cran/clusterProfiler](https://github.com/cran/clusterProfiler) |
-|fgsea           |?       |      |        |     |[cran/fgsea](https://github.com/cran/fgsea)                     |
-|LINC            |?       |      |        |     |[cran/LINC](https://github.com/cran/LINC)                       |
-|MEAL            |?       |      |        |     |[cran/MEAL](https://github.com/cran/MEAL)                       |
-|methylGSA       |?       |      |        |     |[cran/methylGSA](https://github.com/cran/methylGSA)             |
-|ReactomePA      |?       |      |        |     |[cran/ReactomePA](https://github.com/cran/ReactomePA)           |
-|SMITE           |?       |      |        |     |[cran/SMITE](https://github.com/cran/SMITE)                     |
+|package                          |version   |error  |warning |note |
+|:--------------------------------|:---------|:------|:-------|:----|
+|affycoretools                    |1.54.0    |1      |        |     |
+|aslib                            |0.1       |1      |        |     |
+|BaalChIP                         |1.8.0     |1      |        |2    |
+|BACA                             |1.3       |1      |        |     |
+|BACCT                            |1.0       |1      |        |     |
+|bamdit                           |3.2.1     |1      |        |     |
+|BayesRS                          |0.1.3     |1      |        |     |
+|BNSP                             |2.0.8     |1      |        |     |
+|BPEC                             |1.3.0     |1      |        |     |
+|bsam                             |1.1.2     |1      |        |     |
+|BTSPAS                           |2014.0901 |1      |        |1    |
+|CaliCo                           |0.1.1     |1      |        |     |
+|ChIPseeker                       |?         |       |        |     |
+|chromstaR                        |1.8.1     |1      |        |     |
+|clusterProfiler                  |?         |       |        |     |
+|CNVrd2                           |1.20.0    |1      |        |     |
+|CollapsABEL                      |0.10.11   |1      |        |     |
+|colorednoise                     |1.0.4     |1      |        |     |
+|crmPack                          |0.2.9     |1      |        |     |
+|Crossover                        |0.1-17    |1      |        |     |
+|DaMiRseq                         |1.6.2     |1      |        |     |
+|Deducer                          |0.7-9     |1      |        |     |
+|DeLorean                         |1.5.0     |1      |        |     |
+|DiffBind                         |2.10.0    |1      |        |2    |
+|DiversityOccupancy               |1.0.6     |1      |        |     |
+|dynfrail                         |0.5.2     |1      |        |     |
+|dynr                             |0.1.14-9  |1      |        |     |
+|eegc                             |1.8.1     |1      |1       |2    |
+|ELMER                            |2.6.3     |1      |        |     |
+|esATAC                           |1.4.5     |1      |        |2    |
+|evoper                           |0.5.0     |1      |        |     |
+|ewoc                             |0.2.0     |1      |        |     |
+|fgsea                            |?         |       |        |     |
+|fingerPro                        |1.1       |1      |        |     |
+|fsdaR                            |0.4-6     |1      |        |     |
+|G2Sd                             |2.1.5     |1      |        |     |
+|GARS                             |1.2.0     |1      |        |     |
+|[gastempt](failures.md#gastempt) |0.4.4     |__+1__ |        |-3   |
+|HPAanalyze                       |1.0.0     |1      |        |     |
+|iBMQ                             |1.22.0    |1      |        |1    |
+|iCNV                             |1.2.1     |1      |        |     |
+|imageData                        |0.1-50    |1      |        |     |
+|imbalance                        |1.0.0     |1      |        |     |
+|Imetagene                        |1.12.0    |1      |        |     |
+|InSilicoVA                       |1.2.5     |1      |        |     |
+|jarbes                           |1.7.2     |1      |        |     |
+|joineRML                         |0.4.2     |1      |        |     |
+|JointAI                          |0.5.0     |1      |        |     |
+|likeLTD                          |6.3.0     |1      |        |     |
+|lilikoi                          |0.1.0     |1      |        |     |
+|LINC                             |?         |       |        |     |
+|llama                            |0.9.2     |1      |        |     |
+|LLSR                             |0.0.2.19  |1      |        |     |
+|matchingMarkets                  |1.0-1     |1      |        |     |
+|mbgraphic                        |1.0.1     |1      |        |     |
+|mcmcabn                          |0.1       |1      |        |     |
+|MEAL                             |?         |       |        |     |
+|methylGSA                        |?         |       |        |     |
+|mleap                            |0.1.3     |1      |        |     |
+|morse                            |3.2.2     |1      |        |     |
+|MSnbase                          |2.8.3     |1      |        |3    |
+|mwaved                           |1.1.6     |1      |        |     |
+|NPflow                           |0.13.1    |1      |        |     |
+|OpenStreetMap                    |0.3.3     |1      |        |     |
+|openVA                           |1.0.8     |1      |        |     |
+|petro.One                        |0.2.3     |1      |        |     |
+|phase1PRMD                       |1.0.1     |1      |        |     |
+|phase1RMD                        |1.0.8     |1      |        |     |
+|pimeta                           |1.1.2     |1      |        |     |
+|poppr                            |2.8.2     |1      |        |     |
+|PortfolioEffectHFT               |1.8       |1      |        |     |
+|psygenet2r                       |1.14.0    |1      |1       |3    |
+|qdap                             |2.3.2     |1      |        |     |
+|rcellminer                       |2.4.0     |1      |        |1    |
+|RcmdrPlugin.FuzzyClust           |1.1       |1      |        |     |
+|RDAVIDWebService                 |1.20.0    |1      |        |     |
+|Rdrools                          |1.1.1     |1      |        |     |
+|ReactomePA                       |?         |       |        |     |
+|rmcfs                            |1.2.15    |1      |        |     |
+|RnBeads                          |2.0.1     |1      |        |2    |
+|robustHD                         |0.5.1     |1      |        |     |
+|rpanel                           |1.1-4     |1      |        |     |
+|rpf                              |0.62      |1      |        |     |
+|rrepast                          |0.7.0     |1      |        |     |
+|RSCAT                            |1.0.0     |1      |        |     |
+|rstanarm                         |2.18.2    |1      |        |3    |
+|rsvg                             |1.3       |1      |        |     |
+|RtutoR                           |1.2       |1      |        |     |
+|SeqFeatR                         |0.3.1     |1      |        |     |
+|simmr                            |0.3       |1      |        |     |
+|sitmo                            |2.0.1     |1      |        |     |
+|SMITE                            |?         |       |        |     |
+|spcosa                           |0.3-8     |1      |        |     |
+|StarBioTrek                      |1.8.5     |1      |        |     |
+|TCGAbiolinks                     |2.10.5    |1      |        |     |
+|TeachingDemos                    |2.10      |1      |        |1    |
+|vortexR                          |1.1.6     |1      |        |     |
+|XLConnect                        |0.2-15    |1      |        |     |
+|zooaRchGUI                       |1.0.2     |1      |        |     |
 
-## Broken (36)
+## New problems (34)
 
-|package                    |version |error |warning |note |source                                                                                |
-|:--------------------------|:-------|:-----|:-------|:----|:-------------------------------------------------------------------------------------|
-|AneuFinder                 |1.10.2  |      |        |     |[cran/AneuFinder](https://github.com/cran/AneuFinder)                                 |
-|BaalChIP                   |1.8.0   |      |        |     |[cran/BaalChIP](https://github.com/cran/BaalChIP)                                     |
-|Bclim                      |3.1.2   |      |        |     |[cran/Bclim](https://github.com/cran/Bclim)                                           |
-|CATALYST                   |1.6.7   |      |        |     |[cran/CATALYST](https://github.com/cran/CATALYST)                                     |
-|cellHTS2                   |2.46.1  |      |        |     |[cran/cellHTS2](https://github.com/cran/cellHTS2)                                     |
-|ChIPexoQual                |1.6.0   |      |        |     |[cran/ChIPexoQual](https://github.com/cran/ChIPexoQual)                               |
-|chromstaR                  |1.8.1   |      |        |     |[cran/chromstaR](https://github.com/cran/chromstaR)                                   |
-|ClassifyR                  |2.2.6   |      |        |     |[cran/ClassifyR](https://github.com/cran/ClassifyR)                                   |
-|clusternomics              |0.1.1   |      |        |     |[cran/clusternomics](https://github.com/cran/clusternomics)                           |
-|CNPBayes                   |1.12.0  |      |        |     |[cran/CNPBayes](https://github.com/cran/CNPBayes)                                     |
-|DeepBlueR                  |1.8.0   |      |        |     |[cran/DeepBlueR](https://github.com/cran/DeepBlueR)                                   |
-|DiffBind                   |2.10.0  |      |        |     |[cran/DiffBind](https://github.com/cran/DiffBind)                                     |
-|dmrseq                     |1.2.5   |      |        |     |[cran/dmrseq](https://github.com/cran/dmrseq)                                         |
-|FindMyFriends              |1.12.0  |      |        |     |[cran/FindMyFriends](https://github.com/cran/FindMyFriends)                           |
-|GOTHiC                     |1.18.1  |      |        |     |[cran/GOTHiC](https://github.com/cran/GOTHiC)                                         |
-|HTSSIP                     |1.4.0   |      |        |     |[cran/HTSSIP](https://github.com/cran/HTSSIP)                                         |
-|IHWpaper                   |1.10.0  |      |        |     |[cran/IHWpaper](https://github.com/cran/IHWpaper)                                     |
-|lime                       |0.4.1   |      |        |     |[cran/lime](https://github.com/cran/lime)                                             |
-|MSnbase                    |2.8.3   |      |        |     |[cran/MSnbase](https://github.com/cran/MSnbase)                                       |
-|msPurity                   |1.8.1   |      |        |     |[cran/msPurity](https://github.com/cran/msPurity)                                     |
-|onemap                     |2.1.1   |      |        |     |[cran/onemap](https://github.com/cran/onemap)                                         |
-|phylosim                   |3.0.2   |      |        |     |[cran/phylosim](https://github.com/cran/phylosim)                                     |
-|pmc                        |1.0.3   |      |        |     |[cran/pmc](https://github.com/cran/pmc)                                               |
-|pRoloc                     |1.22.2  |      |        |     |[cran/pRoloc](https://github.com/cran/pRoloc)                                         |
-|PureCN                     |1.12.2  |      |        |     |[cran/PureCN](https://github.com/cran/PureCN)                                         |
-|RcmdrPlugin.FuzzyClust     |1.1     |      |        |     |[cran/RcmdrPlugin.FuzzyClust](https://github.com/cran/RcmdrPlugin.FuzzyClust)         |
-|scruff                     |1.0.2   |      |        |     |[cran/scruff](https://github.com/cran/scruff)                                         |
-|sdmpredictors              |0.2.8   |      |        |     |[cran/sdmpredictors](https://github.com/cran/sdmpredictors)                           |
-|simulator                  |0.2.0   |      |        |     |[cran/simulator](https://github.com/cran/simulator)                                   |
-|Single.mTEC.Transcriptomes |1.10.0  |      |        |     |[cran/Single.mTEC.Transcriptomes](https://github.com/cran/Single.mTEC.Transcriptomes) |
-|SNPhood                    |1.12.0  |      |        |     |[cran/SNPhood](https://github.com/cran/SNPhood)                                       |
-|TeachingDemos              |2.10    |      |        |     |[cran/TeachingDemos](https://github.com/cran/TeachingDemos)                           |
-|TPP                        |3.10.1  |      |        |     |[cran/TPP](https://github.com/cran/TPP)                                               |
-|transcriptogramer          |1.4.1   |      |        |     |[cran/transcriptogramer](https://github.com/cran/transcriptogramer)                   |
-|variancePartition          |1.12.3  |      |        |     |[cran/variancePartition](https://github.com/cran/variancePartition)                   |
-|XBSeq                      |1.14.1  |      |        |     |[cran/XBSeq](https://github.com/cran/XBSeq)                                           |
+|package                                          |version |error    |warning |note     |
+|:------------------------------------------------|:-------|:--------|:-------|:--------|
+|[bayesAB](problems.md#bayesab)                   |1.1.1   |__+1__   |        |         |
+|[breathteststan](problems.md#breathteststan)     |0.4.7   |__+1__   |        |1        |
+|[CSTools](problems.md#cstools)                   |1.0.0   |__+1__   |        |         |
+|[esmisc](problems.md#esmisc)                     |0.0.3   |__+1__   |        |         |
+|[fergm](problems.md#fergm)                       |1.1.4   |__+1__   |        |         |
+|[fingertipscharts](problems.md#fingertipscharts) |0.0.5   |__+2__   |        |1        |
+|[ggalt](problems.md#ggalt)                       |0.4.0   |         |__+1__  |1        |
+|[ggforce](problems.md#ggforce)                   |0.2.2   |         |__+1__  |         |
+|[ggpol](problems.md#ggpol)                       |0.0.5   |         |__+1__  |1        |
+|[ggpolypath](problems.md#ggpolypath)             |0.1.0   |         |__+1__  |         |
+|[ggsolvencyii](problems.md#ggsolvencyii)         |0.1.2   |         |__+1__  |         |
+|[ggspatial](problems.md#ggspatial)               |1.0.3   |         |__+1__  |1        |
+|[ggstance](problems.md#ggstance)                 |0.3.1   |__+1__   |        |         |
+|[ggstatsplot](problems.md#ggstatsplot)           |0.0.10  |__+1__   |        |         |
+|[ggtern](problems.md#ggtern)                     |3.1.0   |         |__+1__  |1        |
+|[heatmaply](problems.md#heatmaply)               |0.15.2  |         |        |1 __+1__ |
+|[HistDAWass](problems.md#histdawass)             |1.0.1   |__+1__   |        |         |
+|[incR](problems.md#incr)                         |1.1.0   |__+1__   |        |1        |
+|[interflex](problems.md#interflex)               |1.0.4   |__+1__   |        |         |
+|[jcolors](problems.md#jcolors)                   |0.0.3   |__+1__   |        |         |
+|[lime](problems.md#lime)                         |0.4.1   |__+1__   |        |         |
+|[mlr](problems.md#mlr)                           |2.14.0  |__+1__   |        |1        |
+|[MTLR](problems.md#mtlr)                         |0.2.0   |__+1__   |        |         |
+|[OUTRIDER](problems.md#outrider)                 |1.0.4   |1 __+1__ |        |2        |
+|[PathoStat](problems.md#pathostat)               |1.8.4   |__+1__   |        |1        |
+|[PepsNMR](problems.md#pepsnmr)                   |1.0.2   |__+1__   |        |         |
+|[SCORPIUS](problems.md#scorpius)                 |1.0.2   |__+1__   |        |         |
+|[shiny](problems.md#shiny)                       |1.3.2   |__+1__   |        |1        |
+|[ssMousetrack](problems.md#ssmousetrack)         |1.1.5   |-1       |        |__+2__   |
+|[stats19](problems.md#stats19)                   |0.2.1   |__+1__   |        |         |
+|[trialr](problems.md#trialr)                     |0.1.0   |-1       |        |__+3__   |
+|[vdiffr](problems.md#vdiffr)                     |0.3.0   |__+1__   |        |1        |
+|[vidger](problems.md#vidger)                     |1.2.1   |__+1__   |        |1        |
+|[xpose](problems.md#xpose)                       |0.4.4   |__+2__   |        |         |
 

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -1,0 +1,9186 @@
+# affycoretools
+
+<details>
+
+* Version: 1.54.0
+* Source code: https://github.com/cran/affycoretools
+* Date/Publication: 2018-10-30
+* Number of recursive dependencies: 174
+
+Run `revdep_details(,"affycoretools")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘affycoretools’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/affycoretools/new/affycoretools.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘affycoretools’ ...
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
+  there is no package called 'PFAM.db'
+ERROR: lazy loading failed for package 'affycoretools'
+* removing '/Users/max/github/forks/ggplot2/revdep/checks.noindex/affycoretools/new/affycoretools.Rcheck/affycoretools'
+
+```
+### CRAN
+
+```
+* installing *source* package ‘affycoretools’ ...
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
+  there is no package called 'PFAM.db'
+ERROR: lazy loading failed for package 'affycoretools'
+* removing '/Users/max/github/forks/ggplot2/revdep/checks.noindex/affycoretools/old/affycoretools.Rcheck/affycoretools'
+
+```
+# aslib
+
+<details>
+
+* Version: 0.1
+* Source code: https://github.com/cran/aslib
+* URL: https://github.com/coseal/aslib-r/
+* BugReports: https://github.com/coseal/aslib-r/issues
+* Date/Publication: 2016-11-25 08:42:53
+* Number of recursive dependencies: 66
+
+Run `revdep_details(,"aslib")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘aslib’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/aslib/new/aslib.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘aslib’ ...
+** package ‘aslib’ successfully unpacked and MD5 sums checked
+** R
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/aslib/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/aslib/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/aslib/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘aslib’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/aslib/new/aslib.Rcheck/aslib’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘aslib’ ...
+** package ‘aslib’ successfully unpacked and MD5 sums checked
+** R
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/aslib/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/aslib/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/aslib/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘aslib’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/aslib/old/aslib.Rcheck/aslib’
+
+```
+# BaalChIP
+
+<details>
+
+* Version: 1.8.0
+* Source code: https://github.com/cran/BaalChIP
+* Date/Publication: 2018-10-30
+* Number of recursive dependencies: 83
+
+Run `revdep_details(,"BaalChIP")` for more info
+
+</details>
+
+## In both
+
+*   R CMD check timed out
+    
+
+*   checking installed package size ... NOTE
+    ```
+      installed size is 200.0Mb
+      sub-directories of 1Mb or more:
+        data   96.1Mb
+        doc     1.6Mb
+        test  101.9Mb
+    ```
+
+*   checking R code for possible problems ... NOTE
+    ```
+    applyBayes: no visible binding for global variable ‘SNP_id’
+    plot.filt.barplot: no visible binding for global variable ‘cellname’
+    plot.filt.barplot: no visible binding for global variable ‘value’
+    plot.filt.barplot: no visible binding for global variable ‘variable’
+    plot.filt.boxplot: no visible binding for global variable ‘variable’
+    plot.filt.boxplot: no visible binding for global variable ‘value’
+    plot.filt.boxplot: no visible binding for global variable ‘coltype’
+    plot.filt.pie: no visible binding for global variable ‘variable’
+    plot.filt.pie: no visible binding for global variable ‘value.mean’
+    plot.simul: no visible binding for global variable ‘readslen’
+    plot.simul: no visible binding for global variable ‘perc_right’
+    plotadjustment: no visible binding for global variable ‘value’
+    plotadjustment: no visible binding for global variable ‘variable’
+    Undefined global functions or variables:
+      SNP_id cellname coltype perc_right readslen value value.mean variable
+    ```
+
+# BACA
+
+<details>
+
+* Version: 1.3
+* Source code: https://github.com/cran/BACA
+* Date/Publication: 2015-05-27 08:55:17
+* Number of recursive dependencies: 71
+
+Run `revdep_details(,"BACA")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘BACA’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/BACA/new/BACA.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘BACA’ ...
+** package ‘BACA’ successfully unpacked and MD5 sums checked
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/BACA/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/BACA/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/BACA/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘BACA’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/BACA/new/BACA.Rcheck/BACA’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘BACA’ ...
+** package ‘BACA’ successfully unpacked and MD5 sums checked
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/BACA/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/BACA/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/BACA/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘BACA’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/BACA/old/BACA.Rcheck/BACA’
+
+```
+# BACCT
+
+<details>
+
+* Version: 1.0
+* Source code: https://github.com/cran/BACCT
+* Date/Publication: 2016-06-25 19:07:22
+* Number of recursive dependencies: 35
+
+Run `revdep_details(,"BACCT")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘BACCT’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/BACCT/new/BACCT.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘BACCT’ ...
+** package ‘BACCT’ successfully unpacked and MD5 sums checked
+** R
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/BACCT/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/BACCT/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/BACCT/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘BACCT’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/BACCT/new/BACCT.Rcheck/BACCT’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘BACCT’ ...
+** package ‘BACCT’ successfully unpacked and MD5 sums checked
+** R
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/BACCT/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/BACCT/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/BACCT/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘BACCT’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/BACCT/old/BACCT.Rcheck/BACCT’
+
+```
+# bamdit
+
+<details>
+
+* Version: 3.2.1
+* Source code: https://github.com/cran/bamdit
+* Date/Publication: 2018-09-17 15:00:03 UTC
+* Number of recursive dependencies: 56
+
+Run `revdep_details(,"bamdit")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘bamdit’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/bamdit/new/bamdit.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘bamdit’ ...
+** package ‘bamdit’ successfully unpacked and MD5 sums checked
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/bamdit/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/bamdit/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/bamdit/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘bamdit’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/bamdit/new/bamdit.Rcheck/bamdit’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘bamdit’ ...
+** package ‘bamdit’ successfully unpacked and MD5 sums checked
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/bamdit/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/bamdit/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/bamdit/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘bamdit’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/bamdit/old/bamdit.Rcheck/bamdit’
+
+```
+# BayesRS
+
+<details>
+
+* Version: 0.1.3
+* Source code: https://github.com/cran/BayesRS
+* Date/Publication: 2018-04-06 06:39:35 UTC
+* Number of recursive dependencies: 47
+
+Run `revdep_details(,"BayesRS")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘BayesRS’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/BayesRS/new/BayesRS.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘BayesRS’ ...
+** package ‘BayesRS’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/BayesRS/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/BayesRS/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/BayesRS/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘BayesRS’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/BayesRS/new/BayesRS.Rcheck/BayesRS’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘BayesRS’ ...
+** package ‘BayesRS’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/BayesRS/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/BayesRS/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/BayesRS/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘BayesRS’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/BayesRS/old/BayesRS.Rcheck/BayesRS’
+
+```
+# BNSP
+
+<details>
+
+* Version: 2.0.8
+* Source code: https://github.com/cran/BNSP
+* URL: http://www.bbk.ac.uk/ems/faculty/papageorgiou/BNSP
+* Date/Publication: 2018-09-27 09:10:03 UTC
+* Number of recursive dependencies: 62
+
+Run `revdep_details(,"BNSP")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘BNSP’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/BNSP/new/BNSP.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘BNSP’ ...
+** package ‘BNSP’ successfully unpacked and MD5 sums checked
+** libs
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/BNSP/cubature/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c BNSP_init.c -o BNSP_init.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/BNSP/cubature/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c OneResLtnt.c -o OneResLtnt.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/BNSP/cubature/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c mvrmGAM.c -o mvrmGAM.o
+mvrmGAM.c:26:10: fatal error: 'gsl/gsl_matrix.h' file not found
+#include <gsl/gsl_matrix.h>
+         ^~~~~~~~~~~~~~~~~~
+OneResLtnt.c:29:10: fatal error: 'gsl/gsl_matrix.h' file not found
+#include <gsl/gsl_matrix.h>
+         ^~~~~~~~~~~~~~~~~~
+1 error generated.
+make: *** [mvrmGAM.o] Error 1
+make: *** Waiting for unfinished jobs....
+1 error generated.
+make: *** [OneResLtnt.o] Error 1
+ERROR: compilation failed for package ‘BNSP’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/BNSP/new/BNSP.Rcheck/BNSP’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘BNSP’ ...
+** package ‘BNSP’ successfully unpacked and MD5 sums checked
+** libs
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/BNSP/cubature/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c BNSP_init.c -o BNSP_init.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/BNSP/cubature/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c OneResLtnt.c -o OneResLtnt.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/BNSP/cubature/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c mvrmGAM.c -o mvrmGAM.o
+mvrmGAM.c:26:10: fatal error: 'gsl/gsl_matrix.h' file not found
+#include <gsl/gsl_matrix.h>
+         ^~~~~~~~~~~~~~~~~~
+OneResLtnt.c:29:10: fatal error: 'gsl/gsl_matrix.h' file not found
+#include <gsl/gsl_matrix.h>
+         ^~~~~~~~~~~~~~~~~~
+1 error generated.
+make: *** [mvrmGAM.o] Error 1
+make: *** Waiting for unfinished jobs....
+1 error generated.
+make: *** [OneResLtnt.o] Error 1
+ERROR: compilation failed for package ‘BNSP’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/BNSP/old/BNSP.Rcheck/BNSP’
+
+```
+# BPEC
+
+<details>
+
+* Version: 1.3.0
+* Source code: https://github.com/cran/BPEC
+* Date/Publication: 2018-08-29 20:56:48 UTC
+* Number of recursive dependencies: 80
+
+Run `revdep_details(,"BPEC")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘BPEC’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/BPEC/new/BPEC.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘BPEC’ ...
+** package ‘BPEC’ successfully unpacked and MD5 sums checked
+** libs
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include   -fPIC  -Wall -g -O2  -c bpecfunction.c -o bpecfunction.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include   -fPIC  -Wall -g -O2  -c hashingfunctions.c -o hashingfunctions.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include   -fPIC  -Wall -g -O2  -c loopfunctions.c -o loopfunctions.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include   -fPIC  -Wall -g -O2  -c matrices.c -o matrices.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include   -fPIC  -Wall -g -O2  -c randomnumbers.c -o randomnumbers.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include   -fPIC  -Wall -g -O2  -c registerDynamicSymbol.c -o registerDynamicSymbol.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include   -fPIC  -Wall -g -O2  -c treelikelifunctions.c -o treelikelifunctions.o
+clang -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/Library/Frameworks/R.framework/Resources/lib -L/usr/local/lib -o BPEC.so bpecfunction.o hashingfunctions.o loopfunctions.o matrices.o randomnumbers.o registerDynamicSymbol.o treelikelifunctions.o -F/Library/Frameworks/R.framework/.. -framework R -Wl,-framework -Wl,CoreFoundation
+ld: warning: text-based stub file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation.tbd and library file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation are out of sync. Falling back to library file for linking.
+installing to /Users/max/github/forks/ggplot2/revdep/checks.noindex/BPEC/new/BPEC.Rcheck/BPEC/libs
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/BPEC/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/BPEC/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/BPEC/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘BPEC’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/BPEC/new/BPEC.Rcheck/BPEC’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘BPEC’ ...
+** package ‘BPEC’ successfully unpacked and MD5 sums checked
+** libs
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include   -fPIC  -Wall -g -O2  -c bpecfunction.c -o bpecfunction.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include   -fPIC  -Wall -g -O2  -c hashingfunctions.c -o hashingfunctions.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include   -fPIC  -Wall -g -O2  -c loopfunctions.c -o loopfunctions.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include   -fPIC  -Wall -g -O2  -c matrices.c -o matrices.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include   -fPIC  -Wall -g -O2  -c randomnumbers.c -o randomnumbers.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include   -fPIC  -Wall -g -O2  -c registerDynamicSymbol.c -o registerDynamicSymbol.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include   -fPIC  -Wall -g -O2  -c treelikelifunctions.c -o treelikelifunctions.o
+clang -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/Library/Frameworks/R.framework/Resources/lib -L/usr/local/lib -o BPEC.so bpecfunction.o hashingfunctions.o loopfunctions.o matrices.o randomnumbers.o registerDynamicSymbol.o treelikelifunctions.o -F/Library/Frameworks/R.framework/.. -framework R -Wl,-framework -Wl,CoreFoundation
+ld: warning: text-based stub file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation.tbd and library file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation are out of sync. Falling back to library file for linking.
+installing to /Users/max/github/forks/ggplot2/revdep/checks.noindex/BPEC/old/BPEC.Rcheck/BPEC/libs
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/BPEC/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/BPEC/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/BPEC/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘BPEC’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/BPEC/old/BPEC.Rcheck/BPEC’
+
+```
+# bsam
+
+<details>
+
+* Version: 1.1.2
+* Source code: https://github.com/cran/bsam
+* URL: https://github.com/ianjonsen/bsam
+* BugReports: https://github.com/ianjonsen/bsam/issues
+* Date/Publication: 2017-07-01 02:50:50 UTC
+* Number of recursive dependencies: 48
+
+Run `revdep_details(,"bsam")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘bsam’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/bsam/new/bsam.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘bsam’ ...
+** package ‘bsam’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rjags’:
+ .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/bsam/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/bsam/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/bsam/rjags/libs/rjags.so
+  Reason: image not found
+Error : package ‘rjags’ could not be loaded
+ERROR: lazy loading failed for package ‘bsam’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/bsam/new/bsam.Rcheck/bsam’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘bsam’ ...
+** package ‘bsam’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rjags’:
+ .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/bsam/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/bsam/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/bsam/rjags/libs/rjags.so
+  Reason: image not found
+Error : package ‘rjags’ could not be loaded
+ERROR: lazy loading failed for package ‘bsam’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/bsam/old/bsam.Rcheck/bsam’
+
+```
+# BTSPAS
+
+<details>
+
+* Version: 2014.0901
+* Source code: https://github.com/cran/BTSPAS
+* URL: http://www.stat.sfu.ca/~cschwarz/Consulting/Trinity/Phase2
+* Date/Publication: 2014-08-26 07:51:36
+* Number of recursive dependencies: 40
+
+Run `revdep_details(,"BTSPAS")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘BTSPAS’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/BTSPAS/new/BTSPAS.Rcheck/00install.out’ for details.
+    ```
+
+*   checking package dependencies ... NOTE
+    ```
+    Package suggested but not available for checking: ‘BRugs’
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘BTSPAS’ ...
+** package ‘BTSPAS’ successfully unpacked and MD5 sums checked
+** R
+** demo
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/BTSPAS/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/BTSPAS/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/BTSPAS/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘BTSPAS’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/BTSPAS/new/BTSPAS.Rcheck/BTSPAS’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘BTSPAS’ ...
+** package ‘BTSPAS’ successfully unpacked and MD5 sums checked
+** R
+** demo
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/BTSPAS/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/BTSPAS/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/BTSPAS/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘BTSPAS’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/BTSPAS/old/BTSPAS.Rcheck/BTSPAS’
+
+```
+# CaliCo
+
+<details>
+
+* Version: 0.1.1
+* Source code: https://github.com/cran/CaliCo
+* Date/Publication: 2018-07-24 09:00:20 UTC
+* Number of recursive dependencies: 51
+
+Run `revdep_details(,"CaliCo")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘CaliCo’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/CaliCo/new/CaliCo.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘CaliCo’ ...
+** package ‘CaliCo’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/CaliCo/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/CaliCo/RcppArmadillo/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/CaliCo/Matrix/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c MCMC.cpp -o MCMC.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/CaliCo/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/CaliCo/RcppArmadillo/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/CaliCo/Matrix/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+make: *** [RcppExports.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [MCMC.o] Error 1
+ERROR: compilation failed for package ‘CaliCo’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/CaliCo/new/CaliCo.Rcheck/CaliCo’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘CaliCo’ ...
+** package ‘CaliCo’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/CaliCo/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/CaliCo/RcppArmadillo/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/CaliCo/Matrix/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c MCMC.cpp -o MCMC.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/CaliCo/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/CaliCo/RcppArmadillo/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/CaliCo/Matrix/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang: error: unsupported option '-fopenmp'clang
+: error: unsupported option '-fopenmp'
+make: *** [RcppExports.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [MCMC.o] Error 1
+ERROR: compilation failed for package ‘CaliCo’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/CaliCo/old/CaliCo.Rcheck/CaliCo’
+
+```
+# ChIPseeker
+
+<details>
+
+* Version: 
+* Source code: ???
+* URL: http://ggplot2.tidyverse.org, https://github.com/tidyverse/ggplot2
+* BugReports: https://github.com/tidyverse/ggplot2/issues
+* Number of recursive dependencies: 0
+
+Run `revdep_details(,"")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+installing the source packages ‘GO.db’, ‘org.Hs.eg.db’, ‘reactome.db’, ‘TxDb.Hsapiens.UCSC.hg19.knownGene’
+
+
+
+```
+### CRAN
+
+```
+
+
+
+installing the source packages ‘GO.db’, ‘org.Hs.eg.db’, ‘reactome.db’, ‘TxDb.Hsapiens.UCSC.hg19.knownGene’
+
+
+
+```
+# chromstaR
+
+<details>
+
+* Version: 1.8.1
+* Source code: https://github.com/cran/chromstaR
+* URL: https://github.com/ataudt/chromstaR
+* BugReports: https://github.com/ataudt/chromstaR/issues
+* Date/Publication: 2019-01-04
+* Number of recursive dependencies: 100
+
+Run `revdep_details(,"chromstaR")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘chromstaR’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/chromstaR/new/chromstaR.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘chromstaR’ ...
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c R_interface.cpp -o R_interface.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c densities.cpp -o densities.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c init.cpp -o init.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c scalehmm.cpp -o scalehmm.o
+clang: error: unsupported option '-fopenmp'clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'clang: error: unsupported option '-fopenmp'
+
+
+make: *** [R_interface.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [scalehmm.o] Error 1
+make: *** [init.o] Error 1
+make: *** [densities.o] Error 1
+ERROR: compilation failed for package ‘chromstaR’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/chromstaR/new/chromstaR.Rcheck/chromstaR’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘chromstaR’ ...
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c R_interface.cpp -o R_interface.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c densities.cpp -o densities.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c init.cpp -o init.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c scalehmm.cpp -o scalehmm.o
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+make: *** [densities.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [R_interface.o] Error 1
+make: *** [init.o] Error 1
+clang: error: unsupported option '-fopenmp'
+make: *** [scalehmm.o] Error 1
+ERROR: compilation failed for package ‘chromstaR’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/chromstaR/old/chromstaR.Rcheck/chromstaR’
+
+```
+# clusterProfiler
+
+<details>
+
+* Version: 
+* Source code: ???
+* URL: http://ggplot2.tidyverse.org, https://github.com/tidyverse/ggplot2
+* BugReports: https://github.com/tidyverse/ggplot2/issues
+* Number of recursive dependencies: 0
+
+Run `revdep_details(,"")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+installing the source packages ‘GO.db’, ‘org.Hs.eg.db’, ‘reactome.db’
+
+
+
+```
+### CRAN
+
+```
+
+
+
+installing the source packages ‘GO.db’, ‘org.Hs.eg.db’, ‘reactome.db’
+
+
+
+```
+# CNVrd2
+
+<details>
+
+* Version: 1.20.0
+* Source code: https://github.com/cran/CNVrd2
+* URL: https://github.com/hoangtn/CNVrd2
+* Date/Publication: 2018-10-30
+* Number of recursive dependencies: 91
+
+Run `revdep_details(,"CNVrd2")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘CNVrd2’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/CNVrd2/new/CNVrd2.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘CNVrd2’ ...
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rjags’:
+ .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/CNVrd2/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/CNVrd2/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/CNVrd2/rjags/libs/rjags.so
+  Reason: image not found
+Error : package ‘rjags’ could not be loaded
+ERROR: lazy loading failed for package ‘CNVrd2’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/CNVrd2/new/CNVrd2.Rcheck/CNVrd2’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘CNVrd2’ ...
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rjags’:
+ .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/CNVrd2/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/CNVrd2/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/CNVrd2/rjags/libs/rjags.so
+  Reason: image not found
+Error : package ‘rjags’ could not be loaded
+ERROR: lazy loading failed for package ‘CNVrd2’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/CNVrd2/old/CNVrd2.Rcheck/CNVrd2’
+
+```
+# CollapsABEL
+
+<details>
+
+* Version: 0.10.11
+* Source code: https://github.com/cran/CollapsABEL
+* URL: https://bitbucket.org/kindlychung/collapsabel2/overview
+* BugReports: https://bitbucket.org/kindlychung/collapsabel2/issues
+* Date/Publication: 2016-12-11 20:35:07
+* Number of recursive dependencies: 97
+
+Run `revdep_details(,"CollapsABEL")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘CollapsABEL’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/CollapsABEL/new/CollapsABEL.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘CollapsABEL’ ...
+** package ‘CollapsABEL’ successfully unpacked and MD5 sums checked
+** R
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/CollapsABEL/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/CollapsABEL/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/CollapsABEL/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘CollapsABEL’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/CollapsABEL/new/CollapsABEL.Rcheck/CollapsABEL’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘CollapsABEL’ ...
+** package ‘CollapsABEL’ successfully unpacked and MD5 sums checked
+** R
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/CollapsABEL/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/CollapsABEL/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/CollapsABEL/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘CollapsABEL’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/CollapsABEL/old/CollapsABEL.Rcheck/CollapsABEL’
+
+```
+# colorednoise
+
+<details>
+
+* Version: 1.0.4
+* Source code: https://github.com/cran/colorednoise
+* BugReports: http://github.com/japilo/colorednoise/issues
+* Date/Publication: 2019-01-23 12:50:14 UTC
+* Number of recursive dependencies: 85
+
+Run `revdep_details(,"colorednoise")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘colorednoise’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/colorednoise/new/colorednoise.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘colorednoise’ ...
+** package ‘colorednoise’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/colorednoise/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/colorednoise/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/colorednoise/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/colorednoise/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c noise.cpp -o noise.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/colorednoise/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/colorednoise/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c simulation.cpp -o simulation.o
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+make: *** [RcppExports.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [simulation.o] Error 1
+make: *** [noise.o] Error 1
+ERROR: compilation failed for package ‘colorednoise’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/colorednoise/new/colorednoise.Rcheck/colorednoise’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘colorednoise’ ...
+** package ‘colorednoise’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/colorednoise/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/colorednoise/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/colorednoise/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/colorednoise/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c noise.cpp -o noise.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/colorednoise/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/colorednoise/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c simulation.cpp -o simulation.o
+clang: error: unsupported option '-fopenmp'clang: error: clang: error: unsupported option '-fopenmp'unsupported option '-fopenmp'
+
+
+make: *** [simulation.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [noise.o] Error 1
+make: *** [RcppExports.o] Error 1
+ERROR: compilation failed for package ‘colorednoise’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/colorednoise/old/colorednoise.Rcheck/colorednoise’
+
+```
+# crmPack
+
+<details>
+
+* Version: 0.2.9
+* Source code: https://github.com/cran/crmPack
+* URL: https://github.com/roche/crmPack
+* BugReports: https://github.com/roche/crmPack/issues
+* Date/Publication: 2018-12-21 14:30:09 UTC
+* Number of recursive dependencies: 58
+
+Run `revdep_details(,"crmPack")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘crmPack’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/crmPack/new/crmPack.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘crmPack’ ...
+** package ‘crmPack’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/crmPack/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/crmPack/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/crmPack/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘crmPack’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/crmPack/new/crmPack.Rcheck/crmPack’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘crmPack’ ...
+** package ‘crmPack’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/crmPack/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/crmPack/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/crmPack/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘crmPack’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/crmPack/old/crmPack.Rcheck/crmPack’
+
+```
+# Crossover
+
+<details>
+
+* Version: 0.1-17
+* Source code: https://github.com/cran/Crossover
+* URL: https://github.com/kornl/Crossover/wiki
+* BugReports: https://github.com/kornl/Crossover/issues
+* Date/Publication: 2017-11-10 23:13:30 UTC
+* Number of recursive dependencies: 57
+
+Run `revdep_details(,"Crossover")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘Crossover’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/Crossover/new/Crossover.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘Crossover’ ...
+** package ‘Crossover’ successfully unpacked and MD5 sums checked
+** libs
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/Crossover/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/Crossover/RcppArmadillo/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c Crossover_init.c -o Crossover_init.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/Crossover/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/Crossover/RcppArmadillo/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c searchCOD.cpp -o searchCOD.o
+searchCOD.cpp:122:11: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
+          pinv(trans(X) * cor * X);
+          ^~~~
+1 warning generated.
+clang++ -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/Library/Frameworks/R.framework/Resources/lib -L/usr/local/lib -o Crossover.so Crossover_init.o searchCOD.o -L/Library/Frameworks/R.framework/Resources/lib -lRlapack -L/Library/Frameworks/R.framework/Resources/lib -lRblas -L/usr/local/gfortran/lib/gcc/x86_64-apple-darwin15/6.1.0 -L/usr/local/gfortran/lib -lgfortran -lquadmath -lm -F/Library/Frameworks/R.framework/.. -framework R -Wl,-framework -Wl,CoreFoundation
+ld: warning: text-based stub file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation.tbd and library file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation are out of sync. Falling back to library file for linking.
+installing to /Users/max/github/forks/ggplot2/revdep/checks.noindex/Crossover/new/Crossover.Rcheck/Crossover/libs
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/Crossover/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/Crossover/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/Crossover/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘Crossover’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/Crossover/new/Crossover.Rcheck/Crossover’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘Crossover’ ...
+** package ‘Crossover’ successfully unpacked and MD5 sums checked
+** libs
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/Crossover/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/Crossover/RcppArmadillo/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c Crossover_init.c -o Crossover_init.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/Crossover/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/Crossover/RcppArmadillo/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c searchCOD.cpp -o searchCOD.o
+searchCOD.cpp:122:11: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
+          pinv(trans(X) * cor * X);
+          ^~~~
+1 warning generated.
+clang++ -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/Library/Frameworks/R.framework/Resources/lib -L/usr/local/lib -o Crossover.so Crossover_init.o searchCOD.o -L/Library/Frameworks/R.framework/Resources/lib -lRlapack -L/Library/Frameworks/R.framework/Resources/lib -lRblas -L/usr/local/gfortran/lib/gcc/x86_64-apple-darwin15/6.1.0 -L/usr/local/gfortran/lib -lgfortran -lquadmath -lm -F/Library/Frameworks/R.framework/.. -framework R -Wl,-framework -Wl,CoreFoundation
+ld: warning: text-based stub file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation.tbd and library file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation are out of sync. Falling back to library file for linking.
+installing to /Users/max/github/forks/ggplot2/revdep/checks.noindex/Crossover/old/Crossover.Rcheck/Crossover/libs
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/Crossover/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/Crossover/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/Crossover/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘Crossover’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/Crossover/old/Crossover.Rcheck/Crossover’
+
+```
+# DaMiRseq
+
+<details>
+
+* Version: 1.6.2
+* Source code: https://github.com/cran/DaMiRseq
+* Date/Publication: 2019-01-16
+* Number of recursive dependencies: 201
+
+Run `revdep_details(,"DaMiRseq")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘DaMiRseq’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/DaMiRseq/new/DaMiRseq.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘DaMiRseq’ ...
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/DaMiRseq/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/DaMiRseq/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/DaMiRseq/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘DaMiRseq’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/DaMiRseq/new/DaMiRseq.Rcheck/DaMiRseq’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘DaMiRseq’ ...
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/DaMiRseq/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/DaMiRseq/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/DaMiRseq/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘DaMiRseq’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/DaMiRseq/old/DaMiRseq.Rcheck/DaMiRseq’
+
+```
+# Deducer
+
+<details>
+
+* Version: 0.7-9
+* Source code: https://github.com/cran/Deducer
+* URL: http://www.deducer.org/manual.html http://www.fellstat.com
+* Date/Publication: 2015-12-29 22:16:31
+* Number of recursive dependencies: 115
+
+Run `revdep_details(,"Deducer")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘Deducer’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/Deducer/new/Deducer.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘Deducer’ ...
+** package ‘Deducer’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/Deducer/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/Deducer/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/Deducer/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘Deducer’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/Deducer/new/Deducer.Rcheck/Deducer’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘Deducer’ ...
+** package ‘Deducer’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/Deducer/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/Deducer/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/Deducer/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘Deducer’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/Deducer/old/Deducer.Rcheck/Deducer’
+
+```
+# DeLorean
+
+<details>
+
+* Version: 1.5.0
+* Source code: https://github.com/cran/DeLorean
+* Date/Publication: 2018-10-17 22:30:16 UTC
+* Number of recursive dependencies: 124
+
+Run `revdep_details(,"DeLorean")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘DeLorean’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/DeLorean/new/DeLorean.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘DeLorean’ ...
+** package ‘DeLorean’ successfully unpacked and MD5 sums checked
+** libs
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/exact.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/exactsizes.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/lowrank.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/lowranksizes.stan
+Wrote C++ file "stan_files/exact.cc"
+Wrote C++ file "stan_files/exactsizes.cc"
+Wrote C++ file "stan_files/lowranksizes.cc"
+Wrote C++ file "stan_files/lowrank.cc"
+Error in readRDS("/var/folders/lb/xhxqmcrd7gv302_b1pdfykh80000gn/T//RtmpNeTeBk/file30e5b7818fb") : 
+  error reading from connection
+Calls: .Last -> readRDS
+Execution halted
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"`"/Library/Frameworks/R.framework/Resources/bin/Rscript" --vanilla -e "cat(system.file('include', 'src', package = 'StanHeaders'))"`" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c init.cpp -o init.o
+make: *** [stan_files/exactsizes.cc] Error 1
+make: *** Waiting for unfinished jobs....
+rm stan_files/exact.cc stan_files/exactsizes.cc stan_files/lowranksizes.cc stan_files/lowrank.cc
+ERROR: compilation failed for package ‘DeLorean’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/DeLorean/new/DeLorean.Rcheck/DeLorean’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘DeLorean’ ...
+** package ‘DeLorean’ successfully unpacked and MD5 sums checked
+** libs
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/exact.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/exactsizes.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/lowrank.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/lowranksizes.stan
+Wrote C++ file "stan_files/exact.cc"
+Wrote C++ file "stan_files/exactsizes.cc"
+Wrote C++ file "stan_files/lowranksizes.cc"
+Wrote C++ file "stan_files/lowrank.cc"
+Error in readRDS("/var/folders/lb/xhxqmcrd7gv302_b1pdfykh80000gn/T//RtmpNeTeBk/file30e5da652be") : 
+  error reading from connection
+Calls: .Last -> readRDS
+Execution halted
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"`"/Library/Frameworks/R.framework/Resources/bin/Rscript" --vanilla -e "cat(system.file('include', 'src', package = 'StanHeaders'))"`" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c init.cpp -o init.o
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"`"/Library/Frameworks/R.framework/Resources/bin/Rscript" --vanilla -e "cat(system.file('include', 'src', package = 'StanHeaders'))"`" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c stan_files/exact.cc -o stan_files/exact.o
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"`"/Library/Frameworks/R.framework/Resources/bin/Rscript" --vanilla -e "cat(system.file('include', 'src', package = 'StanHeaders'))"`" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c stan_files/lowrank.cc -o stan_files/lowrank.o
+make: *** [stan_files/exactsizes.cc] Error 1
+make: *** Waiting for unfinished jobs....
+In file included from stan_files/exact.cc:3:
+In file included from stan_files/exact.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:15:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include/boost/random/additive_combine.hpp:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include/boost/random/linear_congruential.hpp:30:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include/boost/random/detail/const_mod.hpp:23:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include/boost/random/detail/large_arithmetic.hpp:19:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include/boost/random/detail/integer_log2.hpp:19:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include/boost/pending/integer_log2.hpp:7:1: warning: This header is deprecated. Use <boost/integer/integer_log2.hpp> instead. [-W#pragma-messages]
+BOOST_HEADER_DEPRECATED("<boost/integer/integer_log2.hpp>");
+^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include/boost/config/header_deprecated.hpp:23:37: note: expanded from macro 'BOOST_HEADER_DEPRECATED'
+# define BOOST_HEADER_DEPRECATED(a) BOOST_PRAGMA_MESSAGE("This header is deprecated. Use " a " instead.")
+                                    ^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include/boost/config/pragma_message.hpp:24:34: note: expanded from macro 'BOOST_PRAGMA_MESSAGE'
+# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
+                                 ^
+<scratch space>:32:2: note: expanded from here
+ message("This header is deprecated. Use " "<boost/integer/integer_log2.hpp>" " instead.")
+ ^
+In file included from stan_files/lowrank.cc:3:
+In file included from stan_files/lowrank.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:15:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include/boost/random/additive_combine.hpp:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include/boost/random/linear_congruential.hpp:30:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include/boost/random/detail/const_mod.hpp:23:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include/boost/random/detail/large_arithmetic.hpp:19:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include/boost/random/detail/integer_log2.hpp:19:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include/boost/pending/integer_log2.hpp:7:1: warning: This header is deprecated. Use <boost/integer/integer_log2.hpp> instead. [-W#pragma-messages]
+BOOST_HEADER_DEPRECATED("<boost/integer/integer_log2.hpp>");
+^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include/boost/config/header_deprecated.hpp:23:37: note: expanded from macro 'BOOST_HEADER_DEPRECATED'
+# define BOOST_HEADER_DEPRECATED(a) BOOST_PRAGMA_MESSAGE("This header is deprecated. Use " a " instead.")
+                                    ^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/BH/include/boost/config/pragma_message.hpp:24:34: note: expanded from macro 'BOOST_PRAGMA_MESSAGE'
+# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
+                                 ^
+<scratch space>:32:2: note: expanded from here
+ message("This header is deprecated. Use " "<boost/integer/integer_log2.hpp>" " instead.")
+ ^
+In file included from stan_files/exact.cc:3:
+In file included from stan_files/exact.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Dense:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Core:535:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/lowrank.cc:3:
+In file included from stan_files/lowrank.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Dense:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Core:535:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/exact.cc:3:
+In file included from stan_files/exact.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Dense:2:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/LU:47:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/exact.cc:3:
+In file included from stan_files/exact.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Cholesky:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Jacobi:29:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/exact.cc:3:
+In file included from stan_files/exact.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Cholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/exact.cc:3:
+In file included from stan_files/exact.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Dense:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/QR:17:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Householder:27:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/lowrank.cc:3:
+In file included from stan_files/lowrank.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Dense:2:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/LU:47:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/lowrank.cc:3:
+In file included from stan_files/lowrank.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Cholesky:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Jacobi:29:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/lowrank.cc:3:
+In file included from stan_files/lowrank.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Cholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/lowrank.cc:3:
+In file included from stan_files/lowrank.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Dense:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/QR:17:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Householder:27:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/exact.cc:3:
+In file included from stan_files/exact.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Dense:5:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/SVD:48:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/lowrank.cc:3:
+In file included from stan_files/lowrank.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Dense:5:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/SVD:48:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/exact.cc:3:
+In file included from stan_files/exact.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Dense:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Geometry:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/exact.cc:3:
+In file included from stan_files/exact.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Dense:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Eigenvalues:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/lowrank.cc:3:
+In file included from stan_files/lowrank.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Dense:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Geometry:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/lowrank.cc:3:
+In file included from stan_files/lowrank.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Dense:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Eigenvalues:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/exact.cc:3:
+In file included from stan_files/exact.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Sparse:26:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/SparseCore:66:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/exact.cc:3:
+In file included from stan_files/exact.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Sparse:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/OrderingMethods:71:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/exact.cc:3:
+In file included from stan_files/exact.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Sparse:29:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/SparseCholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/exact.cc:3:
+In file included from stan_files/exact.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Sparse:32:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/SparseQR:35:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/exact.cc:3:
+In file included from stan_files/exact.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Sparse:33:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/IterativeLinearSolvers:46:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/lowrank.cc:3:
+In file included from stan_files/lowrank.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Sparse:26:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/SparseCore:66:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/lowrank.cc:3:
+In file included from stan_files/lowrank.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Sparse:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/OrderingMethods:71:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/lowrank.cc:3:
+In file included from stan_files/lowrank.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Sparse:29:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/SparseCholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/lowrank.cc:3:
+In file included from stan_files/lowrank.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Sparse:32:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/SparseQR:35:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/lowrank.cc:3:
+In file included from stan_files/lowrank.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/Sparse:33:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/IterativeLinearSolvers:46:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/exact.cc:3:
+In file included from stan_files/exact.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core.hpp:44:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core/set_zero_all_adjoints.hpp:14:13: warning: unused function 'set_zero_all_adjoints' [-Wunused-function]
+static void set_zero_all_adjoints() {
+            ^
+In file included from stan_files/exact.cc:3:
+In file included from stan_files/exact.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat.hpp:70:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/autocorrelation.hpp:18:8: warning: function 'fft_next_good_size' is not needed and will not be emitted [-Wunneeded-internal-declaration]
+size_t fft_next_good_size(size_t N) {
+       ^
+In file included from stan_files/exact.cc:3:
+stan_files/exact.hpp:397:30: warning: unused typedef 'fun_return_scalar_t__' [-Wunused-local-typedef]
+    typedef local_scalar_t__ fun_return_scalar_t__;
+                             ^
+In file included from stan_files/lowrank.cc:3:
+In file included from stan_files/lowrank.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core.hpp:44:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/core/set_zero_all_adjoints.hpp:14:13: warning: unused function 'set_zero_all_adjoints' [-Wunused-function]
+static void set_zero_all_adjoints() {
+            ^
+In file included from stan_files/lowrank.cc:3:
+In file included from stan_files/lowrank.hpp:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat.hpp:70:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/DeLorean/StanHeaders/include/stan/math/prim/mat/fun/autocorrelation.hpp:18:8: warning: function 'fft_next_good_size' is not needed and will not be emitted [-Wunneeded-internal-declaration]
+size_t fft_next_good_size(size_t N) {
+       ^
+In file included from stan_files/lowrank.cc:3:
+stan_files/lowrank.hpp:495:30: warning: unused typedef 'fun_return_scalar_t__' [-Wunused-local-typedef]
+    typedef local_scalar_t__ fun_return_scalar_t__;
+                             ^
+17 warnings generated.
+17 warnings generated.
+rm stan_files/exact.cc stan_files/exactsizes.cc stan_files/lowranksizes.cc stan_files/lowrank.cc
+ERROR: compilation failed for package ‘DeLorean’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/DeLorean/old/DeLorean.Rcheck/DeLorean’
+
+```
+# DiffBind
+
+<details>
+
+* Version: 2.10.0
+* Source code: https://github.com/cran/DiffBind
+* Date/Publication: 2018-10-30
+* Number of recursive dependencies: 150
+
+Run `revdep_details(,"DiffBind")` for more info
+
+</details>
+
+## In both
+
+*   R CMD check timed out
+    
+
+*   checking package dependencies ... NOTE
+    ```
+    Package which this enhances but not available for checking: ‘XLConnect’
+    ```
+
+*   checking R code for possible problems ... NOTE
+    ```
+    pv.DBAplotVolcano: no visible binding for global variable ‘Fold’
+    pv.DBAplotVolcano: no visible binding for global variable ‘Legend’
+    Undefined global functions or variables:
+      Fold Legend
+    ```
+
+# DiversityOccupancy
+
+<details>
+
+* Version: 1.0.6
+* Source code: https://github.com/cran/DiversityOccupancy
+* Date/Publication: 2017-03-02 18:32:36
+* Number of recursive dependencies: 81
+
+Run `revdep_details(,"DiversityOccupancy")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘DiversityOccupancy’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/DiversityOccupancy/new/DiversityOccupancy.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘DiversityOccupancy’ ...
+** package ‘DiversityOccupancy’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/DiversityOccupancy/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/DiversityOccupancy/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/DiversityOccupancy/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘DiversityOccupancy’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/DiversityOccupancy/new/DiversityOccupancy.Rcheck/DiversityOccupancy’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘DiversityOccupancy’ ...
+** package ‘DiversityOccupancy’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/DiversityOccupancy/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/DiversityOccupancy/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/DiversityOccupancy/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘DiversityOccupancy’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/DiversityOccupancy/old/DiversityOccupancy.Rcheck/DiversityOccupancy’
+
+```
+# dynfrail
+
+<details>
+
+* Version: 0.5.2
+* Source code: https://github.com/cran/dynfrail
+* Date/Publication: 2017-10-30 10:11:49 UTC
+* Number of recursive dependencies: 58
+
+Run `revdep_details(,"dynfrail")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘dynfrail’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/dynfrail/new/dynfrail.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘dynfrail’ ...
+** package ‘dynfrail’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/dynfrail/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/dynfrail/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/dynfrail/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/dynfrail/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c estep_new.cpp -o estep_new.o
+clang: error: unsupported option '-fopenmp'
+make: *** [RcppExports.o] Error 1
+make: *** Waiting for unfinished jobs....
+clang: error: unsupported option '-fopenmp'
+make: *** [estep_new.o] Error 1
+ERROR: compilation failed for package ‘dynfrail’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/dynfrail/new/dynfrail.Rcheck/dynfrail’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘dynfrail’ ...
+** package ‘dynfrail’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/dynfrail/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/dynfrail/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/dynfrail/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/dynfrail/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c estep_new.cpp -o estep_new.o
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+make: *** [estep_new.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [RcppExports.o] Error 1
+ERROR: compilation failed for package ‘dynfrail’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/dynfrail/old/dynfrail.Rcheck/dynfrail’
+
+```
+# dynr
+
+<details>
+
+* Version: 0.1.14-9
+* Source code: https://github.com/cran/dynr
+* Date/Publication: 2019-04-02 07:50:03 UTC
+* Number of recursive dependencies: 95
+
+Run `revdep_details(,"dynr")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘dynr’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/dynr/new/dynr.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘dynr’ ...
+** package ‘dynr’ successfully unpacked and MD5 sums checked
+checking for gsl-config... no
+configure: error: gsl-config not found, is GSL installed?
+ERROR: configuration failed for package ‘dynr’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/dynr/new/dynr.Rcheck/dynr’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘dynr’ ...
+** package ‘dynr’ successfully unpacked and MD5 sums checked
+checking for gsl-config... no
+configure: error: gsl-config not found, is GSL installed?
+ERROR: configuration failed for package ‘dynr’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/dynr/old/dynr.Rcheck/dynr’
+
+```
+# eegc
+
+<details>
+
+* Version: 1.8.1
+* Source code: https://github.com/cran/eegc
+* Date/Publication: 2018-12-21
+* Number of recursive dependencies: 154
+
+Run `revdep_details(,"eegc")` for more info
+
+</details>
+
+## In both
+
+*   R CMD check timed out
+    
+
+*   checking Rd cross-references ... WARNING
+    ```
+    Missing link or links in documentation object 'barplotEnrich.Rd':
+      ‘[DOSE]{barplot.enrichResult}’
+    
+    See section 'Cross-references' in the 'Writing R Extensions' manual.
+    ```
+
+*   checking installed package size ... NOTE
+    ```
+      installed size is 11.7Mb
+      sub-directories of 1Mb or more:
+        data  11.0Mb
+    ```
+
+*   checking R code for possible problems ... NOTE
+    ```
+    ...
+    grnPlot: no visible global function definition for ‘legend’
+    markerScatter: no visible global function definition for
+      ‘colorRampPalette’
+    markerScatter: no visible global function definition for ‘plot’
+    markerScatter: no visible global function definition for ‘points’
+    markerScatter: no visible global function definition for ‘lm’
+    markerScatter: no visible global function definition for ‘abline’
+    markerScatter: no visible global function definition for ‘text’
+    markerScatter: no visible global function definition for ‘legend’
+    Undefined global functions or variables:
+      abline adjustcolor axis colorRampPalette control density dev.copy2pdf
+      legend lines lm model.matrix p.adjust par phyper plot points quantile
+      results text title treat
+    Consider adding
+      importFrom("grDevices", "adjustcolor", "colorRampPalette",
+                 "dev.copy2pdf")
+      importFrom("graphics", "abline", "axis", "legend", "lines", "par",
+                 "plot", "points", "text", "title")
+      importFrom("stats", "density", "lm", "model.matrix", "p.adjust",
+                 "phyper", "quantile")
+    to your NAMESPACE file.
+    ```
+
+# ELMER
+
+<details>
+
+* Version: 2.6.3
+* Source code: https://github.com/cran/ELMER
+* Date/Publication: 2019-04-02
+* Number of recursive dependencies: 209
+
+Run `revdep_details(,"ELMER")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘ELMER’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/ELMER/new/ELMER.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘ELMER’ ...
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
+  there is no package called 'sesameData'
+ERROR: lazy loading failed for package 'ELMER'
+* removing '/Users/max/github/forks/ggplot2/revdep/checks.noindex/ELMER/new/ELMER.Rcheck/ELMER'
+
+```
+### CRAN
+
+```
+* installing *source* package ‘ELMER’ ...
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
+  there is no package called 'sesameData'
+ERROR: lazy loading failed for package 'ELMER'
+* removing '/Users/max/github/forks/ggplot2/revdep/checks.noindex/ELMER/old/ELMER.Rcheck/ELMER'
+
+```
+# esATAC
+
+<details>
+
+* Version: 1.4.5
+* Source code: https://github.com/cran/esATAC
+* URL: https://github.com/wzthu/esATAC
+* BugReports: https://github.com/wzthu/esATAC/issues
+* Date/Publication: 2019-03-22
+* Number of recursive dependencies: 180
+
+Run `revdep_details(,"esATAC")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘esATAC’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/esATAC/new/esATAC.Rcheck/00install.out’ for details.
+    ```
+
+*   checking package dependencies ... NOTE
+    ```
+    Packages suggested but not available for checking:
+      ‘BSgenome.Hsapiens.UCSC.hg19’ ‘TxDb.Hsapiens.UCSC.hg19.knownGene’
+    ```
+
+*   checking for hidden files and directories ... NOTE
+    ```
+    Found the following hidden files and directories:
+      .BBSoptions
+    These were most likely included in error. See section ‘Package
+    structure’ in the ‘Writing R Extensions’ manual.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘esATAC’ ...
+** libs
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c BedLine.cpp -o BedLine.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c BedUtils.cpp -o BedUtils.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c ChrDivi.cpp -o ChrDivi.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c CutCountPre.cpp -o CutCountPre.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c CutSiteCount.cpp -o CutSiteCount.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c LibComplexQC.cpp -o LibComplexQC.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c RcppExports.cpp -o RcppExports.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c SortBed.cpp -o SortBed.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c rcpp_wrapper.cpp -o rcpp_wrapper.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c renamer.cpp -o renamer.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c sam2bed.cc -o sam2bed.o
+sam2bed.cc:111:16: warning: unused variable 'xspm' [-Wunused-variable]
+    regmatch_t xspm[1];
+               ^
+sam2bed.cc:280:16: warning: unused variable 'xspm' [-Wunused-variable]
+    regmatch_t xspm[1];
+               ^
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/Library/Frameworks/R.framework/Resources/lib -L/usr/local/lib -o esATAC.so BedLine.o BedUtils.o ChrDivi.o CutCountPre.o CutSiteCount.o LibComplexQC.o RcppExports.o SortBed.o rcpp_wrapper.o renamer.o sam2bed.o -F/Library/Frameworks/R.framework/.. -framework R -Wl,-framework -Wl,CoreFoundation
+ld: warning: text-based stub file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation.tbd and library file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation are out of sync. Falling back to library file for linking.
+installing to /Users/max/github/forks/ggplot2/revdep/checks.noindex/esATAC/new/esATAC.Rcheck/esATAC/libs
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
+  there is no package called ‘TxDb.Hsapiens.UCSC.hg19.knownGene’
+ERROR: lazy loading failed for package ‘esATAC’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/esATAC/new/esATAC.Rcheck/esATAC’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘esATAC’ ...
+** libs
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c BedLine.cpp -o BedLine.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c BedUtils.cpp -o BedUtils.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c ChrDivi.cpp -o ChrDivi.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c CutCountPre.cpp -o CutCountPre.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c CutSiteCount.cpp -o CutSiteCount.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c LibComplexQC.cpp -o LibComplexQC.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c RcppExports.cpp -o RcppExports.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c SortBed.cpp -o SortBed.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c rcpp_wrapper.cpp -o rcpp_wrapper.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c renamer.cpp -o renamer.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -DNDEBUG -DPLF_SYS_LINUX  -DR_EVN_FLAG -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/esATAC/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c sam2bed.cc -o sam2bed.o
+sam2bed.cc:111:16: warning: unused variable 'xspm' [-Wunused-variable]
+    regmatch_t xspm[1];
+               ^
+sam2bed.cc:280:16: warning: unused variable 'xspm' [-Wunused-variable]
+    regmatch_t xspm[1];
+               ^
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/Library/Frameworks/R.framework/Resources/lib -L/usr/local/lib -o esATAC.so BedLine.o BedUtils.o ChrDivi.o CutCountPre.o CutSiteCount.o LibComplexQC.o RcppExports.o SortBed.o rcpp_wrapper.o renamer.o sam2bed.o -F/Library/Frameworks/R.framework/.. -framework R -Wl,-framework -Wl,CoreFoundation
+ld: warning: text-based stub file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation.tbd and library file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation are out of sync. Falling back to library file for linking.
+installing to /Users/max/github/forks/ggplot2/revdep/checks.noindex/esATAC/old/esATAC.Rcheck/esATAC/libs
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
+  there is no package called ‘TxDb.Hsapiens.UCSC.hg19.knownGene’
+ERROR: lazy loading failed for package ‘esATAC’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/esATAC/old/esATAC.Rcheck/esATAC’
+
+```
+# evoper
+
+<details>
+
+* Version: 0.5.0
+* Source code: https://github.com/cran/evoper
+* URL: https://github.com/antonio-pgarcia/evoper
+* BugReports: https://github.com/antonio-pgarcia/evoper/issues
+* Date/Publication: 2018-08-30 23:20:06 UTC
+* Number of recursive dependencies: 58
+
+Run `revdep_details(,"evoper")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘evoper’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/evoper/new/evoper.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘evoper’ ...
+** package ‘evoper’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/evoper/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/evoper/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/evoper/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘evoper’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/evoper/new/evoper.Rcheck/evoper’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘evoper’ ...
+** package ‘evoper’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/evoper/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/evoper/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/evoper/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘evoper’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/evoper/old/evoper.Rcheck/evoper’
+
+```
+# ewoc
+
+<details>
+
+* Version: 0.2.0
+* Source code: https://github.com/cran/ewoc
+* URL: https://github.com/dnzmarcio/ewoc/
+* BugReports: https://github.com/dnzmarcio/ewoc/issues
+* Date/Publication: 2018-01-20 21:16:49 UTC
+* Number of recursive dependencies: 40
+
+Run `revdep_details(,"ewoc")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘ewoc’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/ewoc/new/ewoc.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘ewoc’ ...
+** package ‘ewoc’ successfully unpacked and MD5 sums checked
+** R
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/ewoc/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/ewoc/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/ewoc/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘ewoc’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/ewoc/new/ewoc.Rcheck/ewoc’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘ewoc’ ...
+** package ‘ewoc’ successfully unpacked and MD5 sums checked
+** R
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/ewoc/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/ewoc/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/ewoc/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘ewoc’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/ewoc/old/ewoc.Rcheck/ewoc’
+
+```
+# fgsea
+
+<details>
+
+* Version: 
+* Source code: ???
+* URL: http://ggplot2.tidyverse.org, https://github.com/tidyverse/ggplot2
+* BugReports: https://github.com/tidyverse/ggplot2/issues
+* Number of recursive dependencies: 0
+
+Run `revdep_details(,"")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+installing the source packages ‘org.Mm.eg.db’, ‘reactome.db’
+
+
+
+```
+### CRAN
+
+```
+
+
+
+installing the source packages ‘org.Mm.eg.db’, ‘reactome.db’
+
+
+
+```
+# fingerPro
+
+<details>
+
+* Version: 1.1
+* Source code: https://github.com/cran/fingerPro
+* URL: https://github.com/eead-csic-eesa
+* Date/Publication: 2018-08-28 10:04:54 UTC
+* Number of recursive dependencies: 135
+
+Run `revdep_details(,"fingerPro")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘fingerPro’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/fingerPro/new/fingerPro.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘fingerPro’ ...
+** package ‘fingerPro’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/RcppGSL/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/RcppProgress/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/RcppGSL/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/RcppProgress/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c fingerprinting.cpp -o fingerprinting.o
+In file included from RcppExports.cpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/RcppGSL/include/RcppGSL.h:25:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/RcppGSL/include/RcppGSLForward.h:26:10: fatal error: 'gsl/gsl_vector.h' file not found
+#include <gsl/gsl_vector.h> 
+         ^~~~~~~~~~~~~~~~~~
+1 error generated.
+make: *** [RcppExports.o] Error 1
+make: *** Waiting for unfinished jobs....
+In file included from fingerprinting.cpp:5:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/RcppGSL/include/RcppGSL.h:25:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/RcppGSL/include/RcppGSLForward.h:26:10: fatal error: 'gsl/gsl_vector.h' file not found
+#include <gsl/gsl_vector.h> 
+         ^~~~~~~~~~~~~~~~~~
+1 error generated.
+make: *** [fingerprinting.o] Error 1
+ERROR: compilation failed for package ‘fingerPro’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/fingerPro/new/fingerPro.Rcheck/fingerPro’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘fingerPro’ ...
+** package ‘fingerPro’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/RcppGSL/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/RcppProgress/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/RcppGSL/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/RcppProgress/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c fingerprinting.cpp -o fingerprinting.o
+In file included from RcppExports.cpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/RcppGSL/include/RcppGSL.h:25:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/RcppGSL/include/RcppGSLForward.h:26:10: fatal error: 'gsl/gsl_vector.h' file not found
+#include <gsl/gsl_vector.h> 
+         ^~~~~~~~~~~~~~~~~~
+1 error generated.
+make: *** [RcppExports.o] Error 1
+make: *** Waiting for unfinished jobs....
+In file included from fingerprinting.cpp:5:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/RcppGSL/include/RcppGSL.h:25:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/fingerPro/RcppGSL/include/RcppGSLForward.h:26:10: fatal error: 'gsl/gsl_vector.h' file not found
+#include <gsl/gsl_vector.h> 
+         ^~~~~~~~~~~~~~~~~~
+1 error generated.
+make: *** [fingerprinting.o] Error 1
+ERROR: compilation failed for package ‘fingerPro’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/fingerPro/old/fingerPro.Rcheck/fingerPro’
+
+```
+# fsdaR
+
+<details>
+
+* Version: 0.4-6
+* Source code: https://github.com/cran/fsdaR
+* Date/Publication: 2019-03-14 05:30:03 UTC
+* Number of recursive dependencies: 40
+
+Run `revdep_details(,"fsdaR")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘fsdaR’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/fsdaR/new/fsdaR.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘fsdaR’ ...
+** package ‘fsdaR’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/fsdaR/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/fsdaR/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/fsdaR/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘fsdaR’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/fsdaR/new/fsdaR.Rcheck/fsdaR’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘fsdaR’ ...
+** package ‘fsdaR’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/fsdaR/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/fsdaR/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/fsdaR/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘fsdaR’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/fsdaR/old/fsdaR.Rcheck/fsdaR’
+
+```
+# G2Sd
+
+<details>
+
+* Version: 2.1.5
+* Source code: https://github.com/cran/G2Sd
+* URL: https://cran.r-project.org/package=G2Sd, http://regisgallon.wordpress.com/r-software/
+* Date/Publication: 2015-12-07 22:13:45
+* Number of recursive dependencies: 46
+
+Run `revdep_details(,"G2Sd")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘G2Sd’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/G2Sd/new/G2Sd.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘G2Sd’ ...
+** package ‘G2Sd’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/G2Sd/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/G2Sd/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/G2Sd/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘G2Sd’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/G2Sd/new/G2Sd.Rcheck/G2Sd’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘G2Sd’ ...
+** package ‘G2Sd’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/G2Sd/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/G2Sd/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/G2Sd/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘G2Sd’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/G2Sd/old/G2Sd.Rcheck/G2Sd’
+
+```
+# GARS
+
+<details>
+
+* Version: 1.2.0
+* Source code: https://github.com/cran/GARS
+* Date/Publication: 2018-10-30
+* Number of recursive dependencies: 205
+
+Run `revdep_details(,"GARS")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘GARS’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/GARS/new/GARS.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘GARS’ ...
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/GARS/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/GARS/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/GARS/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘GARS’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/GARS/new/GARS.Rcheck/GARS’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘GARS’ ...
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/GARS/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/GARS/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/GARS/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘GARS’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/GARS/old/GARS.Rcheck/GARS’
+
+```
+# gastempt
+
+<details>
+
+* Version: 0.4.4
+* Source code: https://github.com/cran/gastempt
+* URL: http://github.com/dmenne/gastempt
+* BugReports: http://github.com/dmenne/gastempt/issues
+* Date/Publication: 2019-03-06 16:32:41 UTC
+* Number of recursive dependencies: 82
+
+Run `revdep_details(,"gastempt")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking whether package ‘gastempt’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/gastempt/new/gastempt.Rcheck/00install.out’ for details.
+    ```
+
+## Newly fixed
+
+*   checking installed package size ... NOTE
+    ```
+      installed size is  7.9Mb
+      sub-directories of 1Mb or more:
+        libs   7.5Mb
+    ```
+
+*   checking dependencies in R code ... NOTE
+    ```
+    Namespaces in Imports field not imported from:
+      ‘methods’ ‘rstantools’
+      All declared Imports should be used.
+    ```
+
+*   checking for GNU extensions in Makefiles ... NOTE
+    ```
+    GNU make is a SystemRequirements.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘gastempt’ ...
+** package ‘gastempt’ successfully unpacked and MD5 sums checked
+** libs
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_1b.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_1c.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_1d.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_2b.stan
+Wrote C++ file "stan_files/linexp_gastro_1c.cc"
+Wrote C++ file "stan_files/linexp_gastro_1b.cc"
+Wrote C++ file "stan_files/linexp_gastro_1d.cc"
+Wrote C++ file "stan_files/linexp_gastro_2b.cc"
+Error in readRDS("/var/folders/lb/xhxqmcrd7gv302_b1pdfykh80000gn/T//RtmpNeTeBk/file30e631b2ee0") : 
+  error reading from connection
+Calls: .Last -> readRDS
+Execution halted
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_2c.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/powexp_gastro_1b.stan
+make: *** [stan_files/linexp_gastro_1d.cc] Error 1
+make: *** Waiting for unfinished jobs....
+Wrote C++ file "stan_files/linexp_gastro_2c.cc"
+Wrote C++ file "stan_files/powexp_gastro_1b.cc"
+rm stan_files/linexp_gastro_2c.cc stan_files/linexp_gastro_1d.cc stan_files/linexp_gastro_1b.cc stan_files/linexp_gastro_2b.cc stan_files/linexp_gastro_1c.cc stan_files/powexp_gastro_1b.cc
+ERROR: compilation failed for package ‘gastempt’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/gastempt/new/gastempt.Rcheck/gastempt’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘gastempt’ ...
+** package ‘gastempt’ successfully unpacked and MD5 sums checked
+** libs
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_1b.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_1c.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_1d.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_2b.stan
+Wrote C++ file "stan_files/linexp_gastro_1d.cc"
+Wrote C++ file "stan_files/linexp_gastro_1c.cc"
+Wrote C++ file "stan_files/linexp_gastro_1b.cc"
+Wrote C++ file "stan_files/linexp_gastro_2b.cc"
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_2c.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/powexp_gastro_1b.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/powexp_gastro_2c.stan
+
+
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c init.cpp -o init.o
+
+
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c stan_files/linexp_gastro_1b.cc -o stan_files/linexp_gastro_1b.o
+Wrote C++ file "stan_files/powexp_gastro_1b.cc"
+Wrote C++ file "stan_files/linexp_gastro_2c.cc"
+Wrote C++ file "stan_files/powexp_gastro_2c.cc"
+
+
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c stan_files/linexp_gastro_1c.cc -o stan_files/linexp_gastro_1c.o
+
+
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c stan_files/linexp_gastro_1d.cc -o stan_files/linexp_gastro_1d.o
+
+
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c stan_files/linexp_gastro_2b.cc -o stan_files/linexp_gastro_2b.o
+
+
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:15:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/additive_combine.hpp:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/linear_congruential.hpp:30:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/const_mod.hpp:23:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/large_arithmetic.hpp:19:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/integer_log2.hpp:19:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/pending/integer_log2.hpp:7:1: warning: This header is deprecated. Use <boost/integer/integer_log2.hpp> instead. [-W#pragma-messages]
+BOOST_HEADER_DEPRECATED("<boost/integer/integer_log2.hpp>");
+^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/header_deprecated.hpp:23:37: note: expanded from macro 'BOOST_HEADER_DEPRECATED'
+# define BOOST_HEADER_DEPRECATED(a) BOOST_PRAGMA_MESSAGE("This header is deprecated. Use " a " instead.")
+                                    ^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/pragma_message.hpp:24:34: note: expanded from macro 'BOOST_PRAGMA_MESSAGE'
+# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
+                                 ^
+<scratch space>:32:2: note: expanded from here
+ message("This header is deprecated. Use " "<boost/integer/integer_log2.hpp>" " instead.")
+ ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:15:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/additive_combine.hpp:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/linear_congruential.hpp:30:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/const_mod.hpp:23:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/large_arithmetic.hpp:19:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/integer_log2.hpp:19:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/pending/integer_log2.hpp:7:1: warning: This header is deprecated. Use <boost/integer/integer_log2.hpp> instead. [-W#pragma-messages]
+BOOST_HEADER_DEPRECATED("<boost/integer/integer_log2.hpp>");
+^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/header_deprecated.hpp:23:37: note: expanded from macro 'BOOST_HEADER_DEPRECATED'
+# define BOOST_HEADER_DEPRECATED(a) BOOST_PRAGMA_MESSAGE("This header is deprecated. Use " a " instead.")
+                                    ^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/pragma_message.hpp:24:34: note: expanded from macro 'BOOST_PRAGMA_MESSAGE'
+# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
+                                 ^
+<scratch space>:32:2: note: expanded from here
+ message("This header is deprecated. Use " "<boost/integer/integer_log2.hpp>" " instead.")
+ ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:15:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/additive_combine.hpp:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/linear_congruential.hpp:30:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/const_mod.hpp:23:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/large_arithmetic.hpp:19:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/integer_log2.hpp:19:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/pending/integer_log2.hpp:7:1: warning: This header is deprecated. Use <boost/integer/integer_log2.hpp> instead. [-W#pragma-messages]
+BOOST_HEADER_DEPRECATED("<boost/integer/integer_log2.hpp>");
+^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/header_deprecated.hpp:23:37: note: expanded from macro 'BOOST_HEADER_DEPRECATED'
+# define BOOST_HEADER_DEPRECATED(a) BOOST_PRAGMA_MESSAGE("This header is deprecated. Use " a " instead.")
+                                    ^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/pragma_message.hpp:24:34: note: expanded from macro 'BOOST_PRAGMA_MESSAGE'
+# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
+                                 ^
+<scratch space>:32:2: note: expanded from here
+ message("This header is deprecated. Use " "<boost/integer/integer_log2.hpp>" " instead.")
+ ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:15:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/additive_combine.hpp:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/linear_congruential.hpp:30:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/const_mod.hpp:23:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/large_arithmetic.hpp:19:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/integer_log2.hpp:19:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/pending/integer_log2.hpp:7:1: warning: This header is deprecated. Use <boost/integer/integer_log2.hpp> instead. [-W#pragma-messages]
+BOOST_HEADER_DEPRECATED("<boost/integer/integer_log2.hpp>");
+^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/header_deprecated.hpp:23:37: note: expanded from macro 'BOOST_HEADER_DEPRECATED'
+# define BOOST_HEADER_DEPRECATED(a) BOOST_PRAGMA_MESSAGE("This header is deprecated. Use " a " instead.")
+                                    ^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/pragma_message.hpp:24:34: note: expanded from macro 'BOOST_PRAGMA_MESSAGE'
+# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
+                                 ^
+<scratch space>:32:2: note: expanded from here
+ message("This header is deprecated. Use " "<boost/integer/integer_log2.hpp>" " instead.")
+ ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Core:535:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:2:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/LU:47:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Jacobi:29:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/QR:17:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Householder:27:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:5:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SVD:48:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Geometry:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Eigenvalues:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Core:535:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:2:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/LU:47:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Jacobi:29:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/QR:17:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Householder:27:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:5:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SVD:48:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Geometry:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Eigenvalues:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Core:535:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:2:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/LU:47:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Jacobi:29:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/QR:17:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Householder:27:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:5:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SVD:48:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Geometry:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Eigenvalues:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Core:535:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:2:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/LU:47:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Jacobi:29:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/QR:17:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Householder:27:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:5:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SVD:48:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Geometry:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Eigenvalues:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:26:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCore:66:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/OrderingMethods:71:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:29:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:32:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseQR:35:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:33:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/IterativeLinearSolvers:46:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:26:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCore:66:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/OrderingMethods:71:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:29:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:32:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseQR:35:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:33:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/IterativeLinearSolvers:46:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:26:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCore:66:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/OrderingMethods:71:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:29:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:32:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseQR:35:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:33:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/IterativeLinearSolvers:46:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:26:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCore:66:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/OrderingMethods:71:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:29:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:32:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseQR:35:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:33:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/IterativeLinearSolvers:46:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:44:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/set_zero_all_adjoints.hpp:14:13: warning: unused function 'set_zero_all_adjoints' [-Wunused-function]
+static void set_zero_all_adjoints() {
+            ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:70:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/autocorrelation.hpp:18:8: warning: function 'fft_next_good_size' is not needed and will not be emitted [-Wunneeded-internal-declaration]
+size_t fft_next_good_size(size_t N) {
+       ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:44:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/set_zero_all_adjoints.hpp:14:13: warning: unused function 'set_zero_all_adjoints' [-Wunused-function]
+static void set_zero_all_adjoints() {
+            ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:70:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/autocorrelation.hpp:18:8: warning: function 'fft_next_good_size' is not needed and will not be emitted [-Wunneeded-internal-declaration]
+size_t fft_next_good_size(size_t N) {
+       ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:44:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/set_zero_all_adjoints.hpp:14:13: warning: unused function 'set_zero_all_adjoints' [-Wunused-function]
+static void set_zero_all_adjoints() {
+            ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:70:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/autocorrelation.hpp:18:8: warning: function 'fft_next_good_size' is not needed and will not be emitted [-Wunneeded-internal-declaration]
+size_t fft_next_good_size(size_t N) {
+       ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:44:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/set_zero_all_adjoints.hpp:14:13: warning: unused function 'set_zero_all_adjoints' [-Wunused-function]
+static void set_zero_all_adjoints() {
+            ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:70:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/autocorrelation.hpp:18:8: warning: function 'fft_next_good_size' is not needed and will not be emitted [-Wunneeded-internal-declaration]
+size_t fft_next_good_size(size_t N) {
+       ^
+16 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c stan_files/linexp_gastro_2c.cc -o stan_files/linexp_gastro_2c.o
+
+
+16 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c stan_files/powexp_gastro_1b.cc -o stan_files/powexp_gastro_1b.o
+
+
+16 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c stan_files/powexp_gastro_2c.cc -o stan_files/powexp_gastro_2c.o
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:15:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/additive_combine.hpp:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/linear_congruential.hpp:30:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/const_mod.hpp:23:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/large_arithmetic.hpp:19:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/integer_log2.hpp:19:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/pending/integer_log2.hpp:7:1: warning: This header is deprecated. Use <boost/integer/integer_log2.hpp> instead. [-W#pragma-messages]
+BOOST_HEADER_DEPRECATED("<boost/integer/integer_log2.hpp>");
+^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/header_deprecated.hpp:23:37: note: expanded from macro 'BOOST_HEADER_DEPRECATED'
+# define BOOST_HEADER_DEPRECATED(a) BOOST_PRAGMA_MESSAGE("This header is deprecated. Use " a " instead.")
+                                    ^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/pragma_message.hpp:24:34: note: expanded from macro 'BOOST_PRAGMA_MESSAGE'
+# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
+                                 ^
+<scratch space>:32:2: note: expanded from here
+ message("This header is deprecated. Use " "<boost/integer/integer_log2.hpp>" " instead.")
+ ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Core:535:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:2:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/LU:47:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Jacobi:29:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/QR:17:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Householder:27:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:5:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SVD:48:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Geometry:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Eigenvalues:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:15:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/additive_combine.hpp:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/linear_congruential.hpp:30:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/const_mod.hpp:23:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/large_arithmetic.hpp:19:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/integer_log2.hpp:19:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/pending/integer_log2.hpp:7:1: warning: This header is deprecated. Use <boost/integer/integer_log2.hpp> instead. [-W#pragma-messages]
+BOOST_HEADER_DEPRECATED("<boost/integer/integer_log2.hpp>");
+^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/header_deprecated.hpp:23:37: note: expanded from macro 'BOOST_HEADER_DEPRECATED'
+# define BOOST_HEADER_DEPRECATED(a) BOOST_PRAGMA_MESSAGE("This header is deprecated. Use " a " instead.")
+                                    ^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/pragma_message.hpp:24:34: note: expanded from macro 'BOOST_PRAGMA_MESSAGE'
+# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
+                                 ^
+<scratch space>:32:2: note: expanded from here
+ message("This header is deprecated. Use " "<boost/integer/integer_log2.hpp>" " instead.")
+ ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:15:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/additive_combine.hpp:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/linear_congruential.hpp:30:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/const_mod.hpp:23:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/large_arithmetic.hpp:19:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/integer_log2.hpp:19:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/pending/integer_log2.hpp:7:1: warning: This header is deprecated. Use <boost/integer/integer_log2.hpp> instead. [-W#pragma-messages]
+BOOST_HEADER_DEPRECATED("<boost/integer/integer_log2.hpp>");
+^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/header_deprecated.hpp:23:37: note: expanded from macro 'BOOST_HEADER_DEPRECATED'
+# define BOOST_HEADER_DEPRECATED(a) BOOST_PRAGMA_MESSAGE("This header is deprecated. Use " a " instead.")
+                                    ^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/pragma_message.hpp:24:34: note: expanded from macro 'BOOST_PRAGMA_MESSAGE'
+# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
+                                 ^
+<scratch space>:32:2: note: expanded from here
+ message("This header is deprecated. Use " "<boost/integer/integer_log2.hpp>" " instead.")
+ ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Core:535:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:2:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/LU:47:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Jacobi:29:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/QR:17:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Householder:27:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:5:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SVD:48:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Geometry:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:26:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCore:66:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/OrderingMethods:71:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:29:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Eigenvalues:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:32:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseQR:35:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:33:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/IterativeLinearSolvers:46:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Core:535:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:2:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/LU:47:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Jacobi:29:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/QR:17:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Householder:27:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:5:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SVD:48:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Geometry:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Eigenvalues:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:26:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCore:66:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/OrderingMethods:71:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:29:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:32:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseQR:35:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:33:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/IterativeLinearSolvers:46:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:26:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCore:66:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/OrderingMethods:71:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:29:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:32:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseQR:35:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:33:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/IterativeLinearSolvers:46:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+16 warnings generated.
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:44:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/set_zero_all_adjoints.hpp:14:13: warning: unused function 'set_zero_all_adjoints' [-Wunused-function]
+static void set_zero_all_adjoints() {
+            ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:70:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/autocorrelation.hpp:18:8: warning: function 'fft_next_good_size' is not needed and will not be emitted [-Wunneeded-internal-declaration]
+size_t fft_next_good_size(size_t N) {
+       ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:44:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/set_zero_all_adjoints.hpp:14:13: warning: unused function 'set_zero_all_adjoints' [-Wunused-function]
+static void set_zero_all_adjoints() {
+            ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:70:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/autocorrelation.hpp:18:8: warning: function 'fft_next_good_size' is not needed and will not be emitted [-Wunneeded-internal-declaration]
+size_t fft_next_good_size(size_t N) {
+       ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:44:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/set_zero_all_adjoints.hpp:14:13: warning: unused function 'set_zero_all_adjoints' [-Wunused-function]
+static void set_zero_all_adjoints() {
+            ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:70:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/autocorrelation.hpp:18:8: warning: function 'fft_next_good_size' is not needed and will not be emitted [-Wunneeded-internal-declaration]
+size_t fft_next_good_size(size_t N) {
+       ^
+16 warnings generated.
+16 warnings generated.
+16 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++14 -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/Library/Frameworks/R.framework/Resources/lib -L/usr/local/lib -o gastempt.so stan_files/linexp_gastro_1b.o stan_files/linexp_gastro_1c.o stan_files/linexp_gastro_1d.o stan_files/linexp_gastro_2b.o stan_files/linexp_gastro_2c.o stan_files/powexp_gastro_1b.o stan_files/powexp_gastro_2c.o init.o -F/Library/Frameworks/R.framework/.. -framework R -Wl,-framework -Wl,CoreFoundation
+ld: warning: text-based stub file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation.tbd and library file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation are out of sync. Falling back to library file for linking.
+rm stan_files/linexp_gastro_2c.cc stan_files/linexp_gastro_1d.cc stan_files/powexp_gastro_2c.cc stan_files/linexp_gastro_1b.cc stan_files/linexp_gastro_2b.cc stan_files/linexp_gastro_1c.cc stan_files/powexp_gastro_1b.cc
+installing to /Users/max/github/forks/ggplot2/revdep/checks.noindex/gastempt/old/gastempt.Rcheck/gastempt/libs
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+** help
+*** installing help indices
+** building package indices
+** installing vignettes
+** testing if installed package can be loaded
+* DONE (gastempt)
+
+```
+# HPAanalyze
+
+<details>
+
+* Version: 1.0.0
+* Source code: https://github.com/cran/HPAanalyze
+* Date/Publication: 2018-10-30
+* Number of recursive dependencies: 91
+
+Run `revdep_details(,"HPAanalyze")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘HPAanalyze’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/HPAanalyze/new/HPAanalyze.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘HPAanalyze’ ...
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/HPAanalyze/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/HPAanalyze/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/HPAanalyze/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘HPAanalyze’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/HPAanalyze/new/HPAanalyze.Rcheck/HPAanalyze’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘HPAanalyze’ ...
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/HPAanalyze/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/HPAanalyze/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/HPAanalyze/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘HPAanalyze’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/HPAanalyze/old/HPAanalyze.Rcheck/HPAanalyze’
+
+```
+# iBMQ
+
+<details>
+
+* Version: 1.22.0
+* Source code: https://github.com/cran/iBMQ
+* URL: http://www.rglab.org
+* Date/Publication: 2018-10-30
+* Number of recursive dependencies: 35
+
+Run `revdep_details(,"iBMQ")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘iBMQ’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/iBMQ/new/iBMQ.Rcheck/00install.out’ for details.
+    ```
+
+*   checking for hidden files and directories ... NOTE
+    ```
+    Found the following hidden files and directories:
+      .BBSoptions
+    These were most likely included in error. See section ‘Package
+    structure’ in the ‘Writing R Extensions’ manual.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘iBMQ’ ...
+checking for gcc... clang
+checking whether the C compiler works... yes
+checking for C compiler default output file name... a.out
+checking for suffix of executables... 
+checking whether we are cross compiling... no
+checking for suffix of object files... o
+checking whether we are using the GNU C compiler... yes
+checking whether clang accepts -g... yes
+checking for clang option to accept ISO C89... none needed
+checking how to run the C preprocessor... clang -E
+checking for pkg-config... /usr/local/bin/pkg-config
+checking pkg-config is at least version 0.9.0... yes
+checking for GSL... no
+checking for gsl-config... no
+checking for GSL - version >= 1.2... no
+*** The gsl-config script installed by GSL could not be found
+*** If GSL was installed in PREFIX, make sure PREFIX/bin is in
+*** your path, or set the GSL_CONFIG environment variable to the
+*** full path to gsl-config.
+configure: error: Cannot find Gnu Scientific Library >=1.6
+ERROR: configuration failed for package ‘iBMQ’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/iBMQ/new/iBMQ.Rcheck/iBMQ’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘iBMQ’ ...
+checking for gcc... clang
+checking whether the C compiler works... yes
+checking for C compiler default output file name... a.out
+checking for suffix of executables... 
+checking whether we are cross compiling... no
+checking for suffix of object files... o
+checking whether we are using the GNU C compiler... yes
+checking whether clang accepts -g... yes
+checking for clang option to accept ISO C89... none needed
+checking how to run the C preprocessor... clang -E
+checking for pkg-config... /usr/local/bin/pkg-config
+checking pkg-config is at least version 0.9.0... yes
+checking for GSL... no
+checking for gsl-config... no
+checking for GSL - version >= 1.2... no
+*** The gsl-config script installed by GSL could not be found
+*** If GSL was installed in PREFIX, make sure PREFIX/bin is in
+*** your path, or set the GSL_CONFIG environment variable to the
+*** full path to gsl-config.
+configure: error: Cannot find Gnu Scientific Library >=1.6
+ERROR: configuration failed for package ‘iBMQ’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/iBMQ/old/iBMQ.Rcheck/iBMQ’
+
+```
+# iCNV
+
+<details>
+
+* Version: 1.2.1
+* Source code: https://github.com/cran/iCNV
+* Date/Publication: 2019-01-04
+* Number of recursive dependencies: 86
+
+Run `revdep_details(,"iCNV")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘iCNV’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/iCNV/new/iCNV.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘iCNV’ ...
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : package ‘BSgenome.Hsapiens.UCSC.hg19’ required by ‘CODEX’ could not be found
+ERROR: lazy loading failed for package ‘iCNV’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/iCNV/new/iCNV.Rcheck/iCNV’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘iCNV’ ...
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : package ‘BSgenome.Hsapiens.UCSC.hg19’ required by ‘CODEX’ could not be found
+ERROR: lazy loading failed for package ‘iCNV’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/iCNV/old/iCNV.Rcheck/iCNV’
+
+```
+# imageData
+
+<details>
+
+* Version: 0.1-50
+* Source code: https://github.com/cran/imageData
+* URL: http://chris.brien.name
+* Date/Publication: 2018-06-11 13:25:44 UTC
+* Number of recursive dependencies: 71
+
+Run `revdep_details(,"imageData")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘imageData’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/imageData/new/imageData.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘imageData’ ...
+** package ‘imageData’ successfully unpacked and MD5 sums checked
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/imageData/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/imageData/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/imageData/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘imageData’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/imageData/new/imageData.Rcheck/imageData’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘imageData’ ...
+** package ‘imageData’ successfully unpacked and MD5 sums checked
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/imageData/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/imageData/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/imageData/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘imageData’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/imageData/old/imageData.Rcheck/imageData’
+
+```
+# imbalance
+
+<details>
+
+* Version: 1.0.0
+* Source code: https://github.com/cran/imbalance
+* URL: http://github.com/ncordon/imbalance
+* BugReports: http://github.com/ncordon/imbalance/issues
+* Date/Publication: 2018-02-18 17:06:30 UTC
+* Number of recursive dependencies: 63
+
+Run `revdep_details(,"imbalance")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘imbalance’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/imbalance/new/imbalance.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘imbalance’ ...
+** package ‘imbalance’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/imbalance/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/imbalance/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/imbalance/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/imbalance/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c mwmote.cpp -o mwmote.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/imbalance/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/imbalance/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c neater.cpp -o neater.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/imbalance/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/imbalance/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c pdfos.cpp -o pdfos.o
+clang: error: unsupported option '-fopenmp'clang: error: unsupported option '-fopenmp'clang: error: unsupported option '-fopenmp'
+
+
+clang: error: unsupported option '-fopenmp'
+make: *** [neater.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [pdfos.o] Error 1
+make: *** [mwmote.o] Error 1
+make: *** [RcppExports.o] Error 1
+ERROR: compilation failed for package ‘imbalance’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/imbalance/new/imbalance.Rcheck/imbalance’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘imbalance’ ...
+** package ‘imbalance’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/imbalance/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/imbalance/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/imbalance/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/imbalance/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c mwmote.cpp -o mwmote.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/imbalance/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/imbalance/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c neater.cpp -o neater.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/imbalance/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/imbalance/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c pdfos.cpp -o pdfos.o
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+make: *** [RcppExports.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [neater.o] Error 1
+make: *** [pdfos.o] Error 1
+make: *** [mwmote.o] Error 1
+ERROR: compilation failed for package ‘imbalance’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/imbalance/old/imbalance.Rcheck/imbalance’
+
+```
+# Imetagene
+
+<details>
+
+* Version: 1.12.0
+* Source code: https://github.com/cran/Imetagene
+* BugReports: https://github.com/andronekomimi/Imetagene/issues
+* Date/Publication: 2018-10-30
+* Number of recursive dependencies: 145
+
+Run `revdep_details(,"Imetagene")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘Imetagene’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/Imetagene/new/Imetagene.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘Imetagene’ ...
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for 'metagene' in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]):
+ there is no package called 'EnsDb.Hsapiens.v86'
+Error : package 'metagene' could not be loaded
+ERROR: lazy loading failed for package 'Imetagene'
+* removing '/Users/max/github/forks/ggplot2/revdep/checks.noindex/Imetagene/new/Imetagene.Rcheck/Imetagene'
+
+```
+### CRAN
+
+```
+* installing *source* package ‘Imetagene’ ...
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for 'metagene' in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]):
+ there is no package called 'EnsDb.Hsapiens.v86'
+Error : package 'metagene' could not be loaded
+ERROR: lazy loading failed for package 'Imetagene'
+* removing '/Users/max/github/forks/ggplot2/revdep/checks.noindex/Imetagene/old/Imetagene.Rcheck/Imetagene'
+
+```
+# InSilicoVA
+
+<details>
+
+* Version: 1.2.5
+* Source code: https://github.com/cran/InSilicoVA
+* URL: https://github.com/verbal-autopsy-software/InSilicoVA
+* BugReports: https://github.com/verbal-autopsy-software/InSilicoVA/issues
+* Date/Publication: 2018-10-29 05:40:11 UTC
+* Number of recursive dependencies: 36
+
+Run `revdep_details(,"InSilicoVA")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘InSilicoVA’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/InSilicoVA/new/InSilicoVA.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘InSilicoVA’ ...
+** package ‘InSilicoVA’ successfully unpacked and MD5 sums checked
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/InSilicoVA/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/InSilicoVA/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/InSilicoVA/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘InSilicoVA’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/InSilicoVA/new/InSilicoVA.Rcheck/InSilicoVA’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘InSilicoVA’ ...
+** package ‘InSilicoVA’ successfully unpacked and MD5 sums checked
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/InSilicoVA/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/InSilicoVA/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/InSilicoVA/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘InSilicoVA’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/InSilicoVA/old/InSilicoVA.Rcheck/InSilicoVA’
+
+```
+# jarbes
+
+<details>
+
+* Version: 1.7.2
+* Source code: https://github.com/cran/jarbes
+* Date/Publication: 2019-03-11 16:50:03 UTC
+* Number of recursive dependencies: 59
+
+Run `revdep_details(,"jarbes")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘jarbes’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/jarbes/new/jarbes.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘jarbes’ ...
+** package ‘jarbes’ successfully unpacked and MD5 sums checked
+** R
+** data
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/jarbes/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/jarbes/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/jarbes/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘jarbes’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/jarbes/new/jarbes.Rcheck/jarbes’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘jarbes’ ...
+** package ‘jarbes’ successfully unpacked and MD5 sums checked
+** R
+** data
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/jarbes/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/jarbes/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/jarbes/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘jarbes’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/jarbes/old/jarbes.Rcheck/jarbes’
+
+```
+# joineRML
+
+<details>
+
+* Version: 0.4.2
+* Source code: https://github.com/cran/joineRML
+* URL: https://github.com/petephilipson/joineRML
+* BugReports: https://github.com/graemeleehickey/joineRML/issues
+* Date/Publication: 2018-05-28 23:00:22 UTC
+* Number of recursive dependencies: 68
+
+Run `revdep_details(,"joineRML")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘joineRML’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/joineRML/new/joineRML.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘joineRML’ ...
+** package ‘joineRML’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/joineRML/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/joineRML/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/joineRML/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/joineRML/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c expW.cpp -o expW.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/joineRML/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/joineRML/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c gammaUpdate.cpp -o gammaUpdate.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/joineRML/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/joineRML/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c gammaUpdate_approx.cpp -o gammaUpdate_approx.o
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+make: *** [gammaUpdate_approx.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [gammaUpdate.o] Error 1
+make: *** [expW.o] Error 1
+make: *** [RcppExports.o] Error 1
+ERROR: compilation failed for package ‘joineRML’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/joineRML/new/joineRML.Rcheck/joineRML’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘joineRML’ ...
+** package ‘joineRML’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/joineRML/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/joineRML/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/joineRML/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/joineRML/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c expW.cpp -o expW.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/joineRML/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/joineRML/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c gammaUpdate.cpp -o gammaUpdate.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/joineRML/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/joineRML/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c gammaUpdate_approx.cpp -o gammaUpdate_approx.o
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+make: *** [gammaUpdate_approx.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [RcppExports.o] Error 1
+make: *** [expW.o] Error 1
+make: *** [gammaUpdate.o] Error 1
+ERROR: compilation failed for package ‘joineRML’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/joineRML/old/joineRML.Rcheck/joineRML’
+
+```
+# JointAI
+
+<details>
+
+* Version: 0.5.0
+* Source code: https://github.com/cran/JointAI
+* URL: https://nerler.github.io/JointAI
+* BugReports: https://github.com/nerler/JointAI/issues
+* Date/Publication: 2019-03-08 10:32:53 UTC
+* Number of recursive dependencies: 70
+
+Run `revdep_details(,"JointAI")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘JointAI’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/JointAI/new/JointAI.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘JointAI’ ...
+** package ‘JointAI’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rjags’:
+ .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/JointAI/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/JointAI/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/JointAI/rjags/libs/rjags.so
+  Reason: image not found
+Error : package ‘rjags’ could not be loaded
+ERROR: lazy loading failed for package ‘JointAI’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/JointAI/new/JointAI.Rcheck/JointAI’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘JointAI’ ...
+** package ‘JointAI’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rjags’:
+ .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/JointAI/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/JointAI/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/JointAI/rjags/libs/rjags.so
+  Reason: image not found
+Error : package ‘rjags’ could not be loaded
+ERROR: lazy loading failed for package ‘JointAI’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/JointAI/old/JointAI.Rcheck/JointAI’
+
+```
+# likeLTD
+
+<details>
+
+* Version: 6.3.0
+* Source code: https://github.com/cran/likeLTD
+* URL: https://sites.google.com/site/baldingstatisticalgenetics/
+* Date/Publication: 2018-02-09 17:20:58 UTC
+* Number of recursive dependencies: 40
+
+Run `revdep_details(,"likeLTD")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘likeLTD’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/likeLTD/new/likeLTD.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘likeLTD’ ...
+** package ‘likeLTD’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c gammaDist.cpp -o gammaDist.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c genetics.cpp -o genetics.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c maximizePeaks.cpp -o maximizePeaks.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c module.cpp -o module.o
+clang: clang: error: unsupported option '-fopenmp'error: clang: error: unsupported option '-fopenmp'unsupported option '-fopenmp'
+
+
+clang: error: unsupported option '-fopenmp'
+make: *** [module.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [maximizePeaks.o] Error 1
+make: *** [genetics.o] Error 1
+make: *** [gammaDist.o] Error 1
+ERROR: compilation failed for package ‘likeLTD’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/likeLTD/new/likeLTD.Rcheck/likeLTD’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘likeLTD’ ...
+** package ‘likeLTD’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c gammaDist.cpp -o gammaDist.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c genetics.cpp -o genetics.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c maximizePeaks.cpp -o maximizePeaks.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c module.cpp -o module.o
+clang: error: unsupported option '-fopenmp'clang: error: unsupported option '-fopenmp'
+
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+make: *** [module.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [maximizePeaks.o] Error 1
+make: *** [genetics.o] Error 1
+make: *** [gammaDist.o] Error 1
+ERROR: compilation failed for package ‘likeLTD’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/likeLTD/old/likeLTD.Rcheck/likeLTD’
+
+```
+# lilikoi
+
+<details>
+
+* Version: 0.1.0
+* Source code: https://github.com/cran/lilikoi
+* URL: https://github.com/lanagarmire/lilikoi
+* BugReports: https://github.com/lanagarmire/lilikoi/issues
+* Date/Publication: 2018-07-30 11:10:03 UTC
+* Number of recursive dependencies: 128
+
+Run `revdep_details(,"lilikoi")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘lilikoi’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/lilikoi/new/lilikoi.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘lilikoi’ ...
+** package ‘lilikoi’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/lilikoi/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/lilikoi/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/lilikoi/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘lilikoi’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/lilikoi/new/lilikoi.Rcheck/lilikoi’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘lilikoi’ ...
+** package ‘lilikoi’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/lilikoi/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/lilikoi/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/lilikoi/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘lilikoi’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/lilikoi/old/lilikoi.Rcheck/lilikoi’
+
+```
+# LINC
+
+<details>
+
+* Version: 
+* Source code: ???
+* URL: http://ggplot2.tidyverse.org, https://github.com/tidyverse/ggplot2
+* BugReports: https://github.com/tidyverse/ggplot2/issues
+* Number of recursive dependencies: 0
+
+Run `revdep_details(,"")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+installing the source packages ‘GO.db’, ‘org.Hs.eg.db’, ‘reactome.db’
+
+
+
+```
+### CRAN
+
+```
+
+
+
+installing the source packages ‘GO.db’, ‘org.Hs.eg.db’, ‘reactome.db’
+
+
+
+```
+# llama
+
+<details>
+
+* Version: 0.9.2
+* Source code: https://github.com/cran/llama
+* URL: https://bitbucket.org/lkotthoff/llama
+* Date/Publication: 2018-07-11 14:30:03 UTC
+* Number of recursive dependencies: 46
+
+Run `revdep_details(,"llama")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘llama’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/llama/new/llama.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘llama’ ...
+** package ‘llama’ successfully unpacked and MD5 sums checked
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/llama/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/llama/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/llama/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘llama’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/llama/new/llama.Rcheck/llama’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘llama’ ...
+** package ‘llama’ successfully unpacked and MD5 sums checked
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/llama/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/llama/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/llama/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘llama’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/llama/old/llama.Rcheck/llama’
+
+```
+# LLSR
+
+<details>
+
+* Version: 0.0.2.19
+* Source code: https://github.com/cran/LLSR
+* URL: https://CRAN.R-project.org/package=LLSR
+* BugReports: https://github.com/diegofcoelho/LLSR/issues
+* Date/Publication: 2019-03-05 22:20:11 UTC
+* Number of recursive dependencies: 51
+
+Run `revdep_details(,"LLSR")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘LLSR’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/LLSR/new/LLSR.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘LLSR’ ...
+** package ‘LLSR’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/LLSR/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/LLSR/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/LLSR/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘LLSR’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/LLSR/new/LLSR.Rcheck/LLSR’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘LLSR’ ...
+** package ‘LLSR’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/LLSR/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/LLSR/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/LLSR/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘LLSR’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/LLSR/old/LLSR.Rcheck/LLSR’
+
+```
+# matchingMarkets
+
+<details>
+
+* Version: 1.0-1
+* Source code: https://github.com/cran/matchingMarkets
+* URL: http://matchingMarkets.org, http://klein.uk
+* BugReports: https://github.com/thiloklein/matchingMarkets/issues
+* Date/Publication: 2019-02-04 22:40:02 UTC
+* Number of recursive dependencies: 47
+
+Run `revdep_details(,"matchingMarkets")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘matchingMarkets’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/matchingMarkets/new/matchingMarkets.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘matchingMarkets’ ...
+** package ‘matchingMarkets’ successfully unpacked and MD5 sums checked
+** libs
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c Options.cc -o Options.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c RcppExports.cpp -o RcppExports.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c System.cc -o System.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c kprmatcher.cc -o kprmatcher.o
+In file included from System.cc:24:
+In file included from ../inst/include/System.h:28:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+In file included from Options.cc:20:
+In file included from ../inst/include/Sort.h:24:
+In file included from ../inst/include/Vec.h:28:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+In file included from Options.cc:21:
+../inst/include/Options.h:147:13: warning: variable 'end' is uninitialized when used here [-Wuninitialized]
+        if (end == NULL) 
+            ^~~
+../inst/include/Options.h:143:19: note: initialize the variable 'end' to silence this warning
+        char*  end;
+                  ^
+                   = nullptr
+../inst/include/Options.h:207:13: warning: variable 'end' is uninitialized when used here [-Wuninitialized]
+        if (end == NULL) 
+            ^~~
+../inst/include/Options.h:204:20: note: initialize the variable 'end' to silence this warning
+        char*   end;
+                   ^
+                    = nullptr
+../inst/include/Options.h:275:13: warning: variable 'end' is uninitialized when used here [-Wuninitialized]
+        if (end == NULL) 
+            ^~~
+../inst/include/Options.h:271:20: note: initialize the variable 'end' to silence this warning
+        char*   end;
+                   ^
+                    = nullptr
+In file included from System.cc:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.hIn file included from Options.cc:24:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+:28#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from kprmatcher.cc:41:
+In file included from ../inst/include/kprmatcher.h:36:
+In file included from ../inst/include/damatcher.h:36:
+In file included from ../inst/include/problem.h:43:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from kprmatcher.cc:41:
+In file included from ../inst/include/kprmatcher.h:36:
+In file included from ../inst/include/damatcher.h:36:
+In file included from ../inst/include/problem.h:43:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c params.cc -o params.o
+5 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c problem.cc -o problem.o
+In file included from params.cc:32:
+In file included from ../inst/include/Options.h:28:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+In file included from params.cc:32:
+../inst/include/Options.h:147:13: warning: variable 'end' is uninitialized when used here [-Wuninitialized]
+        if (end == NULL) 
+            ^~~
+../inst/include/Options.h:143:19: note: initialize the variable 'end' to silence this warning
+        char*  end;
+                  ^
+                   = nullptr
+../inst/include/Options.h:207:13: warning: variable 'end' is uninitialized when used here [-Wuninitialized]
+        if (end == NULL) 
+            ^~~
+../inst/include/Options.h:204:20: note: initialize the variable 'end' to silence this warning
+        char*   end;
+                   ^
+                    = nullptr
+../inst/include/Options.h:275:13: warning: variable 'end' is uninitialized when used here [-Wuninitialized]
+        if (end == NULL) 
+            ^~~
+../inst/include/Options.h:271:20: note: initialize the variable 'end' to silence this warning
+        char*   end;
+                   ^
+                    = nullptr
+In file included from RcppExports.cpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from RcppExports.cpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c rcp.cc -o rcp.o
+In file included from params.cc:36:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from problem.cc:36:
+In file included from ../inst/include/problem.h:43:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from problem.cc:36:
+In file included from ../inst/include/problem.h:43:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+5 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c rpmatcher.cc -o rpmatcher.o
+In file included from rcp.cc:33:
+In file included from ../inst/include/rcp.h:41:
+In file included from ../inst/include/problem.h:43:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from rcp.cc:33:
+In file included from ../inst/include/rcp.h:41:
+In file included from ../inst/include/problem.h:43:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c runMatch.cpp -o runMatch.o
+In file included from rpmatcher.cc:46:
+In file included from ../inst/include/rpmatcher.h:36:
+In file included from ../inst/include/damatcher.h:36:
+In file included from ../inst/include/problem.h:43:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from rpmatcher.cc:46:
+In file included from ../inst/include/rpmatcher.h:36:
+In file included from ../inst/include/damatcher.h:36:
+In file included from ../inst/include/problem.h:43:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c stabit2Mat0.cpp -o stabit2Mat0.o
+In file included from runMatch.cpp:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from runMatch.cpp:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c stabit2Mat1.cpp -o stabit2Mat1.o
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c stabit2Sel0.cpp -o stabit2Sel0.o
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c stabit2Sel1.cpp -o stabit2Sel1.o
+In file included from stabit2Mat0.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from stabit2Mat0.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+In file included from stabit2Mat1.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from stabit2Mat1.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+In file included from stabit2Sel0.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from stabit2Sel0.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+In file included from stabit2Sel1.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from stabit2Sel1.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c stabit2Sel2.cpp -o stabit2Sel2.o
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c stabitSel2.cpp -o stabitSel2.o
+In file included from stabit2Sel2.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from stabit2Sel2.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+In file included from stabitSel2.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from stabitSel2.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+2 warnings generated.
+2 warnings generated.
+2 warnings generated.
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/Library/Frameworks/R.framework/Resources/lib -L/usr/local/lib -o matchingMarkets.so Options.o RcppExports.o System.o kprmatcher.o params.o problem.o rcp.o rpmatcher.o runMatch.o stabit2Mat0.o stabit2Mat1.o stabit2Sel0.o stabit2Sel1.o stabit2Sel2.o stabitSel2.o -L/Library/Frameworks/R.framework/Resources/lib -lRlapack -L/Library/Frameworks/R.framework/Resources/lib -lRblas -L/usr/local/gfortran/lib/gcc/x86_64-apple-darwin15/6.1.0 -L/usr/local/gfortran/lib -lgfortran -lquadmath -lm -fopenmp -F/Library/Frameworks/R.framework/.. -framework R -Wl,-framework -Wl,CoreFoundation
+ld: warning: text-based stub file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation.tbd and library file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation are out of sync. Falling back to library file for linking.
+installing to /Users/max/github/forks/ggplot2/revdep/checks.noindex/matchingMarkets/new/matchingMarkets.Rcheck/matchingMarkets/libs
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘matchingMarkets’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/matchingMarkets/new/matchingMarkets.Rcheck/matchingMarkets’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘matchingMarkets’ ...
+** package ‘matchingMarkets’ successfully unpacked and MD5 sums checked
+** libs
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c Options.cc -o Options.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c RcppExports.cpp -o RcppExports.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c System.cc -o System.o
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c kprmatcher.cc -o kprmatcher.o
+In file included from System.cc:24:
+In file included from ../inst/include/System.h:28:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+In file included from Options.cc:20:
+In file included from ../inst/include/Sort.h:24:
+In file included from ../inst/include/Vec.h:28:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+In file included from Options.cc:21:
+../inst/include/Options.h:147:13: warning: variable 'end' is uninitialized when used here [-Wuninitialized]
+        if (end == NULL) 
+            ^~~
+../inst/include/Options.h:143:19: note: initialize the variable 'end' to silence this warning
+        char*  end;
+                  ^
+                   = nullptr
+../inst/include/Options.h:207:13: warning: variable 'end' is uninitialized when used here [-Wuninitialized]
+        if (end == NULL) 
+            ^~~
+../inst/include/Options.h:204:20: note: initialize the variable 'end' to silence this warning
+        char*   end;
+                   ^
+                    = nullptr
+../inst/include/Options.h:275:13: warning: variable 'end' is uninitialized when used here [-Wuninitialized]
+        if (end == NULL) 
+            ^~~
+../inst/include/Options.h:271:20: note: initialize the variable 'end' to silence this warning
+        char*   end;
+                   ^
+                    = nullptr
+In file included from kprmatcher.cc:41:
+In file included from ../inst/include/kprmatcher.h:36:
+In file included from ../inst/include/damatcher.h:36:
+In file included from ../inst/include/problem.h:43:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from kprmatcher.cc:41:
+In file included from ../inst/include/kprmatcher.h:36:
+In file included from ../inst/include/damatcher.h:36:
+In file included from ../inst/include/problem.h:43:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+In file included from System.cc:25:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from Options.cc:24:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c params.cc -o params.o
+5 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c problem.cc -o problem.o
+In file included from params.cc:32:
+In file included from ../inst/include/Options.h:28:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+In file included from params.cc:32:
+../inst/include/Options.h:147:13: warning: variable 'end' is uninitialized when used here [-Wuninitialized]
+        if (end == NULL) 
+            ^~~
+../inst/include/Options.h:143:19: note: initialize the variable 'end' to silence this warning
+        char*  end;
+                  ^
+                   = nullptr
+../inst/include/Options.h:207:13: warning: variable 'end' is uninitialized when used here [-Wuninitialized]
+        if (end == NULL) 
+            ^~~
+../inst/include/Options.h:204:20: note: initialize the variable 'end' to silence this warning
+        char*   end;
+                   ^
+                    = nullptr
+../inst/include/Options.h:275:13: warning: variable 'end' is uninitialized when used here [-Wuninitialized]
+        if (end == NULL) 
+            ^~~
+../inst/include/Options.h:271:20: note: initialize the variable 'end' to silence this warning
+        char*   end;
+                   ^
+                    = nullptr
+In file included from RcppExports.cpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from RcppExports.cpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c rcp.cc -o rcp.o
+In file included from params.cc:36:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from problem.cc:36:
+In file included from ../inst/include/problem.h:43:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from problem.cc:36:
+In file included from ../inst/include/problem.h:43:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+5 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c rpmatcher.cc -o rpmatcher.o
+In file included from rcp.cc:33:
+In file included from ../inst/include/rcp.h:41:
+In file included from ../inst/include/problem.h:43:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from rcp.cc:33:
+In file included from ../inst/include/rcp.h:41:
+In file included from ../inst/include/problem.h:43:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c runMatch.cpp -o runMatch.o
+In file included from rpmatcher.cc:46:
+In file included from ../inst/include/rpmatcher.h:36:
+In file included from ../inst/include/damatcher.h:36:
+In file included from ../inst/include/problem.h:43:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from rpmatcher.cc:46:
+In file included from ../inst/include/rpmatcher.h:36:
+In file included from ../inst/include/damatcher.h:36:
+In file included from ../inst/include/problem.h:43:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c stabit2Mat0.cpp -o stabit2Mat0.o
+In file included from runMatch.cpp:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from runMatch.cpp:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c stabit2Mat1.cpp -o stabit2Mat1.o
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c stabit2Sel0.cpp -o stabit2Sel0.o
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c stabit2Sel1.cpp -o stabit2Sel1.o
+In file included from stabit2Mat0.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from stabit2Mat0.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+In file included from stabit2Mat1.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from stabit2Mat1.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+In file included from stabit2Sel0.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from stabit2Sel0.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+In file included from stabit2Sel1.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from stabit2Sel1.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c stabit2Sel2.cpp -o stabit2Sel2.o
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppProgress/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2 -c stabitSel2.cpp -o stabitSel2.o
+In file included from stabit2Sel2.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from stabit2Sel2.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+In file included from stabitSel2.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:10: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#include <inttypes.h>                   // needed with g++-4.7 to declare intptr_t
+         ^~~~~~~~~~~~
+         <IntTypes.h>
+In file included from stabitSel2.cpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/RcppArmadillo/include/RcppArmadillo.h:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp.h:74:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/sugar/sugar.h:28:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/Rcpp/include/Rcpp/hash/hash.h:25:
+../inst/include/inttypes.h:34:13: warning: non-portable path to file '<IntTypes.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+#   include <inttypes.h>
+            ^~~~~~~~~~~~
+            <IntTypes.h>
+2 warnings generated.
+2 warnings generated.
+2 warnings generated.
+2 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++11 -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/Library/Frameworks/R.framework/Resources/lib -L/usr/local/lib -o matchingMarkets.so Options.o RcppExports.o System.o kprmatcher.o params.o problem.o rcp.o rpmatcher.o runMatch.o stabit2Mat0.o stabit2Mat1.o stabit2Sel0.o stabit2Sel1.o stabit2Sel2.o stabitSel2.o -L/Library/Frameworks/R.framework/Resources/lib -lRlapack -L/Library/Frameworks/R.framework/Resources/lib -lRblas -L/usr/local/gfortran/lib/gcc/x86_64-apple-darwin15/6.1.0 -L/usr/local/gfortran/lib -lgfortran -lquadmath -lm -fopenmp -F/Library/Frameworks/R.framework/.. -framework R -Wl,-framework -Wl,CoreFoundation
+ld: warning: text-based stub file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation.tbd and library file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation are out of sync. Falling back to library file for linking.
+installing to /Users/max/github/forks/ggplot2/revdep/checks.noindex/matchingMarkets/old/matchingMarkets.Rcheck/matchingMarkets/libs
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/matchingMarkets/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘matchingMarkets’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/matchingMarkets/old/matchingMarkets.Rcheck/matchingMarkets’
+
+```
+# mbgraphic
+
+<details>
+
+* Version: 1.0.1
+* Source code: https://github.com/cran/mbgraphic
+* Date/Publication: 2019-04-28 19:20:03 UTC
+* Number of recursive dependencies: 99
+
+Run `revdep_details(,"mbgraphic")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘mbgraphic’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/mbgraphic/new/mbgraphic.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘mbgraphic’ ...
+** package ‘mbgraphic’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/mbgraphic/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/mbgraphic/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c cmasum.cpp -o cmasum.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/mbgraphic/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c mbgraphic_init.c -o mbgraphic_init.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/mbgraphic/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c variableflip.cpp -o variableflip.o
+clang++ -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/Library/Frameworks/R.framework/Resources/lib -L/usr/local/lib -o mbgraphic.so RcppExports.o cmasum.o mbgraphic_init.o variableflip.o -F/Library/Frameworks/R.framework/.. -framework R -Wl,-framework -Wl,CoreFoundation
+ld: warning: text-based stub file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation.tbd and library file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation are out of sync. Falling back to library file for linking.
+installing to /Users/max/github/forks/ggplot2/revdep/checks.noindex/mbgraphic/new/mbgraphic.Rcheck/mbgraphic/libs
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/mbgraphic/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/mbgraphic/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/mbgraphic/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘mbgraphic’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/mbgraphic/new/mbgraphic.Rcheck/mbgraphic’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘mbgraphic’ ...
+** package ‘mbgraphic’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/mbgraphic/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/mbgraphic/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c cmasum.cpp -o cmasum.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/mbgraphic/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c mbgraphic_init.c -o mbgraphic_init.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/mbgraphic/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c variableflip.cpp -o variableflip.o
+clang++ -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/Library/Frameworks/R.framework/Resources/lib -L/usr/local/lib -o mbgraphic.so RcppExports.o cmasum.o mbgraphic_init.o variableflip.o -F/Library/Frameworks/R.framework/.. -framework R -Wl,-framework -Wl,CoreFoundation
+ld: warning: text-based stub file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation.tbd and library file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation are out of sync. Falling back to library file for linking.
+installing to /Users/max/github/forks/ggplot2/revdep/checks.noindex/mbgraphic/old/mbgraphic.Rcheck/mbgraphic/libs
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/mbgraphic/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/mbgraphic/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/mbgraphic/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘mbgraphic’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/mbgraphic/old/mbgraphic.Rcheck/mbgraphic’
+
+```
+# mcmcabn
+
+<details>
+
+* Version: 0.1
+* Source code: https://github.com/cran/mcmcabn
+* URL: https://www.math.uzh.ch/pages/mcmcabn/
+* BugReports: https://git.math.uzh.ch/gkratz/mcmcabn/issues
+* Date/Publication: 2019-03-08 17:10:03 UTC
+* Number of recursive dependencies: 90
+
+Run `revdep_details(,"mcmcabn")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘mcmcabn’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/mcmcabn/new/mcmcabn.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘mcmcabn’ ...
+** package ‘mcmcabn’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/mcmcabn/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/mcmcabn/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/mcmcabn/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘mcmcabn’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/mcmcabn/new/mcmcabn.Rcheck/mcmcabn’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘mcmcabn’ ...
+** package ‘mcmcabn’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/mcmcabn/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/mcmcabn/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/mcmcabn/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘mcmcabn’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/mcmcabn/old/mcmcabn.Rcheck/mcmcabn’
+
+```
+# MEAL
+
+<details>
+
+* Version: 
+* Source code: ???
+* URL: http://ggplot2.tidyverse.org, https://github.com/tidyverse/ggplot2
+* BugReports: https://github.com/tidyverse/ggplot2/issues
+* Number of recursive dependencies: 0
+
+Run `revdep_details(,"")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+  These will not be installed
+
+
+Packages which are only available in source form, and may need
+  compilation of C/C++/Fortran: ‘FDb.InfiniumMethylation.hg19’
+  ‘IlluminaHumanMethylation450kmanifest’
+installing the source packages ‘DMRcatedata’, ‘GO.db’, ‘IlluminaHumanMethylation450kanno.ilmn12.hg19’, ‘IlluminaHumanMethylationEPICanno.ilm10b2.hg19’, ‘IlluminaHumanMethylationEPICanno.ilm10b4.hg19’, ‘IlluminaHumanMethylationEPICmanifest’, ‘minfiData’, ‘org.Hs.eg.db’, ‘TxDb.Hsapiens.UCSC.hg19.knownGene’
+
+
+
+```
+### CRAN
+
+```
+  These will not be installed
+
+
+Packages which are only available in source form, and may need
+  compilation of C/C++/Fortran: ‘FDb.InfiniumMethylation.hg19’
+  ‘IlluminaHumanMethylation450kmanifest’
+installing the source packages ‘DMRcatedata’, ‘GO.db’, ‘IlluminaHumanMethylation450kanno.ilmn12.hg19’, ‘IlluminaHumanMethylationEPICanno.ilm10b2.hg19’, ‘IlluminaHumanMethylationEPICanno.ilm10b4.hg19’, ‘IlluminaHumanMethylationEPICmanifest’, ‘minfiData’, ‘org.Hs.eg.db’, ‘TxDb.Hsapiens.UCSC.hg19.knownGene’
+
+
+
+```
+# methylGSA
+
+<details>
+
+* Version: 
+* Source code: ???
+* URL: http://ggplot2.tidyverse.org, https://github.com/tidyverse/ggplot2
+* BugReports: https://github.com/tidyverse/ggplot2/issues
+* Number of recursive dependencies: 0
+
+Run `revdep_details(,"")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+  These will not be installed
+
+
+Packages which are only available in source form, and may need
+  compilation of C/C++/Fortran: ‘FDb.InfiniumMethylation.hg19’
+  ‘IlluminaHumanMethylation450kmanifest’
+installing the source packages ‘GO.db’, ‘IlluminaHumanMethylation450kanno.ilmn12.hg19’, ‘IlluminaHumanMethylationEPICanno.ilm10b2.hg19’, ‘IlluminaHumanMethylationEPICanno.ilm10b4.hg19’, ‘IlluminaHumanMethylationEPICmanifest’, ‘org.Hs.eg.db’, ‘reactome.db’, ‘TxDb.Hsapiens.UCSC.hg19.knownGene’
+
+
+
+```
+### CRAN
+
+```
+  These will not be installed
+
+
+Packages which are only available in source form, and may need
+  compilation of C/C++/Fortran: ‘FDb.InfiniumMethylation.hg19’
+  ‘IlluminaHumanMethylation450kmanifest’
+installing the source packages ‘GO.db’, ‘IlluminaHumanMethylation450kanno.ilmn12.hg19’, ‘IlluminaHumanMethylationEPICanno.ilm10b2.hg19’, ‘IlluminaHumanMethylationEPICanno.ilm10b4.hg19’, ‘IlluminaHumanMethylationEPICmanifest’, ‘org.Hs.eg.db’, ‘reactome.db’, ‘TxDb.Hsapiens.UCSC.hg19.knownGene’
+
+
+
+```
+# mleap
+
+<details>
+
+* Version: 0.1.3
+* Source code: https://github.com/cran/mleap
+* URL: https://github.com/rstudio/mleap
+* BugReports: https://github.com/rstudio/mleap/issues
+* Date/Publication: 2018-11-01 09:40:03 UTC
+* Number of recursive dependencies: 69
+
+Run `revdep_details(,"mleap")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘mleap’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/mleap/new/mleap.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘mleap’ ...
+** package ‘mleap’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+** help
+*** installing help indices
+** building package indices
+** testing if installed package can be loaded
+Error: package or namespace load failed for ‘mleap’:
+ .onLoad failed in loadNamespace() for 'mleap', details:
+  call: NULL
+  error: .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/mleap/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/mleap/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/mleap/rJava/libs/rJava.so
+  Reason: image not found
+Error: loading failed
+Execution halted
+ERROR: loading failed
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/mleap/new/mleap.Rcheck/mleap’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘mleap’ ...
+** package ‘mleap’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+** help
+*** installing help indices
+** building package indices
+** testing if installed package can be loaded
+Error: package or namespace load failed for ‘mleap’:
+ .onLoad failed in loadNamespace() for 'mleap', details:
+  call: NULL
+  error: .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/mleap/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/mleap/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/mleap/rJava/libs/rJava.so
+  Reason: image not found
+Error: loading failed
+Execution halted
+ERROR: loading failed
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/mleap/old/mleap.Rcheck/mleap’
+
+```
+# morse
+
+<details>
+
+* Version: 3.2.2
+* Source code: https://github.com/cran/morse
+* URL: https://cran.r-project.org/package=morse
+* BugReports: https://github.com/pveber/morse
+* Date/Publication: 2019-02-21 23:30:11 UTC
+* Number of recursive dependencies: 59
+
+Run `revdep_details(,"morse")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘morse’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/morse/new/morse.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘morse’ ...
+** package ‘morse’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/morse/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/morse/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/morse/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘morse’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/morse/new/morse.Rcheck/morse’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘morse’ ...
+** package ‘morse’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/morse/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/morse/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/morse/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘morse’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/morse/old/morse.Rcheck/morse’
+
+```
+# MSnbase
+
+<details>
+
+* Version: 2.8.3
+* Source code: https://github.com/cran/MSnbase
+* URL: https://github.com/lgatto/MSnbase
+* BugReports: https://github.com/lgatto/MSnbase/issues
+* Date/Publication: 2019-01-04
+* Number of recursive dependencies: 215
+
+Run `revdep_details(,"MSnbase")` for more info
+
+</details>
+
+## In both
+
+*   R CMD check timed out
+    
+
+*   checking installed package size ... NOTE
+    ```
+      installed size is 13.2Mb
+      sub-directories of 1Mb or more:
+        R      2.1Mb
+        data   1.9Mb
+        doc    7.8Mb
+    ```
+
+*   checking DESCRIPTION meta-information ... NOTE
+    ```
+    Authors@R field gives more than one person with maintainer role:
+      Laurent Gatto <lg390@cam.ac.uk> [aut, cre]
+      Johannes Rainer <Johannes.Rainer@eurac.edu> [aut, cre]
+      Sebastian Gibb <mail@sebastiangibb.de> [aut, cre]
+    ```
+
+*   checking dependencies in R code ... NOTE
+    ```
+    Unexported objects imported by ':::' calls:
+      ‘Biobase:::.showAnnotatedDataFrame’ ‘MALDIquant:::.estimateNoise’
+      ‘MALDIquant:::.localMaxima’ ‘MALDIquant:::.movingAverage’
+      ‘MALDIquant:::.savitzkyGolay’
+      ‘S4Vectors:::makeClassinfoRowForCompactPrinting’
+      ‘S4Vectors:::makePrettyMatrixForCompactPrinting’
+      ‘mzR:::.hasChromatograms’ ‘mzR:::.hasSpectra’
+      See the note in ?`:::` about the use of this operator.
+    ```
+
+# mwaved
+
+<details>
+
+* Version: 1.1.6
+* Source code: https://github.com/cran/mwaved
+* URL: https://github.com/jrwishart/mwaved
+* BugReports: https://github.com/jrwishart/mwaved/issues
+* Date/Publication: 2019-03-22 22:10:03 UTC
+* Number of recursive dependencies: 55
+
+Run `revdep_details(,"mwaved")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘mwaved’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/mwaved/new/mwaved.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘mwaved’ ...
+** package ‘mwaved’ successfully unpacked and MD5 sums checked
+checking for Rscript... yes
+configure: Checking if FFTW3 library is available using pkg-config
+checking for pkg-config... /usr/local/bin/pkg-config
+checking pkg-config is at least version 0.9.0... yes
+checking for FFTW... no
+FFTW library not found, please install fftw-3-3-3 or greater
+configure: creating ./config.status
+config.status: creating src/Makevars
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/mwaved/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/mwaved/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c mwaved.cpp -o mwaved.o
+mwaved.cpp:1:10: fatal error: 'fftw3.h' file not found
+#include <fftw3.h>
+         ^~~~~~~~~
+1 error generated.
+make: *** [mwaved.o] Error 1
+make: *** Waiting for unfinished jobs....
+ERROR: compilation failed for package ‘mwaved’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/mwaved/new/mwaved.Rcheck/mwaved’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘mwaved’ ...
+** package ‘mwaved’ successfully unpacked and MD5 sums checked
+checking for Rscript... yes
+configure: Checking if FFTW3 library is available using pkg-config
+checking for pkg-config... /usr/local/bin/pkg-config
+checking pkg-config is at least version 0.9.0... yes
+checking for FFTW... no
+FFTW library not found, please install fftw-3-3-3 or greater
+configure: creating ./config.status
+config.status: creating src/Makevars
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/mwaved/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/mwaved/Rcpp/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c mwaved.cpp -o mwaved.o
+mwaved.cpp:1:10: fatal error: 'fftw3.h' file not found
+#include <fftw3.h>
+         ^~~~~~~~~
+1 error generated.
+make: *** [mwaved.o] Error 1
+make: *** Waiting for unfinished jobs....
+ERROR: compilation failed for package ‘mwaved’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/mwaved/old/mwaved.Rcheck/mwaved’
+
+```
+# NPflow
+
+<details>
+
+* Version: 0.13.1
+* Source code: https://github.com/cran/NPflow
+* BugReports: https://github.com/borishejblum/NPflow/issues
+* Date/Publication: 2017-08-02 18:42:55 UTC
+* Number of recursive dependencies: 50
+
+Run `revdep_details(,"NPflow")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘NPflow’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/NPflow/new/NPflow.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘NPflow’ ...
+** package ‘NPflow’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/NPflow/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/NPflow/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c FmeasureC.cpp -o FmeasureC.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/NPflow/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/NPflow/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c NuMatParC.cpp -o NuMatParC.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/NPflow/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/NPflow/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/NPflow/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/NPflow/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c TraceEpsC.cpp -o TraceEpsC.o
+clang: error: unsupported option '-fopenmp'clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+
+clang: error: unsupported option '-fopenmp'
+make: *** [TraceEpsC.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [RcppExports.o] Error 1
+make: *** [NuMatParC.o] Error 1
+make: *** [FmeasureC.o] Error 1
+ERROR: compilation failed for package ‘NPflow’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/NPflow/new/NPflow.Rcheck/NPflow’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘NPflow’ ...
+** package ‘NPflow’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/NPflow/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/NPflow/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c FmeasureC.cpp -o FmeasureC.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/NPflow/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/NPflow/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c NuMatParC.cpp -o NuMatParC.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/NPflow/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/NPflow/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/NPflow/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/NPflow/RcppArmadillo/include" -I/usr/local/include  -fopenmp  -fPIC  -Wall -g -O2  -c TraceEpsC.cpp -o TraceEpsC.o
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+make: *** [RcppExports.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [NuMatParC.o] Error 1
+make: *** [FmeasureC.o] Error 1
+clang: error: unsupported option '-fopenmp'
+make: *** [TraceEpsC.o] Error 1
+ERROR: compilation failed for package ‘NPflow’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/NPflow/old/NPflow.Rcheck/NPflow’
+
+```
+# OpenStreetMap
+
+<details>
+
+* Version: 0.3.3
+* Source code: https://github.com/cran/OpenStreetMap
+* URL: http://www.fellstat.com http://blog.fellstat.com/?cat=15
+* Date/Publication: 2016-09-09 23:49:52
+* Number of recursive dependencies: 39
+
+Run `revdep_details(,"OpenStreetMap")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘OpenStreetMap’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/OpenStreetMap/new/OpenStreetMap.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘OpenStreetMap’ ...
+** package ‘OpenStreetMap’ successfully unpacked and MD5 sums checked
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/OpenStreetMap/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/OpenStreetMap/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/OpenStreetMap/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘OpenStreetMap’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/OpenStreetMap/new/OpenStreetMap.Rcheck/OpenStreetMap’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘OpenStreetMap’ ...
+** package ‘OpenStreetMap’ successfully unpacked and MD5 sums checked
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/OpenStreetMap/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/OpenStreetMap/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/OpenStreetMap/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘OpenStreetMap’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/OpenStreetMap/old/OpenStreetMap.Rcheck/OpenStreetMap’
+
+```
+# openVA
+
+<details>
+
+* Version: 1.0.8
+* Source code: https://github.com/cran/openVA
+* URL: https://github.com/verbal-autopsy-software/openVA
+* BugReports: https://github.com/verbal-autopsy-software/openVA/issues
+* Date/Publication: 2019-02-18 06:40:02 UTC
+* Number of recursive dependencies: 40
+
+Run `revdep_details(,"openVA")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘openVA’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/openVA/new/openVA.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘openVA’ ...
+** package ‘openVA’ successfully unpacked and MD5 sums checked
+** R
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/openVA/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/openVA/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/openVA/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘openVA’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/openVA/new/openVA.Rcheck/openVA’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘openVA’ ...
+** package ‘openVA’ successfully unpacked and MD5 sums checked
+** R
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/openVA/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/openVA/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/openVA/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘openVA’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/openVA/old/openVA.Rcheck/openVA’
+
+```
+# petro.One
+
+<details>
+
+* Version: 0.2.3
+* Source code: https://github.com/cran/petro.One
+* URL: https://github.com/f0nzie/petro.One
+* Date/Publication: 2019-01-13 16:20:03 UTC
+* Number of recursive dependencies: 78
+
+Run `revdep_details(,"petro.One")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘petro.One’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/petro.One/new/petro.One.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘petro.One’ ...
+** package ‘petro.One’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/petro.One/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/petro.One/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/petro.One/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘petro.One’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/petro.One/new/petro.One.Rcheck/petro.One’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘petro.One’ ...
+** package ‘petro.One’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/petro.One/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/petro.One/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/petro.One/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘petro.One’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/petro.One/old/petro.One.Rcheck/petro.One’
+
+```
+# phase1PRMD
+
+<details>
+
+* Version: 1.0.1
+* Source code: https://github.com/cran/phase1PRMD
+* Date/Publication: 2019-02-03 17:00:03 UTC
+* Number of recursive dependencies: 75
+
+Run `revdep_details(,"phase1PRMD")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘phase1PRMD’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/phase1PRMD/new/phase1PRMD.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘phase1PRMD’ ...
+** package ‘phase1PRMD’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/phase1PRMD/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/phase1PRMD/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/phase1PRMD/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘phase1PRMD’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/phase1PRMD/new/phase1PRMD.Rcheck/phase1PRMD’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘phase1PRMD’ ...
+** package ‘phase1PRMD’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/phase1PRMD/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/phase1PRMD/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/phase1PRMD/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘phase1PRMD’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/phase1PRMD/old/phase1PRMD.Rcheck/phase1PRMD’
+
+```
+# phase1RMD
+
+<details>
+
+* Version: 1.0.8
+* Source code: https://github.com/cran/phase1RMD
+* Date/Publication: 2017-11-27 08:49:15 UTC
+* Number of recursive dependencies: 47
+
+Run `revdep_details(,"phase1RMD")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘phase1RMD’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/phase1RMD/new/phase1RMD.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘phase1RMD’ ...
+** package ‘phase1RMD’ successfully unpacked and MD5 sums checked
+** R
+** data
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rjags’:
+ .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/phase1RMD/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/phase1RMD/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/phase1RMD/rjags/libs/rjags.so
+  Reason: image not found
+Error : package ‘rjags’ could not be loaded
+ERROR: lazy loading failed for package ‘phase1RMD’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/phase1RMD/new/phase1RMD.Rcheck/phase1RMD’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘phase1RMD’ ...
+** package ‘phase1RMD’ successfully unpacked and MD5 sums checked
+** R
+** data
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rjags’:
+ .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/phase1RMD/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/phase1RMD/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/phase1RMD/rjags/libs/rjags.so
+  Reason: image not found
+Error : package ‘rjags’ could not be loaded
+ERROR: lazy loading failed for package ‘phase1RMD’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/phase1RMD/old/phase1RMD.Rcheck/phase1RMD’
+
+```
+# pimeta
+
+<details>
+
+* Version: 1.1.2
+* Source code: https://github.com/cran/pimeta
+* Date/Publication: 2019-03-11 08:40:03 UTC
+* Number of recursive dependencies: 46
+
+Run `revdep_details(,"pimeta")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘pimeta’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/pimeta/new/pimeta.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘pimeta’ ...
+** package ‘pimeta’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/pimeta/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/pimeta/RcppEigen/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/pimeta/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/pimeta/RcppEigen/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c init.c -o init.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/pimeta/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/pimeta/RcppEigen/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c pi-boot.cpp -o pi-boot.o
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+make: *** [RcppExports.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [pi-boot.o] Error 1
+ERROR: compilation failed for package ‘pimeta’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/pimeta/new/pimeta.Rcheck/pimeta’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘pimeta’ ...
+** package ‘pimeta’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/pimeta/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/pimeta/RcppEigen/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/pimeta/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/pimeta/RcppEigen/include" -I/usr/local/include   -fPIC  -Wall -g -O2  -c init.c -o init.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/pimeta/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/pimeta/RcppEigen/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c pi-boot.cpp -o pi-boot.o
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+make: *** [pi-boot.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [RcppExports.o] Error 1
+ERROR: compilation failed for package ‘pimeta’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/pimeta/old/pimeta.Rcheck/pimeta’
+
+```
+# poppr
+
+<details>
+
+* Version: 2.8.2
+* Source code: https://github.com/cran/poppr
+* URL: https://github.com/grunwaldlab/poppr, https://grunwaldlab.github.io/poppr, https://grunwaldlab.github.io/Population_Genetics_in_R/
+* BugReports: https://github.com/grunwaldlab/poppr/issues
+* Date/Publication: 2019-03-11 10:30:03 UTC
+* Number of recursive dependencies: 94
+
+Run `revdep_details(,"poppr")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘poppr’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/poppr/new/poppr.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘poppr’ ...
+** package ‘poppr’ successfully unpacked and MD5 sums checked
+** libs
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c adjust_missing.c -o adjust_missing.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c bitwise_distance.c -o bitwise_distance.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c init.c -o init.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c mlg_clustering.c -o mlg_clustering.o
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+clangclang: : error: unsupported option '-fopenmp'
+error: unsupported option '-fopenmp'
+make: *** [mlg_clustering.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [init.o] Error 1
+make: *** [bitwise_distance.o] Error 1
+make: *** [adjust_missing.o] Error 1
+ERROR: compilation failed for package ‘poppr’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/poppr/new/poppr.Rcheck/poppr’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘poppr’ ...
+** package ‘poppr’ successfully unpacked and MD5 sums checked
+** libs
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c adjust_missing.c -o adjust_missing.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c bitwise_distance.c -o bitwise_distance.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c init.c -o init.o
+clang -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c mlg_clustering.c -o mlg_clustering.o
+clang: error: unsupported option '-fopenmp'clang: error: unsupported option '-fopenmp'
+
+clang: error: unsupported option '-fopenmp'
+make: *** [bitwise_distance.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [adjust_missing.o] Error 1
+make: *** [init.o] Error 1
+clang: error: unsupported option '-fopenmp'
+make: *** [mlg_clustering.o] Error 1
+ERROR: compilation failed for package ‘poppr’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/poppr/old/poppr.Rcheck/poppr’
+
+```
+# PortfolioEffectHFT
+
+<details>
+
+* Version: 1.8
+* Source code: https://github.com/cran/PortfolioEffectHFT
+* URL: https://www.portfolioeffect.com/
+* Date/Publication: 2017-03-24 19:54:25 UTC
+* Number of recursive dependencies: 37
+
+Run `revdep_details(,"PortfolioEffectHFT")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘PortfolioEffectHFT’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/PortfolioEffectHFT/new/PortfolioEffectHFT.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘PortfolioEffectHFT’ ...
+** package ‘PortfolioEffectHFT’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** demo
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/PortfolioEffectHFT/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/PortfolioEffectHFT/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/PortfolioEffectHFT/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘PortfolioEffectHFT’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/PortfolioEffectHFT/new/PortfolioEffectHFT.Rcheck/PortfolioEffectHFT’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘PortfolioEffectHFT’ ...
+** package ‘PortfolioEffectHFT’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** demo
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/PortfolioEffectHFT/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/PortfolioEffectHFT/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/PortfolioEffectHFT/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘PortfolioEffectHFT’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/PortfolioEffectHFT/old/PortfolioEffectHFT.Rcheck/PortfolioEffectHFT’
+
+```
+# psygenet2r
+
+<details>
+
+* Version: 1.14.0
+* Source code: https://github.com/cran/psygenet2r
+* Date/Publication: 2018-10-30
+* Number of recursive dependencies: 81
+
+Run `revdep_details(,"psygenet2r")` for more info
+
+</details>
+
+## In both
+
+*   R CMD check timed out
+    
+
+*   checking whether package ‘psygenet2r’ can be installed ... WARNING
+    ```
+    Found the following significant warnings:
+      Note: possible error in 'psygenetGene(x, databse = "ALL")': unused argument (databse = "ALL") 
+      Note: possible error in 'psygenetGene(x, databse = "ALL", ': unused argument (databse = "ALL") 
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/psygenet2r/new/psygenet2r.Rcheck/00install.out’ for details.
+    Information on the location(s) of code generating the ‘Note’s can be
+    obtained by re-running with environment variable R_KEEP_PKG_SOURCE set
+    to ‘yes’.
+    ```
+
+*   checking installed package size ... NOTE
+    ```
+      installed size is  5.7Mb
+      sub-directories of 1Mb or more:
+        doc   5.1Mb
+    ```
+
+*   checking dependencies in R code ... NOTE
+    ```
+    Namespace in Imports field not imported from: ‘GO.db’
+      All declared Imports should be used.
+    package 'methods' is used but not declared
+    ```
+
+*   checking R code for possible problems ... NOTE
+    ```
+    ...
+      ‘Disease1’
+    plot,JaccardIndexPsy-ANY: no visible binding for global variable
+      ‘Disease2’
+    plot,JaccardIndexPsy-ANY: no visible binding for global variable
+      ‘JaccardIndex’
+    plot,JaccardIndexPsy-ANY: no visible binding for global variable
+      ‘value’
+    plot,JaccardIndexPsy-ANY: no visible binding for global variable
+      ‘variable’
+    Undefined global functions or variables:
+      Category Disease1 Disease2 JaccardIndex Var1 c0.Number_of_Abstracts
+      c0.Score c1.Gene_Symbol c2.DiseaseName c2.PsychiatricDisorder
+      category combn database diseases gene new perc phyper pie read.csv
+      read.delim universe value variable
+    Consider adding
+      importFrom("graphics", "pie")
+      importFrom("methods", "new")
+      importFrom("stats", "phyper")
+      importFrom("utils", "combn", "read.csv", "read.delim")
+    to your NAMESPACE file (and ensure that your DESCRIPTION Imports field
+    contains 'methods').
+    ```
+
+# qdap
+
+<details>
+
+* Version: 2.3.2
+* Source code: https://github.com/cran/qdap
+* URL: http://trinker.github.com/qdap/
+* BugReports: http://github.com/trinker/qdap/issues
+* Date/Publication: 2019-01-02 13:40:07 UTC
+* Number of recursive dependencies: 86
+
+Run `revdep_details(,"qdap")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘qdap’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/qdap/new/qdap.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘qdap’ ...
+** package ‘qdap’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/qdap/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/qdap/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/qdap/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘qdap’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/qdap/new/qdap.Rcheck/qdap’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘qdap’ ...
+** package ‘qdap’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/qdap/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/qdap/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/qdap/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘qdap’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/qdap/old/qdap.Rcheck/qdap’
+
+```
+# rcellminer
+
+<details>
+
+* Version: 2.4.0
+* Source code: https://github.com/cran/rcellminer
+* URL: http://discover.nci.nih.gov/cellminer/
+* Date/Publication: 2018-10-30
+* Number of recursive dependencies: 110
+
+Run `revdep_details(,"rcellminer")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘rcellminer’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/rcellminer/new/rcellminer.Rcheck/00install.out’ for details.
+    ```
+
+*   checking for hidden files and directories ... NOTE
+    ```
+    Found the following hidden files and directories:
+      .BBSoptions
+    These were most likely included in error. See section ‘Package
+    structure’ in the ‘Writing R Extensions’ manual.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘rcellminer’ ...
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/rcellminer/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/rcellminer/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/rcellminer/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘rcellminer’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/rcellminer/new/rcellminer.Rcheck/rcellminer’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘rcellminer’ ...
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/rcellminer/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/rcellminer/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/rcellminer/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘rcellminer’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/rcellminer/old/rcellminer.Rcheck/rcellminer’
+
+```
+# RcmdrPlugin.FuzzyClust
+
+<details>
+
+* Version: 1.1
+* Source code: https://github.com/cran/RcmdrPlugin.FuzzyClust
+* Date/Publication: 2016-09-04 09:36:21
+* Number of recursive dependencies: 114
+
+Run `revdep_details(,"RcmdrPlugin.FuzzyClust")` for more info
+
+</details>
+
+## In both
+
+*   R CMD check timed out
+    
+
+# RDAVIDWebService
+
+<details>
+
+* Version: 1.20.0
+* Source code: https://github.com/cran/RDAVIDWebService
+* URL: http://www.bdmg.com.ar, http://david.abcc.ncifcrf.gov/
+* Date/Publication: 2018-10-30
+* Number of recursive dependencies: 63
+
+Run `revdep_details(,"RDAVIDWebService")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘RDAVIDWebService’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/RDAVIDWebService/new/RDAVIDWebService.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘RDAVIDWebService’ ...
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/RDAVIDWebService/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/RDAVIDWebService/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/RDAVIDWebService/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘RDAVIDWebService’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/RDAVIDWebService/new/RDAVIDWebService.Rcheck/RDAVIDWebService’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘RDAVIDWebService’ ...
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/RDAVIDWebService/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/RDAVIDWebService/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/RDAVIDWebService/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘RDAVIDWebService’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/RDAVIDWebService/old/RDAVIDWebService.Rcheck/RDAVIDWebService’
+
+```
+# Rdrools
+
+<details>
+
+* Version: 1.1.1
+* Source code: https://github.com/cran/Rdrools
+* Date/Publication: 2018-12-08 15:00:13 UTC
+* Number of recursive dependencies: 64
+
+Run `revdep_details(,"Rdrools")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘Rdrools’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/Rdrools/new/Rdrools.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘Rdrools’ ...
+** package ‘Rdrools’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/Rdrools/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/Rdrools/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/Rdrools/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘Rdrools’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/Rdrools/new/Rdrools.Rcheck/Rdrools’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘Rdrools’ ...
+** package ‘Rdrools’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/Rdrools/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/Rdrools/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/Rdrools/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘Rdrools’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/Rdrools/old/Rdrools.Rcheck/Rdrools’
+
+```
+# ReactomePA
+
+<details>
+
+* Version: 
+* Source code: ???
+* URL: http://ggplot2.tidyverse.org, https://github.com/tidyverse/ggplot2
+* BugReports: https://github.com/tidyverse/ggplot2/issues
+* Number of recursive dependencies: 0
+
+Run `revdep_details(,"")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+  There is a binary version available but the source version is later:
+          binary source needs_compilation
+checkmate  1.9.1  1.9.3              TRUE
+
+  Binaries will be installed
+
+
+installing the source packages ‘GO.db’, ‘org.Hs.eg.db’, ‘reactome.db’
+
+
+
+```
+### CRAN
+
+```
+
+  There is a binary version available but the source version is later:
+          binary source needs_compilation
+checkmate  1.9.1  1.9.3              TRUE
+
+  Binaries will be installed
+
+
+installing the source packages ‘GO.db’, ‘org.Hs.eg.db’, ‘reactome.db’
+
+
+
+```
+# rmcfs
+
+<details>
+
+* Version: 1.2.15
+* Source code: https://github.com/cran/rmcfs
+* URL: www.ipipan.eu/staff/m.draminski/mcfs.html
+* Date/Publication: 2018-10-20 18:40:03 UTC
+* Number of recursive dependencies: 48
+
+Run `revdep_details(,"rmcfs")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘rmcfs’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/rmcfs/new/rmcfs.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘rmcfs’ ...
+** package ‘rmcfs’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/rmcfs/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/rmcfs/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/rmcfs/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘rmcfs’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/rmcfs/new/rmcfs.Rcheck/rmcfs’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘rmcfs’ ...
+** package ‘rmcfs’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/rmcfs/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/rmcfs/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/rmcfs/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘rmcfs’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/rmcfs/old/rmcfs.Rcheck/rmcfs’
+
+```
+# RnBeads
+
+<details>
+
+* Version: 2.0.1
+* Source code: https://github.com/cran/RnBeads
+* Date/Publication: 2019-01-04
+* Number of recursive dependencies: 219
+
+Run `revdep_details(,"RnBeads")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘RnBeads’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/RnBeads/new/RnBeads.Rcheck/00install.out’ for details.
+    ```
+
+*   checking package dependencies ... NOTE
+    ```
+    Packages suggested but not available for checking:
+      ‘IlluminaHumanMethylation450kmanifest’ ‘RnBeads.hg19’ ‘org.Rn.eg.db’
+      ‘IlluminaHumanMethylation450kanno.ilmn12.hg19’
+    
+    Depends: includes the non-default packages:
+      ‘BiocGenerics’ ‘S4Vectors’ ‘GenomicRanges’ ‘MASS’ ‘cluster’ ‘ff’
+      ‘fields’ ‘ggplot2’ ‘gplots’ ‘gridExtra’ ‘limma’ ‘matrixStats’
+      ‘illuminaio’ ‘methylumi’ ‘plyr’
+    Adding so many packages to the search path is excessive and importing
+    selectively is preferable.
+    ```
+
+*   checking for hidden files and directories ... NOTE
+    ```
+    Found the following hidden files and directories:
+      .travis.yml
+    These were most likely included in error. See section ‘Package
+    structure’ in the ‘Writing R Extensions’ manual.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘RnBeads’ ...
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : package ‘FDb.InfiniumMethylation.hg19’ required by ‘methylumi’ could not be found
+ERROR: lazy loading failed for package ‘RnBeads’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/RnBeads/new/RnBeads.Rcheck/RnBeads’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘RnBeads’ ...
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : package ‘FDb.InfiniumMethylation.hg19’ required by ‘methylumi’ could not be found
+ERROR: lazy loading failed for package ‘RnBeads’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/RnBeads/old/RnBeads.Rcheck/RnBeads’
+
+```
+# robustHD
+
+<details>
+
+* Version: 0.5.1
+* Source code: https://github.com/cran/robustHD
+* Date/Publication: 2016-01-08 12:41:05
+* Number of recursive dependencies: 38
+
+Run `revdep_details(,"robustHD")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘robustHD’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/robustHD/new/robustHD.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘robustHD’ ...
+** package ‘robustHD’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/robustHD/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/robustHD/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c corHuber.cpp -o corHuber.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/robustHD/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/robustHD/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c fastGrplars.cpp -o fastGrplars.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/robustHD/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/robustHD/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c fastLars.cpp -o fastLars.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/robustHD/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/robustHD/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c fastLasso.cpp -o fastLasso.o
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'clang: error: unsupported option '-fopenmp'
+
+clang: error: unsupported option '-fopenmp'
+make: *** [fastGrplars.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [fastLasso.o] Error 1
+make: *** [fastLars.o] Error 1
+make: *** [corHuber.o] Error 1
+ERROR: compilation failed for package ‘robustHD’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/robustHD/new/robustHD.Rcheck/robustHD’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘robustHD’ ...
+** package ‘robustHD’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/robustHD/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/robustHD/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c corHuber.cpp -o corHuber.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/robustHD/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/robustHD/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c fastGrplars.cpp -o fastGrplars.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/robustHD/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/robustHD/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c fastLars.cpp -o fastLars.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/robustHD/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/robustHD/RcppArmadillo/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c fastLasso.cpp -o fastLasso.o
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+clang: error: clang: error: unsupported option '-fopenmp'unsupported option '-fopenmp'
+
+make: *** [corHuber.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [fastLasso.o] Error 1
+make: *** [fastLars.o] Error 1
+make: *** [fastGrplars.o] Error 1
+ERROR: compilation failed for package ‘robustHD’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/robustHD/old/robustHD.Rcheck/robustHD’
+
+```
+# rpanel
+
+<details>
+
+* Version: 1.1-4
+* Source code: https://github.com/cran/rpanel
+* Date/Publication: 2018-05-07 14:58:19 UTC
+* Number of recursive dependencies: 70
+
+Run `revdep_details(,"rpanel")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘rpanel’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/rpanel/new/rpanel.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘rpanel’ ...
+** package ‘rpanel’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** demo
+** inst
+** byte-compile and prepare package for lazy loading
+Warning in fun(libname, pkgname) : couldn't connect to display ""
+Error in structure(.External(.C_dotTcl, ...), class = "tclObj") : 
+  [tcl] can't find package BWidget.
+
+Error : unable to load R code in package ‘rpanel’
+ERROR: lazy loading failed for package ‘rpanel’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/rpanel/new/rpanel.Rcheck/rpanel’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘rpanel’ ...
+** package ‘rpanel’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** demo
+** inst
+** byte-compile and prepare package for lazy loading
+Warning in fun(libname, pkgname) : couldn't connect to display ""
+Error in structure(.External(.C_dotTcl, ...), class = "tclObj") : 
+  [tcl] can't find package BWidget.
+
+Error : unable to load R code in package ‘rpanel’
+ERROR: lazy loading failed for package ‘rpanel’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/rpanel/old/rpanel.Rcheck/rpanel’
+
+```
+# rpf
+
+<details>
+
+* Version: 0.62
+* Source code: https://github.com/cran/rpf
+* URL: https://github.com/jpritikin/rpf
+* Date/Publication: 2019-04-12 19:22:43 UTC
+* Number of recursive dependencies: 69
+
+Run `revdep_details(,"rpf")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘rpf’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/rpf/new/rpf.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘rpf’ ...
+** package ‘rpf’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/rpf/RcppEigen/include" -I/usr/local/include  -fopenmp    -fPIC  -Wall -g -O2  -c ba81quad.cpp -o ba81quad.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/rpf/RcppEigen/include" -I/usr/local/include  -fopenmp    -fPIC  -Wall -g -O2  -c dataframe.cpp -o dataframe.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/rpf/RcppEigen/include" -I/usr/local/include  -fopenmp    -fPIC  -Wall -g -O2  -c diagnose.cpp -o diagnose.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/rpf/RcppEigen/include" -I/usr/local/include  -fopenmp    -fPIC  -Wall -g -O2  -c dmvnorm.cpp -o dmvnorm.o
+clang: error: unsupported option '-fopenmp'
+clang: errorclang: error: clang: error: unsupported option '-fopenmp'unsupported option '-fopenmp': 
+
+unsupported option '-fopenmp'
+make: *** [diagnose.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [dmvnorm.o] Error 1
+make: *** [dataframe.o] Error 1
+make: *** [ba81quad.o] Error 1
+ERROR: compilation failed for package ‘rpf’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/rpf/new/rpf.Rcheck/rpf’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘rpf’ ...
+** package ‘rpf’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/rpf/RcppEigen/include" -I/usr/local/include  -fopenmp    -fPIC  -Wall -g -O2  -c ba81quad.cpp -o ba81quad.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/rpf/RcppEigen/include" -I/usr/local/include  -fopenmp    -fPIC  -Wall -g -O2  -c dataframe.cpp -o dataframe.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/rpf/RcppEigen/include" -I/usr/local/include  -fopenmp    -fPIC  -Wall -g -O2  -c diagnose.cpp -o diagnose.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/rpf/RcppEigen/include" -I/usr/local/include  -fopenmp    -fPIC  -Wall -g -O2  -c dmvnorm.cpp -o dmvnorm.o
+clang: error: unsupported option '-fopenmp'clang: error: 
+unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+make: *** [dmvnorm.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [diagnose.o] Error 1
+make: *** [ba81quad.o] Error 1
+make: *** [dataframe.o] Error 1
+ERROR: compilation failed for package ‘rpf’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/rpf/old/rpf.Rcheck/rpf’
+
+```
+# rrepast
+
+<details>
+
+* Version: 0.7.0
+* Source code: https://github.com/cran/rrepast
+* URL: https://github.com/antonio-pgarcia/rrepast
+* BugReports: https://github.com/antonio-pgarcia/RRepast/issues
+* Date/Publication: 2018-06-25 18:29:13 UTC
+* Number of recursive dependencies: 44
+
+Run `revdep_details(,"rrepast")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘rrepast’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/rrepast/new/rrepast.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘rrepast’ ...
+** package ‘rrepast’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/rrepast/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/rrepast/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/rrepast/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘rrepast’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/rrepast/new/rrepast.Rcheck/rrepast’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘rrepast’ ...
+** package ‘rrepast’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/rrepast/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/rrepast/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/rrepast/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘rrepast’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/rrepast/old/rrepast.Rcheck/rrepast’
+
+```
+# RSCAT
+
+<details>
+
+* Version: 1.0.0
+* Source code: https://github.com/cran/RSCAT
+* BugReports: https://github.com/act-org/RSCAT/issues
+* Date/Publication: 2019-04-12 08:32:42 UTC
+* Number of recursive dependencies: 50
+
+Run `revdep_details(,"RSCAT")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘RSCAT’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/RSCAT/new/RSCAT.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘RSCAT’ ...
+** package ‘RSCAT’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/RSCAT/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/RSCAT/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/RSCAT/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘RSCAT’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/RSCAT/new/RSCAT.Rcheck/RSCAT’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘RSCAT’ ...
+** package ‘RSCAT’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/RSCAT/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/RSCAT/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/RSCAT/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘RSCAT’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/RSCAT/old/RSCAT.Rcheck/RSCAT’
+
+```
+# rstanarm
+
+<details>
+
+* Version: 2.18.2
+* Source code: https://github.com/cran/rstanarm
+* URL: http://discourse.mc-stan.org, http://mc-stan.org/, http://mc-stan.org/rstanarm/
+* BugReports: https://github.com/stan-dev/rstanarm/issues
+* Date/Publication: 2018-11-10 16:30:02 UTC
+* Number of recursive dependencies: 118
+
+Run `revdep_details(,"rstanarm")` for more info
+
+</details>
+
+## In both
+
+*   R CMD check timed out
+    
+
+*   checking installed package size ... NOTE
+    ```
+      installed size is 17.3Mb
+      sub-directories of 1Mb or more:
+        R      2.0Mb
+        libs  13.7Mb
+    ```
+
+*   checking Rd cross-references ... NOTE
+    ```
+    Package unavailable to check Rd xrefs: ‘biglm’
+    ```
+
+*   checking for GNU extensions in Makefiles ... NOTE
+    ```
+    GNU make is a SystemRequirements.
+    ```
+
+# rsvg
+
+<details>
+
+* Version: 1.3
+* Source code: https://github.com/cran/rsvg
+* URL: https://github.com/jeroen/rsvg#readme
+* BugReports: https://github.com/jeroen/rsvg/issues
+* Date/Publication: 2018-05-10 12:17:28 UTC
+* Number of recursive dependencies: 50
+
+Run `revdep_details(,"rsvg")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘rsvg’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/rsvg/new/rsvg.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘rsvg’ ...
+** package ‘rsvg’ successfully unpacked and MD5 sums checked
+Package librsvg-2.0 was not found in the pkg-config search path.
+Perhaps you should add the directory containing `librsvg-2.0.pc'
+to the PKG_CONFIG_PATH environment variable
+No package 'librsvg-2.0' found
+Homebrew 2.1.0
+Homebrew/homebrew-core (git revision 5f500; last commit 2019-04-06)
+Homebrew/homebrew-cask (git revision 2b252; last commit 2019-04-06)
+Using PKG_CFLAGS=-I/usr/local/opt/librsvg/include
+Using PKG_LIBS=-L/usr/local/opt/librsvg/lib -lrsvg
+------------------------- ANTICONF ERROR ---------------------------
+Configuration failed because librsvg-2.0 was not found. Try installing:
+ * deb: librsvg2-dev (Debian, Ubuntu, etc)
+ * rpm: librsvg2-devel (Fedora, EPEL)
+ * csw: librsvg_dev, sunx11_devel (Solaris)
+ * brew: librsvg (OSX)
+If librsvg-2.0 is already installed, check that 'pkg-config' is in your
+PATH and PKG_CONFIG_PATH contains a librsvg-2.0.pc file. If pkg-config
+is unavailable you can set INCLUDE_DIR and LIB_DIR manually via:
+R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'
+--------------------------------------------------------------------
+ERROR: configuration failed for package ‘rsvg’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/rsvg/new/rsvg.Rcheck/rsvg’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘rsvg’ ...
+** package ‘rsvg’ successfully unpacked and MD5 sums checked
+Package librsvg-2.0 was not found in the pkg-config search path.
+Perhaps you should add the directory containing `librsvg-2.0.pc'
+to the PKG_CONFIG_PATH environment variable
+No package 'librsvg-2.0' found
+Homebrew 2.1.0
+Homebrew/homebrew-core (git revision 5f500; last commit 2019-04-06)
+Homebrew/homebrew-cask (git revision 2b252; last commit 2019-04-06)
+Using PKG_CFLAGS=-I/usr/local/opt/librsvg/include
+Using PKG_LIBS=-L/usr/local/opt/librsvg/lib -lrsvg
+------------------------- ANTICONF ERROR ---------------------------
+Configuration failed because librsvg-2.0 was not found. Try installing:
+ * deb: librsvg2-dev (Debian, Ubuntu, etc)
+ * rpm: librsvg2-devel (Fedora, EPEL)
+ * csw: librsvg_dev, sunx11_devel (Solaris)
+ * brew: librsvg (OSX)
+If librsvg-2.0 is already installed, check that 'pkg-config' is in your
+PATH and PKG_CONFIG_PATH contains a librsvg-2.0.pc file. If pkg-config
+is unavailable you can set INCLUDE_DIR and LIB_DIR manually via:
+R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'
+--------------------------------------------------------------------
+ERROR: configuration failed for package ‘rsvg’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/rsvg/old/rsvg.Rcheck/rsvg’
+
+```
+# RtutoR
+
+<details>
+
+* Version: 1.2
+* Source code: https://github.com/cran/RtutoR
+* Date/Publication: 2018-09-14 07:50:07 UTC
+* Number of recursive dependencies: 108
+
+Run `revdep_details(,"RtutoR")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘RtutoR’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/RtutoR/new/RtutoR.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘RtutoR’ ...
+** package ‘RtutoR’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/RtutoR/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/RtutoR/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/RtutoR/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘RtutoR’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/RtutoR/new/RtutoR.Rcheck/RtutoR’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘RtutoR’ ...
+** package ‘RtutoR’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/RtutoR/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/RtutoR/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/RtutoR/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘RtutoR’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/RtutoR/old/RtutoR.Rcheck/RtutoR’
+
+```
+# SeqFeatR
+
+<details>
+
+* Version: 0.3.1
+* Source code: https://github.com/cran/SeqFeatR
+* Date/Publication: 2019-04-12 12:02:37 UTC
+* Number of recursive dependencies: 56
+
+Run `revdep_details(,"SeqFeatR")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘SeqFeatR’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/SeqFeatR/new/SeqFeatR.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘SeqFeatR’ ...
+** package ‘SeqFeatR’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Warning in fun(libname, pkgname) : couldn't connect to display ""
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/SeqFeatR/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/SeqFeatR/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/SeqFeatR/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘SeqFeatR’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/SeqFeatR/new/SeqFeatR.Rcheck/SeqFeatR’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘SeqFeatR’ ...
+** package ‘SeqFeatR’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Warning in fun(libname, pkgname) : couldn't connect to display ""
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/SeqFeatR/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/SeqFeatR/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/SeqFeatR/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘SeqFeatR’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/SeqFeatR/old/SeqFeatR.Rcheck/SeqFeatR’
+
+```
+# simmr
+
+<details>
+
+* Version: 0.3
+* Source code: https://github.com/cran/simmr
+* Date/Publication: 2016-01-19 11:57:28
+* Number of recursive dependencies: 52
+
+Run `revdep_details(,"simmr")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘simmr’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/simmr/new/simmr.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘simmr’ ...
+** package ‘simmr’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rjags’:
+ .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/simmr/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/simmr/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/simmr/rjags/libs/rjags.so
+  Reason: image not found
+Error : package ‘rjags’ could not be loaded
+ERROR: lazy loading failed for package ‘simmr’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/simmr/new/simmr.Rcheck/simmr’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘simmr’ ...
+** package ‘simmr’ successfully unpacked and MD5 sums checked
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rjags’:
+ .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/simmr/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/simmr/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/simmr/rjags/libs/rjags.so
+  Reason: image not found
+Error : package ‘rjags’ could not be loaded
+ERROR: lazy loading failed for package ‘simmr’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/simmr/old/simmr.Rcheck/simmr’
+
+```
+# sitmo
+
+<details>
+
+* Version: 2.0.1
+* Source code: https://github.com/cran/sitmo
+* URL: https://github.com/coatless/sitmo, http://thecoatlessprofessor.com/projects/sitmo/, https://github.com/stdfin/random/
+* BugReports: https://github.com/coatless/sitmo/issues
+* Date/Publication: 2019-01-07 21:40:07 UTC
+* Number of recursive dependencies: 45
+
+Run `revdep_details(,"sitmo")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘sitmo’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/sitmo/new/sitmo.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘sitmo’ ...
+** package ‘sitmo’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/sitmo/Rcpp/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/sitmo/Rcpp/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c sitmo_demo.cpp -o sitmo_demo.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/sitmo/Rcpp/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c sitmo_parallel.cpp -o sitmo_parallel.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/sitmo/Rcpp/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c sitmo_runif.cpp -o sitmo_runif.o
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+make: clang: error: *** [sitmo_runif.o] Error 1unsupported option '-fopenmp'
+
+make: *** Waiting for unfinished jobs....
+make: *** [RcppExports.o] Error 1
+make: *** [sitmo_parallel.o] Error 1
+make: *** [sitmo_demo.o] Error 1
+ERROR: compilation failed for package ‘sitmo’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/sitmo/new/sitmo.Rcheck/sitmo’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘sitmo’ ...
+** package ‘sitmo’ successfully unpacked and MD5 sums checked
+** libs
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/sitmo/Rcpp/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/sitmo/Rcpp/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c sitmo_demo.cpp -o sitmo_demo.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/sitmo/Rcpp/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c sitmo_parallel.cpp -o sitmo_parallel.o
+clang++  -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../inst/include/ -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/sitmo/Rcpp/include" -I/usr/local/include  -fopenmp -fPIC  -Wall -g -O2  -c sitmo_runif.cpp -o sitmo_runif.o
+clang: error: unsupported option '-fopenmp'clang
+clang: error: clang: error: unsupported option '-fopenmp'unsupported option '-fopenmp': 
+error: unsupported option '-fopenmp'
+
+make: *** [sitmo_demo.o] Error 1
+make: *** Waiting for unfinished jobs....
+make: *** [sitmo_parallel.o] Error 1
+make: *** [RcppExports.o] Error 1
+make: *** [sitmo_runif.o] Error 1
+ERROR: compilation failed for package ‘sitmo’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/sitmo/old/sitmo.Rcheck/sitmo’
+
+```
+# SMITE
+
+<details>
+
+* Version: 
+* Source code: ???
+* URL: http://ggplot2.tidyverse.org, https://github.com/tidyverse/ggplot2
+* BugReports: https://github.com/tidyverse/ggplot2/issues
+* Number of recursive dependencies: 0
+
+Run `revdep_details(,"")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+  There is a binary version available but the source version is later:
+          binary source needs_compilation
+checkmate  1.9.1  1.9.3              TRUE
+
+  Binaries will be installed
+
+
+installing the source packages ‘GO.db’, ‘org.Hs.eg.db’, ‘reactome.db’
+
+
+
+```
+### CRAN
+
+```
+
+  There is a binary version available but the source version is later:
+          binary source needs_compilation
+checkmate  1.9.1  1.9.3              TRUE
+
+  Binaries will be installed
+
+
+installing the source packages ‘GO.db’, ‘org.Hs.eg.db’, ‘reactome.db’
+
+
+
+```
+# spcosa
+
+<details>
+
+* Version: 0.3-8
+* Source code: https://github.com/cran/spcosa
+* Date/Publication: 2018-03-30 12:52:26 UTC
+* Number of recursive dependencies: 70
+
+Run `revdep_details(,"spcosa")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘spcosa’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/spcosa/new/spcosa.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘spcosa’ ...
+** package ‘spcosa’ successfully unpacked and MD5 sums checked
+** R
+** demo
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/spcosa/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/spcosa/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/spcosa/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘spcosa’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/spcosa/new/spcosa.Rcheck/spcosa’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘spcosa’ ...
+** package ‘spcosa’ successfully unpacked and MD5 sums checked
+** R
+** demo
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘rJava’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/spcosa/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/spcosa/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/spcosa/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘rJava’ could not be loaded
+ERROR: lazy loading failed for package ‘spcosa’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/spcosa/old/spcosa.Rcheck/spcosa’
+
+```
+# StarBioTrek
+
+<details>
+
+* Version: 1.8.5
+* Source code: https://github.com/cran/StarBioTrek
+* URL: https://github.com/claudiacava/StarBioTrek
+* BugReports: https://github.com/claudiacava/StarBioTrek/issues
+* Date/Publication: 2019-04-15
+* Number of recursive dependencies: 248
+
+Run `revdep_details(,"StarBioTrek")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘StarBioTrek’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/StarBioTrek/new/StarBioTrek.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘StarBioTrek’ ...
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
+  there is no package called ‘miRNAtap.db’
+ERROR: lazy loading failed for package ‘StarBioTrek’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/StarBioTrek/new/StarBioTrek.Rcheck/StarBioTrek’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘StarBioTrek’ ...
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
+  there is no package called ‘miRNAtap.db’
+ERROR: lazy loading failed for package ‘StarBioTrek’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/StarBioTrek/old/StarBioTrek.Rcheck/StarBioTrek’
+
+```
+# TCGAbiolinks
+
+<details>
+
+* Version: 2.10.5
+* Source code: https://github.com/cran/TCGAbiolinks
+* URL: https://github.com/BioinformaticsFMRP/TCGAbiolinks
+* BugReports: https://github.com/BioinformaticsFMRP/TCGAbiolinks/issues
+* Date/Publication: 2019-03-20
+* Number of recursive dependencies: 246
+
+Run `revdep_details(,"TCGAbiolinks")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘TCGAbiolinks’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/TCGAbiolinks/new/TCGAbiolinks.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘TCGAbiolinks’ ...
+** R
+Warning in lazyLoadDBinsertVariable(vars[i], from, datafile, ascii, compress,  :
+  internal error 10 in R_compress3
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
+  there is no package called ‘sesameData’
+ERROR: lazy loading failed for package ‘TCGAbiolinks’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/TCGAbiolinks/new/TCGAbiolinks.Rcheck/TCGAbiolinks’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘TCGAbiolinks’ ...
+** R
+Warning in lazyLoadDBinsertVariable(vars[i], from, datafile, ascii, compress,  :
+  internal error 10 in R_compress3
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
+  there is no package called ‘sesameData’
+ERROR: lazy loading failed for package ‘TCGAbiolinks’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/TCGAbiolinks/old/TCGAbiolinks.Rcheck/TCGAbiolinks’
+
+```
+# TeachingDemos
+
+<details>
+
+* Version: 2.10
+* Source code: https://github.com/cran/TeachingDemos
+* Date/Publication: 2016-02-12 07:40:49
+* Number of recursive dependencies: 69
+
+Run `revdep_details(,"TeachingDemos")` for more info
+
+</details>
+
+## In both
+
+*   R CMD check timed out
+    
+
+*   checking package dependencies ... NOTE
+    ```
+    Package suggested but not available for checking: ‘R2wd’
+    ```
+
+# vortexR
+
+<details>
+
+* Version: 1.1.6
+* Source code: https://github.com/cran/vortexR
+* URL: https://github.com/carlopacioni/vortexR/
+* BugReports: https://github.com/carlopacioni/vortexR/issues
+* Date/Publication: 2019-02-06 12:50:03 UTC
+* Number of recursive dependencies: 104
+
+Run `revdep_details(,"vortexR")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘vortexR’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/vortexR/new/vortexR.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘vortexR’ ...
+** package ‘vortexR’ successfully unpacked and MD5 sums checked
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/vortexR/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/vortexR/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/vortexR/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘vortexR’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/vortexR/new/vortexR.Rcheck/vortexR’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘vortexR’ ...
+** package ‘vortexR’ successfully unpacked and MD5 sums checked
+** R
+** data
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/vortexR/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/vortexR/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/vortexR/rJava/libs/rJava.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘vortexR’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/vortexR/old/vortexR.Rcheck/vortexR’
+
+```
+# XLConnect
+
+<details>
+
+* Version: 0.2-15
+* Source code: https://github.com/cran/XLConnect
+* URL: http://www.mirai-solutions.com https://github.com/miraisolutions/xlconnect
+* BugReports: https://github.com/miraisolutions/xlconnect/issues
+* Date/Publication: 2018-04-05 17:20:46 UTC
+* Number of recursive dependencies: 37
+
+Run `revdep_details(,"XLConnect")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘XLConnect’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/XLConnect/new/XLConnect.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘XLConnect’ ...
+** package ‘XLConnect’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** demo
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘XLConnectJars’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/XLConnect/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/XLConnect/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/XLConnect/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘XLConnectJars’ could not be loaded
+ERROR: lazy loading failed for package ‘XLConnect’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/XLConnect/new/XLConnect.Rcheck/XLConnect’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘XLConnect’ ...
+** package ‘XLConnect’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** demo
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘XLConnectJars’:
+ .onLoad failed in loadNamespace() for 'rJava', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/XLConnect/rJava/libs/rJava.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/XLConnect/rJava/libs/rJava.so, 6): Library not loaded: /Library/Java/JavaVirtualMachines/jdk-11.0.1.jdk/Contents/Home/lib/server/libjvm.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/XLConnect/rJava/libs/rJava.so
+  Reason: image not found
+Error : package ‘XLConnectJars’ could not be loaded
+ERROR: lazy loading failed for package ‘XLConnect’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/XLConnect/old/XLConnect.Rcheck/XLConnect’
+
+```
+# zooaRchGUI
+
+<details>
+
+* Version: 1.0.2
+* Source code: https://github.com/cran/zooaRchGUI
+* URL: http://www.zooarchgui.org/, https://zooarchgui.github.io/zooaRchGUI/
+* BugReports: https://github.com/zooaRchGUI/zooaRchGUI/issues
+* Date/Publication: 2017-06-15 15:09:03 UTC
+* Number of recursive dependencies: 125
+
+Run `revdep_details(,"zooaRchGUI")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘zooaRchGUI’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/zooaRchGUI/new/zooaRchGUI.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘zooaRchGUI’ ...
+** package ‘zooaRchGUI’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/zooaRchGUI/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/zooaRchGUI/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/zooaRchGUI/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘zooaRchGUI’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/zooaRchGUI/new/zooaRchGUI.Rcheck/zooaRchGUI’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘zooaRchGUI’ ...
+** package ‘zooaRchGUI’ successfully unpacked and MD5 sums checked
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error : .onLoad failed in loadNamespace() for 'rjags', details:
+  call: dyn.load(file, DLLpath = DLLpath, ...)
+  error: unable to load shared object '/Users/max/github/forks/ggplot2/revdep/library.noindex/zooaRchGUI/rjags/libs/rjags.so':
+  dlopen(/Users/max/github/forks/ggplot2/revdep/library.noindex/zooaRchGUI/rjags/libs/rjags.so, 10): Library not loaded: /usr/local/lib/libjags.4.dylib
+  Referenced from: /Users/max/github/forks/ggplot2/revdep/library.noindex/zooaRchGUI/rjags/libs/rjags.so
+  Reason: image not found
+ERROR: lazy loading failed for package ‘zooaRchGUI’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/zooaRchGUI/old/zooaRchGUI.Rcheck/zooaRchGUI’
+
+```

--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -1,144 +1,3388 @@
-# AneuFinder
+# bayesAB
 
-Version: 1.10.2
+<details>
 
-# BaalChIP
+* Version: 1.1.1
+* Source code: https://github.com/cran/bayesAB
+* URL: https://github.com/FrankPortman/bayesAB
+* BugReports: https://github.com/FrankPortman/bayesAB/issues
+* Date/Publication: 2018-07-14 21:40:03 UTC
+* Number of recursive dependencies: 52
 
-Version: 1.8.0
+Run `revdep_details(,"bayesAB")` for more info
 
-# Bclim
+</details>
 
-Version: 3.1.2
+## Newly broken
 
-# CATALYST
+*   checking examples ... ERROR
+    ```
+    ...
+    $Probability
+    [1] 0.04541
+    
+    --------------------------------------------
+    
+    Credible Interval on (A - B) / B for interval length(s) (0.9) : 
+    
+    $Probability
+              5%          95% 
+    -0.355943366 -0.006198834 
+    
+    --------------------------------------------
+    
+    Posterior Expected Loss for choosing B over A:
+    
+    $Probability
+    [1] 0.2601664
+    
+    > plot(AB1)
+    Error: Either ymin or ymax must be given as an aesthetic.
+    Execution halted
+    ```
 
-Version: 1.6.7
+# breathteststan
 
-# cellHTS2
+<details>
 
-Version: 2.46.1
+* Version: 0.4.7
+* Source code: https://github.com/cran/breathteststan
+* URL: https://github.com/dmenne/breathteststan
+* BugReports: https://github.com/dmenne/breathteststan/issues
+* Date/Publication: 2018-11-07 08:50:03 UTC
+* Number of recursive dependencies: 123
 
-# ChIPexoQual
+Run `revdep_details(,"breathteststan")` for more info
 
-Version: 1.6.0
+</details>
 
-# chromstaR
+## Newly broken
 
-Version: 1.8.1
+*   checking examples ... ERROR
+    ```
+    ...
+    +   inner_join(d$record, by = "patient_id") %>%
+    +   select(patient_id, m_in = m.y, m_out = m.x,
+    +          beta_in = beta.y, beta_out = beta.x,
+    +          k_in = k.y, k_out = k.x)
+    # A tibble: 3 x 7
+      patient_id  m_in m_out beta_in beta_out    k_in   k_out
+      <chr>      <dbl> <dbl>   <dbl>    <dbl>   <dbl>   <dbl>
+    1 rec_01        34  36.0    2.19     2.00 0.0140  0.0124 
+    2 rec_02        42  44.5    2.30     2.12 0.0108  0.00976
+    3 rec_03        32  36.8    2.23     2.14 0.00795 0.00687
+    > # For a detailed analysis of the fit, use the shinystan library
+    > # The following plots are somewhat degenerate because
+    > # of the few iterations in stan_fit
+    > suppressPackageStartupMessages(library(rstan))
+    > stan_plot(fit$stan_fit, pars = c("beta[1]","beta[2]","beta[3]"))
+    ci_level: 0.8 (80% intervals)
+    outer_level: 0.95 (95% intervals)
+    Error in axis.ticks.length.x.bottom %||% axis.ticks.length.x : 
+      object 'axis.ticks.length.x.bottom' not found
+    Calls: <Anonymous> ... with -> with.default -> eval -> eval -> %||% -> %||%
+    Execution halted
+    ```
 
-# ClassifyR
+## In both
 
-Version: 2.2.6
+*   checking for GNU extensions in Makefiles ... NOTE
+    ```
+    GNU make is a SystemRequirements.
+    ```
 
-# clusternomics
+# CSTools
 
-Version: 0.1.1
+<details>
 
-# CNPBayes
+* Version: 1.0.0
+* Source code: https://github.com/cran/CSTools
+* Date/Publication: 2019-04-24 14:20:02 UTC
+* Number of recursive dependencies: 75
 
-Version: 1.12.0
+Run `revdep_details(,"CSTools")` for more info
 
-# DeepBlueR
+</details>
 
-Version: 1.8.0
+## Newly broken
 
-# DiffBind
+*   checking tests ...
+    ```
+     ERROR
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+      > library(CSTools)
+      Loading required package: maps
+      > 
+      > test_check("CSTools")
+      ── 1. Failure: some checks (@test-PlotForecastPDF.R#13)  ───────────────────────
+      length(...) not equal to 61.
+      1/1 mismatches
+      [1] 67 - 61 == 6
+      
+      ══ testthat results  ═══════════════════════════════════════════════════════════
+      OK: 40 SKIPPED: 0 WARNINGS: 45 FAILED: 1
+      1. Failure: some checks (@test-PlotForecastPDF.R#13) 
+      
+      Error: testthat unit tests failed
+      Execution halted
+    ```
 
-Version: 2.10.0
+# esmisc
 
-# dmrseq
+<details>
 
-Version: 1.2.5
+* Version: 0.0.3
+* Source code: https://github.com/cran/esmisc
+* URL: https://github.com/EDiLD/esmisc
+* BugReports: https://github.com/EDiLD/esmisc/issues
+* Date/Publication: 2017-01-11 10:34:49
+* Number of recursive dependencies: 41
 
-# FindMyFriends
+Run `revdep_details(,"esmisc")` for more info
 
-Version: 1.12.0
+</details>
 
-# GOTHiC
+## Newly broken
 
-Version: 1.18.1
+*   checking examples ... ERROR
+    ```
+    Running examples in ‘esmisc-Ex.R’ failed
+    The error most likely occurred in:
+    
+    > ### Name: theme_edi
+    > ### Title: Custom ggplot2 theme
+    > ### Aliases: theme_edi
+    > 
+    > ### ** Examples
+    > 
+    > library(ggplot2)
+    > p <- ggplot(mtcars) + 
+    +  geom_point(aes(x = wt, y = mpg, 
+    + colour=factor(gear))) + facet_wrap(~am)
+    > p
+    > p + theme_edi()
+    Error in axis.ticks.length.x.bottom %||% axis.ticks.length.x : 
+      object 'axis.ticks.length.x.bottom' not found
+    Calls: <Anonymous> ... with -> with.default -> eval -> eval -> %||% -> %||%
+    Execution halted
+    ```
 
-# HTSSIP
+# fergm
 
-Version: 1.4.0
+<details>
 
-# IHWpaper
+* Version: 1.1.4
+* Source code: https://github.com/cran/fergm
+* URL: http://github.com/benjamin-w-campbell/fergm
+* Date/Publication: 2018-10-17 22:20:11 UTC
+* Number of recursive dependencies: 79
 
-Version: 1.10.0
+Run `revdep_details(,"fergm")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking examples ... ERROR
+    ```
+    ...
+    
+    > ### Name: coef_posterior_density
+    > ### Title: Plots the posterior density for FERGM model terms.
+    > ### Aliases: coef_posterior_density
+    > ### Keywords: FERGM interpret summary
+    > 
+    > ### ** Examples
+    > 
+    > # load example data
+    > data("ergm.fit")
+    > data("fergm.fit")
+    > data("mesa")
+    > 
+    > # rstan functions
+    > # Histogram of the posterior
+    > rstan::stan_hist(fergm.fit$stan.fit, par = "beta")
+    `stat_bin()` using `bins = 30`. Pick better value with `binwidth`.
+    Error in axis.ticks.length.x.bottom %||% axis.ticks.length.x : 
+      object 'axis.ticks.length.x.bottom' not found
+    Calls: <Anonymous> ... with -> with.default -> eval -> eval -> %||% -> %||%
+    Execution halted
+    ```
+
+# fingertipscharts
+
+<details>
+
+* Version: 0.0.5
+* Source code: https://github.com/cran/fingertipscharts
+* BugReports: https://github.com/PublicHealthEngland/fingertipscharts/issues
+* Date/Publication: 2019-04-08 21:23:17 UTC
+* Number of recursive dependencies: 129
+
+Run `revdep_details(,"fingertipscharts")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking examples ... ERROR
+    ```
+    ...
+    > df <- fingertips_data(90316) %>%
+    +         filter(is.na(CategoryType) &
+    +                        Timeperiod == "2016/17" &
+    +                        (AreaName %in% top_names |
+    +                                 ParentName == region) &
+    +                        Sex == "Persons") %>%
+    +         mutate(ComparedtoEnglandvalueorpercentiles =
+    +                        factor(ComparedtoEnglandvalueorpercentiles,
+    +                               levels = ordered_levels))
+    > p <- compare_areas(df, AreaName, Value,
+    +                    fill = ComparedtoEnglandvalueorpercentiles,
+    +                    lowerci = LowerCI95.0limit,
+    +                    upperci = UpperCI95.0limit,
+    +                    order = "desc",
+    +                    top_areas = top_names,
+    +                    title = unique(df$IndicatorName))
+    > p
+    Error in axis.ticks.length.x.bottom %||% axis.ticks.length.x : 
+      object 'axis.ticks.length.x.bottom' not found
+    Calls: <Anonymous> ... with -> with.default -> eval -> eval -> %||% -> %||%
+    Execution halted
+    ```
+
+*   checking tests ...
+    ```
+     ERROR
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+      ══ testthat results  ═══════════════════════════════════════════════════════════
+      OK: 9 SKIPPED: 20 WARNINGS: 12 FAILED: 10
+      1.  Error: box plots draws correctly (@test-box-plots.R#20) 
+      2.  Error: desc compare areas draws correctly (@test-compare-areas.R#55) 
+      3.  Error: no top desc compare areas draws correctly (@test-compare-areas.R#61) 
+      4.  Error: asc compare areas draws correctly (@test-compare-areas.R#67) 
+      5.  Error: no top asc compare areas draws correctly (@test-compare-areas.R#73) 
+      6.  Error: desc compare areas no fill draws correctly (@test-compare-areas.R#79) 
+      7.  Error: trends example draws correctly (@test-examples.R#52) 
+      8.  Error: box plot example draws correctly (@test-examples.R#103) 
+      9.  Error: trends with fill draws correctly (@test-trends.R#41) 
+      10. Error: trends without fill draws correctly (@test-trends.R#47) 
+      
+      Error: testthat unit tests failed
+      Execution halted
+    ```
+
+## In both
+
+*   checking dependencies in R code ... NOTE
+    ```
+    Namespaces in Imports field not imported from:
+      ‘curl’ ‘mapproj’
+      All declared Imports should be used.
+    ```
+
+# gastempt
+
+<details>
+
+* Version: 0.4.4
+* Source code: https://github.com/cran/gastempt
+* URL: http://github.com/dmenne/gastempt
+* BugReports: http://github.com/dmenne/gastempt/issues
+* Date/Publication: 2019-03-06 16:32:41 UTC
+* Number of recursive dependencies: 82
+
+Run `revdep_details(,"gastempt")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking whether package ‘gastempt’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/gastempt/new/gastempt.Rcheck/00install.out’ for details.
+    ```
+
+## Newly fixed
+
+*   checking installed package size ... NOTE
+    ```
+      installed size is  7.9Mb
+      sub-directories of 1Mb or more:
+        libs   7.5Mb
+    ```
+
+*   checking dependencies in R code ... NOTE
+    ```
+    Namespaces in Imports field not imported from:
+      ‘methods’ ‘rstantools’
+      All declared Imports should be used.
+    ```
+
+*   checking for GNU extensions in Makefiles ... NOTE
+    ```
+    GNU make is a SystemRequirements.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘gastempt’ ...
+** package ‘gastempt’ successfully unpacked and MD5 sums checked
+** libs
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_1b.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_1c.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_1d.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_2b.stan
+Wrote C++ file "stan_files/linexp_gastro_1c.cc"
+Wrote C++ file "stan_files/linexp_gastro_1b.cc"
+Wrote C++ file "stan_files/linexp_gastro_1d.cc"
+Wrote C++ file "stan_files/linexp_gastro_2b.cc"
+Error in readRDS("/var/folders/lb/xhxqmcrd7gv302_b1pdfykh80000gn/T//RtmpNeTeBk/file30e631b2ee0") : 
+  error reading from connection
+Calls: .Last -> readRDS
+Execution halted
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_2c.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/powexp_gastro_1b.stan
+make: *** [stan_files/linexp_gastro_1d.cc] Error 1
+make: *** Waiting for unfinished jobs....
+Wrote C++ file "stan_files/linexp_gastro_2c.cc"
+Wrote C++ file "stan_files/powexp_gastro_1b.cc"
+rm stan_files/linexp_gastro_2c.cc stan_files/linexp_gastro_1d.cc stan_files/linexp_gastro_1b.cc stan_files/linexp_gastro_2b.cc stan_files/linexp_gastro_1c.cc stan_files/powexp_gastro_1b.cc
+ERROR: compilation failed for package ‘gastempt’
+* removing ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/gastempt/new/gastempt.Rcheck/gastempt’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘gastempt’ ...
+** package ‘gastempt’ successfully unpacked and MD5 sums checked
+** libs
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_1b.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_1c.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_1d.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_2b.stan
+Wrote C++ file "stan_files/linexp_gastro_1d.cc"
+Wrote C++ file "stan_files/linexp_gastro_1c.cc"
+Wrote C++ file "stan_files/linexp_gastro_1b.cc"
+Wrote C++ file "stan_files/linexp_gastro_2b.cc"
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/linexp_gastro_2c.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/powexp_gastro_1b.stan
+"/Library/Frameworks/R.framework/Resources/bin/Rscript" -e "source(file.path('..', 'tools', 'make_cc.R')); make_cc(commandArgs(TRUE))" stan_files/powexp_gastro_2c.stan
+
+
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c init.cpp -o init.o
+
+
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c stan_files/linexp_gastro_1b.cc -o stan_files/linexp_gastro_1b.o
+Wrote C++ file "stan_files/powexp_gastro_1b.cc"
+Wrote C++ file "stan_files/linexp_gastro_2c.cc"
+Wrote C++ file "stan_files/powexp_gastro_2c.cc"
+
+
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c stan_files/linexp_gastro_1c.cc -o stan_files/linexp_gastro_1c.o
+
+
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c stan_files/linexp_gastro_1d.cc -o stan_files/linexp_gastro_1d.o
+
+
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c stan_files/linexp_gastro_2b.cc -o stan_files/linexp_gastro_2b.o
+
+
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:15:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/additive_combine.hpp:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/linear_congruential.hpp:30:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/const_mod.hpp:23:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/large_arithmetic.hpp:19:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/integer_log2.hpp:19:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/pending/integer_log2.hpp:7:1: warning: This header is deprecated. Use <boost/integer/integer_log2.hpp> instead. [-W#pragma-messages]
+BOOST_HEADER_DEPRECATED("<boost/integer/integer_log2.hpp>");
+^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/header_deprecated.hpp:23:37: note: expanded from macro 'BOOST_HEADER_DEPRECATED'
+# define BOOST_HEADER_DEPRECATED(a) BOOST_PRAGMA_MESSAGE("This header is deprecated. Use " a " instead.")
+                                    ^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/pragma_message.hpp:24:34: note: expanded from macro 'BOOST_PRAGMA_MESSAGE'
+# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
+                                 ^
+<scratch space>:32:2: note: expanded from here
+ message("This header is deprecated. Use " "<boost/integer/integer_log2.hpp>" " instead.")
+ ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:15:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/additive_combine.hpp:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/linear_congruential.hpp:30:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/const_mod.hpp:23:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/large_arithmetic.hpp:19:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/integer_log2.hpp:19:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/pending/integer_log2.hpp:7:1: warning: This header is deprecated. Use <boost/integer/integer_log2.hpp> instead. [-W#pragma-messages]
+BOOST_HEADER_DEPRECATED("<boost/integer/integer_log2.hpp>");
+^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/header_deprecated.hpp:23:37: note: expanded from macro 'BOOST_HEADER_DEPRECATED'
+# define BOOST_HEADER_DEPRECATED(a) BOOST_PRAGMA_MESSAGE("This header is deprecated. Use " a " instead.")
+                                    ^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/pragma_message.hpp:24:34: note: expanded from macro 'BOOST_PRAGMA_MESSAGE'
+# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
+                                 ^
+<scratch space>:32:2: note: expanded from here
+ message("This header is deprecated. Use " "<boost/integer/integer_log2.hpp>" " instead.")
+ ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:15:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/additive_combine.hpp:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/linear_congruential.hpp:30:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/const_mod.hpp:23:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/large_arithmetic.hpp:19:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/integer_log2.hpp:19:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/pending/integer_log2.hpp:7:1: warning: This header is deprecated. Use <boost/integer/integer_log2.hpp> instead. [-W#pragma-messages]
+BOOST_HEADER_DEPRECATED("<boost/integer/integer_log2.hpp>");
+^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/header_deprecated.hpp:23:37: note: expanded from macro 'BOOST_HEADER_DEPRECATED'
+# define BOOST_HEADER_DEPRECATED(a) BOOST_PRAGMA_MESSAGE("This header is deprecated. Use " a " instead.")
+                                    ^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/pragma_message.hpp:24:34: note: expanded from macro 'BOOST_PRAGMA_MESSAGE'
+# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
+                                 ^
+<scratch space>:32:2: note: expanded from here
+ message("This header is deprecated. Use " "<boost/integer/integer_log2.hpp>" " instead.")
+ ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:15:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/additive_combine.hpp:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/linear_congruential.hpp:30:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/const_mod.hpp:23:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/large_arithmetic.hpp:19:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/integer_log2.hpp:19:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/pending/integer_log2.hpp:7:1: warning: This header is deprecated. Use <boost/integer/integer_log2.hpp> instead. [-W#pragma-messages]
+BOOST_HEADER_DEPRECATED("<boost/integer/integer_log2.hpp>");
+^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/header_deprecated.hpp:23:37: note: expanded from macro 'BOOST_HEADER_DEPRECATED'
+# define BOOST_HEADER_DEPRECATED(a) BOOST_PRAGMA_MESSAGE("This header is deprecated. Use " a " instead.")
+                                    ^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/pragma_message.hpp:24:34: note: expanded from macro 'BOOST_PRAGMA_MESSAGE'
+# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
+                                 ^
+<scratch space>:32:2: note: expanded from here
+ message("This header is deprecated. Use " "<boost/integer/integer_log2.hpp>" " instead.")
+ ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Core:535:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:2:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/LU:47:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Jacobi:29:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/QR:17:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Householder:27:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:5:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SVD:48:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Geometry:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Eigenvalues:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Core:535:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:2:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/LU:47:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Jacobi:29:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/QR:17:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Householder:27:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:5:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SVD:48:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Geometry:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Eigenvalues:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Core:535:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:2:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/LU:47:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Jacobi:29:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/QR:17:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Householder:27:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:5:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SVD:48:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Geometry:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Eigenvalues:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Core:535:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:2:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/LU:47:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Jacobi:29:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/QR:17:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Householder:27:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:5:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SVD:48:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Geometry:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Eigenvalues:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:26:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCore:66:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/OrderingMethods:71:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:29:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:32:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseQR:35:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:33:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/IterativeLinearSolvers:46:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:26:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCore:66:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/OrderingMethods:71:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:29:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:32:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseQR:35:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:33:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/IterativeLinearSolvers:46:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:26:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCore:66:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/OrderingMethods:71:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:29:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:32:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseQR:35:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:33:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/IterativeLinearSolvers:46:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:26:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCore:66:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/OrderingMethods:71:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:29:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:32:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseQR:35:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:33:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/IterativeLinearSolvers:46:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:44:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/set_zero_all_adjoints.hpp:14:13: warning: unused function 'set_zero_all_adjoints' [-Wunused-function]
+static void set_zero_all_adjoints() {
+            ^
+In file included from stan_files/linexp_gastro_1b.cc:3:
+In file included from stan_files/linexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:70:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/autocorrelation.hpp:18:8: warning: function 'fft_next_good_size' is not needed and will not be emitted [-Wunneeded-internal-declaration]
+size_t fft_next_good_size(size_t N) {
+       ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:44:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/set_zero_all_adjoints.hpp:14:13: warning: unused function 'set_zero_all_adjoints' [-Wunused-function]
+static void set_zero_all_adjoints() {
+            ^
+In file included from stan_files/linexp_gastro_1c.cc:3:
+In file included from stan_files/linexp_gastro_1c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:70:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/autocorrelation.hpp:18:8: warning: function 'fft_next_good_size' is not needed and will not be emitted [-Wunneeded-internal-declaration]
+size_t fft_next_good_size(size_t N) {
+       ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:44:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/set_zero_all_adjoints.hpp:14:13: warning: unused function 'set_zero_all_adjoints' [-Wunused-function]
+static void set_zero_all_adjoints() {
+            ^
+In file included from stan_files/linexp_gastro_1d.cc:3:
+In file included from stan_files/linexp_gastro_1d.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:70:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/autocorrelation.hpp:18:8: warning: function 'fft_next_good_size' is not needed and will not be emitted [-Wunneeded-internal-declaration]
+size_t fft_next_good_size(size_t N) {
+       ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:44:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/set_zero_all_adjoints.hpp:14:13: warning: unused function 'set_zero_all_adjoints' [-Wunused-function]
+static void set_zero_all_adjoints() {
+            ^
+In file included from stan_files/linexp_gastro_2b.cc:3:
+In file included from stan_files/linexp_gastro_2b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:70:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/autocorrelation.hpp:18:8: warning: function 'fft_next_good_size' is not needed and will not be emitted [-Wunneeded-internal-declaration]
+size_t fft_next_good_size(size_t N) {
+       ^
+16 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c stan_files/linexp_gastro_2c.cc -o stan_files/linexp_gastro_2c.o
+
+
+16 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c stan_files/powexp_gastro_1b.cc -o stan_files/powexp_gastro_1b.o
+
+
+16 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I"../inst/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/Rcpp/include" -I"/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include" -I/usr/local/include   -fPIC  -Wall -g -O2 -c stan_files/powexp_gastro_2c.cc -o stan_files/powexp_gastro_2c.o
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:15:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/additive_combine.hpp:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/linear_congruential.hpp:30:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/const_mod.hpp:23:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/large_arithmetic.hpp:19:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/integer_log2.hpp:19:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/pending/integer_log2.hpp:7:1: warning: This header is deprecated. Use <boost/integer/integer_log2.hpp> instead. [-W#pragma-messages]
+BOOST_HEADER_DEPRECATED("<boost/integer/integer_log2.hpp>");
+^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/header_deprecated.hpp:23:37: note: expanded from macro 'BOOST_HEADER_DEPRECATED'
+# define BOOST_HEADER_DEPRECATED(a) BOOST_PRAGMA_MESSAGE("This header is deprecated. Use " a " instead.")
+                                    ^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/pragma_message.hpp:24:34: note: expanded from macro 'BOOST_PRAGMA_MESSAGE'
+# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
+                                 ^
+<scratch space>:32:2: note: expanded from here
+ message("This header is deprecated. Use " "<boost/integer/integer_log2.hpp>" " instead.")
+ ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Core:535:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:2:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/LU:47:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Jacobi:29:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/QR:17:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Householder:27:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:5:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SVD:48:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Geometry:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Eigenvalues:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:15:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/additive_combine.hpp:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/linear_congruential.hpp:30:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/const_mod.hpp:23:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/large_arithmetic.hpp:19:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/integer_log2.hpp:19:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/pending/integer_log2.hpp:7:1: warning: This header is deprecated. Use <boost/integer/integer_log2.hpp> instead. [-W#pragma-messages]
+BOOST_HEADER_DEPRECATED("<boost/integer/integer_log2.hpp>");
+^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/header_deprecated.hpp:23:37: note: expanded from macro 'BOOST_HEADER_DEPRECATED'
+# define BOOST_HEADER_DEPRECATED(a) BOOST_PRAGMA_MESSAGE("This header is deprecated. Use " a " instead.")
+                                    ^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/pragma_message.hpp:24:34: note: expanded from macro 'BOOST_PRAGMA_MESSAGE'
+# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
+                                 ^
+<scratch space>:32:2: note: expanded from here
+ message("This header is deprecated. Use " "<boost/integer/integer_log2.hpp>" " instead.")
+ ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:15:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/additive_combine.hpp:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/linear_congruential.hpp:30:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/const_mod.hpp:23:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/large_arithmetic.hpp:19:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/random/detail/integer_log2.hpp:19:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/pending/integer_log2.hpp:7:1: warning: This header is deprecated. Use <boost/integer/integer_log2.hpp> instead. [-W#pragma-messages]
+BOOST_HEADER_DEPRECATED("<boost/integer/integer_log2.hpp>");
+^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/header_deprecated.hpp:23:37: note: expanded from macro 'BOOST_HEADER_DEPRECATED'
+# define BOOST_HEADER_DEPRECATED(a) BOOST_PRAGMA_MESSAGE("This header is deprecated. Use " a " instead.")
+                                    ^
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/BH/include/boost/config/pragma_message.hpp:24:34: note: expanded from macro 'BOOST_PRAGMA_MESSAGE'
+# define BOOST_PRAGMA_MESSAGE(x) _Pragma(BOOST_STRINGIZE(message(x)))
+                                 ^
+<scratch space>:32:2: note: expanded from here
+ message("This header is deprecated. Use " "<boost/integer/integer_log2.hpp>" " instead.")
+ ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Core:535:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:2:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/LU:47:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Jacobi:29:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/QR:17:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Householder:27:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:5:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SVD:48:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Geometry:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:26:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCore:66:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/OrderingMethods:71:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:29:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Eigenvalues:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:32:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseQR:35:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:33:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/IterativeLinearSolvers:46:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:1:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Core:535:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:2:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/LU:47:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Jacobi:29:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Cholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/QR:17:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Householder:27:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:5:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SVD:48:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Geometry:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:14:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/matrix_vari.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat/fun/Eigen_NumTraits.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/Eigen.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Dense:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Eigenvalues:58:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:26:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCore:66:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/OrderingMethods:71:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:29:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:32:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseQR:35:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:33:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/IterativeLinearSolvers:46:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:26:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCore:66:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:27:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/OrderingMethods:71:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:29:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseCholesky:43:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:32:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/SparseQR:35:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:96:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/csr_extract_u.hpp:6:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/Sparse:33:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/IterativeLinearSolvers:46:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/RcppEigen/include/Eigen/src/Core/util/ReenableStupidWarnings.h:10:30: warning: pragma diagnostic pop could not pop, no matching push [-Wunknown-pragmas]
+    #pragma clang diagnostic pop
+                             ^
+16 warnings generated.
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:44:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/set_zero_all_adjoints.hpp:14:13: warning: unused function 'set_zero_all_adjoints' [-Wunused-function]
+static void set_zero_all_adjoints() {
+            ^
+In file included from stan_files/linexp_gastro_2c.cc:3:
+In file included from stan_files/linexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:70:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/autocorrelation.hpp:18:8: warning: function 'fft_next_good_size' is not needed and will not be emitted [-Wunneeded-internal-declaration]
+size_t fft_next_good_size(size_t N) {
+       ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:44:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/set_zero_all_adjoints.hpp:14:13: warning: unused function 'set_zero_all_adjoints' [-Wunused-function]
+static void set_zero_all_adjoints() {
+            ^
+In file included from stan_files/powexp_gastro_1b.cc:3:
+In file included from stan_files/powexp_gastro_1b.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:70:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/autocorrelation.hpp:18:8: warning: function 'fft_next_good_size' is not needed and will not be emitted [-Wunneeded-internal-declaration]
+size_t fft_next_good_size(size_t N) {
+       ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core.hpp:44:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/core/set_zero_all_adjoints.hpp:14:13: warning: unused function 'set_zero_all_adjoints' [-Wunused-function]
+static void set_zero_all_adjoints() {
+            ^
+In file included from stan_files/powexp_gastro_2c.cc:3:
+In file included from stan_files/powexp_gastro_2c.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/rstaninc.hpp:3:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/rstan/include/rstan/stan_fit.hpp:34:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/services/diagnose/diagnose.hpp:10:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/test_gradients.hpp:7:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/src/stan/model/log_prob_grad.hpp:4:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/rev/mat.hpp:12:
+In file included from /Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat.hpp:70:
+/Users/max/github/forks/ggplot2/revdep/library.noindex/gastempt/StanHeaders/include/stan/math/prim/mat/fun/autocorrelation.hpp:18:8: warning: function 'fft_next_good_size' is not needed and will not be emitted [-Wunneeded-internal-declaration]
+size_t fft_next_good_size(size_t N) {
+       ^
+16 warnings generated.
+16 warnings generated.
+16 warnings generated.
+/usr/local/clang6/bin/clang++ -std=gnu++14 -dynamiclib -Wl,-headerpad_max_install_names -undefined dynamic_lookup -single_module -multiply_defined suppress -L/Library/Frameworks/R.framework/Resources/lib -L/usr/local/lib -o gastempt.so stan_files/linexp_gastro_1b.o stan_files/linexp_gastro_1c.o stan_files/linexp_gastro_1d.o stan_files/linexp_gastro_2b.o stan_files/linexp_gastro_2c.o stan_files/powexp_gastro_1b.o stan_files/powexp_gastro_2c.o init.o -F/Library/Frameworks/R.framework/.. -framework R -Wl,-framework -Wl,CoreFoundation
+ld: warning: text-based stub file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation.tbd and library file /System/Library/Frameworks//CoreFoundation.framework/CoreFoundation are out of sync. Falling back to library file for linking.
+rm stan_files/linexp_gastro_2c.cc stan_files/linexp_gastro_1d.cc stan_files/powexp_gastro_2c.cc stan_files/linexp_gastro_1b.cc stan_files/linexp_gastro_2b.cc stan_files/linexp_gastro_1c.cc stan_files/powexp_gastro_1b.cc
+installing to /Users/max/github/forks/ggplot2/revdep/checks.noindex/gastempt/old/gastempt.Rcheck/gastempt/libs
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+** help
+*** installing help indices
+** building package indices
+** installing vignettes
+** testing if installed package can be loaded
+* DONE (gastempt)
+
+```
+# ggalt
+
+<details>
+
+* Version: 0.4.0
+* Source code: https://github.com/cran/ggalt
+* URL: https://github.com/hrbrmstr/ggalt
+* BugReports: https://github.com/hrbrmstr/ggalt/issues
+* Date/Publication: 2017-02-15 18:16:00
+* Number of recursive dependencies: 78
+
+Run `revdep_details(,"ggalt")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking whether package ‘ggalt’ can be installed ... WARNING
+    ```
+    Found the following significant warnings:
+      Note: possible error in 'pathGrob(munched$x, munched$y, ': unused argument (pathId = munched$group) 
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/ggalt/new/ggalt.Rcheck/00install.out’ for details.
+    Information on the location(s) of code generating the ‘Note’s can be
+    obtained by re-running with environment variable R_KEEP_PKG_SOURCE set
+    to ‘yes’.
+    ```
+
+## In both
+
+*   checking dependencies in R code ... NOTE
+    ```
+    Namespace in Imports field not imported from: ‘plotly’
+      All declared Imports should be used.
+    ```
+
+# ggforce
+
+<details>
+
+* Version: 0.2.2
+* Source code: https://github.com/cran/ggforce
+* URL: https://ggforce.data-imaginist.com
+* BugReports: https://github.com/thomasp85/ggforce/issues
+* Date/Publication: 2019-04-23 13:20:03 UTC
+* Number of recursive dependencies: 66
+
+Run `revdep_details(,"ggforce")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking whether package ‘ggforce’ can be installed ... WARNING
+    ```
+    Found the following significant warnings:
+      Note: possible error in 'pathGrob(munched$x, munched$y, ': unused argument (pathId = munched$group) 
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/ggforce/new/ggforce.Rcheck/00install.out’ for details.
+    Information on the location(s) of code generating the ‘Note’s can be
+    obtained by re-running with environment variable R_KEEP_PKG_SOURCE set
+    to ‘yes’.
+    ```
+
+# ggpol
+
+<details>
+
+* Version: 0.0.5
+* Source code: https://github.com/cran/ggpol
+* URL: https://github.com/erocoar/ggpol
+* Date/Publication: 2019-03-14 13:40:02 UTC
+* Number of recursive dependencies: 50
+
+Run `revdep_details(,"ggpol")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking whether package ‘ggpol’ can be installed ... WARNING
+    ```
+    Found the following significant warnings:
+      Note: possible error in 'pathGrob(munched$x, munched$y, ': unused argument (pathId = munched$group) 
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/ggpol/new/ggpol.Rcheck/00install.out’ for details.
+    Information on the location(s) of code generating the ‘Note’s can be
+    obtained by re-running with environment variable R_KEEP_PKG_SOURCE set
+    to ‘yes’.
+    ```
+
+## In both
+
+*   checking dependencies in R code ... NOTE
+    ```
+    Namespaces in Imports field not imported from:
+      ‘dplyr’ ‘grDevices’
+      All declared Imports should be used.
+    ```
+
+# ggpolypath
+
+<details>
+
+* Version: 0.1.0
+* Source code: https://github.com/cran/ggpolypath
+* URL: https://github.com/mdsumner/ggpolypath, http://rpubs.com/kohske/3522
+* BugReports: https://github.com/mdsumner/ggpolypath/issues
+* Date/Publication: 2016-08-10 02:53:58
+* Number of recursive dependencies: 45
+
+Run `revdep_details(,"ggpolypath")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking whether package ‘ggpolypath’ can be installed ... WARNING
+    ```
+    Found the following significant warnings:
+      Note: possible error in 'pathGrob(munched$x, munched$y, ': unused argument (pathId = munched$group) 
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/ggpolypath/new/ggpolypath.Rcheck/00install.out’ for details.
+    Information on the location(s) of code generating the ‘Note’s can be
+    obtained by re-running with environment variable R_KEEP_PKG_SOURCE set
+    to ‘yes’.
+    ```
+
+# ggsolvencyii
+
+<details>
+
+* Version: 0.1.2
+* Source code: https://github.com/cran/ggsolvencyii
+* URL: https://github.com/vanzanden/ggsolvencyii
+* BugReports: https://github.com/vanzanden/ggsolvencyii/issues
+* Date/Publication: 2019-01-04 12:10:03 UTC
+* Number of recursive dependencies: 66
+
+Run `revdep_details(,"ggsolvencyii")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking whether package ‘ggsolvencyii’ can be installed ... WARNING
+    ```
+    Found the following significant warnings:
+      Note: possible error in 'pathGrob(munched$x, munched$y, ': unused argument (pathId = munched$group) 
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/ggsolvencyii/new/ggsolvencyii.Rcheck/00install.out’ for details.
+    Information on the location(s) of code generating the ‘Note’s can be
+    obtained by re-running with environment variable R_KEEP_PKG_SOURCE set
+    to ‘yes’.
+    ```
+
+# ggspatial
+
+<details>
+
+* Version: 1.0.3
+* Source code: https://github.com/cran/ggspatial
+* URL: https://github.com/paleolimbot/ggspatial
+* BugReports: https://github.com/paleolimbot/ggspatial/issues
+* Date/Publication: 2018-12-14 21:10:04 UTC
+* Number of recursive dependencies: 80
+
+Run `revdep_details(,"ggspatial")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking whether package ‘ggspatial’ can be installed ... WARNING
+    ```
+    Found the following significant warnings:
+      Note: possible error in 'pathGrob(munched$x, munched$y, ': unused argument (pathId = munched$group) 
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/ggspatial/new/ggspatial.Rcheck/00install.out’ for details.
+    Information on the location(s) of code generating the ‘Note’s can be
+    obtained by re-running with environment variable R_KEEP_PKG_SOURCE set
+    to ‘yes’.
+    ```
+
+## In both
+
+*   checking dependencies in R code ... NOTE
+    ```
+    Namespaces in Imports field not imported from:
+      ‘reshape2’ ‘rosm’
+      All declared Imports should be used.
+    ```
+
+# ggstance
+
+<details>
+
+* Version: 0.3.1
+* Source code: https://github.com/cran/ggstance
+* Date/Publication: 2018-07-20 10:10:03 UTC
+* Number of recursive dependencies: 105
+
+Run `revdep_details(,"ggstance")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking tests ...
+    ```
+     ERROR
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+      > library("testthat")
+      > library("ggstance")
+      > 
+      > test_check("ggstance")
+      ── 1. Failure: position_jitterdodge() flips (@test-positions.R#20)  ────────────
+      `h_data` not identical to `v_data`.
+      Component 1: Component 11: Mean relative difference: 0.006782654
+      Component 1: Component 13: Mean relative difference: 0.006916903
+      
+      ══ testthat results  ═══════════════════════════════════════════════════════════
+      OK: 29 SKIPPED: 28 WARNINGS: 0 FAILED: 1
+      1. Failure: position_jitterdodge() flips (@test-positions.R#20) 
+      
+      Error: testthat unit tests failed
+      Execution halted
+    ```
+
+# ggstatsplot
+
+<details>
+
+* Version: 0.0.10
+* Source code: https://github.com/cran/ggstatsplot
+* URL: https://indrajeetpatil.github.io/ggstatsplot/, https://github.com/IndrajeetPatil/ggstatsplot
+* BugReports: https://github.com/IndrajeetPatil/ggstatsplot/issues
+* Date/Publication: 2019-03-17 17:50:02 UTC
+* Number of recursive dependencies: 217
+
+Run `revdep_details(,"ggstatsplot")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking tests ...
+    ```
+     ERROR
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+      as.character(df2$value[[35]][1]) not identical to "5pt".
+      1/1 mismatches
+      x[1]: "NULL"
+      y[1]: "5pt"
+      
+      ══ testthat results  ═══════════════════════════════════════════════════════════
+      OK: 21 SKIPPED: 184 WARNINGS: 0 FAILED: 5
+      1. Failure: `theme_pie()` works (@test_theme_ggstatsplot.R#65) 
+      2. Failure: `theme_pie()` works (@test_theme_ggstatsplot.R#66) 
+      3. Failure: `theme_pie()` works (@test_theme_ggstatsplot.R#67) 
+      4. Failure: `theme_pie()` works (@test_theme_ggstatsplot.R#68) 
+      5. Failure: `theme_pie()` works (@test_theme_ggstatsplot.R#69) 
+      
+      Error: testthat unit tests failed
+      Execution halted
+    ```
+
+# ggtern
+
+<details>
+
+* Version: 3.1.0
+* Source code: https://github.com/cran/ggtern
+* URL: http://www.ggtern.com
+* Date/Publication: 2018-12-19 11:20:03 UTC
+* Number of recursive dependencies: 44
+
+Run `revdep_details(,"ggtern")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking whether package ‘ggtern’ can be installed ... WARNING
+    ```
+    Found the following significant warnings:
+      Note: possible error in 'pathGrob(munched$x, munched$y, ': unused argument (pathId = munched$group) 
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/ggtern/new/ggtern.Rcheck/00install.out’ for details.
+    Information on the location(s) of code generating the ‘Note’s can be
+    obtained by re-running with environment variable R_KEEP_PKG_SOURCE set
+    to ‘yes’.
+    ```
+
+## In both
+
+*   checking Rd cross-references ... NOTE
+    ```
+    Package unavailable to check Rd xrefs: ‘chemometrics’
+    ```
+
+# heatmaply
+
+<details>
+
+* Version: 0.15.2
+* Source code: https://github.com/cran/heatmaply
+* URL: https://cran.r-project.org/package=heatmaply, https://github.com/talgalili/heatmaply/, https://www.r-statistics.com/tag/heatmaply/
+* BugReports: https://github.com/talgalili/heatmaply/issues
+* Date/Publication: 2018-07-06 13:00:03 UTC
+* Number of recursive dependencies: 107
+
+Run `revdep_details(,"heatmaply")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking installed package size ... NOTE
+    ```
+      installed size is  5.0Mb
+      sub-directories of 1Mb or more:
+        doc   4.6Mb
+    ```
+
+## In both
+
+*   checking Rd cross-references ... NOTE
+    ```
+    Package unavailable to check Rd xrefs: ‘d3heatmap’
+    ```
+
+# HistDAWass
+
+<details>
+
+* Version: 1.0.1
+* Source code: https://github.com/cran/HistDAWass
+* Date/Publication: 2018-03-20 16:23:27 UTC
+* Number of recursive dependencies: 76
+
+Run `revdep_details(,"HistDAWass")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking examples ... ERROR
+    ```
+    Running examples in ‘HistDAWass-Ex.R’ failed
+    The error most likely occurred in:
+    
+    > ### Name: plot-distributionH
+    > ### Title: plot for a distributionH object
+    > ### Aliases: plot-distributionH plot,distributionH-method
+    > 
+    > ### ** Examples
+    > 
+    > ##---- initialize a distributionH
+    >  mydist<-distributionH(x=c(7,8,10,15),p=c(0, 0.2, 0.7, 1))
+    >  # show the histogram
+    >  plot(mydist) #plots mydist
+    >  plot(mydist, type="HISTO", col="red", border="blue") #plots mydist
+    >  plot(mydist, type="DENS", col="red", border="blue") #plots a density approximation for mydist
+    >  plot(mydist, type="HBOXPLOT") #plots a horizontal boxplot for mydist
+    Error: Elements must equal the number of rows or 1
+    Execution halted
+    ```
+
+# incR
+
+<details>
+
+* Version: 1.1.0
+* Source code: https://github.com/cran/incR
+* Date/Publication: 2018-03-21 15:25:24 UTC
+* Number of recursive dependencies: 56
+
+Run `revdep_details(,"incR")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking examples ... ERROR
+    ```
+    ...
+    > ### Name: incRplot
+    > ### Title: Quick visualisation of incubation temperatures, on-bouts and
+    > ###   off-bouts
+    > ### Aliases: incRplot
+    > 
+    > ### ** Examples
+    > 
+    > # loading example data
+    > data(incR_procdata)
+    > my_plot <- incRplot(data = incR_procdata[complete.cases(incR_procdata$temperature),], 
+    +                     time.var = "dec_time", 
+    +                     day.var = "date", 
+    +                     inc.temperature.var = "temperature", 
+    +                     env.temperature.var = "env_temp",
+    +                     vector.incubation = "incR_score")
+    >                     
+    > # see your plot
+    > my_plot
+    Error in scale_apply(layer_data, x_vars, "train", SCALE_X, x_scales) : 
+    Calls: <Anonymous> ... <Anonymous> -> f -> <Anonymous> -> f -> scale_apply
+    Execution halted
+    ```
+
+## In both
+
+*   checking dependencies in R code ... NOTE
+    ```
+    Namespaces in Imports field not imported from:
+      ‘dplyr’ ‘rgeos’
+      All declared Imports should be used.
+    ```
+
+# interflex
+
+<details>
+
+* Version: 1.0.4
+* Source code: https://github.com/cran/interflex
+* Date/Publication: 2018-04-20 09:50:27 UTC
+* Number of recursive dependencies: 46
+
+Run `revdep_details(,"interflex")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking examples ... ERROR
+    ```
+    Running examples in ‘interflex-Ex.R’ failed
+    The error most likely occurred in:
+    
+    > ### Name: inter.binning
+    > ### Title: The Binning Estimator
+    > ### Aliases: inter.binning
+    > ### Keywords: graphics
+    > 
+    > ### ** Examples
+    > 
+    > library(interflex)
+    > data(interflex)
+    > inter.binning(Y = "Y", D = "D", X = "X", Z = "Z1",
+    +                   data = s1, nbins = 3, vartype = "homoscedastic",
+    +                   Ylabel = "Y", Dlabel = "Tr", Xlabel="X")
+    Error: Elements must equal the number of rows or 1
+    Execution halted
+    ```
+
+# jcolors
+
+<details>
+
+* Version: 0.0.3
+* Source code: https://github.com/cran/jcolors
+* URL: https://jaredhuling.github.io/jcolors/
+* BugReports: https://github.com/jaredhuling/jcolors/issues
+* Date/Publication: 2018-08-09 10:20:10 UTC
+* Number of recursive dependencies: 46
+
+Run `revdep_details(,"jcolors")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking examples ... ERROR
+    ```
+    Running examples in ‘jcolors-Ex.R’ failed
+    The error most likely occurred in:
+    
+    > ### Name: theme_dark_bg
+    > ### Title: minimal theme for dark backgrounds
+    > ### Aliases: theme_dark_bg theme_light_bg
+    > 
+    > ### ** Examples
+    > 
+    > library(ggplot2)
+    > 
+    > p <- ggplot(mtcars) + geom_point(aes(x = wt, y = mpg,
+    +          colour = factor(gear))) + facet_grid(vs~am)
+    > p + theme_dark_bg()
+    Error in axis.ticks.length.x.bottom %||% axis.ticks.length.x : 
+      object 'axis.ticks.length.x.bottom' not found
+    Calls: <Anonymous> ... with -> with.default -> eval -> eval -> %||% -> %||%
+    Execution halted
+    ```
 
 # lime
 
-Version: 0.4.1
+<details>
 
-# MSnbase
+* Version: 0.4.1
+* Source code: https://github.com/cran/lime
+* URL: https://github.com/thomasp85/lime
+* BugReports: https://github.com/thomasp85/lime/issues
+* Date/Publication: 2018-11-21 12:50:02 UTC
+* Number of recursive dependencies: 126
 
-Version: 2.8.3
+Run `revdep_details(,"lime")` for more info
 
-# msPurity
+</details>
 
-Version: 1.8.1
+## Newly broken
 
-# onemap
+*   checking tests ...
+    ```
+     ERROR
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+      1: h2o.importFile(path) at testthat/test-h2o.R:12
+      2: h2o.importFolder(path, pattern = "", destination_frame = destination_frame, parse, 
+             header, sep, col.names, col.types, na.strings = na.strings, decrypt_tool = decrypt_tool, 
+             skipped_columns = skipped_columns)
+      3: .h2o.__remoteSend(.h2o.__IMPORT, path = path, pattern = pattern)
+      4: .h2o.doSafeREST(h2oRestApiVersion = h2oRestApiVersion, urlSuffix = page, parms = .params, 
+             method = method)
+      5: stop(msg)
+      
+      ══ testthat results  ═══════════════════════════════════════════════════════════
+      OK: 28 SKIPPED: 0 WARNINGS: 1 FAILED: 1
+      1. Error: H2OBinomialClassification: lime explanation only produces one entry per case and feature (@test-h2o.R#12) 
+      
+      Error: testthat unit tests failed
+      Execution halted
+    ```
 
-Version: 2.1.1
+# mlr
 
-# phylosim
+<details>
 
-Version: 3.0.2
+* Version: 2.14.0
+* Source code: https://github.com/cran/mlr
+* URL: https://github.com/mlr-org/mlr
+* BugReports: https://github.com/mlr-org/mlr/issues
+* Date/Publication: 2019-04-25 22:00:04 UTC
+* Number of recursive dependencies: 359
 
-# pmc
+Run `revdep_details(,"mlr")` for more info
 
-Version: 1.0.3
+</details>
 
-# pRoloc
+## Newly broken
 
-Version: 1.22.2
+*   checking examples ... ERROR
+    ```
+    ...
+    Task: Sonar-example, Learner: classif.rpart
+    Resampling: cross-validation
+    Measures:             acc       ber       
+    [Resample] iter 1:    0.6153846 0.4109375 
+    [Resample] iter 2:    0.7115385 0.2892870 
+    
+    
+    Aggregated Result: acc.test.mean=0.6634615,ber.test.mean=0.3501123
+    
+    
+    > rmat = convertBMRToRankMatrix(bmr)
+    > print(rmat)
+                  Sonar-example iris-example
+    classif.lda               1            1
+    classif.rpart             2            2
+    > plotBMRSummary(bmr)
+    > plotBMRBoxplots(bmr, ber, style = "violin")
+    Warning in max(data$density) :
+      no non-missing arguments to max; returning -Inf
+    Error: Elements must equal the number of rows or 1
+    Execution halted
+    ```
 
-# PureCN
+## In both
 
-Version: 1.12.2
+*   checking installed package size ... NOTE
+    ```
+      installed size is  6.1Mb
+      sub-directories of 1Mb or more:
+        R      2.0Mb
+        data   2.3Mb
+        help   1.4Mb
+    ```
 
-# RcmdrPlugin.FuzzyClust
+# MTLR
 
-Version: 1.1
+<details>
 
-# scruff
+* Version: 0.2.0
+* Source code: https://github.com/cran/MTLR
+* URL: https://github.com/haiderstats/MTLR
+* BugReports: https://github.com/haiderstats/MTLR/issues
+* Date/Publication: 2019-03-09 17:22:41 UTC
+* Number of recursive dependencies: 56
 
-Version: 1.0.2
+Run `revdep_details(,"MTLR")` for more info
 
-# sdmpredictors
+</details>
 
-Version: 0.2.8
+## Newly broken
 
-# simulator
+*   checking tests ...
+    ```
+     ERROR
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+      Component "theme": Component 20: target is NULL, current is margin
+      Component "theme": Component 21: target is NULL, current is unit
+      Component "theme": Component 22: Modes: list, NULL
+      ...
+      
+      ══ testthat results  ═══════════════════════════════════════════════════════════
+      OK: 84 SKIPPED: 2 WARNINGS: 35 FAILED: 5
+      1. Failure: print and plot functions are consistent for basic survival dataset (@test-method.R#15) 
+      2. Failure: plotcurves function is consistent (@test-plotcurves.R#13) 
+      3. Failure: plotcurves function is consistent (@test-plotcurves.R#14) 
+      4. Failure: plotcurves function is consistent (@test-plotcurves.R#15) 
+      5. Failure: plotcurves function is consistent (@test-plotcurves.R#16) 
+      
+      Error: testthat unit tests failed
+      Execution halted
+    ```
 
-Version: 0.2.0
+# OUTRIDER
 
-# Single.mTEC.Transcriptomes
+<details>
 
-Version: 1.10.0
+* Version: 1.0.4
+* Source code: https://github.com/cran/OUTRIDER
+* URL: https://github.com/gagneurlab/OUTRIDER
+* Date/Publication: 2019-03-19
+* Number of recursive dependencies: 151
 
-# SNPhood
+Run `revdep_details(,"OUTRIDER")` for more info
 
-Version: 1.12.0
+</details>
 
-# TeachingDemos
+## Newly broken
 
-Version: 2.10
+*   checking examples ... ERROR
+    ```
+    ...
+    
+    > ### Name: aberrant
+    > ### Title: Number of aberrant events
+    > ### Aliases: aberrant
+    > 
+    > ### ** Examples
+    > 
+    > ods <- makeExampleOutriderDataSet()
+    > ods <- OUTRIDER(ods, implementation='pca')
+    Fri May  3 17:36:07 2019: SizeFactor estimation ...
+    Fri May  3 17:36:07 2019: Controlling for confounders ...
+    Using provided q with: 10
+    Fri May  3 17:36:07 2019: Using the pca implementation for controlling.
+    Fri May  3 17:36:07 2019: Used the pca implementation for controlling.
+    Fri May  3 17:36:07 2019: Fitting the data ...
+    Warning in socketConnection(host, port, TRUE, TRUE, "a+b", timeout = timeout) :
+      port 11896 cannot be opened
+    Error in socketConnection(host, port, TRUE, TRUE, "a+b", timeout = timeout) : 
+      cannot open the connection
+    Calls: OUTRIDER ... .local -> .bpfork -> .bpforkConnect -> socketConnection
+    Execution halted
+    ```
 
-# TPP
+## In both
 
-Version: 3.10.1
+*   checking tests ...
+    ```
+     ERROR
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+      [1] "Fri May  3 17:36:41 2019: Iteration: 15 loss: 3.78202399468212"
+      Time difference of 4.905578 secs
+      [1] "15 Final nb-AE loss: 3.78202399468212"
+      [1] "Evaluation loss: 0.291702213587694"
+      [1] "Initial PCA loss: 6.46616282459584"
+      [1] "Fri May  3 17:36:48 2019: Iteration: 1 loss: 4.81536028479294"
+      [1] "Fri May  3 17:36:48 2019: Iteration: 2 loss: 4.78999714768799"
+      Time difference of 1.036859 secs
+      [1] "2 Final nb-AE loss: 4.78999714768799"
+      ══ testthat results  ═══════════════════════════════════════════════════════════
+      OK: 82 SKIPPED: 0 WARNINGS: 24 FAILED: 1
+      1. Error: Expression filtering (@test_filtering.R#4) 
+      
+      Error: testthat unit tests failed
+      Execution halted
+    ```
 
-# transcriptogramer
+*   checking package dependencies ... NOTE
+    ```
+    Package suggested but not available for checking: ‘TxDb.Hsapiens.UCSC.hg19.knownGene’
+    ```
 
-Version: 1.4.1
+*   checking DESCRIPTION meta-information ... NOTE
+    ```
+    Authors@R field gives more than one person with maintainer role:
+      Felix Brechtmann <brechtma@in.tum.de> [aut, cre]
+      Christian Mertes <mertes@in.tum.de> [aut, cre]
+    ```
 
-# variancePartition
+# PathoStat
 
-Version: 1.12.3
+<details>
 
-# XBSeq
+* Version: 1.8.4
+* Source code: https://github.com/cran/PathoStat
+* URL: https://github.com/mani2012/PathoStat
+* BugReports: https://github.com/mani2012/PathoStat/issues
+* Date/Publication: 2018-12-02
+* Number of recursive dependencies: 177
 
-Version: 1.14.1
+Run `revdep_details(,"PathoStat")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking examples ... ERROR
+    ```
+    Running examples in ‘PathoStat-Ex.R’ failed
+    The error most likely occurred in:
+    
+    > ### Name: findTaxonomy
+    > ### Title: Find the taxonomy for unlimited tids
+    > ### Aliases: findTaxonomy
+    > 
+    > ### ** Examples
+    > 
+    > example_data_dir <- system.file("example/data", package = "PathoStat")
+    > pathoreport_file_suffix <- "-sam-report.tsv"
+    > datlist <- readPathoscopeData(example_data_dir, pathoreport_file_suffix,
+    + input.files.name.vec = as.character(1:6))
+    > dat <- datlist$data
+    > ids <- rownames(dat)
+    > tids <- unlist(lapply(ids, FUN = grepTid))
+    > taxonLevels <- findTaxonomy(tids[1:5])
+    Error: HTTP failure: 429
+    {"error":"API rate limit exceeded","api-key":"208.103.64.29","count":"4","limit":"3"}
+    Execution halted
+    ```
+
+## In both
+
+*   checking dependencies in R code ... NOTE
+    ```
+    Namespaces in Imports field not imported from:
+      ‘ComplexHeatmap’ ‘RColorBrewer’
+      All declared Imports should be used.
+    ```
+
+# PepsNMR
+
+<details>
+
+* Version: 1.0.2
+* Source code: https://github.com/cran/PepsNMR
+* URL: https://github.com/ManonMartin/PepsNMR
+* BugReports: https://github.com/ManonMartin/PepsNMR/issues
+* Date/Publication: 2019-03-08
+* Number of recursive dependencies: 53
+
+Run `revdep_details(,"PepsNMR")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking examples ... ERROR
+    ```
+    Running examples in ‘PepsNMR-Ex.R’ failed
+    The error most likely occurred in:
+    
+    > ### Name: DrawPCA
+    > ### Title: Draw the PCA scores or loadings of the signals
+    > ### Aliases: DrawPCA
+    > ### Keywords: hplot
+    > 
+    > ### ** Examples
+    > 
+    > require(PepsNMRData)
+    Loading required package: PepsNMRData
+    > # Draw loadings
+    > DrawPCA(FinalSpectra_HS, main = "PCA loadings plot", 
+    +       Class = NULL, axes =c(1,3, 5), type ="loadings", loadingstype="l", 
+    +       num.stacked=4, xlab="ppm", createWindow = TRUE)
+    dev.new(): using pdf(file="Rplots2.pdf")
+    Error: Aesthetics must be either length 1 or the same as the data (9): label
+    Execution halted
+    ```
+
+# SCORPIUS
+
+<details>
+
+* Version: 1.0.2
+* Source code: https://github.com/cran/SCORPIUS
+* URL: http://github.com/rcannood/SCORPIUS
+* BugReports: https://github.com/rcannood/SCORPIUS/issues
+* Date/Publication: 2018-06-29 14:55:11 UTC
+* Number of recursive dependencies: 71
+
+Run `revdep_details(,"SCORPIUS")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking tests ...
+    ```
+     ERROR
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+      TSP requires a symmetric matrix
+      1: infer_trajectory(space) at testthat/test-trajectory_inference.R:9
+      2: infer_initial_trajectory(space, k)
+      3: TSP::insert_dummy(TSP::TSP(cluster_distances))
+      4: TSP::TSP(cluster_distances)
+      5: as.TSP(x)
+      6: as.TSP.matrix(x)
+      7: stop("TSP requires a symmetric matrix")
+      
+      ══ testthat results  ═══════════════════════════════════════════════════════════
+      OK: 189 SKIPPED: 0 WARNINGS: 0 FAILED: 1
+      1. Error: With generated data (@test-trajectory_inference.R#9) 
+      
+      Error: testthat unit tests failed
+      Execution halted
+    ```
+
+# shiny
+
+<details>
+
+* Version: 1.3.2
+* Source code: https://github.com/cran/shiny
+* URL: http://shiny.rstudio.com
+* BugReports: https://github.com/rstudio/shiny/issues
+* Date/Publication: 2019-04-22 16:00:09 UTC
+* Number of recursive dependencies: 55
+
+Run `revdep_details(,"shiny")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking tests ...
+    ```
+     ERROR
+    Running the tests in ‘tests/test-all.R’ failed.
+    Last 13 lines of output:
+         3: test_dir
+         2: test_package_dir
+         1: test_check
+        78: <Anonymous>
+      ── 1. Failure: debounce/throttle work properly (with priming) (@test-reactivity.
+      isolate(tr()) not identical to 10.
+      1/1 mismatches
+      [1] 9 - 10 == -1
+      
+      ══ testthat results  ═══════════════════════════════════════════════════════════
+      OK: 760 SKIPPED: 0 WARNINGS: 0 FAILED: 1
+      1. Failure: debounce/throttle work properly (with priming) (@test-reactivity.r#1125) 
+      
+      Error: testthat unit tests failed
+      Execution halted
+    ```
+
+## In both
+
+*   checking installed package size ... NOTE
+    ```
+      installed size is 10.9Mb
+      sub-directories of 1Mb or more:
+        R     2.0Mb
+        www   7.9Mb
+    ```
+
+# ssMousetrack
+
+<details>
+
+* Version: 1.1.5
+* Source code: https://github.com/cran/ssMousetrack
+* BugReports: https://github.com/antcalcagni/ssMousetrack/issues
+* Date/Publication: 2019-01-16 17:00:03 UTC
+* Number of recursive dependencies: 56
+
+Run `revdep_details(,"ssMousetrack")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking installed package size ... NOTE
+    ```
+      installed size is  5.6Mb
+      sub-directories of 1Mb or more:
+        libs   5.3Mb
+    ```
+
+*   checking for GNU extensions in Makefiles ... NOTE
+    ```
+    GNU make is a SystemRequirements.
+    ```
+
+## Newly fixed
+
+*   checking whether package ‘ssMousetrack’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/ssMousetrack/old/ssMousetrack.Rcheck/00install.out’ for details.
+    ```
+
+# stats19
+
+<details>
+
+* Version: 0.2.1
+* Source code: https://github.com/cran/stats19
+* URL: https://itsleeds.github.io/stats19/
+* BugReports: https://github.com/ropensci/stats19/issues
+* Date/Publication: 2019-04-03 08:40:03 UTC
+* Number of recursive dependencies: 114
+
+Run `revdep_details(,"stats19")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking tests ...
+    ```
+     ERROR
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+      Content type 'application/x-zip-compressed' length 1236846 bytes (1.2 MB)
+      ==================================================
+      downloaded 1.2 MB
+      
+      trying URL 'http://data.dft.gov.uk.s3.amazonaws.com/road-accidents-safety-data/dftRoadSafetyData_Casualties_2017.zip'
+      Content type 'application/x-zip-compressed' length 1169376 bytes (1.1 MB)
+      ==================================================
+      downloaded 1.1 MB
+      
+      ══ testthat results  ═══════════════════════════════════════════════════════════
+      OK: 44 SKIPPED: 4 WARNINGS: 7 FAILED: 1
+      1. Error: get_stats19 works (@test-get.R#9) 
+      
+      Error: testthat unit tests failed
+      Execution halted
+    ```
+
+# trialr
+
+<details>
+
+* Version: 0.1.0
+* Source code: https://github.com/cran/trialr
+* URL: https://github.com/brockk/trialr
+* BugReports: https://github.com/brockk/trialr/issues
+* Date/Publication: 2019-04-21 21:00:03 UTC
+* Number of recursive dependencies: 79
+
+Run `revdep_details(,"trialr")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking installed package size ... NOTE
+    ```
+      installed size is  9.5Mb
+      sub-directories of 1Mb or more:
+        doc    1.6Mb
+        libs   7.2Mb
+    ```
+
+*   checking dependencies in R code ... NOTE
+    ```
+    Namespaces in Imports field not imported from:
+      ‘dplyr’ ‘magrittr’ ‘tidyr’
+      All declared Imports should be used.
+    ```
+
+*   checking for GNU extensions in Makefiles ... NOTE
+    ```
+    GNU make is a SystemRequirements.
+    ```
+
+## Newly fixed
+
+*   checking whether package ‘trialr’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/Users/max/github/forks/ggplot2/revdep/checks.noindex/trialr/old/trialr.Rcheck/00install.out’ for details.
+    ```
+
+# vdiffr
+
+<details>
+
+* Version: 0.3.0
+* Source code: https://github.com/cran/vdiffr
+* URL: https://github.com/r-lib/vdiffr
+* BugReports: https://github.com/r-lib/vdiffr/issues
+* Date/Publication: 2019-01-02 19:30:02 UTC
+* Number of recursive dependencies: 87
+
+Run `revdep_details(,"vdiffr")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking tests ...
+    ```
+    ...
+      : 56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='38.8
+      : 3px' lengthAdjust='spacingAndGlyphs'>myplot</text></g>                        
+        </svg>                                                                        
+      
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+      > library("vdiffr")
+      > test_check("vdiffr")
+      ── 1. Failure: Doppelgangers pass (@test-expectations.R#25)  ───────────────────
+      `ggplot_result` inherits from `expectation_failure/expectation/error/condition/vdiffr_mismatch` not `expectation_success`.
+      
+      ── 2. Failure: ggtitle is set correctly (@test-ggplot.R#6)  ────────────────────
+      purrr::every(ggplot_results, inherits, "expectation_success") isn't true.
+      
+      ══ testthat results  ═══════════════════════════════════════════════════════════
+      OK: 29 SKIPPED: 0 WARNINGS: 0 FAILED: 2
+      1. Failure: Doppelgangers pass (@test-expectations.R#25) 
+      2. Failure: ggtitle is set correctly (@test-ggplot.R#6) 
+      
+      Error: testthat unit tests failed
+      Execution halted
+    ```
+
+## In both
+
+*   checking dependencies in R code ... NOTE
+    ```
+    Namespace in Imports field not imported from: ‘freetypeharfbuzz’
+      All declared Imports should be used.
+    ```
+
+# vidger
+
+<details>
+
+* Version: 1.2.1
+* Source code: https://github.com/cran/vidger
+* URL: https://github.com/btmonier/vidger, https://bioconductor.org/packages/release/bioc/html/vidger.html
+* BugReports: https://github.com/btmonier/vidger/issues
+* Date/Publication: 2019-01-04
+* Number of recursive dependencies: 116
+
+Run `revdep_details(,"vidger")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking examples ... ERROR
+    ```
+    Running examples in ‘vidger-Ex.R’ failed
+    The error most likely occurred in:
+    
+    > ### Name: vsMAMatrix
+    > ### Title: MA plot matrix from log_{2} fold changes and -log_{10}(p-values)
+    > ### Aliases: vsMAMatrix
+    > 
+    > ### ** Examples
+    > 
+    > # Cuffdiff example
+    > data("df.cuff")
+    > vsMAMatrix(
+    +  	data = df.cuff, d.factor = NULL, type = "cuffdiff",
+    +  	padj = 0.05, y.lim = NULL, lfc = 1, title = TRUE,
+    +  	grid = TRUE, counts = TRUE, data.return = FALSE
+    + )
+    Error: Aesthetics must be either length 1 or the same as the data (36): label
+    Execution halted
+    ```
+
+## In both
+
+*   checking installed package size ... NOTE
+    ```
+      installed size is 10.5Mb
+      sub-directories of 1Mb or more:
+        data   4.0Mb
+        doc    6.1Mb
+    ```
+
+# xpose
+
+<details>
+
+* Version: 0.4.4
+* Source code: https://github.com/cran/xpose
+* URL: https://github.com/UUPharmacometrics/xpose
+* BugReports: https://github.com/UUPharmacometrics/xpose/issues
+* Date/Publication: 2019-03-21 17:10:03 UTC
+* Number of recursive dependencies: 89
+
+Run `revdep_details(,"xpose")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking examples ... ERROR
+    ```
+    Running examples in ‘xpose-Ex.R’ failed
+    The error most likely occurred in:
+    
+    > ### Name: amt_vs_idv
+    > ### Title: Compartment kinetics
+    > ### Aliases: amt_vs_idv
+    > 
+    > ### ** Examples
+    > 
+    > amt_vs_idv(xpdb_ex_pk)
+    Using data from $prob no.1
+    Tidying data by ID, SEX, MED1, MED2, AMT ... and 20 more variables
+    Error in axis.ticks.length.x.bottom %||% axis.ticks.length.x : 
+      object 'axis.ticks.length.x.bottom' not found
+    Calls: <Anonymous> ... with -> with.default -> eval -> eval -> %||% -> %||%
+    Execution halted
+    ```
+
+*   checking tests ...
+    ```
+     ERROR
+    Running the tests in ‘tests/testthat.R’ failed.
+    Last 13 lines of output:
+      31: with.default(theme, axis.ticks.length.x.bottom %||% axis.ticks.length.x %||% axis.ticks.length)
+      32: eval(substitute(expr), data, enclos = parent.frame())
+      33: eval(substitute(expr), data, enclos = parent.frame())
+      34: axis.ticks.length.x.bottom %||% axis.ticks.length.x %||% axis.ticks.length
+      35: axis.ticks.length.x.bottom %||% axis.ticks.length.x
+      
+      ══ testthat results  ═══════════════════════════════════════════════════════════
+      OK: 515 SKIPPED: 6 WARNINGS: 0 FAILED: 4
+      1. Error: warnings and errors are properly returned (@test-print_xpose_plots.R#19) 
+      2. Error: common graphical device work properly (@test-xpose_save.R#45) 
+      3. Error: template filenames and auto file extension work properly (@test-xpose_save.R#67) 
+      4. Error: mutlitple pages are properly saved (@test-xpose_save.R#80) 
+      
+      Error: testthat unit tests failed
+      Execution halted
+    ```
 


### PR DESCRIPTION
[database file](https://www.dropbox.com/s/llilyu97detb5xv/data.sqlite?dl=0)

We checked 2622 reverse dependencies (2212 from CRAN + 410 from BioConductor), comparing R CMD check results across CRAN and dev versions of this package.

 * We saw 30 new problems
 * We failed to check 70 packages

Issues with CRAN packages are summarised below.

### New problems
(This reports the first line of each new failure)

* bayesAB
  checking examples ... ERROR

* breathteststan
  checking examples ... ERROR

* CSTools
  checking tests ...

* esmisc
  checking examples ... ERROR

* fergm
  checking examples ... ERROR

* fingertipscharts
  checking examples ... ERROR
  checking tests ...

* ggalt
  checking whether package ‘ggalt’ can be installed ... WARNING

* ggforce
  checking whether package ‘ggforce’ can be installed ... WARNING

* ggpol
  checking whether package ‘ggpol’ can be installed ... WARNING

* ggpolypath
  checking whether package ‘ggpolypath’ can be installed ... WARNING

* ggsolvencyii
  checking whether package ‘ggsolvencyii’ can be installed ... WARNING

* ggspatial
  checking whether package ‘ggspatial’ can be installed ... WARNING

* ggstance
  checking tests ...

* ggstatsplot
  checking tests ...

* ggtern
  checking whether package ‘ggtern’ can be installed ... WARNING

* heatmaply
  checking installed package size ... NOTE

* HistDAWass
  checking examples ... ERROR

* incR
  checking examples ... ERROR

* interflex
  checking examples ... ERROR

* jcolors
  checking examples ... ERROR

* lime
  checking tests ...

* mlr
  checking examples ... ERROR

* MTLR
  checking tests ...

* SCORPIUS
  checking tests ...

* shiny
  checking tests ...

* ssMousetrack
  checking installed package size ... NOTE
  checking for GNU extensions in Makefiles ... NOTE

* stats19
  checking tests ...

* trialr
  checking installed package size ... NOTE
  checking dependencies in R code ... NOTE
  checking for GNU extensions in Makefiles ... NOTE

* vdiffr
  checking tests ...

* xpose
  checking examples ... ERROR
  checking tests ...

### Failed to check

* aslib                  (NA)
* BACA                   (NA)
* BACCT                  (NA)
* bamdit                 (NA)
* BayesRS                (NA)
* BNSP                   (NA)
* BPEC                   (NA)
* bsam                   (NA)
* BTSPAS                 (NA)
* CaliCo                 (NA)
* CollapsABEL            (NA)
* colorednoise           (NA)
* crmPack                (NA)
* Crossover              (NA)
* Deducer                (NA)
* DeLorean               (NA)
* DiversityOccupancy     (NA)
* dynfrail               (NA)
* dynr                   (NA)
* evoper                 (NA)
* ewoc                   (NA)
* fingerPro              (NA)
* fsdaR                  (NA)
* G2Sd                   (NA)
* gastempt               (NA)
* imageData              (NA)
* imbalance              (NA)
* InSilicoVA             (NA)
* jarbes                 (NA)
* joineRML               (NA)
* JointAI                (NA)
* likeLTD                (NA)
* lilikoi                (NA)
* llama                  (NA)
* LLSR                   (NA)
* matchingMarkets        (NA)
* mbgraphic              (NA)
* mcmcabn                (NA)
* mleap                  (NA)
* morse                  (NA)
* mwaved                 (NA)
* NPflow                 (NA)
* OpenStreetMap          (NA)
* openVA                 (NA)
* petro.One              (NA)
* phase1PRMD             (NA)
* phase1RMD              (NA)
* pimeta                 (NA)
* poppr                  (NA)
* PortfolioEffectHFT     (NA)
* qdap                   (NA)
* RcmdrPlugin.FuzzyClust (NA)
* Rdrools                (NA)
* rmcfs                  (NA)
* robustHD               (NA)
* rpanel                 (NA)
* rpf                    (NA)
* rrepast                (NA)
* RSCAT                  (NA)
* rstanarm               (NA)
* rsvg                   (NA)
* RtutoR                 (NA)
* SeqFeatR               (NA)
* simmr                  (NA)
* sitmo                  (NA)
* spcosa                 (NA)
* TeachingDemos          (NA)
* vortexR                (NA)
* XLConnect              (NA)
* zooaRchGUI             (NA)