### PR TITLE
Prevent failure of binning algorithm in rare cases.

### DIFF
--- a/R/bin.R
+++ b/R/bin.R
@@ -87,7 +87,11 @@ bin_breaks_width <- function(x_range, width = NULL, center = NULL,
   max_x <- x_range[2] + (1 - 1e-08) * width
   breaks <- seq(origin, max_x, width)
 
-  if (length(breaks) > 1e6) {
+  if (length(breaks) == 1) {
+    # In exceptionally rare cases, the above can fail and produce only a
+    # single break (see issue #3606). We fix this by adding a second break.
+    breaks <- c(breaks, breaks + width)
+  } else if (length(breaks) > 1e6) {
     stop("The number of histogram bins must be less than 1,000,000.\nDid you make `binwidth` too small?", call. = FALSE)
   }
 


### PR DESCRIPTION
 This closes #3606:

``` r
library(ggplot2)
ggplot() + geom_histogram(aes(x= rep(0.25,10)))
#> `stat_bin()` using `bins = 30`. Pick better value with `binwidth`.
```

![](https://i.imgur.com/i7g0hax.png)

<sup>Created on 2019-11-05 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>