### PR TITLE
Set outline type for geom_density as geom_area

### DIFF
--- a/R/geom-density.r
+++ b/R/geom-density.r
@@ -12,6 +12,7 @@
 #'   See [geom_violin()] for a compact density display.
 #' @inheritParams layer
 #' @inheritParams geom_bar
+#' @inheritParams geom_ribbon
 #' @param geom,stat Use to override the default connection between
 #'   `geom_density` and `stat_density`.
 #' @export
@@ -56,7 +57,9 @@ geom_density <- function(mapping = NULL, data = NULL,
                          na.rm = FALSE,
                          orientation = NA,
                          show.legend = NA,
-                         inherit.aes = TRUE) {
+                         inherit.aes = TRUE,
+                         outline.type = 'upper') {
+  outline.type <- match.arg(outline.type, c("both", "upper", "lower", "legacy"))
 
   layer(
     data = data,
@@ -69,6 +72,7 @@ geom_density <- function(mapping = NULL, data = NULL,
     params = list(
       na.rm = na.rm,
       orientation = orientation,
+      outline.type = outline.type,
       ...
     )
   )

--- a/R/geom-density.r
+++ b/R/geom-density.r
@@ -58,7 +58,7 @@ geom_density <- function(mapping = NULL, data = NULL,
                          orientation = NA,
                          show.legend = NA,
                          inherit.aes = TRUE,
-                         outline.type = 'upper') {
+                         outline.type = "upper") {
   outline.type <- match.arg(outline.type, c("both", "upper", "lower", "legacy"))
 
   layer(

--- a/man/geom_density.Rd
+++ b/man/geom_density.Rd
@@ -14,7 +14,8 @@ geom_density(
   na.rm = FALSE,
   orientation = NA,
   show.legend = NA,
-  inherit.aes = TRUE
+  inherit.aes = TRUE,
+  outline.type = "upper"
 )
 
 stat_density(
@@ -81,6 +82,10 @@ display.}
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
+
+\item{outline.type}{Type of the outline of the area; \code{"both"} draws both the
+upper and lower lines, \code{"upper"}/\code{"lower"} draws the either lines only.
+\code{"legacy"} draws a closed polygon around the area.}
 
 \item{geom, stat}{Use to override the default connection between
 \code{geom_density} and \code{stat_density}.}

--- a/tests/testthat/test-function-args.r
+++ b/tests/testthat/test-function-args.r
@@ -14,8 +14,8 @@ test_that("geom_xxx and GeomXxx$draw arg defaults match", {
   geom_fun_names <- setdiff(
     geom_fun_names,
     c("geom_map", "geom_sf", "geom_smooth", "geom_column", "geom_area",
-      "annotation_custom", "annotation_map",
-      "annotation_raster", "annotation_id")
+      "geom_density", "annotation_custom", "annotation_map", "annotation_raster",
+      "annotation_id")
   )
 
   # For each geom_xxx function and the corresponding GeomXxx$draw and


### PR DESCRIPTION
The new stroking of `geom_ribbon()` and `geom_area()` didn't make it to `geom_density()` This PR adds it and make it behave like `geom_area()`