### PR TITLE
Handle label functions that return character(0)

### DIFF
--- a/R/guides-axis.r
+++ b/R/guides-axis.r
@@ -85,14 +85,6 @@ guide_train.axis <- function(guide, scale, aesthetic = NULL) {
     ticks$.value <- breaks
     ticks$.label <- scale$get_labels(breaks)
 
-    if (is.list(ticks$.label)) {
-      if (any(sapply(ticks$.label, is.language))) {
-        ticks$.label <- do.call(expression, ticks$.label)
-      } else {
-        ticks$.label <- unlist(ticks$.label)
-      }
-    }
-
     guide$key <- ticks[is.finite(ticks[[aesthetic]]), ]
   }
 

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -692,6 +692,12 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
       labels[vapply(labels, length, integer(1)) == 0] <- ""
       # Make sure each element is scalar
       labels <- lapply(labels, `[`, 1)
+
+      if (any(vapply(labels, is.language, logical(1)))) {
+        labels <- do.call(expression, labels)
+      } else {
+        labels <- unlist(labels)
+      }
     }
 
     labels

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -690,6 +690,8 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
     if (is.list(labels)) {
       # Guard against list with empty elements
       labels[vapply(labels, length, integer(1)) == 0] <- ""
+      # Make sure each element is scalar
+      labels <- lapply(labels, `[`, 1)
     }
 
     labels

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -687,6 +687,10 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
     if (length(labels) != length(breaks)) {
       abort("Breaks and labels are different lengths")
     }
+    if (is.list(labels)) {
+      # Guard against list with empty elements
+      labels[vapply(labels, length, integer(1)) == 0] <- ""
+    }
 
     labels
   },


### PR DESCRIPTION
This PR addresses an issue in scales. If a label function converts an `NA` break to a `character(0)` label we will get an error later on when we enlist the label list. This is fixed here in the `ScaleContinuous$get_labels()` function by converting such list elements to empty strings (`""`) instead.

It can be argued that this should get fixed in `scales::label_number_auto()` (and perhaps it should as well), but I think it makes sense to have a guard in ggplot2 as well, since otherwise this problem will be carried all the way to `guide_axis()` and create an unintelligible error there.