### PR TITLE
Explicit warning about data removal with limits on positional scales

### DIFF
--- a/R/scale-.r
+++ b/R/scale-.r
@@ -38,6 +38,9 @@
 #'     Use `NA` to refer to the existing minimum or maximum
 #'   - A function that accepts the existing (automatic) limits and returns
 #'     new limits
+#'
+#'  Note that setting limits on positional scales can unpredictably remove data.
+#'  If the purpose is to zoom, use the limit argument in the coordinate system.
 #' @param rescaler A function used to scale the input values to the
 #'   range \[0, 1]. This is always [scales::rescale()], except for
 #'   diverging and n colour gradients (i.e., [scale_colour_gradient2()],

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -39,7 +39,7 @@
 #'   - A function that accepts the existing (automatic) limits and returns
 #'     new limits
 #'
-#'  Note that setting limits on positional scales can unpredictably remove data.
+#'  Note that setting limits on positional scales will **remove** data outside of the limits.
 #'  If the purpose is to zoom, use the limit argument in the coordinate system.
 #' @param rescaler A function used to scale the input values to the
 #'   range \[0, 1]. This is always [scales::rescale()], except for

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -40,7 +40,7 @@
 #'     new limits
 #'
 #'  Note that setting limits on positional scales will **remove** data outside of the limits.
-#'  If the purpose is to zoom, use the limit argument in the coordinate system.
+#'  If the purpose is to zoom, use the limit argument in the coordinate system (see [coord_cartesian()]).
 #' @param rescaler A function used to scale the input values to the
 #'   range \[0, 1]. This is always [scales::rescale()], except for
 #'   diverging and n colour gradients (i.e., [scale_colour_gradient2()],

--- a/man/continuous_scale.Rd
+++ b/man/continuous_scale.Rd
@@ -63,8 +63,8 @@ Use \code{NA} to refer to the existing minimum or maximum
 new limits
 }
 
-Note that setting limits on positional scales can unpredictably remove data.
-If the purpose is to zoom, use the limit argument in the coordinate system.}
+Note that setting limits on positional scales will \strong{remove} data outside of the limits.
+If the purpose is to zoom, use the limit argument in the coordinate system (see \code{\link[=coord_cartesian]{coord_cartesian()}}).}
 
 \item{rescaler}{A function used to scale the input values to the
 range [0, 1]. This is always \code{\link[scales:rescale]{scales::rescale()}}, except for

--- a/man/continuous_scale.Rd
+++ b/man/continuous_scale.Rd
@@ -61,7 +61,10 @@ as output
 Use \code{NA} to refer to the existing minimum or maximum
 \item A function that accepts the existing (automatic) limits and returns
 new limits
-}}
+}
+
+Note that setting limits on positional scales can unpredictably remove data.
+If the purpose is to zoom, use the limit argument in the coordinate system.}
 
 \item{rescaler}{A function used to scale the input values to the
 range [0, 1]. This is always \code{\link[scales:rescale]{scales::rescale()}}, except for

--- a/man/geom_ribbon.Rd
+++ b/man/geom_ribbon.Rd
@@ -60,8 +60,8 @@ that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 }
 \description{
-For each x value, \code{geom_ribbon} displays a y interval defined
-by \code{ymin} and \code{ymax}. \code{geom_area} is a special case of
+For each x value, \code{geom_ribbon()} displays a y interval defined
+by \code{ymin} and \code{ymax}. \code{geom_area()} is a special case of
 \code{geom_ribbon}, where the \code{ymin} is fixed to 0 and \code{y} is used instead
 of \code{ymax}.
 }

--- a/man/scale_continuous.Rd
+++ b/man/scale_continuous.Rd
@@ -77,8 +77,8 @@ Use \code{NA} to refer to the existing minimum or maximum
 new limits
 }
 
-Note that setting limits on positional scales can unpredictably remove data.
-If the purpose is to zoom, use the limit argument in the coordinate system.}
+Note that setting limits on positional scales will \strong{remove} data outside of the limits.
+If the purpose is to zoom, use the limit argument in the coordinate system (see \code{\link[=coord_cartesian]{coord_cartesian()}}).}
 
 \item{expand}{For position scales, a vector of range expansion constants used to add some
 padding around the data to ensure that they are placed some distance

--- a/man/scale_continuous.Rd
+++ b/man/scale_continuous.Rd
@@ -75,7 +75,10 @@ as output
 Use \code{NA} to refer to the existing minimum or maximum
 \item A function that accepts the existing (automatic) limits and returns
 new limits
-}}
+}
+
+Note that setting limits on positional scales can unpredictably remove data.
+If the purpose is to zoom, use the limit argument in the coordinate system.}
 
 \item{expand}{For position scales, a vector of range expansion constants used to add some
 padding around the data to ensure that they are placed some distance

--- a/man/scale_date.Rd
+++ b/man/scale_date.Rd
@@ -95,7 +95,10 @@ like "2 weeks", or "10 years". If both \code{minor_breaks} and
 Use \code{NA} to refer to the existing minimum or maximum
 \item A function that accepts the existing (automatic) limits and returns
 new limits
-}}
+}
+
+Note that setting limits on positional scales can unpredictably remove data.
+If the purpose is to zoom, use the limit argument in the coordinate system.}
 
 \item{expand}{For position scales, a vector of range expansion constants used to add some
 padding around the data to ensure that they are placed some distance

--- a/man/scale_date.Rd
+++ b/man/scale_date.Rd
@@ -97,8 +97,8 @@ Use \code{NA} to refer to the existing minimum or maximum
 new limits
 }
 
