### PR TITLE
Various fixes on GitHub Actions CI

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -98,8 +98,9 @@ jobs:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check
 
-      # TODO: uncomment this when we fix the failure of covr::codecov()
-      # - name: Test coverage
-      #   if: matrix.config.os == 'macOS-latest' && matrix.config.r == '3.6'
-      #   run: covr::codecov()
-      #   shell: Rscript {0}
+      - name: Test coverage
+        if: matrix.config.os == 'macOS-latest' && matrix.config.r == '3.6'
+        run: |
+          remotes::install_github("r-lib/covr")
+          covr::codecov()
+        shell: Rscript {0}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -7,6 +7,8 @@ on:
       - master
 
 name: R-CMD-check
+
+# Increment this version when we want to clear cache
 env:
   cache-version: v1
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -7,6 +7,8 @@ on:
       - master
 
 name: R-CMD-check
+env:
+  cache-version: v1
 
 jobs:
   R-CMD-check:
@@ -56,8 +58,8 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{ hashFiles('depends.Rds') }}
-          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-
+          key: ${{ env.cache-version }}-${{ runner.os }}-r-${{ matrix.config.r }}-${{ hashFiles('depends.Rds') }}
+          restore-keys: ${{ env.cache-version }}-${{ runner.os }}-r-${{ matrix.config.r }}-
 
       - name: Install system dependencies on Linux
         if: runner.os == 'Linux'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,8 +20,7 @@ jobs:
         config:
           - {os: windows-latest, r: '3.6', vdiffr: true}
           - {os: macOS-latest, r: '3.6', vdiffr: true}
-          # TODO
-          # - {os: macOS-latest, r: 'devel', vdiffr: false}
+          - {os: macOS-latest, r: 'devel', vdiffr: false}
           - {os: ubuntu-16.04, r: '3.2', vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04, r: '3.3', vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04, r: '3.4', vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
@@ -46,18 +45,6 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@master
 
-      - name: Install XQuartz on macOS
-        if: runner.os == 'macOS'
-        run: brew cask install xquartz
-
-      # To install vdiffr, these three libraries/tools are needed:
-      # - freetype (already installed, needed by systemfonts)
-      # - cairo (not installed, needed by gdtools)
-      # - pkg-config (not installed, needed to set proper build settings)
-      - name: Install pkg-config and cairo on devel macOS
-        if: runner.os == 'macOS' && matrix.config.r == 'devel'
-        run: brew install pkg-config cairo
-
       - name: Query dependencies
         run: |
           install.packages('remotes')
@@ -72,7 +59,7 @@ jobs:
           key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{ hashFiles('depends.Rds') }}
           restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-
 
-      - name: Install system dependencies
+      - name: Install system dependencies on Linux
         if: runner.os == 'Linux'
         env:
           RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
@@ -80,6 +67,24 @@ jobs:
           Rscript -e "remotes::install_github('r-hub/sysreqs')"
           sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
           sudo -s eval "$sysreqs"
+
+      - name: Install system dependencies on macOS
+        if: runner.os == 'macOS'
+        run: |
+          # XQuartz is needed by vdiffr
+          brew cask install xquartz
+
+          # To install vdiffr, these three libraries/tools are needed in addition to XQuartz
+          # - freetype (already installed, needed by systemfonts)
+          # - cairo (not installed, needed by gdtools)
+          # - pkg-config (not installed, needed to set proper build settings)
+          brew install pkg-config cairo
+
+          # Since sf dependencies are a bit heavy, install them only when they are needed
+          SF_IS_OLD=$(Rscript -e 'if ("sf" %in% old.packages()[,"Package"]) cat("yes")')
+          if [ "${SF_IS_OLD}" == "yes" ]; then
+            brew install udunits gdal
+          fi
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -113,10 +113,3 @@ jobs:
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check
-
-      - name: Test coverage
-        if: matrix.config.os == 'macOS-latest' && matrix.config.r == '3.6'
-        run: |
-          remotes::install_github("r-lib/covr")
-          covr::codecov()
-        shell: Rscript {0}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -83,8 +83,8 @@ jobs:
           brew install pkg-config cairo
 
           # Since sf dependencies are a bit heavy, install them only when they are needed
