### PR TITLE
Change from `unit` to `margin` on line 133

### DIFF
--- a/R/theme.r
+++ b/R/theme.r
@@ -130,7 +130,7 @@
 #'   "top", "topright", "left", "right", "bottomleft", "bottom", "bottomright)
 #'   or a coordinate. If a string, extra space will be added to accommodate the
 #'   tag.
-#' @param plot.margin margin around entire plot (`unit` with the sizes of
+#' @param plot.margin margin around entire plot (`margin` with the sizes of
 #'   the top, right, bottom, and left margins)
 #'
 #' @param strip.background,strip.background.x,strip.background.y


### PR DESCRIPTION
Currently the documentation for `plot.margin` (line 133 of `theme.r`) reads: 

> "plot.margin | margin around entire plot (`unit` with the sizes of the top, right, bottom, and left margins)".

Although this suggests that `unit()` is required for the `plot.margin` specification, using it throws an error:
```
ggplot(mtcars) +
  geom_point(aes(x = disp, y = hp)) +
  theme(plot.margin = unit(50, "pt"))

**> Error in `[.unit`(theme$plot.margin, 2) : 
  index out of bounds ('unit' subsetting)**
```
...while this does not:

```
ggplot(mtcars) +
  geom_point(aes(x = disp, y = hp)) +
  theme(plot.margin = margin(50, 0, 0, 0))
```