### PR TITLE
Pass fill value to legend key icons

### DIFF
--- a/R/legend-draw.r
+++ b/R/legend-draw.r
@@ -136,12 +136,12 @@ draw_key_path <- function(data, params, size) {
 
   segmentsGrob(0.1, 0.5, 0.9, 0.5,
     gp = gpar(
-       col = alpha(data$colour %||% data$fill %||% "black", data$alpha),
-       fill = alpha(params$arrow.fill %||% data$colour
-                    %||% data$fill %||% "black", data$alpha),
-       lwd = (data$size %||% 0.5) * .pt,
-       lty = data$linetype %||% 1,
-       lineend = "butt"
+      col = alpha(data$colour %||% data$fill %||% "black", data$alpha),
+      fill = alpha(params$arrow.fill %||% data$colour
+                   %||% data$fill %||% "black", data$alpha),
+      lwd = (data$size %||% 0.5) * .pt,
+      lty = data$linetype %||% 1,
+      lineend = "butt"
     ),
     arrow = params$arrow
   )

--- a/R/legend-draw.r
+++ b/R/legend-draw.r
@@ -137,6 +137,7 @@ draw_key_path <- function(data, params, size) {
   segmentsGrob(0.1, 0.5, 0.9, 0.5,
     gp = gpar(
       col = alpha(data$colour %||% data$fill %||% "black", data$alpha),
+      fill = alpha(data$colour %||% data$fill %||% "black", data$alpha),
       lwd = (data$size %||% 0.5) * .pt,
       lty = data$linetype %||% 1,
       lineend = "butt"

--- a/R/legend-draw.r
+++ b/R/legend-draw.r
@@ -137,7 +137,7 @@ draw_key_path <- function(data, params, size) {
   segmentsGrob(0.1, 0.5, 0.9, 0.5,
     gp = gpar(
       col = alpha(data$colour %||% data$fill %||% "black", data$alpha),
-      fill = alpha(data$colour %||% data$fill %||% "black", data$alpha),
+      fill = alpha(data$colour %||% data$arrow.fill %||% "black", data$alpha),
       lwd = (data$size %||% 0.5) * .pt,
       lty = data$linetype %||% 1,
       lineend = "butt"

--- a/R/legend-draw.r
+++ b/R/legend-draw.r
@@ -136,11 +136,12 @@ draw_key_path <- function(data, params, size) {
 
   segmentsGrob(0.1, 0.5, 0.9, 0.5,
     gp = gpar(
-      col = alpha(data$colour %||% data$fill %||% "black", data$alpha),
-      fill = alpha(data$colour %||% data$arrow.fill %||% "black", data$alpha),
-      lwd = (data$size %||% 0.5) * .pt,
-      lty = data$linetype %||% 1,
-      lineend = "butt"
+       col = alpha(data$colour %||% data$fill %||% "black", data$alpha),
+       fill = alpha(params$arrow.fill %||% data$colour
+                    %||% data$fill %||% "black", data$alpha),
+       lwd = (data$size %||% 0.5) * .pt,
+       lty = data$linetype %||% 1,
+       lineend = "butt"
     ),
     arrow = params$arrow
   )


### PR DESCRIPTION
Resolves: #3455 

Below is reprex of this working:

```
# sample data
dat <- data.frame(
  x = as.factor(1:10),
  y = c(20,30,13,37,12,50,31,2,40,30),
  z = rep('a', 10)
)

# basic plot
ggplot(dat) +
  geom_segment(
    aes(x = x, xend = x, y = 0, yend = y+15, linetype = z), 
    arrow = arrow(length = unit(0.25, 'cm'), type = 'closed'),
    size = 0.7
  ) 
```

New output:
![image](https://user-images.githubusercontent.com/7990602/73578771-56e49d80-4435-11ea-952e-17d99832f8af.png)

Old output:
![image](https://user-images.githubusercontent.com/7990602/73578812-724fa880-4435-11ea-8e9e-2bfa0766b1d8.png)


