### PR TITLE
Renamed panel titles in gtable of plot with facet_grid()

### DIFF
--- a/R/facet-grid-.r
+++ b/R/facet-grid-.r
@@ -338,7 +338,7 @@ FacetGrid <- ggproto("FacetGrid", Facet,
 
     panel_table <- gtable_matrix("layout", panel_table,
       panel_widths, panel_heights, respect = respect, clip = coord$clip, z = matrix(1, ncol = ncol, nrow = nrow))
-    panel_table$layout$name <- paste0('panel-', rep(seq_len(ncol), nrow), '-', rep(seq_len(nrow), each = ncol))
+    panel_table$layout$name <- paste0('panel-', rep(seq_len(nrow), ncol), '-', rep(seq_len(ncol), each = nrow))
 
     panel_table <- gtable_add_col_space(panel_table,
       theme$panel.spacing.x %||% theme$panel.spacing)


### PR DESCRIPTION
This fixes the inconsistent naming in the `gtable` of `facet_grid()` panels to result in the pattern `panel-[row.nr]-[col.nr]`.

Reprex in issue: https://github.com/tidyverse/ggplot2/issues/3978