### PR TITLE
Alpha affects line geom_sf()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -89,6 +89,8 @@
 
 * Increase the default `nbin` of `guide_colourbar()` to place the ticks more precisely (#3508, @yutannihilation).
 
+* `geom_sf()` no more ignores alpha on linestring geometry (#3589, @yutannihilation).
+
 # ggplot2 3.2.1
 
 This is a patch release fixing a few regressions introduced in 3.2.0 as well as

--- a/NEWS.md
+++ b/NEWS.md
@@ -89,7 +89,7 @@
 
 * Increase the default `nbin` of `guide_colourbar()` to place the ticks more precisely (#3508, @yutannihilation).
 
-* `geom_sf()` no more ignores alpha on linestring geometry (#3589, @yutannihilation).
+* `geom_sf()` now applies alpha to linestring geometries (#3589, @yutannihilation).
 
 # ggplot2 3.2.1
 

--- a/R/geom-sf.R
+++ b/R/geom-sf.R
@@ -167,7 +167,7 @@ sf_grob <- function(x, lineend = "butt", linejoin = "round", linemitre = 10, na.
   })
   alpha <- x$alpha %||% defaults$alpha[type_ind]
   col <- x$colour %||% defaults$colour[type_ind]
-  col[is_point] <- alpha(col[is_point], alpha[is_point])
+  col[is_point | is_line] <- alpha(col[is_point | is_line], alpha[is_point | is_line])
   fill <- x$fill %||% defaults$fill[type_ind]
   fill <- alpha(fill, alpha)
   size <- x$size %||% defaults$size[type_ind]

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -33,6 +33,27 @@ test_that("geom_sf() removes rows containing missing aes", {
   )
 })
 
+test_that("geom_sf() handles alpha properly", {
+  skip_if_not_installed("sf")
+  if (packageVersion("sf") < "0.5.3") skip("Need sf 0.5.3")
+
+  sfc <- sf::st_sfc(
+    sf::st_point(0:1),
+    sf::st_linestring(rbind(0:1, 1:2)),
+    sf::st_polygon(list(rbind(0:1, 1:2, 2:1, 0:1)))
+  )
+  red <- "#FF0000FF"
+  p <- ggplot(sfc) + geom_sf(colour = red, fill = red, alpha = 0.5)
+  g <- layer_grob(p)[[1]]
+
+  # alpha affects the colour of points and lines
+  expect_equal(g[[1]]$gp$col, alpha(red, 0.5))
+  expect_equal(g[[2]]$gp$col, alpha(red, 0.5))
+  # alpha doesn't affect the colour of polygons, but the fill
+  expect_equal(g[[3]]$gp$col, alpha(red, 1.0))
+  expect_equal(g[[3]]$gp$fill, alpha(red, 0.5))
+})
+
 # Visual tests ------------------------------------------------------------
 
 test_that("geom_sf draws correctly", {

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -1,5 +1,37 @@
 context("geom-sf")
 
+test_that("geom_sf() removes rows containing missing aes", {
+  skip_if_not_installed("sf")
+  if (packageVersion("sf") < "0.5.3") skip("Need sf 0.5.3")
+
+  grob_xy_length <- function(x) {
+    g <- layer_grob(x)[[1]]
+    c(length(g$x), length(g$y))
+  }
+
+  pts <- sf::st_sf(
+    geometry = sf::st_sfc(sf::st_point(0:1), sf::st_point(1:2)),
+    size = c(1, NA),
+    shape = c("a", NA),
+    colour = c("red", NA)
+  )
+
+  p <- ggplot(pts) + geom_sf()
+  expect_warning(
+    expect_identical(grob_xy_length(p + aes(size = size)), c(1L, 1L)),
+    "Removed 1 rows containing missing values"
+  )
+  expect_warning(
+    expect_identical(grob_xy_length(p + aes(shape = shape)), c(1L, 1L)),
+    "Removed 1 rows containing missing values"
+  )
+  # default colour scale maps a colour even to a NA, so identity scale is needed to see if NA is removed
+  expect_warning(
+    expect_identical(grob_xy_length(p + aes(colour = colour) + scale_colour_identity()),
+                     c(1L, 1L)),
+    "Removed 1 rows containing missing values"
+  )
+})
 
 # Visual tests ------------------------------------------------------------
 
@@ -62,38 +94,5 @@ test_that("geom_sf_text() and geom_sf_label() draws correctly", {
 
   expect_doppelganger("Labels for North Carolina",
     ggplot() + geom_sf_label(data = nc_3857, aes(label = NAME))
-  )
-})
-
-test_that("geom_sf() removes rows containing missing aes", {
-  skip_if_not_installed("sf")
-  if (packageVersion("sf") < "0.5.3") skip("Need sf 0.5.3")
-
-  grob_xy_length <- function(x) {
-    g <- layer_grob(x)[[1]]
-    c(length(g$x), length(g$y))
-  }
-
-  pts <- sf::st_sf(
-    geometry = sf::st_sfc(sf::st_point(0:1), sf::st_point(1:2)),
-    size = c(1, NA),
-    shape = c("a", NA),
-    colour = c("red", NA)
-  )
-
-  p <- ggplot(pts) + geom_sf()
-  expect_warning(
-    expect_identical(grob_xy_length(p + aes(size = size)), c(1L, 1L)),
-    "Removed 1 rows containing missing values"
-  )
-  expect_warning(
-    expect_identical(grob_xy_length(p + aes(shape = shape)), c(1L, 1L)),
-    "Removed 1 rows containing missing values"
-  )
-  # default colour scale maps a colour even to a NA, so identity scale is needed to see if NA is removed
-  expect_warning(
-    expect_identical(grob_xy_length(p + aes(colour = colour) + scale_colour_identity()),
-                     c(1L, 1L)),
-    "Removed 1 rows containing missing values"
   )
 })


### PR DESCRIPTION
Fix #3589

``` r
library(ggplot2)
library(sf)
#> Linking to GEOS 3.7.2, GDAL 3.0.1, PROJ 6.2.0

d <- data.frame(x = 1:5, y = 1:5)

l <- st_linestring(as.matrix(d))
sf <- st_sf(geometry = st_sfc(l))

p1 <- ggplot(d, aes(x, y)) + geom_line(alpha = 0.1) + ggtitle("geom_line()")
p2 <- ggplot(sf) + geom_sf(alpha = 0.1) + ggtitle("geom_sf()")

patchwork::wrap_plots(p1, p2)
```

![](https://i.imgur.com/X0xF7hW.png)

<sup>Created on 2019-11-04 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
