### PR TITLE
Annotation logticks outside

### DIFF
--- a/R/annotation-logticks.r
+++ b/R/annotation-logticks.r
@@ -156,7 +156,7 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
       if (grepl("t", sides)) {
         ticks$x_t <- with(data, segmentsGrob(
           x0 = unit(xticks$x, "native"), x1 = unit(xticks$x, "native"),
-          y0 = unit(100, "npc") - unit(xticks$start, "cm"), y1 = unit(1, "npc") - unit(xticks$end, "cm"),
+          y0 = unit(1, "npc") - unit(-xticks$end, "cm"), y1 = unit(1, "npc") - unit(xticks$start, "cm"),
           gp = gpar(col = alpha(colour, alpha), lty = linetype, lwd = size * .pt)
         ))
       }

--- a/R/annotation-logticks.r
+++ b/R/annotation-logticks.r
@@ -7,6 +7,7 @@
 #' @param sides a string that controls which sides of the plot the log ticks appear on.
 #'   It can be set to a string containing any of `"trbl"`, for top, right,
 #'   bottom, and left.
+#' @param outside logical that controls whether to move the log ticks outside of the plot area. Default is off (FALSE). You will also need to use `coord_cartesian(clip = "off")`. See examples.
 #' @param short a [grid::unit()] object specifying the length of the
 #'   short tick marks
 #' @param mid a [grid::unit()] object specifying the length of the
@@ -47,6 +48,8 @@
 #' a + annotation_logticks(sides = "lr")    # Log ticks for y, on left and right
 #' a + annotation_logticks(sides = "trbl")  # All four sides
 #'
+#' a + annotation_logticks(sides = "lr", outside = TRUE) + coord_cartesian(clip = "off")  # Ticks outside plot
+#'
 #' # Hide the minor grid lines because they don't align with the ticks
 #' a + annotation_logticks(sides = "trbl") + theme(panel.grid.minor = element_blank())
 #'
@@ -73,9 +76,9 @@
 #'   mid = unit(3,"mm"),
 #'   long = unit(4,"mm")
 #' )
