### PR TITLE
make sure aes renaming is reflected in data

### DIFF
--- a/R/aes.r
+++ b/R/aes.r
@@ -158,7 +158,7 @@ print.uneval <- function(x, ...) {
 #' @export
 standardise_aes_names <- function(x) {
   # convert US to UK spelling of colour
-  x <- sub("^color$", "colour", x, fixed = TRUE)
+  x <- sub("color", "colour", x, fixed = TRUE)
 
   # convert old-style aesthetics names to ggplot version
   revalue(x, ggplot_global$base_to_ggplot)

--- a/R/aes.r
+++ b/R/aes.r
@@ -158,7 +158,7 @@ print.uneval <- function(x, ...) {
 #' @export
 standardise_aes_names <- function(x) {
   # convert US to UK spelling of colour
-  x <- sub("color", "colour", x, fixed = TRUE)
+  x <- sub("^color$", "colour", x, fixed = TRUE)
 
   # convert old-style aesthetics names to ggplot version
   revalue(x, ggplot_global$base_to_ggplot)

--- a/R/layer.r
+++ b/R/layer.r
@@ -279,6 +279,10 @@ Layer <- ggproto("Layer", NULL,
 
   map_statistic = function(self, data, plot) {
     if (empty(data)) return(new_data_frame())
+
+    # Make sure data columns are converted to correct names. If not done, a
+    # column with e.g. a color name will not be found in an after_stat()
+    # evaluation (since the evaluation symbols gets renamed)
     data <- rename_aes(data)
 
     # Assemble aesthetics from layer, plot and stat mappings

--- a/R/layer.r
+++ b/R/layer.r
@@ -279,6 +279,7 @@ Layer <- ggproto("Layer", NULL,
 
   map_statistic = function(self, data, plot) {
     if (empty(data)) return(new_data_frame())
+    data <- rename_aes(data)
 
     # Assemble aesthetics from layer, plot and stat mappings
     aesthetics <- self$mapping


### PR DESCRIPTION
This issue is based on failing revdep check of ggspectra and its reverse dependencies

Currently aes name standardisation changes every occurrence of "color" to "colour", not just the exact string "color". This has not been a problem before, but with the new aesthetic evaluation we have chosen to substituted names inside the expressions used in `after_stat()` and `after_scale()` and this causes problems if the expression references a US spelling column in the data.

This PR fixes it by only matching exactly to "color", but I'm unsure about whether there will be unforeseen consequences of this change. Another approach would be to substitute the names of the columns as well

