### PR TITLE
Add NULL as default for the label parameter of xlab() and ylab()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,10 @@
   more informative warnings when supplied with set aesthetics
   (i.e., `slope`, `intercept`, `yintercept`, and/or `xintercept`)
   and mapped aesthetics (i.e., `data` and/or `mapping`).
+  
+* `xlab()` and `ylab()` now have `NULL` as a default value for the
+  `label` parameter, making it easier to remove axis labels from plots
+  (@moredatapls, #3393)
 
 # ggplot2 3.2.0
 

--- a/R/labels.r
+++ b/R/labels.r
@@ -79,13 +79,13 @@ labs <- function(..., title = waiver(), subtitle = waiver(), caption = waiver(),
 
 #' @rdname labs
 #' @export
-xlab <- function(label) {
+xlab <- function(label = NULL) {
   labs(x = label)
 }
 
 #' @rdname labs
 #' @export
-ylab <- function(label) {
+ylab <- function(label = NULL) {
   labs(y = label)
 }
 

--- a/man/labs.Rd
+++ b/man/labs.Rd
@@ -10,9 +10,9 @@
 labs(..., title = waiver(), subtitle = waiver(), caption = waiver(),
   tag = waiver())
 
-xlab(label)
+xlab(label = NULL)
 
-ylab(label)
+ylab(label = NULL)
 
 ggtitle(label, subtitle = waiver())
 }

--- a/tests/testthat/test-labels.r
+++ b/tests/testthat/test-labels.r
@@ -8,6 +8,9 @@ test_that("setting guide labels works", {
     expect_identical(ylab("my label")$y, "my label")
     expect_identical(labs(y = "my label")$y, "my label")
 
+    expect_identical(xlab()$x, NULL)
+    expect_identical(ylab()$y, NULL)
+
     # Plot titles
     expect_identical(labs(title = "my title")$title, "my title")
     expect_identical(labs(title = "my title",


### PR DESCRIPTION
Adds `NULL` as a default value for the `label` parameter of `xlab()` and `ylab()`, making it easier to remove axis labels from plots.

Resolves #3393 