### PR TITLE
Rename outline.type option "legacy" to "full"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,9 +27,9 @@ fail.
   (`NA`) rather than drawing a white one. (@annennenne, #3180)
 
 * `geom_ribbon()` now draws separate lines for the upper and lower intervals if
-  `colour` is mapped by default. Similarly, `geom_area()` now draws lines for
-  the upper in the same case by default. If you want old-style full stroking, 
-  use `outlier.type = "legacy"` (#3503, @yutannihilation).
+  `colour` is mapped. Similarly, `geom_area()` and `geom_density()` now draw
+  the upper lines only in the same case by default. If you want old-style full
+  stroking, use `outline.type = "full"` (@yutannihilation, #3503 / @thomasp85, #3708).
 
 ## New features
 

--- a/R/geom-density.r
+++ b/R/geom-density.r
@@ -59,7 +59,7 @@ geom_density <- function(mapping = NULL, data = NULL,
                          show.legend = NA,
                          inherit.aes = TRUE,
                          outline.type = "upper") {
-  outline.type <- match.arg(outline.type, c("both", "upper", "lower", "legacy"))
+  outline.type <- match.arg(outline.type, c("both", "upper", "lower", "full"))
 
   layer(
     data = data,

--- a/R/geom-ribbon.r
+++ b/R/geom-ribbon.r
@@ -23,7 +23,7 @@
 #' @inheritParams geom_bar
 #' @param outline.type Type of the outline of the area; `"both"` draws both the
 #'   upper and lower lines, `"upper"`/`"lower"` draws the either lines only.
-#'   `"legacy"` draws a closed polygon around the area.
+#'   `"full"` draws a closed polygon around the area.
 #' @export
 #' @examples
 #' # Generate data
@@ -49,7 +49,7 @@ geom_ribbon <- function(mapping = NULL, data = NULL,
                         show.legend = NA,
                         inherit.aes = TRUE,
                         outline.type = "both") {
-  outline.type <- match.arg(outline.type, c("both", "upper", "lower", "legacy"))
+  outline.type <- match.arg(outline.type, c("both", "upper", "lower", "full"))
 
   layer(
     data = data,
@@ -143,12 +143,12 @@ GeomRibbon <- ggproto("GeomRibbon", Geom,
       default.units = "native",
       gp = gpar(
         fill = alpha(aes$fill, aes$alpha),
-        col = if (identical(outline.type, "legacy")) aes$colour else NA
+        col = if (identical(outline.type, "full")) aes$colour else NA
       )
     )
 
-    if (identical(outline.type, "legacy")) {
-      warn(glue('outline.type = "legacy" is only for backward-compatibility ',
+    if (identical(outline.type, "full")) {
+      warn(glue('outline.type = "full" is only for backward-compatibility ',
                 'and might be removed eventually'))
       return(ggname("geom_ribbon", g_poly))
     }
@@ -181,7 +181,7 @@ geom_area <- function(mapping = NULL, data = NULL, stat = "identity",
                       position = "stack", na.rm = FALSE, orientation = NA,
                       show.legend = NA, inherit.aes = TRUE, ...,
                       outline.type = "upper") {
-  outline.type <- match.arg(outline.type, c("both", "upper", "lower", "legacy"))
+  outline.type <- match.arg(outline.type, c("both", "upper", "lower", "full"))
 
   layer(
     data = data,

--- a/R/geom-ribbon.r
+++ b/R/geom-ribbon.r
@@ -148,8 +148,6 @@ GeomRibbon <- ggproto("GeomRibbon", Geom,
     )
 
     if (identical(outline.type, "full")) {
-      warn(glue('outline.type = "full" is only for backward-compatibility ',
-                'and might be removed eventually'))
       return(ggname("geom_ribbon", g_poly))
     }
 

--- a/man/geom_density.Rd
+++ b/man/geom_density.Rd
@@ -85,7 +85,7 @@ the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 
 \item{outline.type}{Type of the outline of the area; \code{"both"} draws both the
 upper and lower lines, \code{"upper"}/\code{"lower"} draws the either lines only.
-\code{"legacy"} draws a closed polygon around the area.}
+\code{"full"} draws a closed polygon around the area.}
 
 \item{geom, stat}{Use to override the default connection between
 \code{geom_density} and \code{stat_density}.}

--- a/man/geom_ribbon.Rd
+++ b/man/geom_ribbon.Rd
@@ -84,7 +84,7 @@ the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 
 \item{outline.type}{Type of the outline of the area; \code{"both"} draws both the
 upper and lower lines, \code{"upper"}/\code{"lower"} draws the either lines only.
-\code{"legacy"} draws a closed polygon around the area.}
+\code{"full"} draws a closed polygon around the area.}
 }
 \description{
 For each x value, \code{geom_ribbon()} displays a y interval defined

--- a/tests/testthat/test-geom-ribbon.R
+++ b/tests/testthat/test-geom-ribbon.R
@@ -35,11 +35,7 @@ test_that("outline.type option works", {
   g_ribbon_default <- layer_grob(p + geom_ribbon())[[1]]
   g_ribbon_upper   <- layer_grob(p + geom_ribbon(outline.type = "upper"))[[1]]
   g_ribbon_lower   <- layer_grob(p + geom_ribbon(outline.type = "lower"))[[1]]
-  g_ribbon_legacy  <- expect_warning(
-    layer_grob(p + geom_ribbon(outline.type = "legacy"))[[1]],
-    'outline.type = "legacy" is only for backward-compatibility and might be removed eventually',
-    fixed = TRUE
-  )
+  g_ribbon_full    <- layer_grob(p + geom_ribbon(outline.type = "full"))[[1]]
   g_area_default   <- layer_grob(ggplot(df, aes(x, y)) + geom_area())[[1]]
 
   # default
@@ -57,8 +53,8 @@ test_that("outline.type option works", {
   expect_s3_class(g_ribbon_lower$children[[1]]$children[[2]], "polyline")
   expect_equal(g_ribbon_lower$children[[1]]$children[[2]]$id, rep(c(NA, 1L), each = 4))
 
-  # legacy
-  expect_s3_class(g_ribbon_legacy$children[[1]], "polygon")
+  # full
+  expect_s3_class(g_ribbon_full$children[[1]], "polygon")
 
   # geom_area()'s default is upper
   expect_s3_class(g_area_default$children[[1]]$children[[1]], "polygon")


### PR DESCRIPTION
(Followup of #3708)

I originally named this option as `"legacy"` to discourage the usage in the hope of deprecating and removing this option eventually. But, this might be needed a bit longer than expected to keep the backward-compatibility of `geom_density()`. This PR

* renames "legacy" to "full",
* removes a warning, and
* describes about `geom_density()` in the NEWS
