### PR TITLE
Fix typo in ggtheme docs

### DIFF
--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -22,7 +22,7 @@
 #'
 #' \item{`theme_linedraw`}{
 #' A theme with only black lines of various widths on white backgrounds,
-#' reminiscent of a line drawings. Serves a purpose similar to `theme_bw`.
+#' reminiscent of a line drawing. Serves a purpose similar to `theme_bw`.
 #' Note that this theme has some very thin lines (<< 1 pt) which some journals
 #' may refuse.}
 #'

--- a/man/ggtheme.Rd
+++ b/man/ggtheme.Rd
@@ -70,7 +70,7 @@ displayed with a projector.}
 
 \item{\code{theme_linedraw}}{
 A theme with only black lines of various widths on white backgrounds,
-reminiscent of a line drawings. Serves a purpose similar to \code{theme_bw}.
+reminiscent of a line drawing. Serves a purpose similar to \code{theme_bw}.
 Note that this theme has some very thin lines (<< 1 pt) which some journals
 may refuse.}
 


### PR DESCRIPTION
"line drawings" into "line drawing".