### PR TITLE
Test R 4.0 on CI

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,14 +22,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: '3.6', vdiffr: true}
-          - {os: macOS-latest, r: '3.6', vdiffr: true}
-          - {os: macOS-latest, r: 'devel', vdiffr: false}
-          - {os: ubuntu-16.04, r: '3.2', vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04, r: '3.3', vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04, r: '3.4', vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04, r: '3.5', vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04, r: '3.6', vdiffr: true, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: windows-latest, r: 'release', vdiffr: true}
+          - {os: macOS-latest,   r: 'release', vdiffr: true}
+          - {os: macOS-latest,   r: 'devel',   vdiffr: false}
+          - {os: ubuntu-16.04,   r: 'release', vdiffr: true,  cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: 'oldrel',  vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: '3.5',     vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: '3.4',     vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: '3.3',     vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -90,13 +90,6 @@ jobs:
             brew install udunits gdal
           fi
 
-      # TODO: Remove this when https://github.com/r-lib/xml2/issues/296 is fixed on CRAN
-      - name: Install the dev version of xml2 as a workaround
-        if: runner.os == 'macOS' && matrix.config.r == 'devel'
-        run: |
-          remotes::install_github('r-lib/xml2')
-        shell: Rscript {0}
-
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,6 +30,7 @@ jobs:
           - {os: ubuntu-16.04,   r: '3.5',   vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.4',   vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.3',   vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: '3.2',   vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -68,6 +68,9 @@ jobs:
         env:
           RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
         run: |
+          # Use cran:libgit2 PPA to avoid conflicts of libcurl4-gnutls-dev
+          sudo add-apt-repository ppa:cran/libgit2
+
           Rscript -e "remotes::install_github('r-hub/sysreqs')"
           sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
           sudo -s eval "$sysreqs"

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -70,6 +70,7 @@ jobs:
           RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
         run: |
           # Use cran:libgit2 PPA to avoid conflicts of libcurl4-gnutls-dev
+          # Remove this after https://github.com/r-lib/actions/pull/97 gets merged
           sudo add-apt-repository ppa:cran/libgit2
 
           Rscript -e "remotes::install_github('r-hub/sysreqs')"

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,14 +22,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release', vdiffr: true}
-          - {os: macOS-latest,   r: 'release', vdiffr: true}
-          - {os: macOS-latest,   r: 'devel',   vdiffr: false}
-          - {os: ubuntu-16.04,   r: 'release', vdiffr: true,  cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: 'oldrel',  vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.5',     vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.4',     vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.3',     vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: windows-latest, r: '4.0',   vdiffr: true}
+          - {os: macOS-latest,   r: '4.0',   vdiffr: true}
+          - {os: macOS-latest,   r: 'devel', vdiffr: false}
+          - {os: ubuntu-16.04,   r: '4.0',   vdiffr: true,  cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: '3.6',   vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: '3.5',   vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: '3.4',   vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: '3.3',   vdiffr: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,10 @@ matrix:
     env:
       - VDIFFR_RUN_TESTS=true
       - VDIFFR_LOG_PATH="../vdiffr.Rout.fail"
+  - r: 3.6
   - r: 3.5
   - r: 3.4
   - r: 3.3
-  - r: 3.2
-    env: R_REMOTES_NO_ERRORS_FROM_WARNINGS=true
 
 # environment variables set for all builds
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
   - r: 3.5
   - r: 3.4
   - r: 3.3
+  - r: 3.2
+    env: R_REMOTES_NO_ERRORS_FROM_WARNINGS=true
 
 # environment variables set for all builds
 env:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Authors@R: c(
     person("RStudio", role = c("cph"))
     )
 Depends:
-    R (>= 3.2)
+    R (>= 3.3)
 Imports: 
     digest,
     glue,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Authors@R: c(
     person("RStudio", role = c("cph"))
     )
 Depends:
-    R (>= 3.3)
+    R (>= 3.2)
 Imports: 
     digest,
     glue,


### PR DESCRIPTION
Now R 4.0.0 is released, ~~let's drop support for R 3.2 (c.f. we support only 4 previous versions of R https://www.tidyverse.org/blog/2019/04/r-version-support/).~~ let's add R 4.0 runners on CI

In addition, this PR contains the following tweaks:

* Remove a workaround related to xml2 installation problem, as the new version of xml2 was released on CRAN
* Add `cran:libgit2` PPA to avoid conflicts related to `libcurl4-gnutls-dev` (c.f. https://github.com/r-hub/sysreqsdb/issues/77#issuecomment-620025428)