### PR TITLE
feat: add DocSearch as recommended by pkgdown

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,6 +2,10 @@ url: https://ggplot2.tidyverse.org
 
 template:
   package: tidytemplate
+  params:
+      docsearch:
+        api_key: e1261f3df95d2d4704c626ff11a4b536
+        index_name: tidyverse_ggplot2
 
 development:
   mode: auto


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for pkgdown](https://pkgdown.r-lib.org/). We thought it is a shame you can not also used this search.

This PR will add DocSearch to the documentation website. It will allow a user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.