-annotation_logticks <- function(base = 10, sides = "bl", scaled = TRUE,
-      short = unit(0.1, "cm"), mid = unit(0.2, "cm"), long = unit(0.3, "cm"),
-      colour = "black", size = 0.5, linetype = 1, alpha = 1, color = NULL, ...)
+annotation_logticks <- function(base = 10, sides = "bl", outside = FALSE, scaled = TRUE,
+    short = unit(0.1, "cm"), mid = unit(0.2, "cm"), long = unit(0.3, "cm"),
+    colour = "black", size = 0.5, linetype = 1, alpha = 1, color = NULL, ...)
 {
   if (!is.null(color))
     colour <- color
@@ -115,8 +118,8 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
   },
 
   draw_panel = function(data, panel_params, coord, base = 10, sides = "bl",
-    scaled = TRUE, short = unit(0.1, "cm"), mid = unit(0.2, "cm"),
-    long = unit(0.3, "cm"))
+                        outside = FALSE, scaled = TRUE, short = unit(0.1, "cm"),
+                        mid = unit(0.2, "cm"), long = unit(0.3, "cm"))
   {
     ticks <- list()
 
@@ -144,6 +147,10 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
 
       names(xticks)[names(xticks) == "value"] <- "x"   # Rename to 'x' for coordinates$transform
       xticks <- coord$transform(xticks, panel_params)
+      xticks = xticks[xticks$x <= 1 & xticks$x >= 0,]
+
+      if (outside)
+        xticks$end = -xticks$end
 
       # Make the grobs
       if (grepl("b", sides)) {
@@ -156,7 +163,7 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
       if (grepl("t", sides)) {
         ticks$x_t <- with(data, segmentsGrob(
           x0 = unit(xticks$x, "native"), x1 = unit(xticks$x, "native"),
-          y0 = unit(1, "npc") - unit(-xticks$end, "cm"), y1 = unit(1, "npc") - unit(xticks$start, "cm"),
+          y0 = unit(1, "npc") - unit(xticks$start, "cm"), y1 = unit(1, "npc") + unit(xticks$end, "cm"),
           gp = gpar(col = alpha(colour, alpha), lty = linetype, lwd = size * .pt)
         ))
       }
@@ -179,6 +186,10 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
 
       names(yticks)[names(yticks) == "value"] <- "y"   # Rename to 'y' for coordinates$transform
       yticks <- coord$transform(yticks, panel_params)
+      yticks = yticks[yticks$y <= 1 & yticks$y >= 0,]
+
+      if (outside)
+        yticks$end = -yticks$end
 
       # Make the grobs
       if (grepl("l", sides)) {

--- a/R/annotation-logticks.r
+++ b/R/annotation-logticks.r
@@ -156,7 +156,7 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
       if (grepl("t", sides)) {
         ticks$x_t <- with(data, segmentsGrob(
           x0 = unit(xticks$x, "native"), x1 = unit(xticks$x, "native"),
-          y0 = unit(1, "npc") - unit(xticks$start, "cm"), y1 = unit(1, "npc") - unit(xticks$end, "cm"),
+          y0 = unit(100, "npc") - unit(xticks$start, "cm"), y1 = unit(1, "npc") - unit(xticks$end, "cm"),
           gp = gpar(col = alpha(colour, alpha), lty = linetype, lwd = size * .pt)
         ))
       }

--- a/R/annotation-logticks.r
+++ b/R/annotation-logticks.r
@@ -94,6 +94,7 @@ annotation_logticks <- function(base = 10, sides = "bl", outside = FALSE, scaled
     params = list(
       base = base,
       sides = sides,
+      outside = outside,
       scaled = scaled,
       short = short,
       mid = mid,
@@ -163,7 +164,7 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
       if (grepl("t", sides)) {
         ticks$x_t <- with(data, segmentsGrob(
           x0 = unit(xticks$x, "native"), x1 = unit(xticks$x, "native"),
-          y0 = unit(1, "npc") - unit(xticks$start, "cm"), y1 = unit(1, "npc") + unit(xticks$end, "cm"),
+          y0 = unit(1, "npc") - unit(xticks$start, "cm"), y1 = unit(1, "npc") - unit(xticks$end, "cm"),
           gp = gpar(col = alpha(colour, alpha), lty = linetype, lwd = size * .pt)
         ))
       }

--- a/man/annotation_logticks.Rd
+++ b/man/annotation_logticks.Rd
@@ -7,6 +7,7 @@
 annotation_logticks(
   base = 10,
   sides = "bl",
+  outside = FALSE,
   scaled = TRUE,
   short = unit(0.1, "cm"),
   mid = unit(0.2, "cm"),
@@ -25,6 +26,8 @@ annotation_logticks(
 \item{sides}{a string that controls which sides of the plot the log ticks appear on.
 It can be set to a string containing any of \code{"trbl"}, for top, right,
 bottom, and left.}
+
+\item{outside}{logical that controls whether to move the log ticks outside of the plot area. Default is off (FALSE). You will also need to use \code{coord_cartesian(clip = "off")}. See examples.}
 
 \item{scaled}{is the data already log-scaled? This should be \code{TRUE}
 (default) when the data is already transformed with \code{log10()} or when
@@ -73,6 +76,8 @@ a <- ggplot(msleep, aes(bodywt, brainwt)) +
 a + annotation_logticks()                # Default: log ticks on bottom and left
 a + annotation_logticks(sides = "lr")    # Log ticks for y, on left and right
 a + annotation_logticks(sides = "trbl")  # All four sides
+
+#' a + annotation_logticks(sides = "lr", outside = TRUE)  # Ticks outside plot
 
 # Hide the minor grid lines because they don't align with the ticks
 a + annotation_logticks(sides = "trbl") + theme(panel.grid.minor = element_blank())


### PR DESCRIPTION
Allows logticks to be outside of plotting pane, when used with `coord_cartesian(clip = "off")`

Fixed #3660 