### PR TITLE
Allow select alpha to be applied on fill (default), colour, or both

### DIFF
--- a/R/geom-polygon.r
+++ b/R/geom-polygon.r
@@ -87,7 +87,7 @@ geom_polygon <- function(mapping = NULL, data = NULL,
                          na.rm = FALSE,
                          show.legend = NA,
                          alpha_to = c("fill", "colour", "color", "both")) {
-  alpha_to <- standardise_aes_names(match.arg(alpha_to))
+  alpha_to <- standardize_alpha_to(match.arg(alpha_to))
   layer(
     data = data,
     mapping = mapping,

--- a/R/geom-polygon.r
+++ b/R/geom-polygon.r
@@ -15,6 +15,8 @@
 #' @export
 #' @inheritParams layer
 #' @inheritParams geom_point
+#' @param alpha_to
+#'  Whether to apply alpha to "fill" (default), "colour" ("color"), or "both".
 #' @param rule Either `"evenodd"` or `"winding"`. If polygons with holes are
 #' being drawn (using the `subgroup` aesthetic) this argument defines how the
 #' hole coordinates are interpreted. See the examples in [grid::pathGrob()] for
@@ -84,7 +86,8 @@ geom_polygon <- function(mapping = NULL, data = NULL,
                          ...,
                          na.rm = FALSE,
                          show.legend = NA,
-                         inherit.aes = TRUE) {
+                         alpha_to = c("fill", "colour", "color", "both")) {
+  alpha_to <- standardise_aes_names(match.arg(alpha_to))
   layer(
     data = data,
     mapping = mapping,
@@ -96,6 +99,7 @@ geom_polygon <- function(mapping = NULL, data = NULL,
     params = list(
       na.rm = na.rm,
       rule = rule,
+      alpha_to = alpha_to,
       ...
     )
   )
@@ -106,7 +110,8 @@ geom_polygon <- function(mapping = NULL, data = NULL,
 #' @usage NULL
 #' @export
 GeomPolygon <- ggproto("GeomPolygon", Geom,
-  draw_panel = function(data, panel_params, coord, rule = "evenodd") {
+  draw_panel = function(data, panel_params, coord, rule = "evenodd",
+                        alpha_to = "fill") {
     n <- nrow(data)
     if (n == 1) return(zeroGrob())
 
@@ -128,8 +133,8 @@ GeomPolygon <- ggproto("GeomPolygon", Geom,
           munched$x, munched$y, default.units = "native",
           id = munched$group,
           gp = gpar(
-            col = first_rows$colour,
-            fill = alpha(first_rows$fill, first_rows$alpha),
+            col = alpha_col(first_rows$colour, first_rows$alpha, alpha_to),
+            fill = alpha_fill(first_rows$fill, first_rows$alpha, alpha_to),
             lwd = first_rows$size * .pt,
             lty = first_rows$linetype
           )

--- a/R/geom-rect.r
+++ b/R/geom-rect.r
@@ -10,7 +10,7 @@ geom_rect <- function(mapping = NULL, data = NULL,
                       show.legend = NA,
                       inherit.aes = TRUE,
                       alpha_to = c("fill", "colour", "color", "both")) {
-  alpha_to <- standardise_aes_names(match.arg(alpha_to))
+  alpha_to <- standardize_alpha_to(match.arg(alpha_to))
   layer(
     data = data,
     mapping = mapping,

--- a/R/geom-rect.r
+++ b/R/geom-rect.r
@@ -10,8 +10,7 @@ geom_rect <- function(mapping = NULL, data = NULL,
                       show.legend = NA,
                       inherit.aes = TRUE,
                       alpha_to = c("fill", "colour", "color", "both")) {
-  alpha_to <- match.arg(alpha_to)
-  if (alpha_to == "color") alpha_to <- "colour"
+  alpha_to <- standardise_aes_names(match.arg(alpha_to))
   layer(
     data = data,
     mapping = mapping,
@@ -56,16 +55,6 @@ GeomRect <- ggproto("GeomRect", Geom,
       ggname("bar", do.call("grobTree", polys))
     } else {
       coords <- coord$transform(data, panel_params)
-      alpha_fill <- if (alpha_to %in% c("fill", "both")) {
-        function(colour) alpha(colour, coords$alpha)
-      } else {
-        identity
-      }
-      alpha_colour <- if (alpha_to %in% c("colour", "both")) {
-        function(colour) alpha(colour, coords$alpha)
-      } else {
-        identity
-      }
       ggname("geom_rect", rectGrob(
         coords$xmin, coords$ymax,
         width = coords$xmax - coords$xmin,
@@ -73,8 +62,8 @@ GeomRect <- ggproto("GeomRect", Geom,
         default.units = "native",
         just = c("left", "top"),
         gp = gpar(
-          col = alpha_colour(coords$colour),
-          fill = alpha_fill(coords$fill),
+          col = alpha_col(coords$colour, coords$alpha, alpha_to),
+          fill = alpha_fill(coords$fill, coords$alpha, alpha_to),
           lwd = coords$size * .pt,
           lty = coords$linetype,
           linejoin = linejoin,

--- a/R/geom-ribbon.r
+++ b/R/geom-ribbon.r
@@ -41,7 +41,7 @@ geom_ribbon <- function(mapping = NULL, data = NULL,
                         show.legend = NA,
                         inherit.aes = TRUE,
                         alpha_to = c("fill", "colour", "color", "both")) {
-  alpha_to <- standardise_aes_names(match.arg(alpha_to))
+  alpha_to <- standardize_alpha_to(match.arg(alpha_to))
   layer(
     data = data,
     mapping = mapping,

--- a/R/geom-ribbon.r
+++ b/R/geom-ribbon.r
@@ -19,6 +19,8 @@
 #'   [geom_polygon()] for general polygons
 #' @inheritParams layer
 #' @inheritParams geom_point
+#' @param alpha_to
+#'  Whether to apply alpha to "fill" (default), "colour" ("color"), or "both".
 #' @export
 #' @examples
 #' # Generate data
@@ -37,7 +39,9 @@ geom_ribbon <- function(mapping = NULL, data = NULL,
                         ...,
                         na.rm = FALSE,
                         show.legend = NA,
-                        inherit.aes = TRUE) {
+                        inherit.aes = TRUE,
+                        alpha_to = c("fill", "colour", "color", "both")) {
+  alpha_to <- standardise_aes_names(match.arg(alpha_to))
   layer(
     data = data,
     mapping = mapping,
@@ -48,6 +52,7 @@ geom_ribbon <- function(mapping = NULL, data = NULL,
     inherit.aes = inherit.aes,
     params = list(
       na.rm = na.rm,
+      alpha_to = alpha_to,
       ...
     )
   )
@@ -78,7 +83,8 @@ GeomRibbon <- ggproto("GeomRibbon", Geom,
     data
   },
 
-  draw_group = function(data, panel_params, coord, na.rm = FALSE) {
+  draw_group = function(data, panel_params, coord, na.rm = FALSE,
+                        alpha_to = "fill") {
     if (na.rm) data <- data[stats::complete.cases(data[c("x", "ymin", "ymax")]), ]
     data <- data[order(data$group), ]
 
@@ -112,8 +118,8 @@ GeomRibbon <- ggproto("GeomRibbon", Geom,
       munched$x, munched$y, id = munched$id,
       default.units = "native",
       gp = gpar(
-        fill = alpha(aes$fill, aes$alpha),
-        col = aes$colour,
+        fill = alpha_fill(aes$fill, aes$alpha, alpha_to),
+        col = alpha_col(aes$colour, aes$alpha, alpha_to),
         lwd = aes$size * .pt,
         lty = aes$linetype)
     ))

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -18,6 +18,8 @@ alpha_col <- function(colour, alpha = NA, alpha_to = "fill") {
   colour
 }
 
+standardize_alpha_to <- function(x) sub("color", "colour", x, fixed = TRUE)
+
 "%||%" <- function(a, b) {
   if (!is.null(a)) a else b
 }

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -7,6 +7,17 @@
 #'   geom_point(colour = alpha("blue", 0.5))
 scales::alpha
 
+alpha_fill <- function(colour, alpha = NA, alpha_to = "fill") {
+  if (alpha_to %in% c("fill", "both")) return(alpha(colour, alpha))
+  colour
+}
+
+# alpha_to is "fill" by default for backward compatibility
+alpha_col <- function(colour, alpha = NA, alpha_to = "fill") {
+  if (alpha_to %in% c("colour", "both")) return(alpha(colour, alpha))
+  colour
+}
+
 "%||%" <- function(a, b) {
   if (!is.null(a)) a else b
 }

--- a/man/borders.Rd
+++ b/man/borders.Rd
@@ -21,6 +21,7 @@ polygons, see \code{\link[maps:map]{maps::map()}} for details.}
 
 \item{...}{Arguments passed on to \code{geom_polygon}
 \describe{
+  \item{alpha_to}{Whether to apply alpha to "fill" (default), "colour" ("color"), or "both".}
   \item{rule}{Either \code{"evenodd"} or \code{"winding"}. If polygons with holes are
 being drawn (using the \code{subgroup} aesthetic) this argument defines how the
 hole coordinates are interpreted. See the examples in \code{\link[grid:pathGrob]{grid::pathGrob()}} for
@@ -52,10 +53,6 @@ a call to a position adjustment function.}
 \code{FALSE} never includes, and \code{TRUE} always includes.
 It can also be a named logical vector to finely select the aesthetics to
 display.}
-  \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
-rather than combining with them. This is most useful for helper functions
-that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
   \item{na.rm}{If \code{FALSE}, the default, missing values are removed with
 a warning. If \code{TRUE}, missing values are silently removed.}
 }}

--- a/man/geom_polygon.Rd
+++ b/man/geom_polygon.Rd
@@ -6,7 +6,7 @@
 \usage{
 geom_polygon(mapping = NULL, data = NULL, stat = "identity",
   position = "identity", rule = "evenodd", ..., na.rm = FALSE,
-  show.legend = NA, inherit.aes = TRUE)
+  show.legend = NA, alpha_to = c("fill", "colour", "color", "both"))
 }
 \arguments{
 \item{mapping}{Set of aesthetic mappings created by \code{\link[=aes]{aes()}} or
@@ -54,10 +54,7 @@ a warning. If \code{TRUE}, missing values are silently removed.}
 It can also be a named logical vector to finely select the aesthetics to
 display.}
 
-\item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
-rather than combining with them. This is most useful for helper functions
-that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
+\item{alpha_to}{Whether to apply alpha to "fill" (default), "colour" ("color"), or "both".}
 }
 \description{
 Polygons are very similar to paths (as drawn by \code{\link[=geom_path]{geom_path()}})

--- a/man/geom_ribbon.Rd
+++ b/man/geom_ribbon.Rd
@@ -7,7 +7,7 @@
 \usage{
 geom_ribbon(mapping = NULL, data = NULL, stat = "identity",
   position = "identity", ..., na.rm = FALSE, show.legend = NA,
-  inherit.aes = TRUE)
+  inherit.aes = TRUE, alpha_to = c("fill", "colour", "color", "both"))
 
 geom_area(mapping = NULL, data = NULL, stat = "identity",
   position = "stack", na.rm = FALSE, show.legend = NA,
@@ -58,6 +58,8 @@ display.}
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
+
+\item{alpha_to}{Whether to apply alpha to "fill" (default), "colour" ("color"), or "both".}
 }
 \description{
 For each x value, \code{geom_ribbon()} displays a y interval defined

--- a/man/geom_tile.Rd
+++ b/man/geom_tile.Rd
@@ -13,7 +13,8 @@ geom_raster(mapping = NULL, data = NULL, stat = "identity",
 
 geom_rect(mapping = NULL, data = NULL, stat = "identity",
   position = "identity", ..., linejoin = "mitre", na.rm = FALSE,
-  show.legend = NA, inherit.aes = TRUE)
+  show.legend = NA, inherit.aes = TRUE, alpha_to = c("fill",
+  "colour", "color", "both"))
 
 geom_tile(mapping = NULL, data = NULL, stat = "identity",
   position = "identity", ..., linejoin = "mitre", na.rm = FALSE,
@@ -73,6 +74,8 @@ that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 
 \item{linejoin}{Line join style (round, mitre, bevel).}
+
+\item{alpha_to}{Whether to apply alpha to "fill" (default), "colour" ("color"), or "both".}
 }
 \description{
 \code{geom_rect} and \code{geom_tile} do the same thing, but are


### PR DESCRIPTION
This PR is related to https://github.com/tidyverse/ggplot2/issues/1371

In the discussion in #1371, a change was attempted to apply alpha both on `colour` and `fill`.
In this PR, we can select alpha to be applied on `fill` (default), `colour`, or `both`.
The default selection is `fill` and thus is safe in terms of backward compatibility.

Currently, `alpha_to` is implemented for `geom_polygon`, `geom_rect`, and `geom_ribbon`.
It works in some more (e.g., `geom_density`), but not all (`geom_bar`).
So I need some more to work on.

Before I update other functions, I'd like to ask @hadley if you like my PR.

## Examples

Varying `alpha_to` by `fill`, `colour`, and `both`

``` r
library(ggplot2)
d <- data.frame(xmin = 0, xmax = 1, ymin = 0:4, ymax = 1:5)
g <- ggplot(d) +
  aes(
    xmin = xmin, xmax = xmax, ymin = ymin, ymax = ymax,
    colour = ymin, alpha = ymin
  )
g + geom_rect(size = 3) # alpha_to = "fill"
```

![](https://i.imgur.com/2qgo8yX.png)

``` r
g + geom_rect(size = 3, alpha_to = "colour")
```

![](https://i.imgur.com/XacWGAe.png)

``` r
g + geom_rect(size = 3, alpha_to = "both")
```

![](https://i.imgur.com/s2Mcwkm.png)

<sup>Created on 2019-08-15 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

