### PR TITLE
Allow "lower" outline type in geom_ribbon and family

### DIFF
--- a/R/geom-ribbon.r
+++ b/R/geom-ribbon.r
@@ -22,8 +22,8 @@
 #' @inheritParams layer
 #' @inheritParams geom_bar
 #' @param outline.type Type of the outline of the area; `"both"` draws both the
-#'   upper and lower lines, `"upper"` draws the upper lines only. `"legacy"`
-#'   draws a closed polygon around the area.
+#'   upper and lower lines, `"upper"`/`"lower"` draws the either lines only.
+#'   `"legacy"` draws a closed polygon around the area.
 #' @export
 #' @examples
 #' # Generate data
@@ -49,7 +49,7 @@ geom_ribbon <- function(mapping = NULL, data = NULL,
                         show.legend = NA,
                         inherit.aes = TRUE,
                         outline.type = "both") {
-  outline.type <- match.arg(outline.type, c("both", "upper", "legacy"))
+  outline.type <- match.arg(outline.type, c("both", "upper", "lower", "legacy"))
 
   layer(
     data = data,
@@ -158,6 +158,7 @@ GeomRibbon <- ggproto("GeomRibbon", Geom,
     munched_lines$id <- switch(outline.type,
       both = munched_lines$id + rep(c(0, max(ids, na.rm = TRUE)), each = length(ids)),
       upper = munched_lines$id + rep(c(0, NA), each = length(ids)),
+      lower = munched_lines$id + rep(c(NA, 0), each = length(ids)),
       abort(glue("invalid outline.type: {outline.type}"))
     )
     g_lines <- polylineGrob(

--- a/R/geom-ribbon.r
+++ b/R/geom-ribbon.r
@@ -181,7 +181,7 @@ geom_area <- function(mapping = NULL, data = NULL, stat = "identity",
                       position = "stack", na.rm = FALSE, orientation = NA,
                       show.legend = NA, inherit.aes = TRUE, ...,
                       outline.type = "upper") {
-  outline.type <- match.arg(outline.type, c("both", "upper", "legacy"))
+  outline.type <- match.arg(outline.type, c("both", "upper", "lower", "legacy"))
 
   layer(
     data = data,

--- a/man/geom_ribbon.Rd
+++ b/man/geom_ribbon.Rd
@@ -83,8 +83,8 @@ that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 
 \item{outline.type}{Type of the outline of the area; \code{"both"} draws both the
-upper and lower lines, \code{"upper"} draws the upper lines only. \code{"legacy"}
-draws a closed polygon around the area.}
+upper and lower lines, \code{"upper"}/\code{"lower"} draws the either lines only.
+\code{"legacy"} draws a closed polygon around the area.}
 }
 \description{
 For each x value, \code{geom_ribbon()} displays a y interval defined

--- a/tests/testthat/test-geom-ribbon.R
+++ b/tests/testthat/test-geom-ribbon.R
@@ -34,6 +34,7 @@ test_that("outline.type option works", {
 
   g_ribbon_default <- layer_grob(p + geom_ribbon())[[1]]
   g_ribbon_upper   <- layer_grob(p + geom_ribbon(outline.type = "upper"))[[1]]
+  g_ribbon_lower   <- layer_grob(p + geom_ribbon(outline.type = "lower"))[[1]]
   g_ribbon_legacy  <- expect_warning(
     layer_grob(p + geom_ribbon(outline.type = "legacy"))[[1]],
     'outline.type = "legacy" is only for backward-compatibility and might be removed eventually',
@@ -50,6 +51,11 @@ test_that("outline.type option works", {
   expect_s3_class(g_ribbon_upper$children[[1]]$children[[1]], "polygon")
   expect_s3_class(g_ribbon_upper$children[[1]]$children[[2]], "polyline")
   expect_equal(g_ribbon_upper$children[[1]]$children[[2]]$id, rep(c(1L, NA), each = 4))
+
+  # lower
+  expect_s3_class(g_ribbon_lower$children[[1]]$children[[1]], "polygon")
+  expect_s3_class(g_ribbon_lower$children[[1]]$children[[2]], "polyline")
+  expect_equal(g_ribbon_lower$children[[1]]$children[[2]]$id, rep(c(NA, 1L), each = 4))
 
   # legacy
   expect_s3_class(g_ribbon_legacy$children[[1]], "polygon")


### PR DESCRIPTION
Currently only `"both"` and `"upper"` settings are valid for the new stroking in `geom_ribbon()`/`geom_area()` While the need for `"lower"`can perhaps be debated, I don't see a reason to not allow it. This PR adds the functionality