### PR TITLE
Modify printing when limits are a function

### DIFF
--- a/R/scale-.r
+++ b/R/scale-.r
@@ -734,7 +734,11 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
 
     cat("<", class(self)[[1]], ">\n", sep = "")
     cat(" Range:  ", show_range(self$range$range), "\n", sep = "")
-    cat(" Limits: ", show_range(self$dimension()), "\n", sep = "")
+    if (is.function(self$limits)) {
+      cat(" Limits: function()\n")
+    } else {
+      cat(" Limits: ", show_range(self$dimension()), "\n", sep = "")
+    }
   }
 )
 


### PR DESCRIPTION
Fixes #3468 -- prints "function()" instead of "NA NA" for limits when printing scales where limits are set by function.

New result:
``` r
library(ggplot2)
g <- ggplot(iris, aes(Sepal.Width, Sepal.Length,
                      colour = Petal.Width)) +
  geom_point()

goodprint <- g + scale_colour_continuous(limits = range(iris$Petal.Width))
badprint <- g + scale_colour_continuous(limits = function(lims) {1 * lims})

print(goodprint$scales$scales[[1]])
#> <ScaleContinuous>
#>  Range:  
#>  Limits:  0.1 --  2.5

print(badprint$scales$scales[[1]])
#> <ScaleContinuous>
#>  Range:  
#>  Limits: function()
```

<sup>Created on 2020-01-31 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>