### PR TITLE
Strip .data from default labels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -162,8 +162,7 @@ fail.
 * `stat_summary()` and related functions now support rlang-style lambda functions
   (#3568, @dkahle).
 
-* `strip_dots()` strips the data masking pronoun `.data` to make better
-  axis labels.
+* The data mask pronoun, `.data`, is now stripped from default labels.
 
 * Addition of partial themes to plots has been made more predictable;
   stepwise addition of individual partial themes is now equivalent to

--- a/NEWS.md
+++ b/NEWS.md
@@ -162,6 +162,9 @@ fail.
 * `stat_summary()` and related functions now support rlang-style lambda functions
   (#3568, @dkahle).
 
+* `strip_dots()` strips the data masking pronoun `.data` to make better
+  axis labels.
+
 * Addition of partial themes to plots has been made more predictable;
   stepwise addition of individual partial themes is now equivalent to
   addition of multple theme elements at once (@clauswilke, #3039).

--- a/R/aes-evaluation.r
+++ b/R/aes-evaluation.r
@@ -132,7 +132,7 @@ is_staged <- function(x) {
 }
 
 # Strip dots from expressions
-strip_dots <- function(expr, env = globalenv()) {
+strip_dots <- function(expr, env) {
   if (is.atomic(expr)) {
     expr
   } else if (is.name(expr)) {

--- a/R/aes-evaluation.r
+++ b/R/aes-evaluation.r
@@ -145,7 +145,7 @@ strip_dots <- function(expr, env) {
   } else if (is_quosure(expr)) {
     # strip dots from quosure and reconstruct the quosure
     new_quosure(
-      strip_dots(quo_get_expr(expr), quo_get_env(expr)),
+      strip_dots(quo_get_expr(expr), env = quo_get_env(expr)),
       quo_get_env(expr)
     )
   } else if (is.call(expr)) {

--- a/tests/testthat/test-aes-calculated.r
+++ b/tests/testthat/test-aes-calculated.r
@@ -24,6 +24,18 @@ test_that("strip_dots remove dots around calculated aesthetics", {
   )
 })
 
+test_that("strip_dots handles tidy evaluation pronouns", {
+  expect_identical(strip_dots(aes(.data$x))$x, quo(x))
+  expect_identical(strip_dots(aes(.data[["x"]]))$x, quo(x))
+
+  var <- "y"
+  f <- function() {
+    var <- "x"
+    aes(.data[[var]])$x
+  }
+  expect_identical(quo_get_expr(strip_dots(f())), quote(x))
+})
+
 test_that("make_labels() deprases mappings properly", {
   # calculation stripped from labels
   expect_identical(make_labels(aes(x = ..y..)), list(x = "y"))


### PR DESCRIPTION
@thomasp85 this ensures that when you use the `.data` pronoun with ggplot2, it doesn't adversely affect the labels.

@paleolimbot — this should make your talk slightly simpler 😄 