### PR TITLE
Make sure flip is never NA

### DIFF
--- a/R/utilities.r
+++ b/R/utilities.r
@@ -603,8 +603,8 @@ has_flipped_aes <- function(data, params = list(), main_is_orthogonal = NA,
 #' @rdname bidirection
 #' @export
 flip_data <- function(data, flip = NULL) {
-  flip <- flip %||% data$flipped_aes[1] %||% FALSE
-  if (flip) {
+  flip <- flip %||% any(data$flipped_aes) %||% FALSE
+  if (isTRUE(flip)) {
     names(data) <- switch_orientation(names(data))
   }
   data


### PR DESCRIPTION
revdepchecks uncovered a small issue in direction flipping for position subclasses that hasn't adapted to the new setup. This PR fixes it