### PR TITLE
Fix ordering in plyr compats...

### DIFF
--- a/R/zzz.r
+++ b/R/zzz.r
@@ -23,6 +23,12 @@
 
   ggplot_global$theme_current <- theme_gray()
 
+  # Used by rbind_dfs
+  date <- Sys.Date()
+  ggplot_global$date_origin <- date - unclass(date)
+  time <- Sys.time()
+  ggplot_global$time_origin <- time - unclass(time)
+
   # To avoid namespace clash with dplyr.
   # It seems surprising that this hack works
   if (requireNamespace("dplyr", quietly = TRUE)) {

--- a/tests/testthat/test-layer.r
+++ b/tests/testthat/test-layer.r
@@ -60,7 +60,7 @@ test_that("if an aes is mapped to a function that returns NULL, it is removed", 
   df <- data_frame(x = 1:10)
   null <- function(...) NULL
   p <- cdata(ggplot(df, aes(x, null())))
-  expect_identical(names(p[[1]]), c("PANEL", "x", "group"))
+  expect_identical(names(p[[1]]), c("x", "PANEL", "group"))
 })
 
 # Data extraction ---------------------------------------------------------


### PR DESCRIPTION
Fixes #3313 and #3315 

This fixes the differences in ordering between plyr and the replacement functions. Some notes

- the plyr ordering in `ddply()` is based on a pretty weird heuristic but I think I've nailed it
- the difference in `join_keys()` is the result of differences in `rbind_dfs()` and `plyr::rbind.fill()`. I honestly think the current ggplot2 approach is more correct, but I've made Date handling even with plyr to unbreak revdeps... If that fixes everything we should leave it at that instead of pursuing other parity with other weird vector formats

I probably don't have a head for more work this week, so bear with me if there are any problems with the PR