### PR TITLE
Explicitly define all theme elements

### DIFF
--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -236,7 +236,7 @@ theme_grey <- function(base_size = 11, base_family = "",
   )
 
   # make sure all elements are set to NULL if not explicitly defined
-  theme_all_null() %+replace% t
+  ggplot_global$theme_all_null %+replace% t
 }
 #' @export
 #' @rdname ggtheme
@@ -513,7 +513,7 @@ theme_void <- function(base_size = 11, base_family = "",
   )
 
   # make sure all elements are set to NULL if not explicitly defined
-  theme_all_null() %+replace% t
+  ggplot_global$theme_all_null %+replace% t
 }
 
 
@@ -647,7 +647,7 @@ theme_test <- function(base_size = 11, base_family = "",
   )
 
   # make sure all elements are set to NULL if not explicitly defined
-  theme_all_null() %+replace% t
+  ggplot_global$theme_all_null %+replace% t
 }
 
 theme_all_null <- function() {

--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -111,7 +111,7 @@ theme_grey <- function(base_size = 11, base_family = "",
   # Throughout the theme, we use three font sizes, `base_size` (`rel(1)`)
   # for normal, `rel(0.8)` for small, and `rel(1.2)` for large.
 
-  theme(
+  t <- theme(
     # Elements in this first block aren't used directly, but are inherited
     # by others
     line =               element_line(
@@ -234,6 +234,9 @@ theme_grey <- function(base_size = 11, base_family = "",
 
     complete = TRUE
   )
+
+  # make sure all elements are set to NULL if not explicitly defined
+  theme_all_null() %+replace% t
 }
 #' @export
 #' @rdname ggtheme
@@ -455,7 +458,7 @@ theme_void <- function(base_size = 11, base_family = "",
   half_line <- base_size / 2
 
   # Only keep indispensable text: legend and plot titles
-  theme(
+  t <- theme(
     line =               element_blank(),
     rect =               element_blank(),
     text =               element_text(
@@ -508,6 +511,9 @@ theme_void <- function(base_size = 11, base_family = "",
 
     complete = TRUE
   )
+
+  # make sure all elements are set to NULL if not explicitly defined
+  theme_all_null() %+replace% t
 }
 
 
@@ -518,7 +524,7 @@ theme_test <- function(base_size = 11, base_family = "",
                        base_rect_size = base_size / 22) {
   half_line <- base_size / 2
 
-  theme(
+  t <- theme(
     line =               element_line(
                            colour = "black", size = base_line_size,
                            linetype = 1, lineend = "butt"
@@ -639,4 +645,19 @@ theme_test <- function(base_size = 11, base_family = "",
 
     complete = TRUE
   )
+
+  # make sure all elements are set to NULL if not explicitly defined
+  theme_all_null() %+replace% t
+}
+
+theme_all_null <- function() {
+  # set all elements in the element tree to NULL
+  elements <- sapply(
+    names(ggplot_global$element_tree),
+    function(x) NULL,
+    simplify = FALSE, USE.NAMES = TRUE
+  )
+
+  args <- c(elements, list(complete = TRUE))
+  do.call(theme, args)
 }

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -34,6 +34,7 @@ pathGrob <- NULL
   .zeroGrob <<- grob(cl = "zeroGrob", name = "NULL")
 
   # create default theme, store for later use, and set as current theme
+  ggplot_global$theme_all_null <- theme_all_null() # required by theme_grey()
   ggplot_global$theme_grey <- theme_grey()
   ggplot_global$theme_current <- ggplot_global$theme_grey
 

--- a/tests/testthat/test-theme.r
+++ b/tests/testthat/test-theme.r
@@ -484,3 +484,38 @@ test_that("plot titles and caption can be aligned to entire plot", {
   expect_doppelganger("caption aligned to entire plot", plot)
 
 })
+
+test_that("provided themes explicitly define all elements", {
+  elements <- names(ggplot_global$element_tree)
+
+  t <- theme_all_null()
+  expect_true(all(names(t) %in% elements))
+  expect_true(all(vapply(t, is.null, logical(1))))
+
+  t <- theme_grey()
+  expect_true(all(names(t) %in% elements))
+
+  t <- theme_bw()
+  expect_true(all(names(t) %in% elements))
+
+  t <- theme_linedraw()
+  expect_true(all(names(t) %in% elements))
+
+  t <- theme_light()
+  expect_true(all(names(t) %in% elements))
+
+  t <- theme_dark()
+  expect_true(all(names(t) %in% elements))
+
+  t <- theme_minimal()
+  expect_true(all(names(t) %in% elements))
+
+  t <- theme_classic()
+  expect_true(all(names(t) %in% elements))
+
+  t <- theme_void()
+  expect_true(all(names(t) %in% elements))
+
+  t <- theme_test()
+  expect_true(all(names(t) %in% elements))
+})


### PR DESCRIPTION
This PR closes #3584 by making sure every theme explicitly defines every possible theme element. The strategy is to simply set every element that hasn't been defined explicitly to `NULL`. This can be done programmatically in a few lines of code. 