### PR TITLE
Make sure nbins are converted to the correct binwidth

### DIFF
--- a/R/stat-contour.r
+++ b/R/stat-contour.r
@@ -134,7 +134,7 @@ contour_breaks <- function(z_range, bins = NULL, binwidth = NULL, breaks = NULL)
 
   # If provided, use bins to calculate binwidth
   if (!is.null(bins)) {
-    binwidth <- diff(z_range) / bins
+    binwidth <- diff(z_range) / (bins - 1)
   }
 
   # If necessary, compute breaks from binwidth

--- a/R/stat-contour.r
+++ b/R/stat-contour.r
@@ -102,7 +102,7 @@ StatContourFilled <- ggproto("StatContourFilled", Stat,
   compute_group = function(data, scales, bins = NULL, binwidth = NULL, breaks = NULL, na.rm = FALSE) {
 
     z_range <- range(data$z, na.rm = TRUE, finite = TRUE)
-    breaks <- contour_breaks(z_range, bins, binwidth)
+    breaks <- contour_breaks(z_range, bins, binwidth, breaks)
 
     isobands <- xyz_to_isobands(data, breaks)
     names(isobands) <- pretty_isoband_levels(names(isobands))

--- a/tests/testthat/test-stat-contour.R
+++ b/tests/testthat/test-stat-contour.R
@@ -17,7 +17,7 @@ test_that("contour breaks can be set manually and by bins and binwidth", {
   range <- c(0, 1)
   expect_equal(contour_breaks(range), pretty(range, 10))
   expect_identical(contour_breaks(range, breaks = 1:3), 1:3)
-  expect_length(contour_breaks(range, bins = 5), 6)
+  expect_length(contour_breaks(range, bins = 5), 5)
   expect_equal(resolution(contour_breaks(range, binwidth = 0.3)), 0.3)
 })
 


### PR DESCRIPTION
Currently the `bins` argument in `stat_contour_filled()` is treated as the number of breakpoints, rather than the number of bins. I suspect this is a bug, as most people will use it to set the actual number of bins. This PR fixes it by correcting the bin width from bins calculation