### PR TITLE
Restore data order after collide

### DIFF
--- a/R/position-collide.r
+++ b/R/position-collide.r
@@ -38,10 +38,11 @@ collide <- function(data, width = NULL, name, strategy,
   # Reorder by x position, then on group. The default stacking order reverses
   # the group in order to match the legend order.
   if (reverse) {
-    data <- data[order(data$xmin, data$group), ]
+    ord <- order(data$xmin, data$group)
   } else {
-    data <- data[order(data$xmin, -data$group), ]
+    ord <- order(data$xmin, -data$group)
   }
+  data <- data[ord, ]
 
   # Check for overlap
   intervals <- as.numeric(t(unique(data[c("xmin", "xmax")])))
@@ -54,15 +55,15 @@ collide <- function(data, width = NULL, name, strategy,
   }
 
   if (!is.null(data$ymax)) {
-    dapply(data, "xmin", strategy, ..., width = width)
+    data <- dapply(data, "xmin", strategy, ..., width = width)
   } else if (!is.null(data$y)) {
     data$ymax <- data$y
     data <- dapply(data, "xmin", strategy, ..., width = width)
     data$y <- data$ymax
-    data
   } else {
     abort("Neither y nor ymax defined")
   }
+  data[match(seq_along(ord), ord), ]
 }
 
 # Alternate version of collide() used by position_dodge2()

--- a/tests/figs/deps.txt
+++ b/tests/figs/deps.txt
@@ -1,3 +1,3 @@
 - vdiffr-svg-engine: 1.0
-- vdiffr: 0.3.0
+- vdiffr: 0.3.1
 - freetypeharfbuzz: 0.2.5

--- a/tests/figs/position-stack/area-stacking.svg
+++ b/tests/figs/position-stack/area-stacking.svg
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<defs>
+  <clipPath id='cpMjcuODl8NjYxLjM0fDU0NS4xM3wyMi43Nw=='>
+    <rect x='27.89' y='22.77' width='633.46' height='522.36' />
+  </clipPath>
+</defs>
+<rect x='27.89' y='22.77' width='633.46' height='522.36' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMjcuODl8NjYxLjM0fDU0NS4xM3wyMi43Nw==)' />
+<polygon points='56.68,375.27 248.64,265.69 440.59,46.52 632.55,521.39 632.55,375.27 440.59,156.10 248.64,338.74 56.68,375.27 ' style='stroke-width: 1.07; stroke: none; fill: #F8766D;' clip-path='url(#cpMjcuODl8NjYxLjM0fDU0NS4xM3wyMi43Nw==)' />
+<polygon points='56.68,375.27 248.64,338.74 440.59,156.10 632.55,265.69 632.55,375.27 440.59,375.27 248.64,375.27 56.68,375.27 ' style='stroke-width: 1.07; stroke: none; fill: #00BFC4;' clip-path='url(#cpMjcuODl8NjYxLjM0fDU0NS4xM3wyMi43Nw==)' />
+<rect x='27.89' y='22.77' width='633.46' height='522.36' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpMjcuODl8NjYxLjM0fDU0NS4xM3wyMi43Nw==)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='378.30' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='195.65' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text></g>
+<polyline points='25.15,375.27 27.89,375.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='25.15,192.63 27.89,192.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='56.68,547.87 56.68,545.13 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='248.64,547.87 248.64,545.13 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='440.59,547.87 440.59,545.13 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='632.55,547.87 632.55,545.13 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='54.23' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='246.19' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='438.15' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='630.10' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='341.86' y='568.24' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(13.04,297.11) rotate(-90)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='26.31px' lengthAdjust='spacingAndGlyphs'>value</text></g>
+<rect x='672.30' y='259.01' width='42.22' height='49.88' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='672.30' y='267.71' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='42.22px' lengthAdjust='spacingAndGlyphs'>category</text></g>
+<rect x='672.30' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<rect x='673.01' y='275.04' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #F8766D;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<rect x='672.30' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<rect x='673.01' y='292.32' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #00BFC4;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='695.06' y='286.00' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='5.88px' lengthAdjust='spacingAndGlyphs'>A</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='695.06' y='303.28' style='font-size: 8.80px; font-family: Liberation Sans;' textLength='5.88px' lengthAdjust='spacingAndGlyphs'>B</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='27.89' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='79.86px' lengthAdjust='spacingAndGlyphs'>Area stacking</text></g>
+</svg>

--- a/tests/figs/scales-breaks-and-labels/functional-limits.svg
+++ b/tests/figs/scales-breaks-and-labels/functional-limits.svg
@@ -19,18 +19,18 @@
   </clipPath>
 </defs>
 <rect x='37.67' y='22.77' width='638.25' height='522.36' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
-<rect x='50.96' y='497.64' width='79.78' height='23.74' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #619CFF;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
-<rect x='139.61' y='355.18' width='79.78' height='166.21' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #00BA38;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
 <rect x='139.61' y='298.20' width='79.78' height='56.98' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #F8766D;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
-<rect x='228.25' y='340.94' width='79.78' height='180.45' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #00BA38;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
 <rect x='228.25' y='326.69' width='79.78' height='14.25' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #F8766D;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
-<rect x='316.90' y='469.15' width='79.78' height='52.24' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #00BA38;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
 <rect x='405.54' y='364.68' width='79.78' height='156.71' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #F8766D;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
