### PR TITLE
address duplicate aesthetic listings in documentation, re #3618

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -253,6 +253,6 @@ Collate:
     'zxx.r'
     'zzz.r'
 VignetteBuilder: knitr
-RoxygenNote: 7.0.1
+RoxygenNote: 7.0.2
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8

--- a/R/utilities-help.r
+++ b/R/utilities-help.r
@@ -1,4 +1,3 @@
-
 rd_aesthetics <- function(type, name) {
   obj <- switch(type,
     geom = check_subclass(name, "Geom", env = globalenv()),
@@ -22,7 +21,9 @@ rd_aesthetics <- function(type, name) {
 rd_aesthetics_item <- function(x) {
   req <- x$required_aes
   req <- sub("|", "} \\emph{or} \\code{", req, fixed = TRUE)
-  all <- union(req, sort(x$aesthetics()))
+  req_aes <- unlist(strsplit(x$required_aes, "|", fixed = TRUE))
+  optional_aes <- setdiff(x$aesthetics(),req_aes)
+  all <- union(req, sort(optional_aes))
 
   ifelse(all %in% req,
     paste0("\\strong{\\code{", all, "}}"),

--- a/R/utilities-help.r
+++ b/R/utilities-help.r
@@ -22,7 +22,7 @@ rd_aesthetics_item <- function(x) {
   req <- x$required_aes
   req <- sub("|", "} \\emph{or} \\code{", req, fixed = TRUE)
   req_aes <- unlist(strsplit(x$required_aes, "|", fixed = TRUE))
-  optional_aes <- setdiff(x$aesthetics(),req_aes)
+  optional_aes <- setdiff(x$aesthetics(), req_aes)
   all <- union(req, sort(optional_aes))
 
   ifelse(all %in% req,

--- a/man/geom_bar.Rd
+++ b/man/geom_bar.Rd
@@ -162,8 +162,6 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 \item \strong{\code{x} \emph{or} \code{y}}
 \item \code{group}
 \item \code{weight}
-\item \code{x}
-\item \code{y}
 }
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 }

--- a/man/geom_boxplot.Rd
+++ b/man/geom_boxplot.Rd
@@ -163,21 +163,9 @@ See McGill et al. (1978) for more details.
 \item \code{fill}
 \item \code{group}
 \item \code{linetype}
-\item \code{lower}
-\item \code{middle}
 \item \code{shape}
 \item \code{size}
-\item \code{upper}
 \item \code{weight}
-\item \code{x}
-\item \code{xlower}
-\item \code{xmax}
-\item \code{xmiddle}
-\item \code{xmin}
-\item \code{xupper}
-\item \code{y}
-\item \code{ymax}
-\item \code{ymin}
 }
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 }

--- a/man/geom_linerange.Rd
+++ b/man/geom_linerange.Rd
@@ -134,12 +134,6 @@ This geom treats each axis differently and, thus, can thus have two orientations
 \item \code{group}
 \item \code{linetype}
 \item \code{size}
-\item \code{x}
-\item \code{xmax}
-\item \code{xmin}
-\item \code{y}
-\item \code{ymax}
-\item \code{ymin}
 }
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 }

--- a/man/geom_ribbon.Rd
+++ b/man/geom_ribbon.Rd
@@ -112,12 +112,6 @@ This geom treats each axis differently and, thus, can thus have two orientations
 \item \code{group}
 \item \code{linetype}
 \item \code{size}
-\item \code{x}
-\item \code{xmax}
-\item \code{xmin}
-\item \code{y}
-\item \code{ymax}
-\item \code{ymin}
 }
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 }


### PR DESCRIPTION
Fix #3618

```
    in utilities-help.r::rd_aesthetics_item, split required
    aesthetics specified with pipe operator (e.g. "x|y")
    into separate items so that they may be excluded from
    the list of all aesthetics prior to rendering the
    documentation of parameters.
```

My thoughts on approach included in #3618 comments.
Also have concerns about results of ```testthat``` run, but results are identical to master branch.
