### PR TITLE
Fix ScaleBinnedPosition for new axis implementation

### DIFF
--- a/R/guides-axis.r
+++ b/R/guides-axis.r
@@ -80,7 +80,7 @@ guide_train.axis <- function(guide, scale, aesthetic = NULL) {
   } else if (length(breaks) == 0) {
     guide$key <- empty_ticks
   } else {
-    mapped_breaks <- if (scale$scale_is_discrete) scale$map(breaks) else breaks
+    mapped_breaks <- if (scale$is_discrete()) scale$map(breaks) else breaks
     ticks <- new_data_frame(setNames(list(mapped_breaks), aesthetic))
     ticks$.value <- breaks
     ticks$.label <- scale$get_labels(breaks)

--- a/R/guides-axis.r
+++ b/R/guides-axis.r
@@ -80,7 +80,8 @@ guide_train.axis <- function(guide, scale, aesthetic = NULL) {
   } else if (length(breaks) == 0) {
     guide$key <- empty_ticks
   } else {
-    ticks <- new_data_frame(setNames(list(scale$map(breaks)), aesthetic))
+    mapped_breaks <- if (scale$scale_is_discrete) scale$map(breaks) else breaks
+    ticks <- new_data_frame(setNames(list(mapped_breaks), aesthetic))
     ticks$.value <- breaks
     ticks$.label <- scale$get_labels(breaks)
 

--- a/R/scale-binned.R
+++ b/R/scale-binned.R
@@ -25,13 +25,13 @@ scale_x_binned <- function(name = waiver(), n.breaks = 10, nice.breaks = TRUE,
                            breaks = waiver(), labels = waiver(), limits = NULL,
                            expand = waiver(), oob = squish, na.value = NA_real_,
                            right = TRUE, show.limits = FALSE, trans = "identity",
-                           position = "bottom") {
+                           guide = waiver(), position = "bottom") {
   binned_scale(
     aesthetics = c("x", "xmin", "xmax", "xend", "xintercept", "xmin_final", "xmax_final", "xlower", "xmiddle", "xupper"),
     scale_name = "position_b", palette = identity, name = name, breaks = breaks,
     labels = labels, limits = limits, expand = expand, oob = oob, na.value = na.value,
     n.breaks = n.breaks, nice.breaks = nice.breaks, right = right, trans = trans,
-    show.limits = show.limits, guide = "none", position = position, super = ScaleBinnedPosition
+    show.limits = show.limits, guide = guide, position = position, super = ScaleBinnedPosition
   )
 }
 
@@ -42,13 +42,13 @@ scale_y_binned <- function(name = waiver(), n.breaks = 10, nice.breaks = TRUE,
                            breaks = waiver(), labels = waiver(), limits = NULL,
                            expand = waiver(), oob = squish, na.value = NA_real_,
                            right = TRUE, show.limits = FALSE, trans = "identity",
-                           position = "left") {
+                           guide = waiver(), position = "left") {
   binned_scale(
     aesthetics = c("y", "ymin", "ymax", "yend", "yintercept", "ymin_final", "ymax_final", "lower", "middle", "upper"),
     scale_name = "position_b", palette = identity, name = name, breaks = breaks,
     labels = labels, limits = limits, expand = expand, oob = oob, na.value = na.value,
     n.breaks = n.breaks, nice.breaks = nice.breaks, right = right, trans = trans,
-    show.limits = show.limits, guide = "none", position = position, super = ScaleBinnedPosition
+    show.limits = show.limits, guide = guide, position = position, super = ScaleBinnedPosition
   )
 }
 

--- a/man/scale_binned.Rd
+++ b/man/scale_binned.Rd
@@ -18,6 +18,7 @@ scale_x_binned(
   right = TRUE,
   show.limits = FALSE,
   trans = "identity",
+  guide = waiver(),
   position = "bottom"
 )
 
@@ -34,6 +35,7 @@ scale_y_binned(
   right = TRUE,
   show.limits = FALSE,
   trans = "identity",
+  guide = waiver(),
   position = "left"
 )
 }
@@ -119,6 +121,9 @@ and methods for generating breaks and labels. Transformation objects
 are defined in the scales package, and are called \verb{<name>_trans} (e.g.,
 \code{\link[scales:boxcox_trans]{scales::boxcox_trans()}}). You can create your own
 transformation with \code{\link[scales:trans_new]{scales::trans_new()}}.}
+
+\item{guide}{A function used to create a guide or its name. See
+\code{\link[=guides]{guides()}} for more information.}
 
 \item{position}{For position scales, The position of the axis.
 \code{left} or \code{right} for y axes, \code{top} or \code{bottom} for x axes.}


### PR DESCRIPTION
I just came across a spectacular failure of the new bin scale in combination with the new axis implementation. This PR adresses the two issues: Make sure guide is set to `waiver()` instead of `"none"`. And make sure that breaks are not mapped by the scale unless it is a discrete scale. The old approach worked before because mapping with a continuous position scale was a no-op, but this is not true for the bin scale and it would throw the axis completely off.