### PR TITLE
Remove `binwidth` entirely from geom_bar()

### DIFF
--- a/R/geom-bar.r
+++ b/R/geom-bar.r
@@ -41,9 +41,6 @@
 #' rare event that this fails it can be given explicitly by setting `orientation`
 #' to either `"x"` or `"y"`. See the *Orientation* section for more detail.
 #' @param width Bar width. By default, set to 90% of the resolution of the data.
-#' @param binwidth `geom_bar()` no longer has a binwidth argument---if
-#'   you use it you'll get a warning telling to you use
-#'   [geom_histogram()] instead.
 #' @param geom,stat Override the default connection between `geom_bar()` and
 #'   `stat_count()`.
 #' @examples
@@ -87,19 +84,10 @@ geom_bar <- function(mapping = NULL, data = NULL,
                      stat = "count", position = "stack",
                      ...,
                      width = NULL,
-                     binwidth = NULL,
                      na.rm = FALSE,
                      orientation = NA,
                      show.legend = NA,
                      inherit.aes = TRUE) {
-
-  if (!is.null(binwidth)) {
-    warn("`geom_bar()` no longer has a `binwidth` parameter. Please use `geom_histogram()` instead.")
-    return(geom_histogram(mapping = mapping, data = data,
-      position = position, width = width, binwidth = binwidth, ...,
-      na.rm = na.rm, show.legend = show.legend, inherit.aes = inherit.aes))
-  }
-
   layer(
     data = data,
     mapping = mapping,

--- a/man/geom_bar.Rd
+++ b/man/geom_bar.Rd
@@ -13,7 +13,6 @@ geom_bar(
   position = "stack",
   ...,
   width = NULL,
-  binwidth = NULL,
   na.rm = FALSE,
   orientation = NA,
   show.legend = NA,
@@ -74,10 +73,6 @@ often aesthetics, used to set an aesthetic to a fixed value, like
 to the paired geom/stat.}
 
 \item{width}{Bar width. By default, set to 90\% of the resolution of the data.}
-
-\item{binwidth}{\code{geom_bar()} no longer has a binwidth argument---if
-you use it you'll get a warning telling to you use
-\code{\link[=geom_histogram]{geom_histogram()}} instead.}
 
 \item{na.rm}{If \code{FALSE}, the default, missing values are removed with
 a warning. If \code{TRUE}, missing values are silently removed.}


### PR DESCRIPTION
Closes #3809.

``` r
library(ggplot2)

ggplot(iris, aes(x = Sepal.Length)) +
  geom_bar(stat = "bin", binwidth = 0.1)
```

![](https://i.imgur.com/8WrK9tC.png)

``` r

ggplot(mtcars, aes(factor(gear))) +
  geom_bar(binwidth = 0.1)
#> Warning: Ignoring unknown parameters: binwidth
```

![](https://i.imgur.com/vpGIFoY.png)

<sup>Created on 2020-02-11 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup> 