### PR TITLE
Keep missingness of qplot() to label axis nicely

### DIFF
--- a/R/quick-plot.r
+++ b/R/quick-plot.r
@@ -71,13 +71,14 @@ qplot <- function(x, y, ..., data, facets = NULL, margins = FALSE,
   if (!missing(position)) warning("`position` is deprecated", call. = FALSE)
   if (!is.character(geom)) stop("`geom` must be a character vector", call. = FALSE)
 
-  exprs <- enquos(x = x, y = y, ..., .ignore_empty = "all")
+  exprs <- enquos(x = x, y = y, ...)
+  is_missing <- vapply(exprs, quo_is_missing, logical(1))
   # treat arguments as regular parameters if they are wrapped into I() or
   # if they don't have a name that is in the list of all aesthetics
   is_constant <- (!names(exprs) %in% ggplot_global$all_aesthetics) |
     vapply(exprs, quo_is_call, logical(1), name = "I")
 
-  mapping <- new_aes(exprs[!is_constant], env = parent.frame())
+  mapping <- new_aes(exprs[!is_missing & !is_constant], env = parent.frame())
 
   consts <- exprs[is_constant]
 


### PR DESCRIPTION
Closes #3467.

In #2936, I added `.ignore_empty = "all"` to `rlang::enquos()` in `aes()` and in `qplot()` to remove missing `x` and `y` automatically. But, as `qplot()` generates labels directly from the input, missingness should be kept there. This PR reverts #2936's changes about `qplot()`.

``` r
library(ggplot2)

set.seed(2009)
x <- rnorm(100)
qplot(x, geom = "histogram")
#> `stat_bin()` using `bins = 30`. Pick better value with `binwidth`.
```

![](https://i.imgur.com/pHMqqbs.png)

<sup>Created on 2019-08-06 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>