-<rect x='494.19' y='478.65' width='79.78' height='42.74' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #619CFF;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
-<rect x='494.19' y='374.18' width='79.78' height='104.47' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #00BA38;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
 <rect x='494.19' y='355.18' width='79.78' height='18.99' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #F8766D;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
-<rect x='582.83' y='469.15' width='79.78' height='52.24' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #619CFF;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
 <rect x='582.83' y='226.97' width='79.78' height='242.18' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #F8766D;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
+<rect x='139.61' y='355.18' width='79.78' height='166.21' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #00BA38;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
+<rect x='228.25' y='340.94' width='79.78' height='180.45' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #00BA38;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
+<rect x='316.90' y='469.15' width='79.78' height='52.24' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #00BA38;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
+<rect x='494.19' y='374.18' width='79.78' height='104.47' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #00BA38;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
+<rect x='50.96' y='497.64' width='79.78' height='23.74' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #619CFF;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
+<rect x='494.19' y='478.65' width='79.78' height='42.74' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #619CFF;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
+<rect x='582.83' y='469.15' width='79.78' height='52.24' style='stroke-width: 1.07; stroke: none; stroke-linecap: square; stroke-linejoin: miter; fill: #619CFF;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
 <rect x='37.67' y='22.77' width='638.25' height='522.36' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpMzcuNjd8Njc1LjkxfDU0NS4xM3wyMi43Nw==)' />
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>

--- a/tests/testthat/test-position-stack.R
+++ b/tests/testthat/test-position-stack.R
@@ -1,6 +1,6 @@
 context("position_stack")
 
-test_that("data is sorted prior to stacking", {
+test_that("data keeps its order after stacking", {
   df <- data_frame(
     x = rep(c(1:10), 3),
     var = rep(c("a", "b", "c"), 10),
@@ -9,7 +9,8 @@ test_that("data is sorted prior to stacking", {
   p <- ggplot(df, aes(x = x, y = y, fill = var)) +
     geom_area(position = "stack")
   dat <- layer_data(p)
-  expect_true(all(dat$group == 3:1))
+  expect_true(all(dat$group == rep(1:3, each = 10)))
+  expect_true(all(dat$x == df$x))
 })
 
 test_that("negative and positive values are handled separately", {
@@ -21,8 +22,8 @@ test_that("negative and positive values are handled separately", {
   p <- ggplot(df, aes(x, y, fill = factor(g))) + geom_col()
   dat <- layer_data(p)
 
-  expect_equal(dat$ymin[dat$x == 1], c(0, -1, 1))
-  expect_equal(dat$ymax[dat$x == 1], c(1, 0, 2))
+  expect_equal(dat$ymin[dat$x == 1], c(1, -1, 0))
+  expect_equal(dat$ymax[dat$x == 1], c(2, 0, 1))
 
   expect_equal(dat$ymin[dat$x == 2], c(0, -3))
   expect_equal(dat$ymax[dat$x == 2], c(2, 0))
@@ -49,12 +50,25 @@ test_that("data with no extent is stacked correctly", {
   p0 <- base + geom_text(aes(label = y), position = position_stack(vjust = 0))
   p1 <- base + geom_text(aes(label = y), position = position_stack(vjust = 1))
 
-  expect_equal(layer_data(p0)$y, c(-75, -115))
-  expect_equal(layer_data(p1)$y, c(0, -75))
+  expect_equal(layer_data(p0)$y, c(-115, -75))
+  expect_equal(layer_data(p1)$y, c(-75, 0))
 })
 
 test_that("position_stack() can stack correctly when ymax is NA", {
   df <- data_frame(x = c(1, 1), y = c(1, 1))
   p <- ggplot(df, aes(x, y, ymax = NA_real_)) + geom_point(position = "stack")
   expect_equal(layer_data(p)$y, c(1, 2))
+})
+
+# Visual tests ------------------------------------------------------------
+
+test_that("Stacking produces the expected output", {
+  data <- data_frame(
+    x = rep(1:4, each = 2),
+    category = rep(c("A","B"), 4),
+    value = c(0, 0, 2, 1, 3, 6, -4, 3)
+  )
+  p <- ggplot(data, aes(x = x, y = value, fill = category)) +
+    geom_area(stat = "identity")
+  expect_doppelganger("Area stacking", p)
 })

--- a/tests/testthat/test-position_dodge.R
+++ b/tests/testthat/test-position_dodge.R
@@ -8,6 +8,6 @@ test_that("can control whether to preserve total or individual width", {
   p_single <- ggplot(df, aes(x, fill = y)) +
     geom_bar(position = position_dodge(preserve = "single"), width = 1)
 
-  expect_equal(layer_data(p_total)$x, c(1, 2.25, 1.75))
-  expect_equal(layer_data(p_single)$x, c(0.75, 2.25, 1.75))
+  expect_equal(layer_data(p_total)$x, c(1, 1.75, 2.25))
+  expect_equal(layer_data(p_single)$x, c(0.75, 1.75, 2.25))
 })


### PR DESCRIPTION
Fix #3498 This seems to be the last leftover from moving the area/ribbon reorder into setup_data like the rest of the geoms.

This change make sure that data returned from `collide()` is in the same order is it came in.

I think a general rule should be that positions should never change the order of data, only the content. There are situations where this is not possible, but as a general rule of thumb I think it is sane