### PR TITLE
Add trans field to ScaleContinuous

### DIFF
--- a/R/scale-.r
+++ b/R/scale-.r
@@ -531,6 +531,7 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
   oob = censor,
   minor_breaks = waiver(),
   n.breaks = NULL,
+  trans = identity_trans(),
 
   is_discrete = function() FALSE,
 


### PR DESCRIPTION
The ScaleContinuous implementation has never specified a `trans` field, despite its methods referencing the field. This has not really been a problem as it is always subclassed, but recent changes mean that it's `print` method will throw an error now.

This PR adds an identity trans object as it's trans field and makes the error go away