### PR TITLE
Fix stat_function() for transformed scales

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 * `annotation_raster()` adds support for native rasters. For large rasters,
   native rasters render significantly faster than arrays (@kent37, #3388)
   
+* `stat_function()` now works with transformed y axes, e.g. `scale_y_log10()`
+  (@clauswilke, #3905).
+  
 * A newly added geom `geom_density_2d_filled()` and associated stat 
   `stat_density_2d_filled()` can draw filled density contours
   (@clauswilke, #3846).

--- a/R/stat-function.r
+++ b/R/stat-function.r
@@ -113,9 +113,15 @@ StatFunction <- ggproto("StatFunction", Stat,
 
     if (is.formula(fun)) fun <- as_function(fun)
 
+    y_out <- do.call(fun, c(list(quote(x_trans)), args))
+    if (!is.null(scales$y) && !scales$y$is_discrete()) {
+      # For continuous scales, need to apply transform
+      y_out <- scales$y$trans$transform(y_out)
+    }
+
     new_data_frame(list(
       x = xseq,
-      y = do.call(fun, c(list(quote(x_trans)), args))
+      y = y_out
     ))
   }
 )

--- a/R/stat-function.r
+++ b/R/stat-function.r
@@ -97,7 +97,7 @@ stat_function <- function(mapping = NULL, data = NULL,
 #' @usage NULL
 #' @export
 StatFunction <- ggproto("StatFunction", Stat,
-  default_aes = aes(y = after_stat(y)),
+  default_aes = aes(y = after_scale(y)),
 
   compute_group = function(data, scales, fun, xlim = NULL, n = 101, args = list()) {
     range <- xlim %||% scales$x$dimension()

--- a/tests/testthat/test-stats-function.r
+++ b/tests/testthat/test-stats-function.r
@@ -35,6 +35,23 @@ test_that("works with discrete x", {
   expect_equal(ret$y, 1:2)
 })
 
+test_that("works with transformed scales", {
+  dat <- data_frame(x = 1:10)
+
+  base <- ggplot(dat, aes(x, group = 1)) +
+    stat_function(fun = ~ .x^2, geom = "point", n = 5)
+
+  ret <- layer_data(base)
+  expect_equal(ret$y, ret$x^2)
+
+  ret <- layer_data(base + scale_x_log10())
+  expect_equal(ret$y, (10^ret$x)^2)
+
+  ret <- layer_data(base + scale_y_log10(limits = c(.1, 100)))
+  expect_equal(log10(ret$y), ret$x^2)
+})
+
+
 test_that("works with formula syntax", {
   dat <- data_frame(x = 1:10)
 

--- a/tests/testthat/test-stats-function.r
+++ b/tests/testthat/test-stats-function.r
@@ -36,19 +36,47 @@ test_that("works with discrete x", {
 })
 
 test_that("works with transformed scales", {
-  dat <- data_frame(x = 1:10)
+  dat <- data_frame(x = 1:10, y = (1:10)^2)
 
+  # first without explicit mapping of y
   base <- ggplot(dat, aes(x, group = 1)) +
-    stat_function(fun = ~ .x^2, geom = "point", n = 5)
+    stat_function(fun = ~ .x^2, n = 5)
 
   ret <- layer_data(base)
+  expect_equal(nrow(ret), 5)
   expect_equal(ret$y, ret$x^2)
 
   ret <- layer_data(base + scale_x_log10())
+  expect_equal(nrow(ret), 5)
   expect_equal(ret$y, (10^ret$x)^2)
 
-  ret <- layer_data(base + scale_y_log10(limits = c(.1, 100)))
-  expect_equal(log10(ret$y), ret$x^2)
+  ret <- layer_data(base + scale_y_log10())
+  expect_equal(nrow(ret), 5)
+  expect_equal(10^ret$y, ret$x^2)
+
+  ret <- layer_data(base + scale_x_log10() + scale_y_log10())
+  expect_equal(nrow(ret), 5)
+  expect_equal(10^ret$y, (10^ret$x)^2)
+
+  # now with explicit mapping of y
+  base <- ggplot(dat, aes(x, y)) + geom_point() +
+    stat_function(fun = ~ .x^2, n = 5)
+
+  ret <- layer_data(base, 2)
+  expect_equal(nrow(ret), 5)
+  expect_equal(ret$y, ret$x^2)
+
+  ret <- layer_data(base + scale_x_log10(), 2)
+  expect_equal(nrow(ret), 5)
+  expect_equal(ret$y, (10^ret$x)^2)
+
+  ret <- layer_data(base + scale_y_log10(), 2)
+  expect_equal(nrow(ret), 5)
+  expect_equal(10^ret$y, ret$x^2)
+
+  ret <- layer_data(base + scale_x_log10() + scale_y_log10(), 2)
+  expect_equal(nrow(ret), 5)
+  expect_equal(10^ret$y, (10^ret$x)^2)
 })
 
 


### PR DESCRIPTION
Closes #3905.

``` r
library(tidyverse)
library(patchwork)

fn <- function(x) {exp(x)}
data <- tibble(x = c(1:10), y = exp(x))

# without data points
p <- ggplot(data, aes(x)) + stat_function(fun = fn)

# with data points
q <- ggplot(data, aes(x, y)) + geom_point() + 
  stat_function(fun = fn)

p / q
```

![](https://i.imgur.com/j4krFoF.png)

``` r
(p + scale_y_log10()) / q + scale_y_log10()
```

![](https://i.imgur.com/9gLJ1QQ.png)

``` r
(p + scale_y_sqrt()) / q + scale_y_sqrt()
```

![](https://i.imgur.com/Z4t37Jx.png)

``` r
(p + scale_y_reverse()) / q + scale_y_reverse()
```

![](https://i.imgur.com/S2iAaIl.png)

``` r
(p + scale_x_log10()) / q + scale_x_log10()
```

![](https://i.imgur.com/RT6txKL.png)

``` r
(p + scale_x_log10() + scale_y_log10()) /
  q + scale_x_log10() + scale_y_log10()
```

![](https://i.imgur.com/XAcvDzv.png)

<sup>Created on 2020-03-21 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>