-          SF_IS_OLD=$(Rscript -e 'if ("sf" %in% old.packages()[,"Package"]) cat("yes")')
-          if [ "${SF_IS_OLD}" == "yes" ]; then
+          SF_NEEDS_UPDATED=$(Rscript -e 'if (!"sf" %in% installed.packages()[,"Package"] || "sf" %in% old.packages()[,"Package"]) cat("yes")')
+          if [ "${SF_NEEDS_UPDATED}" == "yes" ]; then
             brew install udunits gdal
           fi
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -90,7 +90,7 @@ jobs:
             brew install udunits gdal
           fi
 
-      # Remove this when https://github.com/r-lib/xml2/issues/296 is fixed on CRAN
+      # TODO: Remove this when https://github.com/r-lib/xml2/issues/296 is fixed on CRAN
       - name: Install the dev version of xml2 as a workaround
         if: runner.os == 'macOS' && matrix.config.r == 'devel'
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -88,6 +88,13 @@ jobs:
             brew install udunits gdal
           fi
 
+      # Remove this when https://github.com/r-lib/xml2/issues/296 is fixed on CRAN
+      - name: Install the dev version of xml2 as a workaround
+        if: runner.os == 'macOS' && matrix.config.r == 'devel'
+        run: |
+          remotes::install_github('r-lib/xml2')
+        shell: Rscript {0}
+
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,7 +20,8 @@ jobs:
         config:
           - {os: windows-latest, r: '3.6', vdiffr: true}
           - {os: macOS-latest, r: '3.6', vdiffr: true}
-          - {os: macOS-latest, r: 'devel', vdiffr: false}
+          # TODO
+          # - {os: macOS-latest, r: 'devel', vdiffr: false}
           - {os: ubuntu-16.04, r: '3.2', vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04, r: '3.3', vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04, r: '3.4', vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -7,33 +7,13 @@ on:
 
 name: pkgdown
 
-# Increment this version when we want to clear cache
-env:
-  cache-version: v1
-
 jobs:
   pkgdown:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
-
       - uses: r-lib/actions/setup-r@master
-
       - uses: r-lib/actions/setup-pandoc@master
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), "depends.Rds", version = 2)
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        uses: actions/cache@v1
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ env.cache-version }}-macOS-r-3.6-${{ hashFiles('depends.Rds') }}
-          restore-keys: ${{ env.cache-version }}-macOS-r-3.6-
-
       - name: Install dependencies
         run: |
           install.packages("remotes")
@@ -41,10 +21,8 @@ jobs:
           remotes::install_github("tidyverse/tidytemplate")
           remotes::install_dev("pkgdown")
         shell: Rscript {0}
-
       - name: Install package
         run: R CMD INSTALL .
-
       - name: Deploy package
         run: pkgdown::deploy_to_branch(new_process = FALSE)
         shell: Rscript {0}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -7,6 +7,10 @@ on:
 
 name: pkgdown
 
+# Increment this version when we want to clear cache
+env:
+  cache-version: v1
+
 jobs:
   pkgdown:
     runs-on: macOS-latest
@@ -27,8 +31,8 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: macOS-r-3.6-${{ hashFiles('depends.Rds') }}
-          restore-keys: macOS-r-3.6-
+          key: ${{ env.cache-version }}-macOS-r-3.6-${{ hashFiles('depends.Rds') }}
+          restore-keys: ${{ env.cache-version }}-macOS-r-3.6-
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -17,12 +17,6 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@master
 
-      - name: Install sf-dependencies
-        run: |
-          brew install pkg-config
-          brew install udunits
-          brew install gdal
-
       - name: Query dependencies
         run: |
           install.packages('remotes')
@@ -35,13 +29,6 @@ jobs:
           path: ${{ env.R_LIBS_USER }}
           key: macOS-r-3.6-${{ hashFiles('depends.Rds') }}
           restore-keys: macOS-r-3.6-
-
-      - name: Workaround for installing sf
-        if: runner.os == 'macOS'
-        run: |
-          remotes::install_github('RcppCore/Rcpp')
-          remotes::install_cran('sf', configure.args = '--with-proj-include=/usr/local/include/ --with-proj-lib=/usr/local/lib/')
-        shell: Rscript {0}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -12,8 +12,37 @@ jobs:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
+
       - uses: r-lib/actions/setup-r@master
