### PR TITLE
Permit function devices to use `file` argument

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,9 @@ ggplot2 1.0.1
 * Improvements to order of colours and legend display for continuous colour
   scales extracted from colorbrewer palettes by `scale_*_distiller()` (@jiho, 1076)
 
+ * Support graphics devices that use the `file` argument instead of `fileneame` 
+   in `ggsave()` (@bwiernik, 3810)
+
 ggplot2 1.0.0
 ----------------------------------------------------------------
 

--- a/NEWS
+++ b/NEWS
@@ -6,9 +6,6 @@ ggplot2 1.0.1
 * Improvements to order of colours and legend display for continuous colour
   scales extracted from colorbrewer palettes by `scale_*_distiller()` (@jiho, 1076)
 
- * Support graphics devices that use the `file` argument instead of `fileneame` 
-   in `ggsave()` (@bwiernik, 3810)
-
 ggplot2 1.0.0
 ----------------------------------------------------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 * `annotation_raster()` adds support for native rasters. For large rasters,
   native rasters render significantly faster than arrays (@kent37, #3388)
   
+* Support graphics devices that use the `file` argument instead of `fileneame` 
+  in `ggsave()` (@bwiernik, #3810)
+  
 # ggplot2 3.3.0
 
 * Fix a bug in `geom_raster()` that squeezed the image when it went outside 

--- a/R/save.r
+++ b/R/save.r
@@ -149,8 +149,12 @@ plot_dev <- function(device, filename = NULL, dpi = 300) {
   force(filename)
   force(dpi)
 
-  if (is.function(device))
-    return(device)
+  if (is.function(device)) {
+    if ("file" %in% names(formals(device))) {
+      dev <- function(filename, ...) device(file = filename, ...)
+      return(dev)
+    } else return(device)
+  }
 
   eps <- function(filename, ...) {
     grDevices::postscript(file = filename, ..., onefile = FALSE, horizontal = FALSE,

--- a/R/save.r
+++ b/R/save.r
@@ -153,7 +153,9 @@ plot_dev <- function(device, filename = NULL, dpi = 300) {
     if ("file" %in% names(formals(device))) {
       dev <- function(filename, ...) device(file = filename, ...)
       return(dev)
-    } else return(device)
+    } else {
+      return(device)
+    }
   }
 
   eps <- function(filename, ...) {


### PR DESCRIPTION
Devices like `devEMF::emf` or `Cairo::CairoSVG` use `file` instead of `filename`. They currently fail when provided in `device` to ggsave. This fixes that.

Closes https://github.com/tidyverse/ggplot2/issues/3807