### PR TITLE
Fix theme inheritance when not inheriting from blank

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -253,6 +253,6 @@ Collate:
     'zxx.r'
     'zzz.r'
 VignetteBuilder: knitr
-RoxygenNote: 7.0.1
+RoxygenNote: 7.0.2
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8

--- a/R/theme.r
+++ b/R/theme.r
@@ -525,6 +525,8 @@ add_theme <- function(t1, t2, t2name) {
 #' @param element The name of the theme element to calculate
 #' @param theme A theme object (like [theme_grey()])
 #' @param verbose If TRUE, print out which elements this one inherits from
+#' @param skip_blank If TRUE, elements of type `element_blank` in the
+#'   inheritance hierarchy will be ignored.
 #' @keywords internal
 #' @export
 #' @examples
@@ -548,10 +550,10 @@ calc_element <- function(element, theme, verbose = FALSE, skip_blank = FALSE) {
   # If result is element_blank, we skip it if `skip_blank` is `TRUE`,
   # and otherwise we don't inherit anything from parents
   if (inherits(el_out, "element_blank")) {
-    if (verbose) message("element_blank (no inheritance)")
     if (isTRUE(skip_blank)) {
       el_out <- NULL
     } else {
+      if (verbose) message("element_blank (no inheritance)")
       return(el_out)
     }
   }

--- a/R/theme.r
+++ b/R/theme.r
@@ -540,15 +540,20 @@ add_theme <- function(t1, t2, t2name) {
 #' t$axis.text.x
 #' t$axis.text
 #' t$text
-calc_element <- function(element, theme, verbose = FALSE) {
+calc_element <- function(element, theme, verbose = FALSE, skip_blank = FALSE) {
   if (verbose) message(element, " --> ", appendLF = FALSE)
 
   el_out <- theme[[element]]
 
-  # If result is element_blank, don't inherit anything from parents
+  # If result is element_blank, we skip it if `skip_blank` is `TRUE`,
+  # and otherwise we don't inherit anything from parents
   if (inherits(el_out, "element_blank")) {
     if (verbose) message("element_blank (no inheritance)")
-    return(el_out)
+    if (isTRUE(skip_blank)) {
+      el_out <- NULL
+    } else {
+      return(el_out)
+    }
   }
 
   # Obtain the element tree and check that the element is in it
@@ -592,7 +597,16 @@ calc_element <- function(element, theme, verbose = FALSE) {
 
   # Calculate the parent objects' inheritance
   if (verbose) message(paste(pnames, collapse = ", "))
-  parents <- lapply(pnames, calc_element, theme, verbose)
+  parents <- lapply(
+    pnames,
+    calc_element,
+    theme,
+    verbose = verbose,
+    # once we've started skipping blanks, we continue doing so until the end of the
+    # recursion; we initiate skipping blanks if we encounter an element that
+    # doesn't inherit blank.
+    skip_blank = skip_blank || (!is.null(el_out) && !isTRUE(el_out$inherit.blank))
+  )
 
   # Combine the properties of this element with all parents
   Reduce(combine_elements, parents, el_out)

--- a/man/calc_element.Rd
+++ b/man/calc_element.Rd
@@ -4,7 +4,7 @@
 \alias{calc_element}
 \title{Calculate the element properties, by inheriting properties from its parents}
 \usage{
-calc_element(element, theme, verbose = FALSE)
+calc_element(element, theme, verbose = FALSE, skip_blank = FALSE)
 }
 \arguments{
 \item{element}{The name of the theme element to calculate}
@@ -12,6 +12,9 @@ calc_element(element, theme, verbose = FALSE)
 \item{theme}{A theme object (like \code{\link[=theme_grey]{theme_grey()}})}
 
 \item{verbose}{If TRUE, print out which elements this one inherits from}
+
+\item{skip_blank}{If TRUE, elements of type \code{element_blank} in the
+inheritance hierarchy will be ignored.}
 }
 \description{
 Calculate the element properties, by inheriting properties from its parents

--- a/tests/figs/deps.txt
+++ b/tests/figs/deps.txt
@@ -1,3 +1,3 @@
 - vdiffr-svg-engine: 1.0
-- vdiffr: 0.3.1
+- vdiffr: 0.3.0
 - freetypeharfbuzz: 0.2.5

--- a/tests/figs/themes/axes-styling.svg
+++ b/tests/figs/themes/axes-styling.svg
@@ -50,7 +50,7 @@
     <rect x='0.00' y='0.00' width='720.00' height='576.00' />
   </clipPath>
 </defs>
-<polyline points='40.10,48.16 679.90,48.16 ' style='stroke-width: 0.75; stroke: #FF0000;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='40.10,48.16 679.90,48.16 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='160.16' y='43.23' style='font-size: 8.80px; fill: #FF0000; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='321.55' y='43.23' style='font-size: 8.80px; fill: #FF0000; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>5.0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='482.94' y='43.23' style='font-size: 8.80px; fill: #FF0000; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>7.5</text></g>
@@ -59,7 +59,7 @@
 <polyline points='327.66,48.16 327.66,45.42 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <polyline points='489.05,48.16 489.05,45.42 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <polyline points='651.08,48.16 651.08,45.42 ' style='stroke-width: 1.07; stroke: #FF0000; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='40.10,545.13 40.10,48.16 ' style='stroke-width: 0.75; stroke: #0000FF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='40.10,545.13 40.10,48.16 ' style='stroke-width: 1.07; stroke: #0000FF; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='22.95' y='450.27' style='font-size: 8.80px; fill: #0000FF; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>2.5</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='22.95' y='324.77' style='font-size: 8.80px; fill: #0000FF; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>5.0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='22.95' y='199.27' style='font-size: 8.80px; fill: #0000FF; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>7.5</text></g>
@@ -68,7 +68,7 @@
 <polyline points='37.36,321.75 40.10,321.75 ' style='stroke-width: 1.07; stroke: #0000FF; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <polyline points='37.36,196.25 40.10,196.25 ' style='stroke-width: 1.07; stroke: #0000FF; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <polyline points='37.36,70.75 40.10,70.75 ' style='stroke-width: 1.07; stroke: #0000FF; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='679.90,545.13 679.90,48.16 ' style='stroke-width: 0.75; stroke: #FFFF00;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='679.90,545.13 679.90,48.16 ' style='stroke-width: 1.07; stroke: #FFFF00; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <polyline points='679.90,447.13 682.64,447.13 ' style='stroke-width: 1.07; stroke: #FFFF00; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <polyline points='679.90,321.77 682.64,321.77 ' style='stroke-width: 1.07; stroke: #FFFF00; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <polyline points='679.90,196.41 682.64,196.41 ' style='stroke-width: 1.07; stroke: #FFFF00; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
@@ -77,7 +77,7 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='684.83' y='324.79' style='font-size: 8.80px; fill: #FFFF00; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>5.0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='684.83' y='199.43' style='font-size: 8.80px; fill: #FFFF00; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>7.5</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='684.83' y='73.57' style='font-size: 8.80px; fill: #FFFF00; font-family: Liberation Sans;' textLength='17.11px' lengthAdjust='spacingAndGlyphs'>10.0</text></g>
-<polyline points='40.10,545.13 679.90,545.13 ' style='stroke-width: 0.75; stroke: #00FF00;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='40.10,545.13 679.90,545.13 ' style='stroke-width: 1.07; stroke: #00FF00; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <polyline points='166.12,547.87 166.12,545.13 ' style='stroke-width: 1.07; stroke: #00FF00; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <polyline points='327.69,547.87 327.69,545.13 ' style='stroke-width: 1.07; stroke: #00FF00; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <polyline points='489.25,547.87 489.25,545.13 ' style='stroke-width: 1.07; stroke: #00FF00; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />

--- a/tests/testthat/test-theme.r
+++ b/tests/testthat/test-theme.r
@@ -154,6 +154,24 @@ test_that("calculating theme element inheritance works", {
       inherit.blank = TRUE # this is true because we're requesting a complete theme
     ), class = c("element_dummyrect", "element_rect", "element"))
   )
+
+  # Check that blank elements are skipped in inheritance tree if and only if elements
+  # don't inherit from blank.
+  t <- theme_gray() +
+    theme(
+      strip.text = element_blank(),
+      strip.text.x = element_text() # inherit.blank = FALSE is default
+    )
+  e1 <- calc_element("strip.text.x", t)
+  e2 <- calc_element("text", t)
+  e2$inherit.blank <- FALSE # b/c inherit.blank = TRUE for complete themes
+  expect_identical(e1, e2)
+
+  theme <- theme_gray() +
+    theme(strip.text = element_blank(), strip.text.x = element_text(inherit.blank = TRUE))
+  e1 <- ggplot2:::calc_element("strip.text.x", theme)
+  e2 <- ggplot2:::calc_element("strip.text", theme)
+  expect_identical(e1, e2)
 })
 
 test_that("complete and non-complete themes interact correctly with each other", {


### PR DESCRIPTION
I think this fixes #3662. I still want to add a few additional unit tests to prevent future such regressions.

I had to update one vdiffr reference image because it wasn't drawn correctly previously. (Line styling wasn't properly inherited across a blank element.)

``` r
library(ggplot2)

ggplot(mtcars) + 
  geom_point(aes(disp, mpg)) + 
  facet_wrap(~gear) + 
  theme(strip.text = element_blank(), strip.text.x = element_text())
```

![](https://i.imgur.com/DxPaNuT.png)

<sup>Created on 2019-12-11 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>