### PR TITLE
Clarified difference between filename and path arguments in `ggsave()`

### DIFF
--- a/R/save.r
+++ b/R/save.r
@@ -18,8 +18,9 @@
 #' @param device Device to use. Can either be a device function
 #'   (e.g. [png()]), or one of "eps", "ps", "tex" (pictex),
 #'   "pdf", "jpeg", "tiff", "png", "bmp", "svg" or "wmf" (windows only).
-#' @param path Path of the directory to save plot to, defaults to the working
-#'   directory (filename is appended to form the fully qualified file name).
+#' @param path Path of the directory to save plot to: `path` and `filename`
+#'   are combined to create the fully qualified file name. Defaults to the
+#'   working directory.
 #' @param scale Multiplicative scaling factor.
 #' @param width,height,units Plot size in `units` ("in", "cm", or "mm").
 #'   If not supplied, uses the size of current graphics device.

--- a/R/save.r
+++ b/R/save.r
@@ -18,7 +18,8 @@
 #' @param device Device to use. Can either be a device function
 #'   (e.g. [png()]), or one of "eps", "ps", "tex" (pictex),
 #'   "pdf", "jpeg", "tiff", "png", "bmp", "svg" or "wmf" (windows only).
-#' @param path Path to save plot to (combined with filename).
+#' @param path Path of the directory to save plot to, defaults to the working
+#'   directory (filename is appended to form the fully qualified file name).
 #' @param scale Multiplicative scaling factor.
 #' @param width,height,units Plot size in `units` ("in", "cm", or "mm").
 #'   If not supplied, uses the size of current graphics device.

--- a/man/ggsave.Rd
+++ b/man/ggsave.Rd
@@ -17,8 +17,9 @@ ggsave(filename, plot = last_plot(), device = NULL, path = NULL,
 (e.g. \code{\link[=png]{png()}}), or one of "eps", "ps", "tex" (pictex),
 "pdf", "jpeg", "tiff", "png", "bmp", "svg" or "wmf" (windows only).}
 
-\item{path}{Path of the directory to save plot to, defaults to the working
-directory (filename is appended to form the fully qualified file name).}
+\item{path}{Path of the directory to save plot to: \code{path} and \code{filename}
+are combined to create the fully qualified file name. Defaults to the
+working directory.}
 
 \item{scale}{Multiplicative scaling factor.}
 

--- a/man/ggsave.Rd
+++ b/man/ggsave.Rd
@@ -17,7 +17,8 @@ ggsave(filename, plot = last_plot(), device = NULL, path = NULL,
 (e.g. \code{\link[=png]{png()}}), or one of "eps", "ps", "tex" (pictex),
 "pdf", "jpeg", "tiff", "png", "bmp", "svg" or "wmf" (windows only).}
 
-\item{path}{Path to save plot to (combined with filename).}
+\item{path}{Path of the directory to save plot to, defaults to the working
+directory (filename is appended to form the fully qualified file name).}
 
 \item{scale}{Multiplicative scaling factor.}
 


### PR DESCRIPTION
Closes #3295 

Added clarification that path is a path to a directory, and that filename is appended to path to create the fully qualified file name