### PR TITLE
Clean up theme addition

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,10 @@
   `colour = c("red", "green", "blue")`. Such use is discouraged and not officially supported
    (@clauswilke, #3492).
 
+* Addition of partial themes to plots has been made more predictable;
+  stepwise addition of individual partial themes is now equivalent to
+  addition of multple theme elements at once (@clauswilke, #3039).
+
 * stacking text when calculating the labels and the y axis with
   `stat_summary()` now works (@ikosmidis, #2709)
 

--- a/R/plot-construction.r
+++ b/R/plot-construction.r
@@ -101,7 +101,7 @@ ggplot_add.data.frame <- function(object, plot, object_name) {
 }
 #' @export
 ggplot_add.theme <- function(object, plot, object_name) {
-  plot$theme <- update_theme(plot$theme, object)
+  plot$theme <- add_theme(plot$theme, object)
   plot
 }
 #' @export

--- a/R/theme-current.R
+++ b/R/theme-current.R
@@ -72,7 +72,7 @@ theme_get <- function() {
 #' @param new new theme (a list of theme elements)
 #' @export
 theme_set <- function(new) {
-  missing <- setdiff(names(theme_gray()), names(new))
+  missing <- setdiff(names(ggplot_global$theme_grey), names(new))
   if (length(missing) > 0) {
     warning("New theme missing the following elements: ",
       paste(missing, collapse = ", "), call. = FALSE)

--- a/R/theme.r
+++ b/R/theme.r
@@ -519,8 +519,8 @@ calc_element <- function(element, theme, verbose = FALSE) {
       return(el_out) # no null properties, return element as is
     }
 
-    # if we have null properties, try to fill in from theme_gray()
-    el_out <- combine_elements(el_out, theme_gray()[[element]])
+    # if we have null properties, try to fill in from theme_grey()
+    el_out <- combine_elements(el_out, ggplot_global$theme_grey[[element]])
     nullprops <- vapply(el_out, is.null, logical(1))
     if (!any(nullprops)) {
       return(el_out) # no null properties remaining, return element

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -33,7 +33,9 @@ pathGrob <- NULL
 
   .zeroGrob <<- grob(cl = "zeroGrob", name = "NULL")
 
-  ggplot_global$theme_current <- theme_gray()
+  # create default theme, store for later use, and set as current theme
+  ggplot_global$theme_grey <- theme_grey()
+  ggplot_global$theme_current <- ggplot_global$theme_grey
 
   # Used by rbind_dfs
   date <- Sys.Date()

--- a/tests/testthat/test-theme.r
+++ b/tests/testthat/test-theme.r
@@ -73,6 +73,18 @@ test_that("adding theme object to ggplot object with + operator works", {
   expect_null(p$theme$text$lineheight)
   expect_null(p$theme$text$margin)
   expect_null(p$theme$text$debug)
+
+  ## stepwise addition of partial themes is identical to one-step addition
+  p <- qplot(1:3, 1:3)
+  p1 <- p + theme_light() +
+    theme(axis.line.x = element_line(color = "blue")) +
+    theme(axis.ticks.x = element_line(color = "red"))
+
+  p2 <- p + theme_light() +
+    theme(axis.line.x = element_line(color = "blue"),
+          axis.ticks.x = element_line(color = "red"))
+
+  expect_identical(p1$theme, p2$theme)
 })
 
 test_that("replacing theme elements with %+replace% operator works", {

--- a/tests/testthat/test-theme.r
+++ b/tests/testthat/test-theme.r
@@ -42,8 +42,8 @@ test_that("modifying theme element properties with + operator works", {
 })
 
 test_that("adding theme object to ggplot object with + operator works", {
-
-  p <- qplot(1:3, 1:3)
+  ## test with complete theme
+  p <- qplot(1:3, 1:3) + theme_grey()
   p <- p + theme(axis.title = element_text(size = 20))
   expect_true(p$theme$axis.title$size == 20)
 
@@ -55,6 +55,24 @@ test_that("adding theme object to ggplot object with + operator works", {
   expect_true(tt$inherit.blank)
   tt$inherit.blank <- FALSE
   expect_identical(p$theme$text, tt)
+
+  ## test without complete theme
+  p <- qplot(1:3, 1:3)
+  p <- p + theme(axis.title = element_text(size = 20))
+  expect_true(p$theme$axis.title$size == 20)
+
+  # Should update specified properties, but not reset other properties
+  p <- p + theme(text = element_text(colour = 'red'))
+  expect_true(p$theme$text$colour == 'red')
+  expect_null(p$theme$text$family)
+  expect_null(p$theme$text$face)
+  expect_null(p$theme$text$size)
+  expect_null(p$theme$text$hjust)
+  expect_null(p$theme$text$vjust)
+  expect_null(p$theme$text$angle)
+  expect_null(p$theme$text$lineheight)
+  expect_null(p$theme$text$margin)
+  expect_null(p$theme$text$debug)
 })
 
 test_that("replacing theme elements with %+replace% operator works", {
@@ -112,14 +130,16 @@ test_that("calculating theme element inheritance works", {
     "panel.background",
     theme(
       rect = element_rect(fill = "white", colour = "black", size = 0.5, linetype = 1),
-      panel.background = element_dummyrect(dummy = 5))
+      panel.background = element_dummyrect(dummy = 5),
+      complete = TRUE # need to prevent pulling in default theme
+    )
   )
 
   expect_identical(
     e,
     structure(list(
       fill = "white", colour = "black", dummy = 5, size = 0.5, linetype = 1,
-      inherit.blank = FALSE
+      inherit.blank = TRUE # this is true because we're requesting a complete theme
     ), class = c("element_dummyrect", "element_rect", "element"))
   )
 })


### PR DESCRIPTION
Here is an attempt at fixing #3039. Recall: That issue shows that adding theme elements piecewise behaves differently from adding them all at once. The problem is that when adding a theme to a plot object, the current implementation pulls missing info from the default theme, but this is not the case when adding a theme to a theme. In my mind, this behavior is inconsistent. The addition should behave the same in both cases. The solution is to delete the plot-specific update function.

This is the reprex from #3039, which now works just fine:
``` r
library(ggplot2)

p <- ggplot(mtcars, aes(wt, mpg)) + geom_point()
p1 <- p + theme_light() + 
  theme(axis.line.x = element_line(color = "blue")) +
  theme(axis.ticks.x = element_line(color = "red"))

p2 <- p + theme_light() +
  theme(axis.line.x = element_line(color = "blue"),
        axis.ticks.x = element_line(color = "red"))

identical(p1$theme, p2$theme)
#> [1] TRUE

p1
```

![](https://i.imgur.com/EYZDk2I.png)

``` r
p2
```

![](https://i.imgur.com/QESJWpC.png)

<sup>Created on 2019-10-14 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup> 

However, this is potentially a breaking change (and in fact, some unit tests currently break), because partially updating root elements of a theme doesn't work anymore:
(**Update:** This has now been fixed, see below.)
``` r
library(ggplot2)

# this now breaks but works in current ggplot2 by magically pulling info from default theme
ggplot(iris, aes(Sepal.Length, Sepal.Width)) +
  geom_point() +
  theme(text = element_text(color = "red"))
#> Error in FUN(X[[i]], ...): Theme element 'text' has NULL property: family, face, size, hjust, vjust, angle, lineheight, margin, debug

# this still works
ggplot(iris, aes(Sepal.Length, Sepal.Width)) +
  geom_point() +
  theme(axis.title = element_text(color = "red"))
```

![](https://i.imgur.com/y44DTFz.png)

<sup>Created on 2019-10-14 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

I think the new behavior is correct. If we're messing with a root element, we should have to specify it completely. However, if that's considered to be bad, we could also fix the problem at this point in the code:
https://github.com/tidyverse/ggplot2/blob/115c3960d0fd068f1ca4cfe4650c0e0474aabba5/R/theme.r#L558-L565
by pulling values from the ggplot2 default theme where available instead of issuing an error.