### PR TITLE
Fix guide_bins() when the data has no size

### DIFF
--- a/R/guide-bins.R
+++ b/R/guide-bins.R
@@ -322,6 +322,8 @@ guide_gengrob.bins <- function(guide, theme) {
     lapply(guide$geoms, function(g) g$data$size / 10)
   )
 
+  # key_size_mat can be an empty matrix (e.g. the data doesn't contain size
+  # column), so subset it only when it has any rows and columns.
   if (nrow(key_size_mat) == 0 || ncol(key_size_mat) == 0) {
     key_size_mat <- matrix(0, ncol = 1, nrow = n_keys)
   } else {

--- a/R/guide-bins.R
+++ b/R/guide-bins.R
@@ -320,10 +320,12 @@ guide_gengrob.bins <- function(guide, theme) {
 
   key_size_mat <- do.call("cbind",
     lapply(guide$geoms, function(g) g$data$size / 10)
-  )[seq_len(n_keys), , drop = FALSE]
+  )
 
   if (nrow(key_size_mat) == 0 || ncol(key_size_mat) == 0) {
     key_size_mat <- matrix(0, ncol = 1, nrow = n_keys)
+  } else {
+    key_size_mat <- key_size_mat[seq_len(n_keys), , drop = FALSE]
   }
   key_sizes <- apply(key_size_mat, 1, max)
 


### PR DESCRIPTION
Fix #3582

The result of `do.call("cbind", lapply(guide$geoms, function(g) g$data$size / 10))` can be an empty matrix, which cannot be subsetted. I guess the branch `if (nrow(key_size_mat) == 0 || ncol(key_size_mat) == 0) {` is prepared to handle this.