### PR TITLE
WIP: Allow expressions in facet specs even when some variables are not available on some layers

### DIFF
--- a/R/facet-.r
+++ b/R/facet-.r
@@ -423,17 +423,6 @@ eval_facets <- function(facets, data, possible_columns = NULL) {
   new_data_frame(tibble::as_tibble(vars))
 }
 eval_facet <- function(facet, data, possible_columns = NULL) {
-  if (quo_is_symbol(facet)) {
-    facet <- as.character(quo_get_expr(facet))
-
-    if (facet %in% names(data)) {
-      out <- data[[facet]]
-    } else {
-      out <- NULL
-    }
-    return(out)
-  }
-
   # clone the env in order to prevent side effects (hopefully)
   env <- env_clone(quo_get_env(facet))
 

--- a/R/facet-.r
+++ b/R/facet-.r
@@ -444,8 +444,7 @@ eval_facet <- function(facet, data, possible_columns = NULL) {
   # layer data but exists in other layer
   missing_columns <- setdiff(possible_columns, names(data))
   undefined_error <- function(e) abort("", class = "ggplot2_undefined_aes_error")
-  bindings <- rep_along(missing_columns, list(undefined_error))
-  names(bindings) <- missing_columns
+  bindings <- rep_named(missing_columns, list(undefined_error))
   env_bind_active(env, !!!bindings)
 
   # Create a data mask and install a data pronoun manually (see ?new_data_mask)

--- a/R/facet-.r
+++ b/R/facet-.r
@@ -443,10 +443,9 @@ eval_facet <- function(facet, data, possible_columns = NULL) {
   # so that we can detect and ignore the case when a variable is missing from the
   # layer data but exists in other layer
   missing_columns <- setdiff(possible_columns, names(data))
-  bindings <- lapply(
-    set_names(missing_columns),
-    function(...) function(e) abort("", class = "ggplot2_undefined_aes_error")
-  )
+  undefined_error <- function(e) abort("", class = "ggplot2_undefined_aes_error")
+  bindings <- rep_along(missing_columns, list(undefined_error))
+  names(bindings) <- missing_columns
   env_bind_active(env, !!!bindings)
 
   # Create a data mask and install a data pronoun manually (see ?new_data_mask)

--- a/R/facet-.r
+++ b/R/facet-.r
@@ -423,6 +423,19 @@ eval_facets <- function(facets, data, possible_columns = NULL) {
   new_data_frame(tibble::as_tibble(vars))
 }
 eval_facet <- function(facet, data, possible_columns = NULL) {
+  # Treat the case when `facet` is a quosure of a symbol specifically
+  # to issue a friendlier warning
+  if (quo_is_symbol(facet)) {
+    facet <- as.character(quo_get_expr(facet))
+
+    if (facet %in% names(data)) {
+      out <- data[[facet]]
+    } else {
+      out <- NULL
+    }
+    return(out)
+  }
+
   # clone the env in order to prevent side effects (hopefully)
   env <- env_clone(quo_get_env(facet))
 

--- a/R/facet-.r
+++ b/R/facet-.r
@@ -439,8 +439,9 @@ eval_facet <- function(facet, data, possible_columns = NULL) {
   # Create an environment for data mask
   env <- new_environment(data)
 
-  # Bind all possible column names to raise a custom error to detect the case
-  # when a variable is missing from the layer data but exists in other layer
+  # Bind all possible column names that remains undefined to raise a custom error
+  # so that we can detect and ignore the case when a variable is missing from the
+  # layer data but exists in other layer
   missing_columns <- setdiff(possible_columns, names(data))
   bindings <- lapply(
     set_names(missing_columns),
@@ -452,6 +453,8 @@ eval_facet <- function(facet, data, possible_columns = NULL) {
   mask <- new_data_mask(env)
   mask$.data <- as_data_pronoun(mask)
 
+  # Do not treat the cases as errors when it refers to a column name unavailable
+  # in the layer data
   tryCatch(
     eval_tidy(facet, mask),
     ggplot2_undefined_aes_error = function(e) NULL

--- a/R/facet-grid-.r
+++ b/R/facet-grid-.r
@@ -252,7 +252,7 @@ FacetGrid <- ggproto("FacetGrid", Facet,
       intersect(names(cols), names(data)))
     data <- reshape_add_margins(data, margin_vars, params$margins)
 
-    facet_vals <- eval_facets(c(rows, cols), data, params$plot_env)
+    facet_vals <- eval_facets(c(rows, cols), data, params$plot_env, params$.possible_columns)
 
     # If any faceting variables are missing, add them in by
     # duplicating the data

--- a/R/facet-grid-.r
+++ b/R/facet-grid-.r
@@ -252,7 +252,7 @@ FacetGrid <- ggproto("FacetGrid", Facet,
       intersect(names(cols), names(data)))
     data <- reshape_add_margins(data, margin_vars, params$margins)
 
-    facet_vals <- eval_facets(c(rows, cols), data, params$plot_env, params$.possible_columns)
+    facet_vals <- eval_facets(c(rows, cols), data, params$.possible_columns)
 
     # If any faceting variables are missing, add them in by
     # duplicating the data

--- a/R/facet-wrap.r
+++ b/R/facet-wrap.r
@@ -187,7 +187,7 @@ FacetWrap <- ggproto("FacetWrap", Facet,
       return(data)
     }
 
-    facet_vals <- eval_facets(vars, data, params$plot_env, params$.possible_columns)
+    facet_vals <- eval_facets(vars, data, params$.possible_columns)
     facet_vals[] <- lapply(facet_vals[], as.factor)
 
     missing_facets <- setdiff(names(vars), names(facet_vals))

--- a/R/facet-wrap.r
+++ b/R/facet-wrap.r
@@ -187,7 +187,7 @@ FacetWrap <- ggproto("FacetWrap", Facet,
       return(data)
     }
 
-    facet_vals <- eval_facets(vars, data, params$plot_env)
+    facet_vals <- eval_facets(vars, data, params$plot_env, params$.possible_columns)
     facet_vals[] <- lapply(facet_vals[], as.factor)
 
     missing_facets <- setdiff(names(vars), names(facet_vals))

--- a/tests/testthat/test-facet-.r
+++ b/tests/testthat/test-facet-.r
@@ -302,6 +302,27 @@ test_that("combine_vars() generates the correct combinations with multiple data 
   )
 })
 
+test_that("eval_facet() is tolerant for missing columns (#2963)", {
+  expect_null(eval_facet(quo(2 * x), data_frame(foo = 1), possible_columns = c("x")))
+  expect_null(eval_facet(quo(2 * .data$x), data_frame(foo = 1), possible_columns = c("x")))
+
+  # Even if there's the same name of external variable, eval_facet() returns NULL before
+  # reaching to the variable
+  bar <- 2
+  expect_null(eval_facet(quo(2 * bar), data_frame(foo = 1), possible_columns = c("bar")))
+  # If there's no same name of columns, the external variable is used
+  expect_equal(
+    eval_facet(quo(2 * bar), data_frame(foo = 1), possible_columns = c("x")),
+    4
+  )
+
+  # If the expression contains any non-existent variable, it fails
+  expect_error(
+    eval_facet(quo(no_such_variable * x), data_frame(foo = 1), possible_columns = c("x")),
+    "object 'no_such_variable' not found"
+  )
+})
+
 # Visual tests ------------------------------------------------------------
 
 test_that("facet labels respect both justification and margin arguments", {


### PR DESCRIPTION
Fix #2963

Not all variables in a facet spec are available on all the layers. A solution suggested on https://github.com/r-lib/rlang/issues/888#issuecomment-573691024 is:

> bind the same symbols inside each panel, and when the symbols are undefined use an active binding to throw a typed error? And then you'd only catch these particular errors in the `tryCatch()`

This PR injects such an active bindings on the column names of all the plot data so that we can let `eval_facet()` fail gracefully.

Note that this PR removes `env` argument of `eval_facet()` to avoid confusion. I believe all facet specs are converted to quosures and bare expressions are not allowed, which means `env` is always ignored on `eval_tidy()`.

``` r
devtools::load_all("~/repo/ggplot2/")
#> Loading ggplot2

# works fine with expressions
ggplot(mtcars, aes(mpg, cyl)) +
  geom_point() +
  geom_vline(xintercept = 20) +
  facet_wrap(vars(2 * am))
```

![](https://i.imgur.com/DXE7ycD.png)

``` r

# works fine with external variables
two <- 2
ggplot(mtcars, aes(mpg, cyl)) +
  geom_point() +
  geom_vline(xintercept = 20) +
  facet_wrap(vars(two * am))
```

![](https://i.imgur.com/tWhUCXh.png)

``` r

# raises an error when the expression refers to some non-existent variable
ggplot(mtcars, aes(mpg, cyl)) +
  geom_point() +
  geom_vline(xintercept = 20) +
  facet_wrap(vars(no_such_variable * am))
#> Error in eval_tidy(facet, data): object 'no_such_variable' not found

# special case: raises a friendlier error when the expression is a symbol
ggplot(mtcars, aes(mpg, cyl)) +
  geom_point() +
  geom_vline(xintercept = 20) +
  facet_wrap(vars(no_such_variable))
#> Error: At least one layer must contain all faceting variables: `no_such_variable`.
#> * Plot is missing `no_such_variable`
#> * Layer 1 is missing `no_such_variable`
#> * Layer 2 is missing `no_such_variable`
```

![](https://i.imgur.com/N5jHPCG.png)

<sup>Created on 2020-01-16 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

----
TODO:
- [ ] Add a NEWS bullet
- [ ] Consider using `warn_for_aes_extract_usage()` here as well
- [ ] Consider if it's really OK to add a param to `Facet` (I bet it's OK)