### PR TITLE
prefix lm() and loess() with stats:: instead of base::

### DIFF
--- a/R/stat-smooth.r
+++ b/R/stat-smooth.r
@@ -1,9 +1,9 @@
 #' @param method Smoothing method (function) to use, accepts either a character vector,
 #'   e.g. `"auto"`, `"lm"`, `"glm"`, `"gam"`, `"loess"` or a function, e.g.
-#'   `MASS::rlm` or `mgcv::gam`, `base::lm`, or `base::loess`.
+#'   `MASS::rlm` or `mgcv::gam`, `stats::lm`, or `stats::loess`.
 #'
 #'   For `method = "auto"` the smoothing method is chosen based on the
-#'   size of the largest group (across all panels). [loess()] is
+#'   size of the largest group (across all panels). [stats::loess()] is
 #'   used for less than 1,000 observations; otherwise [mgcv::gam()] is
 #'   used with `formula = y ~ s(x, bs = "cs")`. Somewhat anecdotally,
 #'   `loess` gives a better appearance, but is \eqn{O(N^{2})}{O(N^2)} in memory,

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -46,7 +46,7 @@ to the paired geom/stat.}
 
 \item{method}{Smoothing method (function) to use, accepts either a character vector,
 e.g. \code{"auto"}, \code{"lm"}, \code{"glm"}, \code{"gam"}, \code{"loess"} or a function, e.g.
-\code{MASS::rlm} or \code{mgcv::gam}, \code{base::lm}, or \code{base::loess}.
+\code{MASS::rlm} or \code{mgcv::gam}, \code{stats::lm}, or \code{stats::loess}.
 
 For \code{method = "auto"} the smoothing method is chosen based on the
 size of the largest group (across all panels). \code{\link[=loess]{loess()}} is


### PR DESCRIPTION
```
> "lm" %in% ls("package:base")
[1] FALSE
> "loess" %in% ls("package:base")
[1] FALSE
> "lm" %in% ls("package:stats")
[1] TRUE
> "loess" %in% ls("package:stats")
[1] TRUE
```