### PR TITLE
Faster scale_apply

### DIFF
--- a/R/layout.R
+++ b/R/layout.R
@@ -296,10 +296,7 @@ scale_apply <- function(data, vars, method, scale_id, scales) {
     abort("`scale_id` must not be `NA`")
   }
 
-  scale_index <- unname(split(
-    seq_along(scale_id),
-    factor(scale_id, levels = seq_along(scales))
-  ))
+  scale_index <- split_with_index(seq_along(scale_id), scale_id, length(scales))
 
   lapply(vars, function(var) {
     pieces <- lapply(seq_along(scales), function(i) {

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -640,3 +640,10 @@ flipped_names <- function(flip = FALSE) {
   names(ret) <- c(x_aes, y_aes)
   ret
 }
+
+split_with_index <- function(x, f, n = max(f)) {
+  if (n == 1) return(list(x))
+  f <- as.integer(f)
+  attributes(f) <- list(levels = as.character(seq_len(n)), class = "factor")
+  unname(split(x, f))
+}

--- a/vignettes/profiling.Rmd
+++ b/vignettes/profiling.Rmd
@@ -55,7 +55,15 @@ To keep track of changes focused on improving the performance of gtable they
 are summarised below:
 
 ### v`r packageVersion('ggplot2')`
+- **Avoid costly factor construction in scale_apply** This issue only really 
+  appeared when plotting huge datasets (>1e6 rows). In order to train and map 
+  the position aesthetics rows has to be matched based on their panel. This 
+  require splitting the row indexes by panel which included a `factor()` call. 
+  The factor constructor is very slow for large vectors and can be simplified 
+  considerably for this specific case. Further, the split can be avoided 
+  completely when there is only one panel
 
+### v3.1.0
 - **Caching of calls to `grid::descentDetails()`** The absolute biggest offender
   was the construction of titles. In recent versions this has included calls to
   `grid::descentDetails()` to ensure that they are aligned across plots, but 


### PR DESCRIPTION
When handling large datasets (>1e6 rows), scale_apply ends up being the main bottleneck (around 50% of the rendering time) This is all due to a call to `factor()` on the vector identifying which positional scale each row belongs two (this happens 8 time in total, as the scales are trained and mapped twice for both x and y).

This PR simplifies the factor construction as well as bypass it completely in the case of only a single scale (which is the predominant case). It speeds up the step 1000-fold for single panel plots and 2-3 fold otherwise