### PR TITLE
Fix single value detection in has_flipped_aes()

### DIFF
--- a/R/utilities.r
+++ b/R/utilities.r
@@ -592,10 +592,10 @@ has_flipped_aes <- function(data, params = list(), main_is_orthogonal = NA,
     return(y_is_int != main_is_continuous)
   }
   # Is one of the axes a single value
-  if (all(x == 1)) {
+  if (zero_range(range(x, na.rm = TRUE))) {
     return(main_is_continuous)
   }
-  if (all(y == 1)) {
+  if (zero_range(range(y, na.rm = TRUE))) {
     return(!main_is_continuous)
   }
   # If both are discrete like, which have most 0 or 1-spaced values


### PR DESCRIPTION
These lines are to detect the case "the axes is a single value," but, in actual, they check whether all values are a fixed value`1` or not.

https://github.com/tidyverse/ggplot2/blob/5e6b1e5daa1599661bf5841353a067e9eee88161/R/utilities.r#L594-L600

This causes different behaviours between the case of `1` and that of another value. This PR fixes the check to `zero_range(range())`.

``` r
library(ggplot2)

df <- data.frame(value = 1:3, group = c("a", "a", "b"))
l <-  stat_summary(fun = "mean", geom = "bar", position = "dodge")
p1 <- ggplot(df, aes(value, 1, fill = group)) + l
p2 <- ggplot(df, aes(value, 0, fill = group)) + l

patchwork::wrap_plots(p1, p2, ncol = 1)
```

![](https://i.imgur.com/p0SQHuO.png)

<sup>Created on 2020-01-29 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>