+
       - uses: r-lib/actions/setup-pandoc@master
+
+      - name: Install sf-dependencies
+        run: |
+          brew install pkg-config
+          brew install udunits
+          brew install gdal
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), "depends.Rds", version = 2)
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: macOS-r-3.6-${{ hashFiles('depends.Rds') }}
+          restore-keys: macOS-r-3.6-
+
+      - name: Workaround for installing sf
+        if: runner.os == 'macOS'
+        run: |
+          remotes::install_github('RcppCore/Rcpp')
+          remotes::install_cran('sf', configure.args = '--with-proj-include=/usr/local/include/ --with-proj-lib=/usr/local/lib/')
+        shell: Rscript {0}
+
       - name: Install dependencies
         run: |
           install.packages("remotes")
@@ -21,8 +50,10 @@ jobs:
           remotes::install_github("tidyverse/tidytemplate")
           remotes::install_dev("pkgdown")
         shell: Rscript {0}
+
       - name: Install package
         run: R CMD INSTALL .
+
       - name: Deploy package
         run: pkgdown::deploy_to_branch(new_process = FALSE)
         shell: Rscript {0}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,51 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+name: test-coverage
+
+# Increment this version when we want to clear cache
+env:
+  cache-version: v1
+
+jobs:
+  test-coverage:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@master
+
+      - uses: r-lib/actions/setup-pandoc@master
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ env.cache-version }}-macOS-r-3.6-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ env.cache-version }}-macOS-r-3.6-
+
+      - name: Install dependencies
+        run: |
+          install.packages(c("remotes"))
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_cran("covr")
+        shell: Rscript {0}
+
+      # TODO: Remove remotes::install_github() after covr > 3.5.0 is released
+      #       c.f. https://github.com/r-lib/covr/commit/cc710804aeff6f337777465bf902914197c0b713
+      - name: Test coverage
+        run: |
+          remotes::install_github("r-lib/covr")
+          covr::codecov()
+        shell: Rscript {0}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -35,6 +35,31 @@ jobs:
           key: ${{ env.cache-version }}-macOS-r-3.6-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ env.cache-version }}-macOS-r-3.6-
 
+      - name: Install system dependencies on macOS
+        if: runner.os == 'macOS'
+        run: |
+          # XQuartz is needed by vdiffr
+          brew cask install xquartz
+
+          # To install vdiffr, these three libraries/tools are needed in addition to XQuartz
+          # - freetype (already installed, needed by systemfonts)
+          # - cairo (not installed, needed by gdtools)
+          # - pkg-config (not installed, needed to set proper build settings)
+          brew install pkg-config cairo
+
+          # Since sf dependencies are a bit heavy, install them only when they are needed
+          SF_NEEDS_UPDATED=$(Rscript -e 'if (!"sf" %in% installed.packages()[,"Package"] || "sf" %in% old.packages()[,"Package"]) cat("yes")')
+          if [ "${SF_NEEDS_UPDATED}" == "yes" ]; then
+            brew install udunits gdal
+          fi
+
+      # TODO: Remove this when https://github.com/r-lib/xml2/issues/296 is fixed on CRAN
+      - name: Install the dev version of xml2 as a workaround
+        if: runner.os == 'macOS' && matrix.config.r == 'devel'
+        run: |
+          remotes::install_github('r-lib/xml2')
+        shell: Rscript {0}
+
       - name: Install dependencies
         run: |
           install.packages(c("remotes"))


### PR DESCRIPTION
This PR addresses the following issues:

* ~~Add a workaround for problem about Rcpp on macOS runner (https://github.com/RcppCore/Rcpp/issues/1060).~~ (Rcpp is fixed on CRAN)
* Install xml2 from GitHub on macOS runner (c.f https://github.com/r-lib/xml2/issues/296).
* Install covr from GitHub to enable codecov again (c.f. https://github.com/tidyverse/ggplot2/pull/3862#issuecomment-599557468).
* Add `cache-version` to enable cache clear.