### PR TITLE
Improved error messages for plot addition.

### DIFF
--- a/R/plot-construction.r
+++ b/R/plot-construction.r
@@ -88,7 +88,7 @@ ggplot_add <- function(object, plot, object_name) {
 }
 #' @export
 ggplot_add.default <- function(object, plot, object_name) {
-  stop("Don't know how to add ", object_name, " to a plot", call. = FALSE)
+  stop("Can't add `", object_name, "` to a ggplot object.", call. = FALSE)
 }
 #' @export
 ggplot_add.NULL <- function(object, plot, object_name) {
@@ -102,8 +102,9 @@ ggplot_add.data.frame <- function(object, plot, object_name) {
 #' @export
 ggplot_add.function <- function(object, plot, object_name) {
   stop(
-    "Don't know how to add ", object_name, " to a plot. Did you mean ",
-    object_name, "()?", call. = FALSE
+    "Can't add `", object_name, "` to a ggplot object.\n",
+    "Did you forget to add parentheses, as in `",
+    object_name, "()`?", call. = FALSE
   )
 }
 #' @export

--- a/R/theme.r
+++ b/R/theme.r
@@ -436,7 +436,7 @@ plot_theme <- function(x, default = theme_get()) {
 #' @keywords internal
 add_theme <- function(t1, t2, t2name) {
   if (!is.theme(t2)) {
-    stop("Don't know how to add ", t2name, " to a theme object",
+    stop("Can't add `", t2name, "` to a theme object.",
       call. = FALSE)
   }
 


### PR DESCRIPTION
I made a few improvements to the error messages when plot addition fails, based on recommendations in the tidyverse style guide and also based on feedback from this Twitter thread: https://twitter.com/ClausWilke/status/1189725947508989953?s=20

``` r
library(ggplot2)

ggplot() + 1
#> Error: Can't add `1` to a ggplot object.

ggplot() + geom_point
#> Error: Can't add `geom_point` to a ggplot object.
#> Did you forget to add parentheses, as in `geom_point()`?
```

<sup>Created on 2019-10-30 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>