### PR TITLE
fix stat_contour() for irregular data grids.

### DIFF
--- a/R/stat-contour.r
+++ b/R/stat-contour.r
@@ -206,14 +206,14 @@ xyz_to_isobands <- function(data, breaks) {
 #'
 isoband_z_matrix <- function(data) {
   # Convert vector of data to raster
-  x_pos <- as.integer((data$x - min(data$x)) / resolution(data$x, FALSE))
-  y_pos <- as.integer((max(data$y) - data$y) / resolution(data$y, FALSE))
+  x_pos <- as.integer(factor(data$x, levels = sort(unique(data$x))))
+  y_pos <- as.integer(factor(data$y, levels = sort(unique(data$y))))
 
-  nrow <- max(y_pos) + 1
-  ncol <- max(x_pos) + 1
+  nrow <- max(y_pos)
+  ncol <- max(x_pos)
 
   raster <- matrix(NA_real_, nrow = nrow, ncol = ncol)
-  raster[cbind(nrow - y_pos, x_pos + 1)] <- data$z
+  raster[cbind(y_pos, x_pos)] <- data$z
 
   raster
 }

--- a/tests/testthat/test-stat-contour.R
+++ b/tests/testthat/test-stat-contour.R
@@ -13,6 +13,25 @@ test_that("contouring sparse data results in a warning", {
   expect_warning(ggplot_build(p), "Zero contours were generated")
 })
 
+test_that("contouring irregularly spaced data works", {
+  tbl <- expand.grid(x = c(1, 10, 100, 1000), y = 1:3)
+  tbl$z <- 1
+  tbl[c(6, 7), ]$z <- 10
+  p <- ggplot(tbl, aes(x, y, z = z)) + geom_contour(breaks = c(4, 8))
+
+  # we're testing for set equality here because contour lines are not
+  # guaranteed to start and end at the same point on all architectures
+  d <- layer_data(p)
+  d4 <- d[d$level == 4,]
+  expect_equal(nrow(d4), 7)
+  expect_setequal(d4$x, c(4, 10, 100, 700))
+  expect_setequal(d4$y, c(2, 8/3, 4/3))
+  d8 <- d[d$level == 8,]
+  expect_equal(nrow(d8), 7)
+  expect_setequal(d8$x, c(8, 10, 100, 300))
+  expect_setequal(d8$y, c(2, 20/9, 16/9))
+})
+
 test_that("contour breaks can be set manually and by bins and binwidth", {
   range <- c(0, 1)
   expect_equal(contour_breaks(range), pretty(range, 10))

--- a/tests/testthat/test-stat-contour.R
+++ b/tests/testthat/test-stat-contour.R
@@ -10,7 +10,7 @@ test_that("a warning is issued when there is more than one z per x+y", {
 test_that("contouring sparse data results in a warning", {
   tbl <- data_frame(x = c(1, 27, 32), y = c(1, 1, 30), z = c(1, 2, 3))
   p <- ggplot(tbl, aes(x, y, z = z)) + geom_contour()
-  expect_warning(ggplot_build(p), "Number of x coordinates must match")
+  expect_warning(ggplot_build(p), "Zero contours were generated")
 })
 
 test_that("contour breaks can be set manually and by bins and binwidth", {


### PR DESCRIPTION
Closes #3906.

``` r
library(ggplot2)

v <- ggplot(faithfuld, aes(waiting, eruptions, z = density)) +
  geom_point(aes(color = density)) + geom_contour(color = "white")

v
```

![](https://i.imgur.com/alqDHnZ.png)

``` r
v + scale_x_log10()
```

![](https://i.imgur.com/BBzsacZ.png)

<sup>Created on 2020-03-21 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>