### PR TITLE
Fixes #3718

### DIFF
--- a/R/guides-axis.r
+++ b/R/guides-axis.r
@@ -193,10 +193,18 @@ draw_axis <- function(break_positions, break_labels, axis_position, theme,
   # override label element parameters for rotation
   if (inherits(label_element, "element_text")) {
     label_overrides <- axis_label_element_overrides(axis_position, angle)
-    # label_overrides is always an element_text(), but in order for the merge to
-    # keep the new class, the override must also have the new class
-    class(label_overrides) <- class(label_element)
-    label_element <- merge_element(label_overrides, label_element)
+    # label_overrides is an element_text, but label_element may not be;
+    # to merge the two elements, we just copy angle, hjust, and vjust
+    # unless their values are NULL
+    if (!is.null(label_overrides$angle)) {
+      label_element$angle <- label_overrides$angle
+    }
+    if (!is.null(label_overrides$hjust)) {
+      label_element$hjust <- label_overrides$hjust
+    }
+    if (!is.null(label_overrides$vjust)) {
+      label_element$vjust <- label_overrides$vjust
+    }
   }
 
   # conditionally set parameters that depend on axis orientation


### PR DESCRIPTION
This fixes #3718. I am confident about this fix. It doesn't touch `merge_element()` at all, only makes a minor change in `draw_axis()`, and simply copies over the relevant properties manually instead of merging the elements. Reprex below shows that things work as expected with this fix.

``` r
library(ggplot2)
library(ggtext)

ggplot(mpg, aes(class)) + 
  geom_bar() +
  scale_x_discrete(
    name = "vehicle *class*",
    labels = c("2seater", "*compact*", "midsize", "**minivan**", "pickup", "<sub>sub</sub>compact", "suv")
  ) +
  theme(
    axis.title.x = element_markdown(
      linetype = 1, fill = "cornsilk", r = unit(5, "pt"), padding = margin(4, 4, 4, 4)
    ),
    axis.text.x = element_markdown(
      linetype = 1, fill = "cornsilk", r = unit(5, "pt"), padding = margin(4, 4, 4, 4)
    )
  )
```

![](https://i.imgur.com/FcGdHcT.png)

<sup>Created on 2020-01-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>