### PR TITLE
Dynamically assign pathGrob in .onLoad()

### DIFF
--- a/R/zzz.r
+++ b/R/zzz.r
@@ -16,8 +16,20 @@
   })
 }
 
+# Assigning pathGrob in .onLoad ensures that packages that subclass GeomPolygon
+# do not install with error `possible error in 'pathGrob(munched$x, munched$y, ':
+# unused argument (pathId = munched$group)` despite the fact that this is correct
+# usage
+pathGrob <- NULL
+
 .onLoad <- function(...) {
   backport_unit_methods()
+
+  if (getRversion() < as.numeric_version("3.6")) {
+    pathGrob <<- function(..., pathId.lengths) {
+      grid::pathGrob(...)
+    }
+  }
 
   .zeroGrob <<- grob(cl = "zeroGrob", name = "NULL")
 


### PR DESCRIPTION
This is a PR to fix #3313, where packages that subclass `GeomPolygon` were giving install warnings with the new version of ggplot2 in the revdep checks (#3303).

I was hesitant to prepare this PR, because I don't understand why this works, and because I can't replicate the install warning that occurred in the revdep checks, I can't verify that this PR fixes the problem. I can verify that it doesn't cause any CMD check failures for either ggplot2 or ggspatial, which was one of the packages affected by the revdep check issue.