### PR TITLE
Use na.value in ScaleBinned$map()

### DIFF
--- a/R/scale-.r
+++ b/R/scale-.r
@@ -986,7 +986,8 @@ ScaleBinned <- ggproto("ScaleBinned", Scale,
         self$palette.cache <- pal
       }
 
-      pal[x_binned]
+      scaled <- pal[x_binned]
+      ifelse(!is.na(scaled), scaled, self$na.value)
     }
   },
 


### PR DESCRIPTION
Fix #3867 

``` r
devtools::load_all("~/repo/ggplot2")
#> Loading ggplot2
library(dplyr, warn.conflicts = FALSE)

df <- tibble(x = rep(1:3, 2), y = rep(1:2, 3), z = 1:6) %>% 
  mutate(z = ifelse(x == 1 & y == 1, NA, z))

p <- ggplot(df, aes(x = x, y = y)) +
  geom_tile(aes(fill = z))

p + scale_fill_viridis_b(na.value = "red")
```

![](https://i.imgur.com/cRtwg32.png)

<sup>Created on 2020-03-08 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
