### PR TITLE
Allow specifying the limit of Coord in the opposite order to the Scale

### DIFF
--- a/R/scale-view.r
+++ b/R/scale-view.r
@@ -16,7 +16,9 @@ view_scale_primary <- function(scale, limits = scale$get_limits(),
                                continuous_range = scale$dimension(limits = limits)) {
 
   if(!scale$is_discrete()) {
-    breaks <- scale$get_breaks(continuous_range)
+    # continuous_range can be specified in arbitrary order, but
+    # continuous scales expect the one in ascending order.
+    breaks <- scale$get_breaks(sort(continuous_range))
     minor_breaks <- scale$get_breaks_minor(b = breaks, limits = continuous_range)
   } else {
     breaks <- scale$get_breaks(limits)

--- a/tests/testthat/test-scales-breaks-labels.r
+++ b/tests/testthat/test-scales-breaks-labels.r
@@ -260,7 +260,12 @@ test_that("equal length breaks and labels can be passed to ViewScales with limit
 
   test_view_scale <- view_scale_primary(test_scale)
   expect_identical(test_view_scale$get_breaks(), c(NA, 20, NA))
-  expect_identical(test_scale$get_labels(), c(c("0", "20", "40")))
+  expect_identical(test_view_scale$get_labels(), c(c("0", "20", "40")))
+
+  # ViewScale accepts the limits in the opposite order (#3952)
+  test_view_scale_rev <- view_scale_primary(test_scale, limits = rev(test_scale$get_limits()))
+  expect_identical(test_view_scale_rev$get_breaks(), c(NA, 20, NA))
+  expect_identical(test_view_scale_rev$get_labels(), c(c("0", "20", "40")))
 })
 
 # Visual tests ------------------------------------------------------------


### PR DESCRIPTION
Fix #3952

`ylim` and `xlim` of `coord_cartesian()` can be specified in arbitrary order. But, `ScaleContinuous$get_breaks()` always expects the limits are in the same order to their order. If not, it returns `NA` and we'll see no ticks. So, the limits should be sorted before passing to it.

I think scale should raise more explicit warnings or errors, but it's out of scope of this PR.

``` r
devtools::load_all("~/repo/ggplot2/")
#> Loading ggplot2

library(patchwork)

d <- base::data.frame(
  x = 1:4,
  y = 1:4
)

p <- ggplot(d, aes(x, y)) +
  geom_point()

p1 <- p + coord_cartesian(ylim = c(1, 10)) + ggtitle("(usual plot)")
p2 <- p + coord_cartesian(ylim = c(10, 1)) + ggtitle("Coord is reversed")
p3 <- p + scale_y_reverse() + coord_cartesian(ylim = c(1, 10)) + ggtitle("Scale is reversed, but Coord is not")
p4 <- p + scale_y_reverse() + coord_cartesian(ylim = c(10, 1)) + ggtitle("Scale and Coord are reversed")

wrap_plots(p1, p2, p3, p4)
```

![](https://i.imgur.com/LRcCtAM.png)

<sup>Created on 2020-04-22 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
