### PR TITLE
Fix typos that were causing the CMD check not to pass

### DIFF
--- a/R/limits.r
+++ b/R/limits.r
@@ -17,7 +17,7 @@
 #' @seealso For changing x or y axis limits \strong{without} dropping data
 #'   observations, see [coord_cartesian()]. To expand the range of
 #'   a plot to always include certain values, see [expand_limits()]. For other
-#'   types of data, see [scale_x_discrete(), scale_x_continuous(), scale_x_date()].
+#'   types of data, see [scale_x_discrete()], [scale_x_continuous()], [scale_x_date()].
 #'
 #' @export
 #' @examples

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -186,7 +186,7 @@ rescale01 <- function(x) {
 #' @keywords internal
 #' @export
 gg_dep <- function(version, msg) {
-  .Deprecate()
+  .Deprecated()
   v <- as.package_version(version)
   cv <- utils::packageVersion("ggplot2")
 

--- a/man/gg_dep.Rd
+++ b/man/gg_dep.Rd
@@ -14,24 +14,5 @@ gg_dep(version, msg)
 }
 \description{
 This function is deprecated.
-Version numbers have the format <major>.<minor>.<subminor>, like 0.9.2.
-This function compares the current version number of ggplot2 against the
-specified \code{version}, which is the most recent version before the
-function (or other object) was deprecated.
-}
-\details{
-\code{gg_dep} will give an error, warning, or message, depending on the
-difference between the current ggplot2 version and the specified
-\code{version}.
-
-If the current major number is greater than \code{version}'s major number,
-or if the current minor number is more than 1 greater than \code{version}'s
-minor number, give an error.
-
-If the current minor number differs from \code{version}'s minor number by
-one, give a warning.
-
-If the current subminor number differs from \code{version}'s subminor
-number, print a message.
 }
 \keyword{internal}

--- a/man/lims.Rd
+++ b/man/lims.Rd
@@ -86,5 +86,5 @@ p + coord_cartesian(xlim =c(Sys.Date() - 30, NA), ylim = c(10, 20))
 For changing x or y axis limits \strong{without} dropping data
 observations, see \code{\link[=coord_cartesian]{coord_cartesian()}}. To expand the range of
 a plot to always include certain values, see \code{\link[=expand_limits]{expand_limits()}}. For other
-types of data, see \code{\link[=scale_x_discrete(), scale_x_continuous(), scale_x_date]{scale_x_discrete(), scale_x_continuous(), scale_x_date()}}.
+types of data, see \code{\link[=scale_x_discrete]{scale_x_discrete()}}, \code{\link[=scale_x_continuous]{scale_x_continuous()}}, \code{\link[=scale_x_date]{scale_x_date()}}.
 }


### PR DESCRIPTION
These are a few typo fixes from the last few PRs that might cause automatic checks to fail.