-Note that setting limits on positional scales can unpredictably remove data.
-If the purpose is to zoom, use the limit argument in the coordinate system.}
+Note that setting limits on positional scales will \strong{remove} data outside of the limits.
+If the purpose is to zoom, use the limit argument in the coordinate system (see \code{\link[=coord_cartesian]{coord_cartesian()}}).}
 
 \item{expand}{For position scales, a vector of range expansion constants used to add some
 padding around the data to ensure that they are placed some distance

--- a/man/scale_gradient.Rd
+++ b/man/scale_gradient.Rd
@@ -86,7 +86,10 @@ as output
 Use \code{NA} to refer to the existing minimum or maximum
 \item A function that accepts the existing (automatic) limits and returns
 new limits
-}}
+}
+
+Note that setting limits on positional scales can unpredictably remove data.
+If the purpose is to zoom, use the limit argument in the coordinate system.}
   \item{rescaler}{A function used to scale the input values to the
 range [0, 1]. This is always \code{\link[scales:rescale]{scales::rescale()}}, except for
 diverging and n colour gradients (i.e., \code{\link[=scale_colour_gradient2]{scale_colour_gradient2()}},

--- a/man/scale_gradient.Rd
+++ b/man/scale_gradient.Rd
@@ -88,8 +88,8 @@ Use \code{NA} to refer to the existing minimum or maximum
 new limits
 }
 
-Note that setting limits on positional scales can unpredictably remove data.
-If the purpose is to zoom, use the limit argument in the coordinate system.}
+Note that setting limits on positional scales will \strong{remove} data outside of the limits.
+If the purpose is to zoom, use the limit argument in the coordinate system (see \code{\link[=coord_cartesian]{coord_cartesian()}}).}
   \item{rescaler}{A function used to scale the input values to the
 range [0, 1]. This is always \code{\link[scales:rescale]{scales::rescale()}}, except for
 diverging and n colour gradients (i.e., \code{\link[=scale_colour_gradient2]{scale_colour_gradient2()}},

--- a/man/scale_size.Rd
+++ b/man/scale_size.Rd
@@ -54,7 +54,10 @@ as output
 Use \code{NA} to refer to the existing minimum or maximum
 \item A function that accepts the existing (automatic) limits and returns
 new limits
-}}
+}
+
+Note that setting limits on positional scales can unpredictably remove data.
+If the purpose is to zoom, use the limit argument in the coordinate system.}
 
 \item{range}{a numeric vector of length 2 that specifies the minimum and
 maximum size of the plotting symbol after transformation.}
@@ -113,7 +116,10 @@ as output
 Use \code{NA} to refer to the existing minimum or maximum
 \item A function that accepts the existing (automatic) limits and returns
 new limits
-}}
+}
+
+Note that setting limits on positional scales can unpredictably remove data.
+If the purpose is to zoom, use the limit argument in the coordinate system.}
   \item{oob}{Function that handles limits outside of the scale limits
 (out of bounds). The default (\code{\link[scales:censor]{scales::censor()}}) replaces out of
 bounds values with \code{NA}.}

--- a/man/scale_size.Rd
+++ b/man/scale_size.Rd
@@ -56,8 +56,8 @@ Use \code{NA} to refer to the existing minimum or maximum
 new limits
 }
 
-Note that setting limits on positional scales can unpredictably remove data.
-If the purpose is to zoom, use the limit argument in the coordinate system.}
+Note that setting limits on positional scales will \strong{remove} data outside of the limits.
+If the purpose is to zoom, use the limit argument in the coordinate system (see \code{\link[=coord_cartesian]{coord_cartesian()}}).}
 
 \item{range}{a numeric vector of length 2 that specifies the minimum and
 maximum size of the plotting symbol after transformation.}
@@ -118,8 +118,8 @@ Use \code{NA} to refer to the existing minimum or maximum
 new limits
 }
 
-Note that setting limits on positional scales can unpredictably remove data.
-If the purpose is to zoom, use the limit argument in the coordinate system.}
+Note that setting limits on positional scales will \strong{remove} data outside of the limits.
+If the purpose is to zoom, use the limit argument in the coordinate system (see \code{\link[=coord_cartesian]{coord_cartesian()}}).}
   \item{oob}{Function that handles limits outside of the scale limits
 (out of bounds). The default (\code{\link[scales:censor]{scales::censor()}}) replaces out of
 bounds values with \code{NA}.}


### PR DESCRIPTION
Fixes #2887 

Added an explicit warning in scales documentation about limits sometimes removing data.