### PR TITLE
Make bin guides compatible with discrete scales

### DIFF
--- a/R/guide-bins.R
+++ b/R/guide-bins.R
@@ -16,6 +16,18 @@
 #' @param show.limits Logical. Should the limits of the scale be shown with
 #'   labels and ticks.
 #'
+#' @section Use with discrete scale:
+#' This guide is intended to show binned data and work together with ggplot2's
+#' binning scales. However, it is sometimes desirable to perform the binning in
+#' a separate step, either as part of a stat (e.g. [stat_contour_filled()]) or
+#' prior to the visualisation. If you want to use this guide for discrete data
+#' the levels must follow the naming scheme implemented by [base::cut()]. This
+#' means that a bin must be encoded as `"(<lower>, <upper>]"` with `<lower>`
+#' giving the lower bound of the bin and `<upper>` giving the upper bound
+#' (`"[<lower>, <upper>)"` is also accepted). If you use [base::cut()] to
+#' perform the binning everything should work as expected, if not, some recoding
+#' may be needed.
+#'
 #' @return A guide object
 #' @family guides
 #' @export
@@ -133,6 +145,9 @@ guide_train.bins <- function(guide, scale, aesthetic = NULL) {
     all_breaks <- c(limits[1], breaks, limits[2])
     bin_at <- all_breaks[-1] - diff(all_breaks) / 2
   } else {
+    # If the breaks are not numeric it is used with a discrete scale. We check
+    # if the breaks follow the allowed format "(<lower>, <upper>]", and if it
+    # does we convert it into bin specs
     bin_at <- breaks
     breaks <- as.character(breaks)
     breaks <- strsplit(gsub("\\(|\\)|\\[|\\]", "", breaks), ",\\s?")

--- a/R/guide-bins.R
+++ b/R/guide-bins.R
@@ -123,13 +123,25 @@ guide_train.bins <- function(guide, scale, aesthetic = NULL) {
   if (length(breaks) == 0 || all(is.na(breaks))) {
     return()
   }
-  limits <- scale$get_limits()
-  all_breaks <- c(limits[1], breaks, limits[2])
-  bin_at <- all_breaks[-1] - diff(all_breaks) / 2
   # in the key data frame, use either the aesthetic provided as
   # argument to this function or, as a fall back, the first in the vector
   # of possible aesthetics handled by the scale
   aes_column_name <- aesthetic %||% scale$aesthetics[1]
+
+  if (is.numeric(breaks)) {
+    limits <- scale$get_limits()
+    all_breaks <- c(limits[1], breaks, limits[2])
+    bin_at <- all_breaks[-1] - diff(all_breaks) / 2
+  } else {
+    bin_at <- breaks
+    breaks <- as.character(breaks)
+    breaks <- strsplit(gsub("\\(|\\)|\\[|\\]", "", breaks), ",\\s?")
+    breaks <- as.numeric(unlist(breaks))
+    if (anyNA(breaks)) {
+      abort('Breaks not formatted correctly for a bin legend. Use `(<lower>, <upper>]` format to indicate bins')
+    }
+    all_breaks <- breaks[c(1, seq_along(bin_at) * 2)]
+  }
   key <- new_data_frame(setNames(list(c(scale$map(bin_at), NA)), aes_column_name))
   key$.label <- scale$get_labels(all_breaks)
   guide$show.limits <- guide$show.limits %||% scale$show_limits %||% FALSE

--- a/R/guide-colorsteps.R
+++ b/R/guide-colorsteps.R
@@ -12,6 +12,8 @@
 #'   visible.
 #' @inheritDotParams guide_colourbar -nbin -raster -ticks -available_aes
 #'
+#' @inheritSection guide_bins Use with discrete scale
+#'
 #' @return A guide object
 #' @export
 #'
@@ -64,6 +66,9 @@ guide_train.colorsteps <- function(guide, scale, aesthetic = NULL) {
       all_breaks <- c(limits[1], breaks, limits[2])
       bin_at <- all_breaks[-1] - diff(all_breaks) / 2
     } else {
+      # If the breaks are not numeric it is used with a discrete scale. We check
+      # if the breaks follow the allowed format "(<lower>, <upper>]", and if it
+      # does we convert it into bin specs
       bin_at <- breaks
       breaks_num <- as.character(breaks)
       breaks_num <- strsplit(gsub("\\(|\\)|\\[|\\]", "", breaks_num), ",\\s?")

--- a/R/guide-colorsteps.R
+++ b/R/guide-colorsteps.R
@@ -55,7 +55,6 @@ guide_colorsteps <- guide_coloursteps
 #' @export
 guide_train.colorsteps <- function(guide, scale, aesthetic = NULL) {
   breaks <- scale$get_breaks()
-  browser()
   if (guide$even.steps || !is.numeric(breaks)) {
     if (length(breaks) == 0 || all(is.na(breaks))) {
       return()

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -848,7 +848,6 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
     }
 
     if (is.waive(self$labels)) {
-      breaks <- self$get_breaks()
       if (is.numeric(breaks)) {
         # Only format numbers, because on Windows, format messes up encoding
         format(breaks, justify = "none")

--- a/R/stat-contour.r
+++ b/R/stat-contour.r
@@ -108,7 +108,7 @@ StatContourFilled <- ggproto("StatContourFilled", Stat,
     names(isobands) <- pretty_isoband_levels(names(isobands))
     path_df <- iso_to_path(isobands, data$group[1])
 
-    path_df$level <- factor(path_df$level, levels = names(isobands))
+    path_df$level <- ordered(path_df$level, levels = names(isobands))
 
     path_df
   }

--- a/man/guide_bins.Rd
+++ b/man/guide_bins.Rd
@@ -115,6 +115,20 @@ for all non-position aesthetics though colour and fill defaults to
 \code{\link[=guide_coloursteps]{guide_coloursteps()}}, and it will merge aesthetics together into the same
 guide if they are mapped in the same way.
 }
+\section{Use with discrete scale}{
+
+This guide is intended to show binned data and work together with ggplot2's
+binning scales. However, it is sometimes desirable to perform the binning in
+a separate step, either as part of a stat (e.g. \code{\link[=stat_contour_filled]{stat_contour_filled()}}) or
+prior to the visualisation. If you want to use this guide for discrete data
+the levels must follow the naming scheme implemented by \code{\link[base:cut]{base::cut()}}. This
+means that a bin must be encoded as \code{"(<lower>, <upper>]"} with \verb{<lower>}
+giving the lower bound of the bin and \verb{<upper>} giving the upper bound
+(\code{"[<lower>, <upper>)"} is also accepted). If you use \code{\link[base:cut]{base::cut()}} to
+perform the binning everything should work as expected, if not, some recoding
+may be needed.
+}
+
 \examples{
 p <- ggplot(mtcars) +
   geom_point(aes(disp, mpg, size = hp)) +

--- a/man/guide_coloursteps.Rd
+++ b/man/guide_coloursteps.Rd
@@ -86,6 +86,20 @@ This guide is version of \code{\link[=guide_colourbar]{guide_colourbar()}} for b
 scales. It shows areas between breaks as a single constant colour instead of
 the gradient known from the colourbar counterpart.
 }
+\section{Use with discrete scale}{
+
+This guide is intended to show binned data and work together with ggplot2's
+binning scales. However, it is sometimes desirable to perform the binning in
+a separate step, either as part of a stat (e.g. \code{\link[=stat_contour_filled]{stat_contour_filled()}}) or
+prior to the visualisation. If you want to use this guide for discrete data
+the levels must follow the naming scheme implemented by \code{\link[base:cut]{base::cut()}}. This
+means that a bin must be encoded as \code{"(<lower>, <upper>]"} with \verb{<lower>}
+giving the lower bound of the bin and \verb{<upper>} giving the upper bound
+(\code{"[<lower>, <upper>)"} is also accepted). If you use \code{\link[base:cut]{base::cut()}} to
+perform the binning everything should work as expected, if not, some recoding
+may be needed.
+}
+
 \examples{
 df <- expand.grid(X1 = 1:10, X2 = 1:10)
 df$value <- df$X1 * df$X2


### PR DESCRIPTION
This PR makes the new bin guides work with discrete scales if the breaks are given in a `cut()` compliant format (e.g. `(4, 19]`).

This, most importantly, makes the bin guides work with `geom_contour_filled()` but also gives a venue for users to pre-bin their data and still benefit from the new guides.

Example:

``` r
library(ggplot2)

volcano_long <- data.frame(
  x = as.vector(col(volcano)),
  y = as.vector(row(volcano)),
  z = as.vector(volcano)
)

ggplot(volcano_long, aes(x, y, z = z)) + 
  geom_contour_filled(aes(fill = stat(level)), bins = 8) + 
  scale_fill_brewer()
```

![](https://i.imgur.com/jMO7eim.png)

``` r

ggplot(volcano_long, aes(x, y, z = z)) + 
  geom_contour_filled(aes(fill = stat(level)), bins = 8) + 
  scale_fill_brewer(guide = guide_colorsteps())
```

![](https://i.imgur.com/JtCb8bQ.png)

<sup>Created on 2020-01-08 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>