### PR TITLE
Use rlang to generate quosure list

### DIFF
--- a/tests/testthat/helper-facet.r
+++ b/tests/testthat/helper-facet.r
@@ -1,6 +1,4 @@
 
 quos_list <- function(...) {
-  x <- list(...)
-  names(x) <- names2(x)
-  structure(x, class = "quosures")
+  new_quosures(list(...))
 }


### PR DESCRIPTION
Avoids making assumptions about internals of quosure lists. Fixes a test failure with dev rlang.