### PR TITLE
Fix typos in examples of annotation_map()

### DIFF
--- a/R/annotation-map.r
+++ b/R/annotation-map.r
@@ -15,7 +15,7 @@ NULL
 #'
 #' seal.sub <- subset(seals, long > -130 & lat < 45 & lat > 40)
 #' ggplot(seal.sub, aes(x = long, y = lat)) +
-#'   annotation_map(usamap, fill = "NA", colour = "grey50") +
+#'   annotation_map(usamap, fill = NA, colour = "grey50") +
 #'   geom_segment(aes(xend = long + delta_long, yend = lat + delta_lat))
 #' }
 #'
@@ -25,7 +25,7 @@ NULL
 #'   longr = cut(long, 2))
 #'
 #' ggplot(seal2,  aes(x = long, y = lat)) +
-#'   annotation_map(usamap, fill = "NA", colour = "grey50") +
+#'   annotation_map(usamap, fill = NA, colour = "grey50") +
 #'   geom_segment(aes(xend = long + delta_long, yend = lat + delta_lat)) +
 #'   facet_grid(latr ~ longr, scales = "free", space = "free")
 #' }

--- a/man/annotation_map.Rd
+++ b/man/annotation_map.Rd
@@ -21,7 +21,7 @@ usamap <- map_data("state")
 
 seal.sub <- subset(seals, long > -130 & lat < 45 & lat > 40)
 ggplot(seal.sub, aes(x = long, y = lat)) +
-  annotation_map(usamap, fill = "NA", colour = "grey50") +
+  annotation_map(usamap, fill = NA, colour = "grey50") +
   geom_segment(aes(xend = long + delta_long, yend = lat + delta_lat))
 }
 
@@ -31,7 +31,7 @@ seal2 <- transform(seal.sub,
   longr = cut(long, 2))
 
 ggplot(seal2,  aes(x = long, y = lat)) +
-  annotation_map(usamap, fill = "NA", colour = "grey50") +
+  annotation_map(usamap, fill = NA, colour = "grey50") +
   geom_segment(aes(xend = long + delta_long, yend = lat + delta_lat)) +
   facet_grid(latr ~ longr, scales = "free", space = "free")
 }


### PR DESCRIPTION
Fix #3712

The new farver package now raises an error for invalid colour names (c.f. #3644) for example when we typoed `NA` as `"NA"`. This PR fixes the example.