### PR TITLE
Let geom_sf() remove rows when shape, size or colour is NA

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,8 @@
   
 * `stat_density2d()` can now take an `adjust` parameter to scale the default bandwidth. (#2860, @haleyjeppson)
 
+* `geom_sf()` now removes rows that contain missing `shape`/`size`/`colour` (#3483, @yutannihilation)
+
 # ggplot2 3.2.1
 
 This is a patch release fixing a few regressions introduced in 3.2.0 as well as

--- a/R/geom-sf.R
+++ b/R/geom-sf.R
@@ -97,6 +97,8 @@ GeomSf <- ggproto("GeomSf", Geom,
                     stroke = 0.5
                   ),
 
+  non_missing_aes = c("size", "shape", "colour"),
+                  
   draw_panel = function(data, panel_params, coord, legend = NULL,
                         lineend = "butt", linejoin = "round", linemitre = 10) {
     if (!inherits(coord, "CoordSf")) {

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -76,10 +76,24 @@ test_that("geom_sf() removes rows containing missing aes", {
 
   pts <- sf::st_sf(
     geometry = sf::st_sfc(sf::st_point(0:1), sf::st_point(1:2)),
-    val_c = c(1, NA),
-    val_d = c("a", NA)
+    size = c(1, NA),
+    shape = c("a", NA),
+    colour = c("red", NA)
   )
 
-  expect_identical(grob_xy_length(ggplot(pts) + geom_sf(aes(size = val_c))), c(1L, 1L))
-  expect_identical(grob_xy_length(ggplot(pts) + geom_sf(aes(shape = val_d))), c(1L, 1L))
+  p <- ggplot(pts) + geom_sf()
+  expect_warning(
+    expect_identical(grob_xy_length(p + aes(size = size)), c(1L, 1L)),
+    "Removed 1 rows containing missing values"
+  )
+  expect_warning(
+    expect_identical(grob_xy_length(p + aes(shape = shape)), c(1L, 1L)),
+    "Removed 1 rows containing missing values"
+  )
+  # default colour scale maps a colour even to a NA, so identity scale is needed to see if NA is removed
+  expect_warning(
+    expect_identical(grob_xy_length(p + aes(colour = colour) + scale_colour_identity()),
+                     c(1L, 1L)),
+    "Removed 1 rows containing missing values"
+  )
 })

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -64,3 +64,22 @@ test_that("geom_sf_text() and geom_sf_label() draws correctly", {
     ggplot() + geom_sf_label(data = nc_3857, aes(label = NAME))
   )
 })
+
+test_that("geom_sf() removes rows containing missing aes", {
+  skip_if_not_installed("sf")
+  if (packageVersion("sf") < "0.5.3") skip("Need sf 0.5.3")
+
+  grob_xy_length <- function(x) {
+    g <- layer_grob(x)[[1]]
+    c(length(g$x), length(g$y))
+  }
+
+  pts <- sf::st_sf(
+    geometry = sf::st_sfc(sf::st_point(0:1), sf::st_point(1:2)),
+    val_c = c(1, NA),
+    val_d = c("a", NA)
+  )
+
+  expect_identical(grob_xy_length(ggplot(pts) + geom_sf(aes(size = val_c))), c(1L, 1L))
+  expect_identical(grob_xy_length(ggplot(pts) + geom_sf(aes(shape = val_d))), c(1L, 1L))
+})


### PR DESCRIPTION
Fix #3483

Currently, `GeomSf` doesn't have `non_missing_aes`, but it should be set to avoid errors reported on #3483. I chose `shape`, `size` and `colour` here because

* As `GeomSf` is a mix of points, lines, and polygons, it should use the combination of `non_missing_aes` of `GeomPoint`, `GeomLine` and `GeomPolygon`.
    * `GeomPoint` uses `shape`, `size` and `colour`
    * `GeomLine` and `GeomPolygon` don't have their `non_missing_aes`.
* For lines and polygons, `GeomSf` removes rows (e.g. the size is `NA`) that `GeomLine` and `GeomPolygon` won't. But, the result is the same; lines and polygons whose sizes are all `NA` won't be drawn. So, I think it's no problem to remove the whole rows.

``` r
devtools::load_all("~/repo/R/ggplot2")
#> Loading ggplot2

pts <- sf::st_sf(
  geometry = sf::st_sfc(sf::st_point(0:1), sf::st_point(1:2)),
  size = c(1, NA),
  shape = c("a", NA),
  colour = c("red", NA)
)

ggplot(pts) + geom_sf(aes(size = size))
#> Warning: Removed 1 rows containing missing values (geom_sf).
```

![](https://i.imgur.com/cAYOe4R.png)

``` r
ggplot(pts) + geom_sf(aes(shape = shape))
#> Warning: Removed 1 rows containing missing values (geom_sf).
```

![](https://i.imgur.com/kcVNK9P.png)

``` r

# default colour scale maps a colour even to a NA, so identity scale is needed to see if NA is removed
ggplot(pts) + geom_sf(aes(colour = colour)) + scale_colour_identity()
#> Warning: Removed 1 rows containing missing values (geom_sf).
```

![](https://i.imgur.com/fUhXGde.png)

<sup>Created on 2019-08-18 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
