### PR TITLE
Add setup_params method to Geom

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* `Geom` now gains a `setup_params()` method in line with the other ggproto
+  classes (@thomasp85, #3509)
+
 * `element_text()` now issues a warning when vectorized arguments are provided, as in
   `colour = c("red", "green", "blue")`. Such use is discouraged and not officially supported
    (@clauswilke, #3492).

--- a/R/geom-.r
+++ b/R/geom-.r
@@ -104,6 +104,8 @@ Geom <- ggproto("Geom",
     stop("Not implemented")
   },
 
+  setup_params = function(data, params) params,
+
   setup_data = function(data, params) data,
 
   # Combine data with defaults and set aesthetics from parameters

--- a/R/layer.r
+++ b/R/layer.r
@@ -340,8 +340,8 @@ Layer <- ggproto("Layer", NULL,
       c(names(data), names(self$aes_params)),
       snake_class(self$geom)
     )
-
-    self$geom$setup_data(data, c(self$geom_params, self$aes_params))
+    self$geom_params <- self$geom$setup_params(data, c(self$geom_params, self$aes_params))
+    self$geom$setup_data(data, self$geom_params)
   },
 
   compute_position = function(self, data, layout) {


### PR DESCRIPTION
For unknown reasons `Geom` and subclasses doesn't have a `setup_params()` method. It may have not been needed before, but for consistency this PR add's it and calls it right before `setup_data()`

This will make certain parts of #3506 look better/more consistent