### PR TITLE
Run visual tests on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
   - r: release
     env: VDIFFR_RUN_TESTS=true
     env: VDIFFR_LOG_PATH="../vdiffr.Rout.fail"
+    before_install:
+      - echo $VDIFFR_RUN_TESTS
   - r: 3.5
   - r: 3.4
   - r: 3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ matrix:
     # avoind errors due to world clock API (hopefully can be removed in future)
     env: _R_CHECK_SYSTEM_CLOCK_=false
   - r: release
-    env: VDIFFR_RUN_TESTS=true
-    env: VDIFFR_LOG_PATH="../vdiffr.Rout.fail"
+    env:
+      - VDIFFR_RUN_TESTS=true
+      - VDIFFR_LOG_PATH="../vdiffr.Rout.fail"
     before_install:
       - echo $VDIFFR_RUN_TESTS
   - r: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
     env:
       - VDIFFR_RUN_TESTS=true
       - VDIFFR_LOG_PATH="../vdiffr.Rout.fail"
-    before_install:
-      - echo $VDIFFR_RUN_TESTS
   - r: 3.5
   - r: 3.4
   - r: 3.3


### PR DESCRIPTION
I'm pretty sure vdiffr hasn't been running on Travis CI since https://github.com/tidyverse/ggplot2/commit/9fdf452d34be3986c778c9f4306ce96c7c14af8e