### PR TITLE
Improve documentation for `scale_*_gradient`

### DIFF
--- a/R/scale-gradient.r
+++ b/R/scale-gradient.r
@@ -29,6 +29,14 @@
 #'   z2 = abs(rnorm(100))
 #' )
 #'
+#' # Dataframe with missing values
+#' df_na <- data.frame(
+#'   value = seq(1,20),
+#'   x = runif(20),
+#'   y = runif(20),
+#'   z1 = c(rep(NA, 10), rnorm(10))
+#' )
+#'
 #' # Default colour scale colours from light blue to dark blue
 #' ggplot(df, aes(x, y)) +
 #'   geom_point(aes(colour = z2))
@@ -54,6 +62,19 @@
 #'   scale_colour_gradient(low = "white", high = "black")
 #' # Avoid red-green colour contrasts because ~10% of men have difficulty
 #' # seeing them
+#'
+#' # Pass na.value = NA with the fill aesthetic to result in no fill for missing values
+#' ggplot(df_na, aes(x = value, y)) +
+#'   geom_bar(aes(fill = z1), stat = "identity") +
+#'   scale_fill_gradient(low = "yellow", high = "red",
+#'                       na.value = NA)
+#'
+#' # Pass na.value = NA with the colour aesthetic to hide data points with missing values
+#'  ggplot(df_na, aes(x, y)) +
+#'    geom_point(aes(colour = z1)) +
+#'    scale_colour_gradient(low = "yellow", high = "red",
+#'                          na.value = NA)
+#'
 scale_colour_gradient <- function(..., low = "#132B43", high = "#56B1F7", space = "Lab",
                                   na.value = "grey50", guide = "colourbar", aesthetics = "colour") {
   continuous_scale(aesthetics, "gradient", seq_gradient_pal(low, high, space),

--- a/R/scale-gradient.r
+++ b/R/scale-gradient.r
@@ -29,9 +29,8 @@
 #'   z2 = abs(rnorm(100))
 #' )
 #'
-#' # Dataframe with missing values
 #' df_na <- data.frame(
-#'   value = seq(1,20),
+#'   value = seq(1, 20),
 #'   x = runif(20),
 #'   y = runif(20),
 #'   z1 = c(rep(NA, 10), rnorm(10))
@@ -63,17 +62,14 @@
 #' # Avoid red-green colour contrasts because ~10% of men have difficulty
 #' # seeing them
 #'
-#' # Pass na.value = NA with the fill aesthetic to result in no fill for missing values
+#'# Use `na.value = NA` to hide missing values but keep the original axis range
 #' ggplot(df_na, aes(x = value, y)) +
 #'   geom_bar(aes(fill = z1), stat = "identity") +
-#'   scale_fill_gradient(low = "yellow", high = "red",
-#'                       na.value = NA)
+#'   scale_fill_gradient(low = "yellow", high = "red", na.value = NA)
 #'
-#' # Pass na.value = NA with the colour aesthetic to hide data points with missing values
 #'  ggplot(df_na, aes(x, y)) +
 #'    geom_point(aes(colour = z1)) +
-#'    scale_colour_gradient(low = "yellow", high = "red",
-#'                          na.value = NA)
+#'    scale_colour_gradient(low = "yellow", high = "red", na.value = NA)
 #'
 scale_colour_gradient <- function(..., low = "#132B43", high = "#56B1F7", space = "Lab",
                                   na.value = "grey50", guide = "colourbar", aesthetics = "colour") {

--- a/man/scale_gradient.Rd
+++ b/man/scale_gradient.Rd
@@ -164,6 +164,14 @@ df <- data.frame(
   z2 = abs(rnorm(100))
 )
 
+# Dataframe with missing values
+df_na <- data.frame(
+  value = seq(1,20),
+  x = runif(20),
+  y = runif(20),
+  z1 = c(rep(NA, 10), rnorm(10))
+)
+
 # Default colour scale colours from light blue to dark blue
 ggplot(df, aes(x, y)) +
   geom_point(aes(colour = z2))
@@ -189,6 +197,19 @@ ggplot(df, aes(x, y)) +
   scale_colour_gradient(low = "white", high = "black")
 # Avoid red-green colour contrasts because ~10\% of men have difficulty
 # seeing them
+
+# Pass `na.value = NA` with the fill aesthetic for no fill for missing values
+ggplot(df_na, aes(x = value, y)) +
+  geom_bar(aes(fill = z1), stat = "identity") +
+  scale_fill_gradient(low = "yellow", high = "red",
+                      na.value = NA)
+
+# Pass `na.value = NA` with the colour aesthetic to hide data points with missing values
+ ggplot(df_na, aes(x, y)) +
+   geom_point(aes(colour = z1)) +
+   scale_colour_gradient(low = "yellow", high = "red",
+                         na.value = NA)
+
 }
 \seealso{
 \code{\link[scales:seq_gradient_pal]{scales::seq_gradient_pal()}} for details on underlying

--- a/man/scale_gradient.Rd
+++ b/man/scale_gradient.Rd
@@ -164,9 +164,8 @@ df <- data.frame(
   z2 = abs(rnorm(100))
 )
 
-# Dataframe with missing values
 df_na <- data.frame(
-  value = seq(1,20),
+  value = seq(1, 20),
   x = runif(20),
   y = runif(20),
   z1 = c(rep(NA, 10), rnorm(10))
@@ -198,17 +197,14 @@ ggplot(df, aes(x, y)) +
 # Avoid red-green colour contrasts because ~10\% of men have difficulty
 # seeing them
 
-# Pass `na.value = NA` with the fill aesthetic for no fill for missing values
+# Use `na.value = NA` to hide missing values but keep the original axis range
 ggplot(df_na, aes(x = value, y)) +
   geom_bar(aes(fill = z1), stat = "identity") +
-  scale_fill_gradient(low = "yellow", high = "red",
-                      na.value = NA)
+  scale_fill_gradient(low = "yellow", high = "red", na.value = NA)
 
-# Pass `na.value = NA` with the colour aesthetic to hide data points with missing values
  ggplot(df_na, aes(x, y)) +
    geom_point(aes(colour = z1)) +
-   scale_colour_gradient(low = "yellow", high = "red",
-                         na.value = NA)
+   scale_colour_gradient(low = "yellow", high = "red", na.value = NA)
 
 }
 \seealso{


### PR DESCRIPTION
Addresses #3299 

Added examples to illustrate the different behaviour when setting `na.value = NA` when used with the fill and colour aesthetics, and data has missing values.

The second suggested bullet point of #3299 is dependent on a bug fix and hence I did not document this.