### PR TITLE
Temporarily disable Test coverage step on GitHub Action CI

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -97,7 +97,8 @@ jobs:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check
 
-      - name: Test coverage
-        if: matrix.config.os == 'macOS-latest' && matrix.config.r == '3.6'
-        run: covr::codecov()
-        shell: Rscript {0}
+      # TODO: uncomment this when we fix the failure of covr::codecov()
+      # - name: Test coverage
+      #   if: matrix.config.os == 'macOS-latest' && matrix.config.r == '3.6'
+      #   run: covr::codecov()
+      #   shell: Rscript {0}


### PR DESCRIPTION
`covr::codecov()` keeps failing on GitHub Action CI.

```
Error in curl::curl_fetch_memory(url, handle = handle) : 
  HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)
Calls: <Anonymous> ... request_fetch -> request_fetch.write_memory -> <Anonymous>
Execution halted
##[error]Process completed with exit code 1.
```
https://github.com/tidyverse/ggplot2/runs/509138337?check_suite_focus=true#step:13:14

I tried some tweaks on my forked repo (https://github.com/yutannihilation/ggplot2/pull/4/), but none of these worked. As the other repos (e.g. [roxygen2](https://github.com/r-lib/roxygen2/blob/2a068b181bc15ec55545ddd752f5341471f5e74a/.github/workflows/R-CMD-check.yaml#L83-L86)) works without error, this seems specific to ggplot2. So, I think it takes some time to figure out what's happening here, so this should be disabled for now.

Fortunately(?), I forgot to remove the test coverage step on Travis CI in #3862, so we can rely on it for a while.