### PR TITLE
Add support for native rasters to `annotation_raster()` #3388

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* `annotation_raster()` adds support for native rasters. For large rasters,
+  native rasters render significantly faster than arrays (@kent37, #3388)
+  
 # ggplot2 3.3.0
 
 * Fix a bug in `geom_raster()` that squeezed the image when it went outside 

--- a/R/annotation-raster.r
+++ b/R/annotation-raster.r
@@ -10,7 +10,7 @@ NULL
 #' of the raster, and the raster must already have its own colours). This
 #' is useful for adding bitmap images.
 #'
-#' @param raster raster object to display
+#' @param raster raster object to display, may be an `array` or a `nativeRaster`
 #' @param xmin,xmax x location (in data coordinates) giving horizontal
 #'   location of raster
 #' @param ymin,ymax y location (in data coordinates) giving vertical
@@ -39,7 +39,8 @@ NULL
 #'   geom_point()
 annotation_raster <- function(raster, xmin, xmax, ymin, ymax,
                               interpolate = FALSE) {
-  raster <- grDevices::as.raster(raster)
+  if (!inherits(raster, 'nativeRaster'))
+    raster <- grDevices::as.raster(raster)
 
   layer(
     data = dummy_data(),

--- a/man/annotation_raster.Rd
+++ b/man/annotation_raster.Rd
@@ -7,7 +7,7 @@
 annotation_raster(raster, xmin, xmax, ymin, ymax, interpolate = FALSE)
 }
 \arguments{
-\item{raster}{raster object to display}
+\item{raster}{raster object to display, may be an \code{array} or a \code{nativeRaster}}
 
 \item{xmin, xmax}{x location (in data coordinates) giving horizontal
 location of raster}


### PR DESCRIPTION
Small change to allow passing a `nativeRaster` object to `annotation_raster()`. This is a significant performance improvement for large rasters.

I didn't include an example because I don't see a source for a native raster in `{ggplot2}`. I could use the R logo from `{png}` but that package is not currently used by ggplot2. If you think an example is called for, please advise.