### PR TITLE
Better secondary axis tick positioning

### DIFF
--- a/R/axis-secondary.R
+++ b/R/axis-secondary.R
@@ -201,12 +201,32 @@ AxisSecondary <- ggproto("AxisSecondary", NULL,
       range_info <- temp_scale$break_info()
 
       # Map the break values back to their correct position on the primary scale
-      old_val <- lapply(range_info$major_source, function(x) which.min(abs(full_range - x)))
-      old_val <- old_range[unlist(old_val)]
+      old_val <- sapply(range_info$major_source, function(x) {
+                which_less <- full_range < x
+                index_lower <- which(which_less & (abs(full_range - x) == min(abs(full_range[which_less] - x))))
+
+                which_greater <- full_range > x
+                index_upper <- which(which_greater & abs(full_range - x) == min(abs(full_range[which_greater] - x)))
+
+                index <- c(index_lower, index_upper)
+
+                offset <- approx(full_range[index], c(0, 1), x)$y
+                approx(c(0, 1), old_range[index], offset)$y
+            })
       old_val_trans <- scale$trans$transform(old_val)
 
-      old_val_minor <- lapply(range_info$minor_source, function(x) which.min(abs(full_range - x)))
-      old_val_minor <- old_range[unlist(old_val_minor)]
+      old_val_minor <- sapply(range_info$minor_source, function(x) {
+                which_less <- full_range < x
+                index_lower <- which(which_less & (abs(full_range - x) == min(abs(full_range[which_less] - x))))
+
+                which_greater <- full_range > x
+                index_upper <- which(which_greater & abs(full_range - x) == min(abs(full_range[which_greater] - x)))
+
+                index <- c(index_lower, index_upper)
+
+                offset <- approx(full_range[index], c(0, 1), x)$y
+                approx(c(0, 1), old_range[index], offset)$y
+            })
       old_val_minor_trans <- scale$trans$transform(old_val_minor)
 
       # rescale values from 0 to 1


### PR DESCRIPTION
This PR suggests a solution that addresses issue #3576.
When plotting the secondary axis, tick positions of the secondary should be transformed to the range of the primary axis (`AxisSecondary$break_info()`). To achieve this, a grid (`old_range`) is generated (of the size `AxisSecondary$detail`, defaulted to `1000`). This grid is then transformed to the secondary axis scale (named `full_range`). Each tick of the secondary axis is transformed to the primary's scale by finding the `index` of the closest value in the `full_range` (`index <- which.min(abs(full_range - x))`) and adopting `old_range[index]` as tick position in the primary axis scale. 

It is easy to understand that if `full_range` does not contain values equal to the secondary axis ticks, transformation is not accurate and the quality of this transformation depends on the grid size. This is observed in #3576, when duplicated axis (`dup_axis`) cannot properly position its ticks.

A simple alternative solution is to introduce linear interpolation. Instead of using the closest grid value, it is better to use two grid values and interpolate in between to increase the quality of the transformation. This works exceptionally well in the case of linear transformations of the secondary axis, including duplicated axes (`dup_axis`).

The method works well for different combinations of primary/secondary transformations, including when one axis is monotonically increasing while another is decreasing. There are no checks for boundary cases, i.e. when ticks are found at the edges of the grid, which I assume never happens.
