### PR TITLE
Enable inheritance for derived theme elements

### DIFF
--- a/R/theme.r
+++ b/R/theme.r
@@ -655,7 +655,7 @@ combine_elements <- function(e1, e2) {
   }
 
   # If e1 has any NULL properties, inherit them from e2
-  n <- vapply(e1[names(e2)], is.null, logical(1))
+  n <- names(e1)[vapply(e1, is.null, logical(1))]
   e1[n] <- e2[n]
 
   # Calculate relative sizes

--- a/tests/testthat/test-theme.r
+++ b/tests/testthat/test-theme.r
@@ -99,6 +99,29 @@ test_that("calculating theme element inheritance works", {
   # Check that a theme_blank in a parent node gets passed along to children
   t <- theme_grey() + theme(text = element_blank())
   expect_identical(calc_element('axis.title.x', t), element_blank())
+
+  # Check that inheritance from derived class works
+  element_dummyrect <- function(dummy) { # like element_rect but w/ dummy argument
+    structure(list(
+      fill = NULL, colour = NULL, dummy = dummy, size = NULL,
+      linetype = NULL, inherit.blank = FALSE
+    ), class = c("element_dummyrect", "element_rect", "element"))
+  }
+
+  e <- calc_element(
+    "panel.background",
+    theme(
+      rect = element_rect(fill = "white", colour = "black", size = 0.5, linetype = 1),
+      panel.background = element_dummyrect(dummy = 5))
+  )
+
+  expect_identical(
+    e,
+    structure(list(
+      fill = "white", colour = "black", dummy = 5, size = 0.5, linetype = 1,
+      inherit.blank = FALSE
+    ), class = c("element_dummyrect", "element_rect", "element"))
+  )
 })
 
 test_that("complete and non-complete themes interact correctly with each other", {


### PR DESCRIPTION
This closes #3549.

``` r
library(ggplot2)

# like element_rect but with a meaningless dummy argument
element_dummyrect <- function(dummy) {
  structure(list(
    fill = NULL, colour = NULL, dummy = dummy, size = NULL,
    linetype = NULL, inherit.blank = FALSE
  ), class = c("element_dummyrect", "element_rect", "element"))
}

ggplot2:::calc_element(
  "panel.background",
  theme(
    rect = element_rect(fill = "white", colour = "black", size = 0.5, linetype = 1),
    panel.background = element_dummyrect(dummy = 5))
)
#> List of 6
#>  $ fill         : chr "white"
#>  $ colour       : chr "black"
#>  $ dummy        : num 5
#>  $ size         : num 0.5
#>  $ linetype     : num 1
#>  $ inherit.blank: logi FALSE
#>  - attr(*, "class")= chr [1:3] "element_dummyrect" "element_rect" "element"
```

<sup>Created on 2019-10-04 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>