### PR TITLE
Improve pkgdown reference index

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -103,7 +103,7 @@ reference:
     Guides are mostly controlled via the scale (e.g. with the `limits`,
     `breaks`, and `labels` arguments), but sometimes you will need additional
     control over guide appearance. Use `guides()` or the `guide` argument to
-    individual scales along with `guide_colourbar()` or `guide_legend()`.
+    individual scales along with `guide_*()` functions.
   contents:
   - draw_key
   - guide_colourbar

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -10,9 +10,9 @@ home:
   strip_header: true
   links:
   - text: Learn more
-    href: http://r4ds.had.co.nz/data-visualisation.html
+    href: https://r4ds.had.co.nz/data-visualisation.html
   - text: Extensions
-    href: http://www.ggplot2-exts.org/gallery/
+    href: https://www.ggplot2-exts.org/gallery/
 
 reference:
 - title: Plot basics
@@ -249,4 +249,4 @@ navbar:
         href: news/index.html
     extensions:
       text: Extensions
-      href: http://www.ggplot2-exts.org/gallery/
+      href: https://www.ggplot2-exts.org/gallery/

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -40,7 +40,7 @@ reference:
   desc: >
     A handful of layers are more easily specified with a `stat_` function,
     drawing attention to the statistical transformation rather than the visual
-    appearance. The computed variables can be mapped using `stat()`.
+    appearance. The computed variables can be mapped using `after_stat()`.
   contents:
   - stat_ecdf
   - stat_ellipse
@@ -50,7 +50,7 @@ reference:
   - stat_summary_bin
   - stat_unique
   - stat_sf_coordinates
-  - stat
+  - after_stat
 
 - title: "Layer: position adjustment"
   desc: >

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -105,8 +105,13 @@ reference:
     control over guide appearance. Use `guides()` or the `guide` argument to
     individual scales along with `guide_colourbar()` or `guide_legend()`.
   contents:
+  - draw_key
   - guide_colourbar
   - guide_legend
+  - guide_axis
+  - guide_bins
+  - guide_coloursteps
+  - guide_none
   - guides
   - sec_axis
 


### PR DESCRIPTION
Fixes #3697 

This PR is primarily to fix the following missing topics:

> Warning: Topics missing from index: draw_key, guide_axis, guide_bins, guide_coloursteps, guide_none
(https://travis-ci.org/tidyverse/ggplot2/jobs/633940915#L1365)

In addition, this tweaks the index a bit more:

* Replace `stat()` with `after_stat()`
* Use https URLs