### PR TITLE
calculate z.range in stat_contour and stat_contour_filled on the full layer data

### DIFF
--- a/R/stat-contour.r
+++ b/R/stat-contour.r
@@ -70,15 +70,17 @@ stat_contour_filled <- function(mapping = NULL, data = NULL,
 #' @usage NULL
 #' @export
 StatContour <- ggproto("StatContour", Stat,
-
+  setup_params = function(data, params) {
+    params$z.range <- range(data$z, na.rm = TRUE, finite = TRUE)
+    params
+  },
   required_aes = c("x", "y", "z"),
   default_aes = aes(order = after_stat(level)),
 
-  compute_group = function(data, scales, bins = NULL, binwidth = NULL,
+  compute_group = function(data, scales, z.range, bins = NULL, binwidth = NULL,
                            breaks = NULL, na.rm = FALSE) {
 
-    z_range <- range(data$z, na.rm = TRUE, finite = TRUE)
-    breaks <- contour_breaks(z_range, bins, binwidth, breaks)
+    breaks <- contour_breaks(z.range, bins, binwidth, breaks)
 
     isolines <- xyz_to_isolines(data, breaks)
     path_df <- iso_to_path(isolines, data$group[1])
@@ -95,14 +97,17 @@ StatContour <- ggproto("StatContour", Stat,
 #' @usage NULL
 #' @export
 StatContourFilled <- ggproto("StatContourFilled", Stat,
-
+  setup_params = function(data, params) {
+    params$z.range <- range(data$z, na.rm = TRUE, finite = TRUE)
+    params
+  },
   required_aes = c("x", "y", "z"),
   default_aes = aes(order = after_stat(level), fill = after_stat(level)),
 
-  compute_group = function(data, scales, bins = NULL, binwidth = NULL, breaks = NULL, na.rm = FALSE) {
+  compute_group = function(data, scales, z.range, bins = NULL, binwidth = NULL,
+                           breaks = NULL, na.rm = FALSE) {
 
-    z_range <- range(data$z, na.rm = TRUE, finite = TRUE)
-    breaks <- contour_breaks(z_range, bins, binwidth, breaks)
+    breaks <- contour_breaks(z.range, bins, binwidth, breaks)
 
     isobands <- xyz_to_isobands(data, breaks)
     names(isobands) <- pretty_isoband_levels(names(isobands))


### PR DESCRIPTION
Fixes #3875 

This PR fixes the issue as discussed in the thread. The issue is also present in the standard `stat_contour` where the levels of the contour lines would not be equivalent across panels

## Old buggy behaviour

``` r
library(ggplot2)
ggplot(faithfuld, aes(waiting, eruptions, z = density)) + 
  geom_contour_filled() + 
  facet_wrap(~waiting < 70)
```

![](https://i.imgur.com/9wyIuMP.png)

<sup>Created on 2020-03-10 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

## Working example with PR

``` r
library(ggplot2)
ggplot(faithfuld, aes(waiting, eruptions, z = density)) + 
  geom_contour_filled() + 
  facet_wrap(~waiting < 70)
```

![](https://i.imgur.com/z39250C.png)

<sup>Created on 2020-03-10 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>