### PR TITLE
Allow empty annotations.

### DIFF
--- a/R/annotation.r
+++ b/R/annotation.r
@@ -48,8 +48,8 @@ annotate <- function(geom, x = NULL, y = NULL, xmin = NULL, xmax = NULL,
   lengths <- vapply(aesthetics, length, integer(1))
   n <- unique(setdiff(lengths, 1L))
   if (length(n) == 0L) n <- 1L # if all lengths are equal to 1L then above line fails, this fixes that
-  unequal <- length(n) > 1L
-  if (unequal) {
+
+  if (length(n) > 1L) {
     bad <- lengths != 1L
     details <- paste(names(aesthetics)[bad], " (", lengths[bad], ")",
       sep = "", collapse = ", ")

--- a/R/annotation.r
+++ b/R/annotation.r
@@ -46,14 +46,14 @@ annotate <- function(geom, x = NULL, y = NULL, xmin = NULL, xmax = NULL,
 
   # Check that all aesthetic have compatible lengths
   lengths <- vapply(aesthetics, length, integer(1))
+  n <- unique(lengths)
 
-  # To determine the final number of rows `n` in the data frame,
-  # we need to find the unique lengths not equal to 1L (and there
-  # should be at most one such length). However, if all lengths
-  # are equal to 1L, then the final number of rows is also 1L.
-  n <- unique(setdiff(lengths, 1L)) # unique lengths except 1L
-  if (length(n) == 0L) n <- 1L # all lengths are equal to 1L
+  # if there is more than one unique length, ignore constants
+  if (length(n) > 1L) {
+    n <- setdiff(n, 1L)
+  }
 
+  # if there is still more than one unique length, we error out
   if (length(n) > 1L) {
     bad <- lengths != 1L
     details <- paste(names(aesthetics)[bad], " (", lengths[bad], ")",

--- a/R/annotation.r
+++ b/R/annotation.r
@@ -46,8 +46,13 @@ annotate <- function(geom, x = NULL, y = NULL, xmin = NULL, xmax = NULL,
 
   # Check that all aesthetic have compatible lengths
   lengths <- vapply(aesthetics, length, integer(1))
-  n <- unique(setdiff(lengths, 1L))
-  if (length(n) == 0L) n <- 1L # if all lengths are equal to 1L then above line fails, this fixes that
+
+  # To determine the final number of rows `n` in the data frame,
+  # we need to find the unique lengths not equal to 1L (and there
+  # should be at most one such length). However, if all lengths
+  # are equal to 1L, then the final number of rows is also 1L.
+  n <- unique(setdiff(lengths, 1L)) # unique lengths except 1L
+  if (length(n) == 0L) n <- 1L # all lengths are equal to 1L
 
   if (length(n) > 1L) {
     bad <- lengths != 1L

--- a/R/annotation.r
+++ b/R/annotation.r
@@ -47,6 +47,7 @@ annotate <- function(geom, x = NULL, y = NULL, xmin = NULL, xmax = NULL,
   # Check that all aesthetic have compatible lengths
   lengths <- vapply(aesthetics, length, integer(1))
   n <- unique(setdiff(lengths, 1L))
+  if (length(n) == 0L) n <- 1L # if all lengths are equal to 1L then above line fails, this fixes that
   unequal <- length(n) > 1L
   if (unequal) {
     bad <- lengths != 1L

--- a/R/annotation.r
+++ b/R/annotation.r
@@ -46,7 +46,8 @@ annotate <- function(geom, x = NULL, y = NULL, xmin = NULL, xmax = NULL,
 
   # Check that all aesthetic have compatible lengths
   lengths <- vapply(aesthetics, length, integer(1))
-  unequal <- length(unique(setdiff(lengths, 1L))) > 1L
+  n <- unique(setdiff(lengths, 1L))
+  unequal <- length(n) > 1L
   if (unequal) {
     bad <- lengths != 1L
     details <- paste(names(aesthetics)[bad], " (", lengths[bad], ")",
@@ -54,7 +55,7 @@ annotate <- function(geom, x = NULL, y = NULL, xmin = NULL, xmax = NULL,
     stop("Unequal parameter lengths: ", details, call. = FALSE)
   }
 
-  data <- new_data_frame(position, n = max(lengths))
+  data <- new_data_frame(position, n = n)
   layer(
     geom = geom,
     params = list(

--- a/R/performance.R
+++ b/R/performance.R
@@ -4,7 +4,7 @@ new_data_frame <- function(x = list(), n = NULL) {
   if (length(x) != 0 && is.null(names(x))) stop("Elements must be named", call. = FALSE)
   lengths <- vapply(x, length, integer(1))
   if (is.null(n)) {
-    n <- if (length(x) == 0) 0 else max(lengths)
+    n <- if (length(x) == 0 || min(lengths) == 0) 0 else max(lengths)
   }
   for (i in seq_along(x)) {
     if (lengths[i] == n) next
@@ -32,7 +32,7 @@ split_matrix <- function(x, col_names = colnames(x)) {
   if (!is.null(col_names)) names(x) <- col_names
   x
 }
-              
+
 mat_2_df <- function(x, col_names = colnames(x)) {
   new_data_frame(split_matrix(x, col_names))
 }

--- a/tests/testthat/test-performance.R
+++ b/tests/testthat/test-performance.R
@@ -1,5 +1,8 @@
 context("Performance related alternatives")
 
+# ********************
+# modify_list()
+
 testlist <- list(
   a = 5.5,
   b = "x",
@@ -31,4 +34,36 @@ test_that("modify_list erases null elements", {
   res <- modify_list(testlist, testappend)
   expect_null(res$c)
   expect_named(res, c('a', 'b', 'd'))
+})
+
+
+# ********************
+# new_data_frame()
+
+test_that("new_data_frame handles zero-length inputs", {
+  # zero-length input creates zero-length data frame
+  d <- new_data_frame(list(x = numeric(0), y = numeric(0)))
+  expect_equal(nrow(d), 0L)
+
+  # constants are ignored in the context of zero-length input
+  d <- new_data_frame(list(x = numeric(0), y = numeric(0), z = 1))
+  expect_equal(nrow(d), 0L)
+
+  # vectors of length > 1 don't mix with zero-length input
+  expect_error(
+    new_data_frame(list(x = numeric(0), y = numeric(0), z = 1, a = c(1, 2))),
+    "Elements must equal the number of rows or 1"
+  )
+
+  # explicit recycling doesn't work with zero-length input
+  expect_error(
+    new_data_frame(list(x = numeric(0), z = 1), n = 5),
+    "Elements must equal the number of rows or 1"
+  )
+  # but it works without
+  d <- new_data_frame(list(x = 1, y = "a"), n = 5)
+  expect_equal(nrow(d), 5L)
+  expect_identical(d$x, rep(1, 5L))
+  expect_identical(d$y, rep("a", 5L))
+
 })

--- a/tests/testthat/test-performance.R
+++ b/tests/testthat/test-performance.R
@@ -1,7 +1,6 @@
 context("Performance related alternatives")
 
-# ********************
-# modify_list()
+# modify_list() -----------------------------------------------------------
 
 testlist <- list(
   a = 5.5,
@@ -37,8 +36,7 @@ test_that("modify_list erases null elements", {
 })
 
 
-# ********************
-# new_data_frame()
+# new_data_frame() --------------------------------------------------------
 
 test_that("new_data_frame handles zero-length inputs", {
   # zero-length input creates zero-length data frame


### PR DESCRIPTION
This fixes #3317, and likely some other current issues.

``` r

library(ggplot2)
ggplot() +
  annotate("point", x = numeric(0), y = numeric(0), colour = "red")
```

![](https://i.imgur.com/yc4alZY.png)

<sup>Created on 2019-05-08 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>