### PR TITLE
Move the domain of ggplot2-exts to exts.ggplot2.tidyverse.org

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -58,7 +58,7 @@ ggplot(mpg, aes(displ, hwy, colour = class)) +
 
 ggplot2 is now over 10 years old and is used by hundreds of thousands of people to make millions of plots. That means, by-and-large, ggplot2 itself changes relatively little. When we do make changes, they will be generally to add new functions or arguments rather than changing the behaviour of existing functions, and if we do make changes to existing behaviour we will do them for compelling reasons. 
 
-If you are looking for innovation, look to ggplot2's rich ecosystem of extensions. See a community maintained list at <https://www.ggplot2-exts.org/gallery/>.
+If you are looking for innovation, look to ggplot2's rich ecosystem of extensions. See a community maintained list at <https://exts.ggplot2.tidyverse.org/gallery/>.
 
 ## Learning ggplot2
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ behaviour we will do them for compelling reasons.
 
 If you are looking for innovation, look to ggplot2’s rich ecosystem of
 extensions. See a community maintained list at
-<https://www.ggplot2-exts.org/gallery/>.
+<https://exts.ggplot2.tidyverse.org/gallery/>.
 
 ## Learning ggplot2
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -12,7 +12,7 @@ home:
   - text: Learn more
     href: https://r4ds.had.co.nz/data-visualisation.html
   - text: Extensions
-    href: https://www.ggplot2-exts.org/gallery/
+    href: https://exts.ggplot2.tidyverse.org/gallery/
 
 reference:
 - title: Plot basics
@@ -251,4 +251,4 @@ navbar:
         href: news/index.html
     extensions:
       text: Extensions
-      href: https://www.ggplot2-exts.org/gallery/
+      href: https://exts.ggplot2.tidyverse.org/gallery/


### PR DESCRIPTION
ggplot2 extension site has been moved to exts.ggplot2.tidyverse.org. For more details, see ggplot2-exts/gallery#87.