### PR TITLE
Bump scales dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     MASS,
     mgcv,
     rlang (>= 0.3.0),
-    scales (>= 0.5.0),
+    scales (>= 1.0.0),
     stats,
     tibble,
     withr (>= 2.0.0)


### PR DESCRIPTION
Scales 1.0.0 fixed a bug https://github.com/r-lib/scales/pull/81. The bug can lead to wrong plots when they are defined inside for loops, because some scales 0.5.0 functions  evaluated some arguments when the plot was rendered instead of when the plot was created.

I contributed the fix for that bug some years ago and I hit myself with it last week because an old version of scales was still installed in a computer from a friend.

Most CI tests happen with the latest version of the pkg dependencies, so I guess it may make sense to upgrade to the latest 1.1.0, but that is up to you, I guess.