### PR TITLE
Fix guide merging when there are repeated labels

### DIFF
--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -230,7 +230,8 @@ guide_train.legend <- function(guide, scale, aesthetic = NULL) {
 
 #' @export
 guide_merge.legend <- function(guide, new_guide) {
-  guide$key <- merge(guide$key, new_guide$key, sort = FALSE)
+  new_guide$key$.label <- NULL
+  guide$key <- cbind(guide$key, new_guide$key)
   guide$override.aes <- c(guide$override.aes, new_guide$override.aes)
   if (any(duplicated(names(guide$override.aes)))) {
     warning("Duplicated override.aes is ignored.")

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -122,7 +122,6 @@ test_that("guide merging for guide_legend() works as expected", {
     scales$add(scale1)
     scales$add(scale2)
 
-    direction <- "vertical"
     guide_list <- guides_train(scales, theme = theme_gray(), labels = labs(), guides = guides())
     guides_merge(guide_list)
   }

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -155,6 +155,13 @@ test_that("guide merging for guide_legend() works as expected", {
   )
   expect_length(same_labels_different_scale, 1)
   expect_equal(same_labels_different_scale[[1]]$key$.label, c("a", "b", "c"))
+
+  repeated_identical_labels <- merge_test_guides(
+    scale_colour_discrete(limits = c("one", "two", "three"), labels = c("label1", "label1", "label2")),
+    scale_linetype_discrete(limits = c("1", "2", "3"), labels = c("label1", "label1", "label2"))
+  )
+  expect_length(repeated_identical_labels, 1)
+  expect_equal(repeated_identical_labels[[1]]$key$.label, c("label1", "label1", "label2"))
 })
 
 # Visual tests ------------------------------------------------------------

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -113,6 +113,50 @@ test_that("Using non-position guides for position scales results in an informati
   expect_error(ggplot_gtable(built), "does not implement guide_transform()")
 })
 
+test_that("guide merging for guide_legend() works as expected", {
+
+  merge_test_guides <- function(scale1, scale2) {
+    scale1$guide <- guide_legend(direction = "vertical")
+    scale2$guide <- guide_legend(direction = "vertical")
+    scales <- scales_list()
+    scales$add(scale1)
+    scales$add(scale2)
+
+    direction <- "vertical"
+    guide_list <- guides_train(scales, theme = theme_gray(), labels = labs(), guides = guides())
+    guides_merge(guide_list)
+  }
+
+  different_limits <- merge_test_guides(
+    scale_colour_discrete(limits = c("a", "b", "c", "d")),
+    scale_linetype_discrete(limits = c("a", "b", "c"))
+  )
+  expect_length(different_limits, 2)
+  expect_equal(different_limits[[1]]$key$.label, c("a", "b", "c", "d"))
+  expect_equal(different_limits[[2]]$key$.label, c("a", "b", "c"))
+
+  same_limits <- merge_test_guides(
+    scale_colour_discrete(limits = c("a", "b", "c")),
+    scale_linetype_discrete(limits = c("a", "b", "c"))
+  )
+  expect_length(same_limits, 1)
+  expect_equal(same_limits[[1]]$key$.label, c("a", "b", "c"))
+
+  same_labels_different_limits <- merge_test_guides(
+    scale_colour_discrete(limits = c("a", "b", "c")),
+    scale_linetype_discrete(limits = c("one", "two", "three"), labels = c("a", "b", "c"))
+  )
+  expect_length(same_labels_different_limits, 1)
+  expect_equal(same_labels_different_limits[[1]]$key$.label, c("a", "b", "c"))
+
+  same_labels_different_scale <- merge_test_guides(
+    scale_colour_continuous(limits = c(0, 4), breaks = 1:3, labels = c("a", "b", "c")),
+    scale_linetype_discrete(limits = c("a", "b", "c"))
+  )
+  expect_length(same_labels_different_scale, 1)
+  expect_equal(same_labels_different_scale[[1]]$key$.label, c("a", "b", "c"))
+})
+
 # Visual tests ------------------------------------------------------------
 
 test_that("axis guides are drawn correctly", {

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -132,8 +132,6 @@ test_that("guide merging for guide_legend() works as expected", {
     scale_linetype_discrete(limits = c("a", "b", "c"))
   )
   expect_length(different_limits, 2)
-  expect_equal(different_limits[[1]]$key$.label, c("a", "b", "c", "d"))
-  expect_equal(different_limits[[2]]$key$.label, c("a", "b", "c"))
 
   same_limits <- merge_test_guides(
     scale_colour_discrete(limits = c("a", "b", "c")),


### PR DESCRIPTION
This is a PR to fix #3573, a bug whereby guides with repeated labels were merged incorrectly. This bug occurred because the two guides keys were merged using `merge()`, which only works when there are no duplicate values in the `.label` column.

<details>
Current behaviour:

```r
guide1 <- list(
  key = tibble::tibble(
    colour = 1:4, 
    .label = c("low", "low", "high", "high")
  )
)

guide2 <- list(
  key = tibble::tibble(
    linetype = 1:4, 
    .label = c("low", "low", "high", "high")
  )
)

ggplot2:::guide_merge.legend(guide1, guide2)$key
#>   .label colour linetype
#> 1    low      1        1
#> 2    low      1        2
#> 3    low      2        1
#> 4    low      2        2
#> 5   high      3        3
#> 6   high      3        4
#> 7   high      4        3
#> 8   high      4        4
```

Behaviour after this PR:

``` r
guide1 <- list(
  key = tibble::tibble(
    colour = 1:4, 
    .label = c("low", "low", "high", "high")
  )
)

guide2 <- list(
  key = tibble::tibble(
    linetype = 1:4, 
    .label = c("low", "low", "high", "high")
  )
)

ggplot2:::guide_merge.legend(guide1, guide2)$key
#>   colour .label linetype
#> 1      1    low        1
#> 2      2    low        2
#> 3      3   high        3
#> 4      4   high        4
```
</details>

In the current implementation of merging, guides are only merged when they have identical `direction`, `key$.label`, `title`, and `name`. Because `key$.label` has to be identical for both guides, it should be safe to use `cbind()` in `guide_merge.guide_legend()` instead of `merge()`. I took the opportunity to write (non-visual) tests for guide merging to make sure it didn't break anything. As always, happy to be convinced otherwise (or that this shouldn't be fixed right now).