### PR TITLE
Catch errors when applying after_scale mods to legend keys

### DIFF
--- a/R/guide-bins.R
+++ b/R/guide-bins.R
@@ -200,7 +200,16 @@ guide_geom.bins <- function(guide, layers, default_mapping) {
       n <- vapply(layer$aes_params, length, integer(1))
       params <- layer$aes_params[n == 1]
 
-      data <- layer$geom$use_defaults(guide$key[matched], params)
+      aesthetics <- layer$mapping
+      modifiers <- aesthetics[is_scaled_aes(aesthetics) | is_staged_aes(aesthetics)]
+
+      data <- tryCatch(
+        layer$geom$use_defaults(guide$key[matched], params, modifiers),
+        error = function(...) {
+          warn("Failed to apply `after_scale()` modifications to legend")
+          layer$geom$use_defaults(guide$key[matched], params, list())
+        }
+      )
     } else {
       data <- layer$geom$use_defaults(NULL, layer$aes_params)[rep(1, nrow(guide$key)), ]
     }

--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -262,7 +262,13 @@ guide_geom.legend <- function(guide, layers, default_mapping) {
       aesthetics <- layer$mapping
       modifiers <- aesthetics[is_scaled_aes(aesthetics) | is_staged_aes(aesthetics)]
 
-      data <- layer$geom$use_defaults(guide$key[matched], params, modifiers)
+      data <- tryCatch(
+        layer$geom$use_defaults(guide$key[matched], params, modifiers),
+        error = function(...) {
+          warn("Failed to apply `after_scale()` modifications to legend")
+          layer$geom$use_defaults(guide$key[matched], params, list())
+        }
+      )
     } else {
       data <- layer$geom$use_defaults(NULL, layer$aes_params)[rep(1, nrow(guide$key)), ]
     }


### PR DESCRIPTION
Fixes #3729 

This PR catches any errors happening when applying `after_scale()` modifications to legend keys. If it errors it will simply discard them all with a warning.

It may be done more fine grained, but not without a lot of weird refactoring of the code to accommodate this edge-case. This PR fixes the surprise of the legend disappearing and gives a meaningful warning. If we get a lot of requests for better support (I doubt it) we can revisit it in the future