### PR TITLE
Ensure that draw_axis() works with element_text() subclasses

### DIFF
--- a/R/guides-axis.r
+++ b/R/guides-axis.r
@@ -35,10 +35,11 @@ draw_axis <- function(break_positions, break_labels, axis_position, theme,
 
   # override label element parameters for rotation
   if (inherits(label_element, "element_text")) {
-    label_element <- merge_element(
-      axis_label_element_overrides(axis_position, angle),
-      label_element
-    )
+    label_overrides <- axis_label_element_overrides(axis_position, angle)
+    # label_overrides is always an element_text(), but in order for the merge to
+    # keep the new class, the override must also have the new class
+    class(label_overrides) <- class(label_element)
+    label_element <- merge_element(label_overrides, label_element)
   }
 
   # conditionally set parameters that depend on axis orientation


### PR DESCRIPTION
The latest update of the `draw_axis()` code (#3375) broke the ability of `element_text()` subclasses to be rendered as axis labels. This PR fixes this, such that any S3 element inheriting from `element_text()` is rendered correctly. This is important for gridtext integration, which uses `element_text()` subclasses extensively (#3373). An excellent reprex for this is available here: https://github.com/clauswilke/gridtext/blob/master/examples/ggplot2-integration.R