### PR TITLE
Better error message when geom_boxplot() gets group data with more than 1 row 

### DIFF
--- a/R/geom-boxplot.r
+++ b/R/geom-boxplot.r
@@ -203,7 +203,7 @@ GeomBoxplot <- ggproto("GeomBoxplot", Geom,
     # this may occur when using geom_boxplot(stat = "identity")
     if (nrow(data) != 1) {
       stop(
-        "Can't draw more than one boxplot per group. Did you forget aes(group=...)?",
+        "Can't draw more than one boxplot per group. Did you forget aes(group = ...)?",
         call. = FALSE
       )
     }

--- a/R/geom-boxplot.r
+++ b/R/geom-boxplot.r
@@ -200,6 +200,14 @@ GeomBoxplot <- ggproto("GeomBoxplot", Geom,
                         outlier.alpha = NULL,
                         notch = FALSE, notchwidth = 0.5, varwidth = FALSE) {
 
+    # this may occur when using geom_boxplot(stat = "identity")
+    if (nrow(data) != 1) {
+      stop(
+        "Can't draw more than one boxplot per group. Did you forget aes(group=...)?",
+        call. = FALSE
+      )
+    }
+
     common <- list(
       colour = data$colour,
       size = data$size,

--- a/R/geom-boxplot.r
+++ b/R/geom-boxplot.r
@@ -159,7 +159,7 @@ geom_boxplot <- function(mapping = NULL, data = NULL,
 #' @export
 GeomBoxplot <- ggproto("GeomBoxplot", Geom,
 
-  # need to declare `width`` here in case this geom is used with a stat that
+  # need to declare `width` here in case this geom is used with a stat that
   # doesn't have a `width` parameter (e.g., `stat_identity`).
   extra_params = c("na.rm", "width"),
 

--- a/tests/testthat/test-geom-boxplot.R
+++ b/tests/testthat/test-geom-boxplot.R
@@ -47,6 +47,16 @@ test_that("boxes with variable widths do not overlap", {
   expect_false(any(duplicated(xid)))
 })
 
+test_that("boxplots with a group size >1 error", {
+  p <- ggplot(
+    data_frame(x = "one value", y = 3, value = 4:6),
+    aes(x, ymin = 0, lower = 1, middle = y, upper = value, ymax = 10)
+  ) +
+    geom_boxplot(stat = "identity")
+
+  expect_equal(nrow(layer_data(p, 1)), 3)
+  expect_error(layer_grob(p, 1), "Can't draw more than one boxplot")
+})
 
 # Visual tests ------------------------------------------------------------
 


### PR DESCRIPTION
This is a PR to fix #3316, where group data with more than 1 row in `GeomBoxplot$draw_layer()` was causing an error that was difficult to diagnose. This may occur when using `geom_boxplot(stat = "identity")`, and is likely to occur if a user wants to draw several boxplots at specific locations on a plot in a boxplot/scatter mashup situation.

```r
library(ggplot2)
ggplot(
  data.frame(x = "one value", y = 3, value = 4:6),
  aes(x, ymin = 0, lower = 1, middle = y, upper = value, ymax = 10)
) + 
  geom_boxplot(stat = "identity", position = "identity")
#> Error: Elements must equal the number of rows or 1
```

