### PR TITLE
Force eval_facets() to return a data.frame, not a tibble

### DIFF
--- a/R/facet-.r
+++ b/R/facet-.r
@@ -419,7 +419,7 @@ is_facets <- function(x) {
 # but that seems like a reasonable tradeoff.
 eval_facets <- function(facets, data, env = globalenv()) {
   vars <- compact(lapply(facets, eval_facet, data, env = env))
-  tibble::as_tibble(vars)
+  new_data_frame(tibble::as_tibble(vars))
 }
 eval_facet <- function(facet, data, env = emptyenv()) {
   if (quo_is_symbol(facet)) {


### PR DESCRIPTION
Closes #3489 (I think it should be fixed on tibble's side, though)

As we saw #3048, using tibble internally causes unexpected errors because the existing codes expects a bare data.frame. I think #3489 is just a bug on tibble's side, but, I believe it's better for ggplot2 internals to stick with a bare data.frame for consistency.

Note that this pull request leaves these two `tibble()` uses as is because they don't seem the cases when the result is used internally.

https://github.com/tidyverse/ggplot2/blob/b8420241309c8eea00d7086002c01cdf38a50eac/R/summarise-plot.R#L66-L70
https://github.com/tidyverse/ggplot2/blob/b8420241309c8eea00d7086002c01cdf38a50eac/R/summarise-plot.R#L134-L136