### PR TITLE
Fix remove_missing() call in Stat$compute_layer()

### DIFF
--- a/R/stat-.r
+++ b/R/stat-.r
@@ -76,8 +76,15 @@ Stat <- ggproto("Stat",
       snake_class(self)
     )
 
+    # Make sure required_aes consists of the used set of aesthetics in case of
+    # "|" notation in self$required_aes
+    required_aes <- intersect(
+      names(data),
+      unlist(strsplit(self$required_aes, "|", fixed = TRUE))
+    )
+
     data <- remove_missing(data, params$na.rm,
-      c(self$required_aes, self$non_missing_aes),
+      c(required_aes, self$non_missing_aes),
       snake_class(self),
       finite = TRUE
     )


### PR DESCRIPTION
Fix #3548 

The old call to `remove_missing()` in `Stat$compute_layer()` did not factor in the new `x|y` notation allowed in `Stat$required_aes` for bidirectional layers. This caused missing data to not be removed correctly. This PR fixes the problem