### PR TITLE
warn user when even.steps=FALSE is used with a discrete scale

### DIFF
--- a/R/guide-colorsteps.R
+++ b/R/guide-colorsteps.R
@@ -69,6 +69,9 @@ guide_train.colorsteps <- function(guide, scale, aesthetic = NULL) {
       # If the breaks are not numeric it is used with a discrete scale. We check
       # if the breaks follow the allowed format "(<lower>, <upper>]", and if it
       # does we convert it into bin specs
+      if (!guide$even.steps) {
+        warn("`even.steps = FALSE` is not supported when used together with a discrete scale")
+      }
       bin_at <- breaks
       breaks_num <- as.character(breaks)
       breaks_num <- strsplit(gsub("\\(|\\)|\\[|\\]", "", breaks_num), ",\\s?")


### PR DESCRIPTION
This PR addresses #3877 without providing a true fix. The `even.steps = FALSE` feature piggybacks on the `guide_colourbar()` rendering which does not work on discrete scales. A complete rewrite of the functionality would be needed which is not a priority before the guide rewrite.

This PR simply emits a warning about the feature not working for that particular case