### PR TITLE
fix a bug in ScaleBinned$get_breaks()

### DIFF
--- a/R/scale-.r
+++ b/R/scale-.r
@@ -989,8 +989,15 @@ ScaleBinned <- ggproto("ScaleBinned", Scale,
         self$limits <- self$trans$transform(limits)
       }
     } else if (is.function(self$breaks)) {
-      n.breaks <- self$n.breaks %||% 5 # same default as trans objects
-      breaks <- self$breaks(limits, n.breaks)
+      if ("n.breaks" %in% names(formals(environment(self$breaks)$f))) {
+        n.breaks <- self$n.breaks %||% 5 # same default as trans objects
+        breaks <- self$breaks(limits, n.breaks)
+      } else {
+        if (!is.null(self$n.breaks)) {
+          warning("Ignoring n.breaks. Use a breaks function that supports setting number of breaks", call. = FALSE)
+        }
+        breaks <- self$breaks(limits)
+      }      
     } else {
       breaks <- self$breaks
     }

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -989,7 +989,8 @@ ScaleBinned <- ggproto("ScaleBinned", Scale,
         self$limits <- self$trans$transform(limits)
       }
     } else if (is.function(self$breaks)) {
-      breaks <- self$breaks(limits, self$n_bins)
+      n.breaks <- self$n.breaks %||% 5 # same default as trans objects
+      breaks <- self$breaks(limits, n.breaks)
     } else {
       breaks <- self$breaks
     }

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -991,7 +991,7 @@ ScaleBinned <- ggproto("ScaleBinned", Scale,
     } else if (is.function(self$breaks)) {
       if ("n.breaks" %in% names(formals(environment(self$breaks)$f))) {
         n.breaks <- self$n.breaks %||% 5 # same default as trans objects
-        breaks <- self$breaks(limits, n.breaks)
+        breaks <- self$breaks(limits, n.breaks = n.breaks)
       } else {
         if (!is.null(self$n.breaks)) {
           warning("Ignoring n.breaks. Use a breaks function that supports setting number of breaks", call. = FALSE)


### PR DESCRIPTION
this pull request try to fix the bug in issue #3574 . 

I set n.breaks as the second parameter of breaks function.
if the n.breaks is not set by users, it will set to the default value 5, which is the same default as trans objects.

n.breaks can be set by end users.
So, after this fix, users can get meaningful breaks by set breaks as a function and get meaningful breaks using the values of limits and n.breaks.