### PR TITLE
Improve error message for geom_density() when using y

### DIFF
--- a/R/stat-density.r
+++ b/R/stat-density.r
@@ -66,6 +66,13 @@ StatDensity <- ggproto("StatDensity", Stat,
   required_aes = "x",
   default_aes = aes(y = stat(density), fill = NA, weight = NULL),
 
+  setup_params = function(data, params) {
+    if (!is.null(data$y)) {
+      stop("stat_density() must not be used with a y aesthetic.", call. = FALSE)
+    }
+    params
+  },
+
   compute_group = function(data, scales, bw = "nrd0", adjust = 1, kernel = "gaussian",
                            n = 512, trim = FALSE, na.rm = FALSE) {
     if (trim) {

--- a/tests/testthat/test-stat-density.R
+++ b/tests/testthat/test-stat-density.R
@@ -12,3 +12,10 @@ test_that("compute_density returns useful df and throws warning when <2 values",
   expect_equal(names(dens), c("x", "density", "scaled", "ndensity", "count", "n"))
   expect_type(dens$x, "double")
 })
+
+test_that("stat_density throws error when y aesthetic is present", {
+  dat <- data_frame(x = 1:3, y = 1:3)
+
+  expect_error(ggplot_build(ggplot(dat, aes(x, y)) + stat_density()),
+    "must not be used with a y aesthetic.")
+})


### PR DESCRIPTION
Close #3514.

This PR make `StatDensity` raise a consistent error with other stats like `StatCount`.

``` r
devtools::load_all("~/Documents/repo/ggplot2/")
#> Loading ggplot2

library(ggplot2)

d <- base::data.frame(x = 1:3)

ggplot(d) +
  geom_density(aes(x, x))
#> Error: stat_density() must not be used with a y aesthetic.
```