### PR TITLE
Cleanup Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: R
 cache: packages
-sudo: true
-dist: trusty
 
 # build matrix; turn on vdiffr only on r release
 matrix:
@@ -35,8 +33,13 @@ env:
 after_success:
   - Rscript -e 'covr::codecov()'
 
-before_install:
-  - sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable --yes
-  - sudo apt-get --yes --force-yes update -qq
-  - sudo apt-get install --yes libudunits2-dev libproj-dev libgeos-dev libgdal-dev
-  - Rscript -e 'update.packages(ask = FALSE)'
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:ubuntugis/ppa'
+    packages:
+      - libudunits2-dev
+      - libproj-dev
+      - libgeos-dev
+      - libgdal-dev
+


### PR DESCRIPTION
Using declarative installation of `apt` packages will result in better caching. Also `sudo` is deprecated and `dist: trusty` is EOL soon, it's better to use the default linux distribution.