### PR TITLE
don't drop ordering from ordinal factors

### DIFF
--- a/tests/testthat/test-rbind-dfs.R
+++ b/tests/testthat/test-rbind-dfs.R
@@ -1,0 +1,14 @@
+context("data.frame binding")
+
+test_that("rbind_dfs keep classes of columns", {
+  df <- data_frame(
+    integer = seq_len(10),
+    numeric = as.numeric(seq_len(10)),
+    character = letters[1:10],
+    factor = factor(letters[1:10]),
+    ordered = ordered(letters[1:10]),
+    date = Sys.Date()
+  )
+  df2 <- rbind_dfs(list(df[1:5, ], df[6:10, ]))
+  expect_equal(df2, df)
+})


### PR DESCRIPTION
When I wrote out ply, I inadvertently dropped support for ordered factors. This is such a niche data structure that it didn't set of any alarms, but I noticed it when I wanted `stat_contour_filled()` to return levels as ordered.

This PR fixes the regression by not converting ordered factors into factors when binding data.frames