### PR TITLE
ignore min/max variables when detecting orientation in geom_bar

### DIFF
--- a/R/geom-bar.r
+++ b/R/geom-bar.r
@@ -119,7 +119,7 @@ GeomBar <- ggproto("GeomBar", GeomRect,
   non_missing_aes = c("xmin", "xmax", "ymin", "ymax"),
 
   setup_params = function(data, params) {
-    params$flipped_aes <- has_flipped_aes(data, params, range_is_orthogonal = FALSE)
+    params$flipped_aes <- has_flipped_aes(data, params)
     params
   },
 

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -461,9 +461,7 @@ switch_orientation <- function(aesthetics) {
 #' - `range_is_orthogonal`: This argument controls whether the existance of
 #'   range-like aesthetics (e.g. `xmin` and `xmax`) represents the main or
 #'   secondary axis. If `TRUE` then the range is given for the secondary axis as
-#'   seen in e.g. [geom_ribbon()] and [geom_linerange()]. `FALSE` is less
-#'   prevalent but can be seen in [geom_bar()] where it may encode the span of
-#'   each bar.
+#'   seen in e.g. [geom_ribbon()] and [geom_linerange()].
 #' - `group_has_equal`: This argument controls whether to test for equality of
 #'   all `x` and `y` values inside each group and set the main axis to the one
 #'   where all is equal. This test is only performed if `TRUE`, and only after

--- a/man/bidirection.Rd
+++ b/man/bidirection.Rd
@@ -86,9 +86,7 @@ axis as seen in e.g. \code{\link[=stat_bin]{stat_bin()}}, \code{\link[=geom_coun
 \item \code{range_is_orthogonal}: This argument controls whether the existance of
 range-like aesthetics (e.g. \code{xmin} and \code{xmax}) represents the main or
 secondary axis. If \code{TRUE} then the range is given for the secondary axis as
-seen in e.g. \code{\link[=geom_ribbon]{geom_ribbon()}} and \code{\link[=geom_linerange]{geom_linerange()}}. \code{FALSE} is less
-prevalent but can be seen in \code{\link[=geom_bar]{geom_bar()}} where it may encode the span of
-each bar.
+seen in e.g. \code{\link[=geom_ribbon]{geom_ribbon()}} and \code{\link[=geom_linerange]{geom_linerange()}}.
 \item \code{group_has_equal}: This argument controls whether to test for equality of
 all \code{x} and \code{y} values inside each group and set the main axis to the one
 where all is equal. This test is only performed if \code{TRUE}, and only after


### PR DESCRIPTION
Fixes #3866 

The check for `range_is_orthogonal` in `geom_bar()` was unneeded and resulted in failure with edge cases