### PR TITLE
Fix merge warning for `guide_axis()` when merging with `guide_none()`

### DIFF
--- a/R/guides-axis.r
+++ b/R/guides-axis.r
@@ -119,7 +119,7 @@ guide_transform.axis <- function(guide, coord, panel_params) {
 # discards the new guide with a warning
 #' @export
 guide_merge.axis <- function(guide, new_guide) {
-  if (!inherits(guide, "guide_none")) {
+  if (!inherits(new_guide, "guide_none")) {
     warn("guide_axis(): Discarding guide on merge. Do you have more than one guide with the same position?")
   }
 

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -84,6 +84,16 @@ test_that("a warning is generated when more than one position guide is drawn at 
   expect_warning(ggplot_gtable(built), "Discarding guide")
 })
 
+test_that("a warning is not generated when properly changing the position of a guide_axis()", {
+  plot <- ggplot(mpg, aes(class, hwy)) +
+    geom_point() +
+    guides(
+      y = guide_axis(position = "right")
+    )
+  built <- expect_silent(ggplot_build(plot))
+  expect_silent(ggplot_gtable(built))
+})
+
 test_that("guide_none() can be used in non-position scales", {
   p <- ggplot(mpg, aes(cty, hwy, colour = class)) +
     geom_point() +


### PR DESCRIPTION
This is a fix for #3874, which gave warnings when changing the position of a `guide_axis()`. I *think* this is a four character fix (typo in my implementation of `guide_merge.axis()`). The warnings are now gone:

``` r
library(ggplot2)
ggplot(mpg) +
  geom_bar(aes(x = manufacturer)) + 
  guides(x = guide_axis(position = 'top'))
```

![](https://i.imgur.com/6b74gmz.png)

<sup>Created on 2020-03-10 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>