### PR TITLE
Added feature to separately color the middle line of crossbar and box…

### DIFF
--- a/R/geom-boxplot.r
+++ b/R/geom-boxplot.r
@@ -44,6 +44,10 @@
 #'   it only hides them, so the range calculated for the y-axis will be the
 #'   same with outliers shown and outliers hidden.
 #'
+#' @param separate.middle Controls whether to color the middle bar separately, 
+#'   default is `TRUE`, if `FALSE`, the middle bar is colored with the outline of the boxplot
+#' @param middle.colour, middle.color Set the color of middle bar separately, 
+#'   only effects when separate.middle is `TRUE`
 #' @param notch If `FALSE` (default) make a standard box plot. If
 #'   `TRUE`, make a notched box plot. Notches are used to compare groups;
 #'   if the notches of two boxes do not overlap, this suggests that the medians
@@ -112,6 +116,9 @@ geom_boxplot <- function(mapping = NULL, data = NULL,
                          outlier.size = 1.5,
                          outlier.stroke = 0.5,
                          outlier.alpha = NULL,
+                         separate.middle = TRUE,
+                         middle.colour = "grey20",
+                         middle.color = NULL,
                          notch = FALSE,
                          notchwidth = 0.5,
                          varwidth = FALSE,
@@ -144,6 +151,8 @@ geom_boxplot <- function(mapping = NULL, data = NULL,
       outlier.size = outlier.size,
       outlier.stroke = outlier.stroke,
       outlier.alpha = outlier.alpha,
+      separate.middle = separate.middle,
+      middle.colour = middle.color %||% middle.colour,
       notch = notch,
       notchwidth = notchwidth,
       varwidth = varwidth,
@@ -198,6 +207,8 @@ GeomBoxplot <- ggproto("GeomBoxplot", Geom,
                         outlier.shape = 19,
                         outlier.size = 1.5, outlier.stroke = 0.5,
                         outlier.alpha = NULL,
+                        separate.middle = TRUE,
+                        middle.colour = "grey20",
                         notch = FALSE, notchwidth = 0.5, varwidth = FALSE) {
 
     # this may occur when using geom_boxplot(stat = "identity")
@@ -262,8 +273,13 @@ GeomBoxplot <- ggproto("GeomBoxplot", Geom,
     ggname("geom_boxplot", grobTree(
       outliers_grob,
       GeomSegment$draw_panel(whiskers, panel_params, coord),
-      GeomCrossbar$draw_panel(box, fatten = fatten, panel_params, coord)
-    ))
+      GeomCrossbar$draw_panel(box, 
+                              fatten = fatten, 
+                              separate.middle = separate.middle,
+                              middle.colour = middle.colour,
+                              panel_params, coord)
+      )
+    )
   },
 
   draw_key = draw_key_boxplot,

--- a/R/geom-crossbar.r
+++ b/R/geom-crossbar.r
@@ -3,6 +3,9 @@
 geom_crossbar <- function(mapping = NULL, data = NULL,
                           stat = "identity", position = "identity",
                           ...,
+                          separate.middle = TRUE,
+                          middle.colour = "grey20",
+                          middle.color = NULL,
                           fatten = 2.5,
                           na.rm = FALSE,
                           show.legend = NA,
@@ -16,6 +19,8 @@ geom_crossbar <- function(mapping = NULL, data = NULL,
     show.legend = show.legend,
     inherit.aes = inherit.aes,
     params = list(
+    	separate.middle = separate.middle,
+      middle.colour = middle.color %||% middle.colour,
       fatten = fatten,
       na.rm = na.rm,
       ...
@@ -39,8 +44,17 @@ GeomCrossbar <- ggproto("GeomCrossbar", Geom,
 
   draw_key = draw_key_crossbar,
 
-  draw_panel = function(data, panel_params, coord, fatten = 2.5, width = NULL) {
+  draw_panel = function(data, 
+                        panel_params, 
+                        coord, fatten = 2.5, 
+                        width = NULL, 
+                        separate.middle = TRUE, 
+                        middle.colour = "grey20") {
     middle <- transform(data, x = xmin, xend = xmax, yend = y, size = size * fatten, alpha = NA)
+    
+    if (separate.middle) {
+      middle$colour <- middle.colour
+    }
 
     has_notch <- !is.null(data$ynotchlower) && !is.null(data$ynotchupper) &&
       !is.na(data$ynotchlower) && !is.na(data$ynotchupper)

--- a/R/legend-draw.r
+++ b/R/legend-draw.r
@@ -100,7 +100,7 @@ draw_key_boxplot <- function(data, params, size) {
     linesGrob(0.5, c(0.1, 0.25)),
     linesGrob(0.5, c(0.75, 0.9)),
     rectGrob(height = 0.5, width = 0.75),
-    linesGrob(c(0.125, 0.875), 0.5),
+    linesGrob(c(0.125, 0.875), 0.5, gp = if (params$separate.middle) {gpar(col = params$middle.colour %||% "grey20")}),
     gp = gpar(
       col = data$colour %||% "grey20",
       fill = alpha(data$fill %||% "white", data$alpha),
@@ -115,7 +115,7 @@ draw_key_boxplot <- function(data, params, size) {
 draw_key_crossbar <- function(data, params, size) {
   grobTree(
     rectGrob(height = 0.5, width = 0.75),
-    linesGrob(c(0.125, 0.875), 0.5),
+    linesGrob(c(0.125, 0.875), 0.5, gp = if (params$separate.middle) {gpar(col = params$middle.colour %||% "grey20")}),
     gp = gpar(
       col = data$colour %||% "grey20",
       fill = alpha(data$fill %||% "white", data$alpha),


### PR DESCRIPTION
…plot

To realize the minimalist style of boxplot like the one inside
http://biochemres.com/beautiful-minimalist-boxplots-with-r-and-ggplot2
Instead of adding extra geom_segment over geom_boxplot, now the color of middle bar can be colored separately by setting middle.colo(u)r. And this feature can be turned off by setting separate.middle = FALSE, the middle bar will be colored with the outline of boxplot/crossbar by the col parameter, which acts as what ggplot2 does currently