### PR TITLE
Fix the discrete scale when all values are continuous

### DIFF
--- a/R/scale-discrete-.r
+++ b/R/scale-discrete-.r
@@ -83,17 +83,18 @@ ScaleDiscretePosition <- ggproto("ScaleDiscretePosition", ScaleDiscrete,
   },
 
   get_limits = function(self) {
-      if (self$is_empty()) {
-          c(0, 1)
-      } else if (!is.null(self$limits) & !is.function(self$limits)){
-          self$limits
-      } else if (is.null(self$limits)) {
-          self$range$range
-      } else if (is.function(self$limits)) {
-          self$limits(self$range$range)
-      } else {
-          integer(0)
-      }
+    # if scale contains no information, return the default limit
+    if (self$is_empty()) {
+      return(c(0, 1))
+    }
+
+    # if self$limits is not NULL and is a function, apply it to range
+    if (is.function(self$limits)){
+      return(self$limits(self$range$range))
+    }
+
+    # self$range$range can be NULL because non-discrete values use self$range_c
+    self$limits %||% self$range$range %||% integer()
   },
 
   is_empty = function(self) {

--- a/tests/testthat/test-scale-discrete.R
+++ b/tests/testthat/test-scale-discrete.R
@@ -62,6 +62,12 @@ test_that("discrete ranges also encompass continuous values", {
   expect_equal(x_range(base + geom_point(aes(x1)) + geom_point(aes(x2))), c(0, 4))
 })
 
+test_that("discrete ranges have limits even when all values are continuous", {
+  scale <- scale_x_discrete()
+  scale$train(1:3)
+  expect_identical(scale$get_limits(), integer())
+})
+
 test_that("discrete scale shrinks to range when setting limits", {
   df <- data_frame(x = letters[1:10], y = 1:10)
   p <- ggplot(df, aes(x, y)) + geom_point() +


### PR DESCRIPTION
Fix #3463

After #3426, the following fails because `scale$get_limits()` returns `NULL`. This PR fixes this by reverting `if` branches to the previous code while the functional limits are still accepted.

``` r
library(ggplot2)

df <- data.frame(x = c(0, 2, 4), y = 1:3, stringsAsFactors = FALSE)

ggplot(df, aes(x, y)) +
  geom_point() +
  scale_x_discrete()
#> Warning in structure(in_domain, pos = match(in_domain, breaks)): Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
#>   Consider 'structure(list(), *)' instead.

#> Warning in structure(in_domain, pos = match(in_domain, breaks)): Calling 'structure(NULL, *)' is deprecated, as NULL cannot have attributes.
#>   Consider 'structure(list(), *)' instead.
#> Error in UseMethod("rescale"): no applicable method for 'rescale' applied to an object of class "list"
```
<sup>Created on 2019-07-30 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

(As this bug only exists in the dev version, no NEWS bullet is needed here)