### PR TITLE
Add after_script to ensure the documents are regenerated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ after_success:
 
 after_script:
   # make sure the documents are regenerated
-  - Rscript -e 'devtools::documents()'
+  - Rscript -e 'devtools::document()'
   - |
     if [ -n "$(git diff --name-only man)" ]; then
       echo "Did you forget to regenerated the documents? (This error might be ignorable)."

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,15 @@ env:
 after_success:
   - Rscript -e 'covr::codecov()'
 
+after_script:
+  # make sure the documents are regenerated
+  - Rscript -e 'devtools::documents()'
+  - |
+    if [ -n "$(git diff --name-only man)" ]; then
+      echo "Did you forget to regenerated the documents? (This error might be ignorable)."
+      exit 1
+    fi
+
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ after_script:
   - Rscript -e 'devtools::document()'
   - |
     if [ -n "$(git diff --name-only man)" ]; then
-      echo "Did you forget to regenerated the documents? (This error might be ignorable)."
+      echo "Did you forget to regenerate the documents? (This error might be ignorable)."
       exit 1
     fi
 


### PR DESCRIPTION
It's a common mistake to forget to run `devtools::documents()`, but it's hard to detect them by reviewing on GitHub. It would be nice if it can be detected on Travis CI. This PR adds an `after_script` for this; the error might be false positive so it can be ignored by manually checking the CI results.