### PR TITLE
ggplot2 incorrect documentation #3626

### DIFF
--- a/R/stat-density.r
+++ b/R/stat-density.r
@@ -9,12 +9,7 @@
 #' @param n number of equally spaced points at which the density is to be
 #'   estimated, should be a power of two, see [density()] for
 #'   details
-#' @param trim This parameter only matters if you are displaying multiple
-#'   densities in one plot. If `FALSE`, the default, each density is
-#'   computed on the full range of the data. If `TRUE`, each density
-#'   is computed over the range of that group: this typically means the
-#'   estimated x values will not line-up, and hence you won't be able to
-#'   stack density values.
+#' @param trim if TRUE, the default, densities are trimmed to the actual range of the data. If FALSE, the default, they are extended by the default 3 bandwidths (as specified by the cut parameter to densit
 #' @section Computed variables:
 #' \describe{
 #'   \item{density}{density estimate}

--- a/R/stat-density.r
+++ b/R/stat-density.r
@@ -9,7 +9,9 @@
 #' @param n number of equally spaced points at which the density is to be
 #'   estimated, should be a power of two, see [density()] for
 #'   details
-#' @param trim if TRUE, the default, densities are trimmed to the actual range of the data. If FALSE, the default, they are extended by the default 3 bandwidths (as specified by the cut parameter to densit
+#' @param trim if TRUE, the default, densities are trimmed to the actual
+#' range of the data. If FALSE, the default, they are extended by the
+#' default 3 bandwidths (as specified by the cut parameter to densit
 #' @section Computed variables:
 #' \describe{
 #'   \item{density}{density estimate}

--- a/man/geom_density.Rd
+++ b/man/geom_density.Rd
@@ -100,12 +100,7 @@ For example, \code{adjust = 1/2} means use half of the default bandwidth.}
 estimated, should be a power of two, see \code{\link[=density]{density()}} for
 details}
 
-\item{trim}{This parameter only matters if you are displaying multiple
-densities in one plot. If \code{FALSE}, the default, each density is
-computed on the full range of the data. If \code{TRUE}, each density
-is computed over the range of that group: this typically means the
-estimated x values will not line-up, and hence you won't be able to
-stack density values.}
+\item{trim}{if TRUE, the default, densities are trimmed to the actual range of the data. If FALSE, the default, they are extended by the default 3 bandwidths (as specified by the cut parameter to densit}
 }
 \description{
 Computes and draws kernel density estimate, which is a smoothed version of


### PR DESCRIPTION
updating text for the ggplot 2 stat_density function, trim argument. Updated the text from the website https://www.rdocumentation.org/packages/ggplot2/versions/1.0.1/topics/stat_density