### PR TITLE
Do not change order of positive and negative values in PositionStack

### DIFF
--- a/R/position-stack.r
+++ b/R/position-stack.r
@@ -195,7 +195,7 @@ PositionStack <- ggproto("PositionStack", Position,
       )
     }
 
-    rbind(neg, pos)
+    rbind(neg, pos)[match(seq_len(nrow(data)), c(which(negative), which(!negative))),]
   }
 )
 

--- a/tests/testthat/test-position-stack.R
+++ b/tests/testthat/test-position-stack.R
@@ -21,11 +21,11 @@ test_that("negative and positive values are handled separately", {
   p <- ggplot(df, aes(x, y, fill = factor(g))) + geom_col()
   dat <- layer_data(p)
 
-  expect_equal(dat$ymin[dat$x == 1], c(-1, 0, 1))
-  expect_equal(dat$ymax[dat$x == 1], c(0, 1, 2))
+  expect_equal(dat$ymin[dat$x == 1], c(0, -1, 1))
+  expect_equal(dat$ymax[dat$x == 1], c(1, 0, 2))
 
-  expect_equal(dat$ymin[dat$x == 2], c(-3, 0))
-  expect_equal(dat$ymax[dat$x == 2], c(0, 2))
+  expect_equal(dat$ymin[dat$x == 2], c(0, -3))
+  expect_equal(dat$ymax[dat$x == 2], c(2, 0))
 })
 
 test_that("can request reverse stacking", {
@@ -36,7 +36,7 @@ test_that("can request reverse stacking", {
   p <- ggplot(df, aes(1, y, fill = g)) +
     geom_col(position = position_stack(reverse = TRUE))
   dat <- layer_data(p)
-  expect_equal(dat$ymin, c(-2, -3, 0, 2))
+  expect_equal(dat$ymin, c(-2, 0, -3, 2))
 })
 
 test_that("data with no extent is stacked correctly", {


### PR DESCRIPTION
fixes #3390 

@karawoo I have checked that this fix does not cause regressions in #1552. Basically what this does is avoid positive and negative y-values to get reordered, not fiddle with the group-based reordering