### PR TITLE
Don't switch relationship of ymin/ymax during stacking

### DIFF
--- a/R/position-stack.r
+++ b/R/position-stack.r
@@ -221,10 +221,11 @@ pos_stack <- function(df, width, vjust = 1, fill = FALSE) {
   } else {
     max_is_lower <- rep(FALSE, nrow(df))
   }
-  df$ymin <- pmin(heights[-n], heights[-1])
-  df$ymax <- pmax(heights[-n], heights[-1])
-  df$y <- (1 - vjust) * df$ymin + vjust * df$ymax
-  df[max_is_lower, c('ymin', 'ymax')] <- df[max_is_lower, c('ymax', 'ymin')]
+  ymin <- pmin(heights[-n], heights[-1])
+  ymax <- pmax(heights[-n], heights[-1])
+  df$y <- (1 - vjust) * ymin + vjust * ymax
+  df$ymin <- ifelse(max_is_lower, ymax, ymin)
+  df$ymax <- ifelse(max_is_lower, ymin, ymax)
   df
 }
 

--- a/R/position-stack.r
+++ b/R/position-stack.r
@@ -216,6 +216,7 @@ pos_stack <- function(df, width, vjust = 1, fill = FALSE) {
   if (fill) {
     heights <- heights / abs(heights[length(heights)])
   }
+# We need to preserve ymin/ymax order. If ymax is lower than ymin in input, it should remain that way
   if (!is.null(df$ymin) && !is.null(df$ymax)) {
     max_is_lower <- df$ymax < df$ymin
   } else {

--- a/R/position-stack.r
+++ b/R/position-stack.r
@@ -216,10 +216,15 @@ pos_stack <- function(df, width, vjust = 1, fill = FALSE) {
   if (fill) {
     heights <- heights / abs(heights[length(heights)])
   }
-
+  if (!is.null(df$ymin) && !is.null(df$ymax)) {
+    max_is_lower <- df$ymax < df$ymin
+  } else {
+    max_is_lower <- rep(FALSE, nrow(df))
+  }
   df$ymin <- pmin(heights[-n], heights[-1])
   df$ymax <- pmax(heights[-n], heights[-1])
   df$y <- (1 - vjust) * df$ymin + vjust * df$ymax
+  df[max_is_lower, c('ymin', 'ymax')] <- df[max_is_lower, c('ymax', 'ymin')]
   df
 }
 


### PR DESCRIPTION
This PR addresses the problem uncovered in #3529 where position_stack changes the relation of ymin/ymax during stacking, making it difficult to recover the correct line to draw. It is less drastic than what #3607 proposes, and simply ensure minimal changes to the incoming data