### PR TITLE
Change minor_breaks interface

### DIFF
--- a/R/scale-.r
+++ b/R/scale-.r
@@ -24,7 +24,8 @@
 #'   - `waiver()` for the default breaks (one minor break between
 #'     each major break)
 #'   - A numeric vector of positions
-#'   - A function that given the limits returns a vector of minor breaks.
+#'   - A function passed the limits and major breaks, which should return a
+#'     vector of minor breaks.
 #' @param labels One of:
 #'   - `NULL` for no labels
 #'   - `waiver()` for the default labels computed by the
@@ -613,8 +614,15 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
         breaks <- self$trans$minor_breaks(b, limits, n)
       }
     } else if (is.function(self$minor_breaks)) {
-      # Find breaks in data space, and convert to numeric
-      breaks <- self$minor_breaks(self$trans$inverse(limits))
+      breaks_fun <- self$minor_breaks
+
+      if (length(formals(breaks_fun)) == 1) {
+        # Old API just gets limits
+        breaks <- breaks_fun(self$trans$inverse(limits))
+      } else {
+        # New API gets limits and breaks
+        breaks <- breaks_fun(self$trans$inverse(limits), b)
+      }
       breaks <- self$trans$transform(breaks)
     } else {
       breaks <- self$trans$transform(self$minor_breaks)

--- a/man/continuous_scale.Rd
+++ b/man/continuous_scale.Rd
@@ -41,7 +41,8 @@ as output (e.g., a function returned by \code{\link[scales:extended_breaks]{scal
 \item \code{waiver()} for the default breaks (one minor break between
 each major break)
 \item A numeric vector of positions
-\item A function that given the limits returns a vector of minor breaks.
+\item A function passed the limits and major breaks, which should return a
+vector of minor breaks.
 }}
 
 \item{labels}{One of:

--- a/man/scale_continuous.Rd
+++ b/man/scale_continuous.Rd
@@ -57,7 +57,8 @@ as output (e.g., a function returned by \code{\link[scales:extended_breaks]{scal
 \item \code{waiver()} for the default breaks (one minor break between
 each major break)
 \item A numeric vector of positions
-\item A function that given the limits returns a vector of minor breaks.
+\item A function passed the limits and major breaks, which should return a
+vector of minor breaks.
 }}
 
 \item{labels}{One of:

--- a/man/scale_gradient.Rd
+++ b/man/scale_gradient.Rd
@@ -69,7 +69,8 @@ as output (e.g., a function returned by \code{\link[scales:extended_breaks]{scal
 \item \code{waiver()} for the default breaks (one minor break between
 each major break)
 \item A numeric vector of positions
-\item A function that given the limits returns a vector of minor breaks.
+\item A function passed the limits and major breaks, which should return a
+vector of minor breaks.
 }}
   \item{labels}{One of:
 \itemize{

--- a/man/scale_size.Rd
+++ b/man/scale_size.Rd
@@ -116,7 +116,8 @@ as output (e.g., a function returned by \code{\link[scales:extended_breaks]{scal
 \item \code{waiver()} for the default breaks (one minor break between
 each major break)
 \item A numeric vector of positions
-\item A function that given the limits returns a vector of minor breaks.
+\item A function passed the limits and major breaks, which should return a
+vector of minor breaks.
 }}
   \item{labels}{One of:
 \itemize{


### PR DESCRIPTION
To pass in both limits and major breaks. This will make it much easier to create useful families of minor break functions in scales.

Fixes #3583

@thomasp85 — if you think this approach is reasonable I'll work on a NEWS bullet. I think documentation will need to happen in a separate PR because all of `breaks`, `labels`, and `minor_breaks` need revision to point to the reader towards the scales package.