### PR TITLE
Rewrite guide_axis() and rename to draw_axis()

### DIFF
--- a/R/coord-.r
+++ b/R/coord-.r
@@ -158,9 +158,9 @@ expand_default <- function(scale, discrete = c(0, 0.6, 0, 0.6), continuous = c(0
 # generated
 render_axis <- function(panel_params, axis, scale, position, theme) {
   if (axis == "primary") {
-    guide_axis(panel_params[[paste0(scale, ".major")]], panel_params[[paste0(scale, ".labels")]], position, theme)
+    draw_axis(panel_params[[paste0(scale, ".major")]], panel_params[[paste0(scale, ".labels")]], position, theme)
   } else if (axis == "secondary" && !is.null(panel_params[[paste0(scale, ".sec.major")]])) {
-    guide_axis(panel_params[[paste0(scale, ".sec.major")]], panel_params[[paste0(scale, ".sec.labels")]], position, theme)
+    draw_axis(panel_params[[paste0(scale, ".sec.major")]], panel_params[[paste0(scale, ".sec.labels")]], position, theme)
   } else {
     zeroGrob()
   }

--- a/R/coord-map.r
+++ b/R/coord-map.r
@@ -308,8 +308,8 @@ CoordMap <- ggproto("CoordMap", Coord,
     pos <- self$transform(x_intercept, panel_params)
 
     axes <- list(
-      top = guide_axis(pos$x, panel_params$x.labels, "top", theme),
-      bottom = guide_axis(pos$x, panel_params$x.labels, "bottom", theme)
+      top = draw_axis(pos$x, panel_params$x.labels, "top", theme),
+      bottom = draw_axis(pos$x, panel_params$x.labels, "bottom", theme)
     )
     axes[[which(arrange == "secondary")]] <- zeroGrob()
     axes
@@ -332,8 +332,8 @@ CoordMap <- ggproto("CoordMap", Coord,
     pos <- self$transform(x_intercept, panel_params)
 
     axes <- list(
-      left = guide_axis(pos$y, panel_params$y.labels, "left", theme),
-      right = guide_axis(pos$y, panel_params$y.labels, "right", theme)
+      left = draw_axis(pos$y, panel_params$y.labels, "left", theme),
+      right = draw_axis(pos$y, panel_params$y.labels, "right", theme)
     )
     axes[[which(arrange == "secondary")]] <- zeroGrob()
     axes

--- a/R/coord-polar.r
+++ b/R/coord-polar.r
@@ -190,7 +190,7 @@ CoordPolar <- ggproto("CoordPolar", Coord,
   render_axis_h = function(panel_params, theme) {
     list(
       top = zeroGrob(),
-      bottom = guide_axis(NA, "", "bottom", theme)
+      bottom = draw_axis(NA, "", "bottom", theme)
     )
   },
 

--- a/R/coord-sf.R
+++ b/R/coord-sf.R
@@ -243,7 +243,7 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
     tick_labels <- c(ticks1$degree_label, ticks2$degree_label)
 
     if (length(tick_positions) > 0) {
-      top <- guide_axis(
+      top <- draw_axis(
         tick_positions,
         tick_labels,
         position = "top",
@@ -279,7 +279,7 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
     tick_labels <- c(ticks1$degree_label, ticks2$degree_label)
 
     if (length(tick_positions) > 0) {
-      bottom <- guide_axis(
+      bottom <- draw_axis(
         tick_positions,
         tick_labels,
         position = "bottom",
@@ -321,7 +321,7 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
     tick_labels <- c(ticks1$degree_label, ticks2$degree_label)
 
     if (length(tick_positions) > 0) {
-      right <- guide_axis(
+      right <- draw_axis(
         tick_positions,
         tick_labels,
         position = "right",
@@ -357,7 +357,7 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
     tick_labels <- c(ticks1$degree_label, ticks2$degree_label)
 
     if (length(tick_positions) > 0) {
-      left <- guide_axis(
+      left <- draw_axis(
         tick_positions,
         tick_labels,
         position = "left",

--- a/R/coord-sf.R
+++ b/R/coord-sf.R
@@ -246,7 +246,7 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
       top <- draw_axis(
         tick_positions,
         tick_labels,
-        position = "top",
+        axis_position = "top",
         theme = theme
       )
     } else {
@@ -282,7 +282,7 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
       bottom <- draw_axis(
         tick_positions,
         tick_labels,
-        position = "bottom",
+        axis_position = "bottom",
         theme = theme
       )
     } else {
@@ -324,7 +324,7 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
       right <- draw_axis(
         tick_positions,
         tick_labels,
-        position = "right",
+        axis_position = "right",
         theme = theme
       )
     } else {
@@ -360,7 +360,7 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
       left <- draw_axis(
         tick_positions,
         tick_labels,
-        position = "left",
+        axis_position = "left",
         theme = theme
       )
     } else {

--- a/R/guides-axis.r
+++ b/R/guides-axis.r
@@ -4,7 +4,7 @@
 # @param labels at ticks
 # @param position of axis (top, bottom, left or right)
 # @param range of data values
-guide_axis <- function(at, labels, position = "right", theme) {
+draw_axis <- function(at, labels, position = "right", theme) {
   line <- switch(position,
     top =    element_render(theme, "axis.line.x.top", c(0, 1), c(0, 0), id.lengths = 2),
     bottom = element_render(theme, "axis.line.x.bottom", c(0, 1), c(1, 1), id.lengths = 2),

--- a/R/guides-axis.r
+++ b/R/guides-axis.r
@@ -1,146 +1,139 @@
-# Grob for axes
-#
-# @param position of ticks
-# @param labels at ticks
-# @param position of axis (top, bottom, left or right)
-# @param range of data values
-draw_axis <- function(at, labels, position = "right", theme) {
-  line <- switch(position,
-    top =    element_render(theme, "axis.line.x.top", c(0, 1), c(0, 0), id.lengths = 2),
-    bottom = element_render(theme, "axis.line.x.bottom", c(0, 1), c(1, 1), id.lengths = 2),
-    right =  element_render(theme, "axis.line.y.right", c(0, 0), c(0, 1), id.lengths = 2),
-    left =   element_render(theme, "axis.line.y.left", c(1, 1), c(0, 1), id.lengths = 2)
-  )
-  position <- match.arg(position, c("top", "bottom", "right", "left"))
 
-  zero <- unit(0, "npc")
-  one <- unit(1, "npc")
+#' Grob for axes
+#'
+#' @param break_position position of ticks
+#' @param break_labels labels at ticks
+#' @param axis_position position of axis (top, bottom, left or right)
+#' @param theme A [theme()] object
+#'
+#' @noRd
+#'
+draw_axis <- function(break_positions, break_labels, axis_position, theme) {
 
-  if (length(at) == 0) {
-    vertical <- position %in% c("left", "right")
-    return(absoluteGrob(
-      gList(line),
-      width = if (vertical) zero else one,
-      height = if (vertical) one else zero
-    ))
+  axis_position <- match.arg(axis_position, c("top", "bottom", "right", "left"))
+  aesthetic <- if(axis_position %in% c("top", "bottom")) "x" else "y"
+
+  is_vertical <- axis_position %in% c("left",  "right")
+  is_second <- axis_position %in% c("right", "top") # refers to positive npc coordinates
+  is_first_gtable <- axis_position %in% c("left", "top") # refers to position in gtable
+  n_breaks <- length(break_positions)
+  opposite_positions <- c("top" = "bottom", "bottom" = "top", "right" = "left", "left" = "right")
+  axis_position_opposite <- unname(opposite_positions[axis_position])
+
+  # resolve elements
+  line_element_name <- paste0("axis.line.", aesthetic, ".", axis_position)
+  tick_element_name <- paste0("axis.ticks.", aesthetic, ".", axis_position)
+  tick_length_element_name <- paste0("axis.ticks.length.", aesthetic, ".", axis_position)
+  label_element_name <- paste0("axis.text.", aesthetic, ".", axis_position)
+
+  line_element <- calc_element(line_element_name, theme)
+  tick_element <- calc_element(tick_element_name, theme)
+  tick_length <- calc_element(tick_length_element_name, theme)
+  label_element <- calc_element(label_element_name, theme)
+
+  if (is_vertical) {
+    position_dim <- "y"
+    non_position_dim <- "x"
+    position_size <- "height"
+    non_position_size <- "width"
+    label_margin_name <- "margin_x"
+    gtable_element <- gtable_row
+    measure_gtable <- gtable_width
+    measure_labels <- grobWidth
+  } else {
+    position_dim <- "x"
+    non_position_dim <- "y"
+    position_size <- "width"
+    non_position_size <- "height"
+    label_margin_name <- "margin_y"
+    gtable_element <- gtable_col
+    measure_gtable <- gtable_height
+    measure_labels <- grobHeight
   }
 
-  at <- unit(at, "native")
-
-  theme$axis.ticks.length.x.bottom <- with(
-    theme,
-    axis.ticks.length.x.bottom %||%
-      axis.ticks.length.x %||%
-      axis.ticks.length
-  )
-  theme$axis.ticks.length.x.top <- with(
-    theme,
-    axis.ticks.length.x.top %||%
-      axis.ticks.length.x %||%
-      axis.ticks.length
-  )
-  theme$axis.ticks.length.y.left <- with(
-    theme,
-    axis.ticks.length.y.left %||%
-      axis.ticks.length.y %||%
-      axis.ticks.length
-  )
-  theme$axis.ticks.length.y.right <- with(
-    theme,
-    axis.ticks.length.y.right %||%
-      axis.ticks.length.y %||%
-      axis.ticks.length
-  )
-
-  label_render <- switch(position,
-    top = "axis.text.x.top", bottom = "axis.text.x.bottom",
-    left = "axis.text.y.left", right = "axis.text.y.right"
-  )
-
-  label_x <- switch(position,
-    top = ,
-    bottom = at,
-    right = theme$axis.ticks.length.y.right,
-    left = one - theme$axis.ticks.length.y.left
-  )
-  label_y <- switch(position,
-    top = theme$axis.ticks.length.x.top,
-    bottom = one - theme$axis.ticks.length.x.bottom,
-    right = ,
-    left = at
-  )
-
-  if (is.list(labels)) {
-    if (any(sapply(labels, is.language))) {
-      labels <- do.call(expression, labels)
-    } else {
-      labels <- unlist(labels)
-    }
+  if (is_second) {
+    tick_direction <- 1
+    non_position_panel <- unit(0, "npc")
+    tick_coordinate_order <- c(2, 1)
+  } else {
+    tick_direction <- -1
+    non_position_panel <- unit(1, "npc")
+    tick_coordinate_order <- c(1, 2)
   }
 
-  labels <- switch(position,
-    top = ,
-    bottom = element_render(theme, label_render, labels, x = label_x, margin_y = TRUE),
-    right = ,
-    left =  element_render(theme, label_render, labels, y = label_y, margin_x = TRUE))
+  if (is_first_gtable) {
+    table_order <- c("labels", "ticks")
+  } else {
+    table_order <- c("ticks", "labels")
+  }
 
-
-
-  nticks <- length(at)
-
-  ticks <- switch(position,
-    top = element_render(theme, "axis.ticks.x.top",
-      x          = rep(at, each = 2),
-      y          = rep(unit.c(zero, theme$axis.ticks.length.x.top), nticks),
-      id.lengths = rep(2, nticks)),
-    bottom = element_render(theme, "axis.ticks.x.bottom",
-      x          = rep(at, each = 2),
-      y          = rep(unit.c(one - theme$axis.ticks.length.x.bottom, one), nticks),
-      id.lengths = rep(2, nticks)),
-    right = element_render(theme, "axis.ticks.y.right",
-      x          = rep(unit.c(zero, theme$axis.ticks.length.y.right), nticks),
-      y          = rep(at, each = 2),
-      id.lengths = rep(2, nticks)),
-    left = element_render(theme, "axis.ticks.y.left",
-      x          = rep(unit.c(one - theme$axis.ticks.length.y.left, one), nticks),
-      y          = rep(at, each = 2),
-      id.lengths = rep(2, nticks))
+  # draw elements
+  line_coords <- list(
+    position = unit(c(0, 1), "npc"),
+    non_position = unit.c(non_position_panel, non_position_panel)
   )
+  names(line_coords) <- c(position_dim, non_position_dim)
+  line_grob <- do.call(element_grob, c(list(line_element), line_coords))
 
-  # Create the gtable for the ticks + labels
-  gt <- switch(position,
-    top    = gtable_col("axis",
-      grobs   = list(labels, ticks),
-      width   = one,
-      heights = unit.c(grobHeight(labels), theme$axis.ticks.length.x.top)
-    ),
-    bottom = gtable_col("axis",
-      grobs   = list(ticks, labels),
-      width   = one,
-      heights = unit.c(theme$axis.ticks.length.x.bottom, grobHeight(labels))
-    ),
-    right  = gtable_row("axis",
-      grobs   = list(ticks, labels),
-      widths  = unit.c(theme$axis.ticks.length.y.right, grobWidth(labels)),
-      height  = one
-    ),
-    left   = gtable_row("axis",
-      grobs   = list(labels, ticks),
-      widths  = unit.c(grobWidth(labels), theme$axis.ticks.length.y.left),
-      height  = one
+  if (n_breaks == 0) {
+    return(
+      absoluteGrob(
+        gList(line_grob),
+        width = grobWidth(line_grob),
+        height = grobHeight(line_grob)
+      )
     )
+  }
+
+  label_coords <- list(
+    position = unit(break_positions, "native"),
+    label = break_labels,
+    margin = TRUE
   )
 
-  # Viewport for justifying the axis grob
-  justvp <- switch(position,
-    top    = viewport(y = 0, just = "bottom", height = gtable_height(gt)),
-    bottom = viewport(y = 1, just = "top",    height = gtable_height(gt)),
-    right  = viewport(x = 0, just = "left",   width  = gtable_width(gt)),
-    left   = viewport(x = 1, just = "right",  width  = gtable_width(gt))
+  tick_coords <- list(
+    position = rep(label_coords$position, each = 2),
+    non_position = rep(
+      unit.c(non_position_panel + (tick_direction * tick_length), non_position_panel)[tick_coordinate_order],
+      times = n_breaks
+    ),
+    id.lengths = rep(2, times = n_breaks)
   )
+
+  names(label_coords) <- c(position_dim, "label", label_margin_name)
+  names(tick_coords) <- c(position_dim, non_position_dim, "id.lengths")
+
+  grobs <- list(
+    line = line_grob,
+    labels = do.call(element_grob, c(list(label_element), label_coords)),
+    ticks = do.call(element_grob, c(list(tick_element), tick_coords))
+  )
+
+  # assemble elements
+  gt_element_order <- match(table_order, c("labels", "ticks"))
+  gt_dims <- list(
+    dims = unit.c(measure_labels(grobs$labels), tick_length),
+    dim = unit(1, "npc")
+  )
+  gt_dims$dims <- gt_dims$dims[gt_element_order]
+  names(gt_dims) <- c(paste0(non_position_size, "s"), position_size)
+
+  gt <- do.call(
+    gtable_element,
+    c(list(name = "axis", grobs = grobs[table_order]), gt_dims)
+  )
+
+  justvp_args <- list(
+    non_position_dim = non_position_panel,
+    just = axis_position_opposite,
+    non_position_size = measure_gtable(gt)
+  )
+  names(justvp_args) <- c(non_position_dim, "just", non_position_size)
+
+  justvp <- do.call(viewport, justvp_args)
 
   absoluteGrob(
-    gList(line, gt),
+    gList(grobs$line, gt),
     width = gtable_width(gt),
     height = gtable_height(gt),
     vp = justvp

--- a/R/guides-axis.r
+++ b/R/guides-axis.r
@@ -11,7 +11,7 @@
 draw_axis <- function(break_positions, break_labels, axis_position, theme) {
 
   axis_position <- match.arg(axis_position, c("top", "bottom", "right", "left"))
-  aesthetic <- if(axis_position %in% c("top", "bottom")) "x" else "y"
+  aesthetic <- if (axis_position %in% c("top", "bottom")) "x" else "y"
 
   # resolve elements
   line_element_name <- paste0("axis.line.", aesthetic, ".", axis_position)
@@ -27,27 +27,27 @@ draw_axis <- function(break_positions, break_labels, axis_position, theme) {
   # conditionally set parameters that depend on axis orientation
   is_vertical <- axis_position %in% c("left",  "right")
 
-  position_dim <- if(is_vertical) "y" else "x"
-  non_position_dim <- if(is_vertical) "x" else "y"
-  position_size <- if(is_vertical) "height" else "width"
-  non_position_size <- if(is_vertical) "width" else "height"
-  label_margin_name <- if(is_vertical) "margin_x" else "margin_y"
-  gtable_element <- if(is_vertical) gtable_row else gtable_col
-  measure_gtable <- if(is_vertical) gtable_width else gtable_height
-  measure_labels <- if(is_vertical) grobWidth else grobHeight
+  position_dim <- if (is_vertical) "y" else "x"
+  non_position_dim <- if (is_vertical) "x" else "y"
+  position_size <- if (is_vertical) "height" else "width"
+  non_position_size <- if (is_vertical) "width" else "height"
+  label_margin_name <- if (is_vertical) "margin_x" else "margin_y"
+  gtable_element <- if (is_vertical) gtable_row else gtable_col
+  measure_gtable <- if (is_vertical) gtable_width else gtable_height
+  measure_labels <- if (is_vertical) grobWidth else grobHeight
 
   # conditionally set parameters that depend on which side of the panel
   # the axis is on
   is_second <- axis_position %in% c("right", "top")
 
-  tick_direction <- if(is_second) 1 else -1
-  non_position_panel <- if(is_second) unit(0, "npc") else unit(1, "npc")
-  tick_coordinate_order <- if(is_second) c(2, 1) else c(1, 2)
+  tick_direction <- if (is_second) 1 else -1
+  non_position_panel <- if (is_second) unit(0, "npc") else unit(1, "npc")
+  tick_coordinate_order <- if (is_second) c(2, 1) else c(1, 2)
 
   # conditionally set the gtable ordering
   labels_first_gtable <- axis_position %in% c("left", "top") # refers to position in gtable
 
-  table_order <- if(labels_first_gtable) c("labels", "ticks") else c("ticks", "labels")
+  table_order <- if (labels_first_gtable) c("labels", "ticks") else c("ticks", "labels")
 
   # set common parameters
   n_breaks <- length(break_positions)

--- a/R/theme.r
+++ b/R/theme.r
@@ -612,21 +612,31 @@ merge_element.element <- function(new, old) {
   new
 }
 
-# Combine the properties of two elements
-#
-# @param e1 An element object
-# @param e2 An element object which e1 inherits from
+#' Combine the properties of two elements
+#'
+#' @param e1 An element object
+#' @param e2 An element object from which e1 inherits
+#'
+#' @noRd
+#'
 combine_elements <- function(e1, e2) {
 
   # If e2 is NULL, nothing to inherit
   if (is.null(e2) || inherits(e1, "element_blank"))  return(e1)
+
   # If e1 is NULL inherit everything from e2
   if (is.null(e1)) return(e2)
+
+  # If neither of e1 or e2 are element_* objects, return e1
+  if (!inherits(e1, "element") && !inherits(e2, "element")) return(e1)
+
   # If e2 is element_blank, and e1 inherits blank inherit everything from e2,
   # otherwise ignore e2
   if (inherits(e2, "element_blank")) {
-    if (e1$inherit.blank) return(e2)
-    else return(e1)
+    if (e1$inherit.blank)
+      return(e2)
+    else
+      return(e1)
   }
 
   # If e1 has any NULL properties, inherit them from e2

--- a/R/theme.r
+++ b/R/theme.r
@@ -622,21 +622,28 @@ merge_element.element <- function(new, old) {
 combine_elements <- function(e1, e2) {
 
   # If e2 is NULL, nothing to inherit
-  if (is.null(e2) || inherits(e1, "element_blank"))  return(e1)
+  if (is.null(e2) || inherits(e1, "element_blank")) {
+    return(e1)
+  }
 
   # If e1 is NULL inherit everything from e2
-  if (is.null(e1)) return(e2)
+  if (is.null(e1)) {
+    return(e2)
+  }
 
   # If neither of e1 or e2 are element_* objects, return e1
-  if (!inherits(e1, "element") && !inherits(e2, "element")) return(e1)
+  if (!inherits(e1, "element") && !inherits(e2, "element")) {
+    return(e1)
+  }
 
   # If e2 is element_blank, and e1 inherits blank inherit everything from e2,
   # otherwise ignore e2
   if (inherits(e2, "element_blank")) {
-    if (e1$inherit.blank)
+    if (e1$inherit.blank) {
       return(e2)
-    else
+    } else {
       return(e1)
+    }
   }
 
   # If e1 has any NULL properties, inherit them from e2

--- a/tests/testthat/test-theme.r
+++ b/tests/testthat/test-theme.r
@@ -213,6 +213,12 @@ test_that("elements can be merged", {
   )
 })
 
+test_that("theme elements that don't inherit from element can be combined", {
+  expect_identical(combine_elements(1, NULL), 1)
+  expect_identical(combine_elements(NULL, 1), 1)
+  expect_identical(combine_elements(1, 0), 1)
+})
+
 test_that("complete plot themes shouldn't inherit from default", {
   default_theme <- theme_gray() + theme(axis.text.x = element_text(colour = "red"))
   base <- qplot(1, 1)


### PR DESCRIPTION
This is a PR to prepare for improvements in axis guides as part of #3322. This PR  renames the internal function `guide_axis()` to `draw_axis()` and includes a complete rewrite of (what is now) `draw_axis()`.

Renaming `guide_axis()` to `draw_axis()` is necessary to make way for an exported `guide_axis()` function that returns a guide (instead of a grob). I used the term "draw" because it is used in many places in ggplot2 for functions that return grobs.

The rewrite of `draw_axis()` is necessary because the current code is difficult to read and contains much duplication. This makes it difficult to change or improve, as is planned for #3322. The rewrite does not introduce any visual changes in the current tests, and I didn't add any new tests because I couldn't find any part of axis appearance that wasn't already tested between the guides and themes.