### PR TITLE
Fix typo in docs

### DIFF
--- a/R/utilities.r
+++ b/R/utilities.r
@@ -435,11 +435,11 @@ switch_orientation <- function(aesthetics) {
   aesthetics
 }
 
-#' Utilities for working with bidirecitonal layers
+#' Utilities for working with bidirectional layers
 #'
 #' These functions are what underpins the ability of certain geoms to work
-#' automatically in both directions. See the *Extending ggplot2* for how they
-#' are used when implementing `Geom`, `Stat`, and `Position` classes.
+#' automatically in both directions. See the *Extending ggplot2* vignette for
+#' how they are used when implementing `Geom`, `Stat`, and `Position` classes.
 #'
 #' `has_flipped_aes()` is used to sniff out the orientation of the layer from
 #' the data. It has a range of arguments that can be used to finetune the

--- a/man/bidirection.Rd
+++ b/man/bidirection.Rd
@@ -5,7 +5,7 @@
 \alias{has_flipped_aes}
 \alias{flip_data}
 \alias{flipped_names}
-\title{Utilities for working with bidirecitonal layers}
+\title{Utilities for working with bidirectional layers}
 \usage{
 has_flipped_aes(
   data,
@@ -61,8 +61,8 @@ the flipped name, e.g. \code{flipped_names(FALSE)$x == "y"}
 }
 \description{
 These functions are what underpins the ability of certain geoms to work
-automatically in both directions. See the \emph{Extending ggplot2} for how they
-are used when implementing \code{Geom}, \code{Stat}, and \code{Position} classes.
+automatically in both directions. See the \emph{Extending ggplot2} vignette for
+how they are used when implementing \code{Geom}, \code{Stat}, and \code{Position} classes.
 }
 \details{
 \code{has_flipped_aes()} is used to sniff out the orientation of the layer from

--- a/man/ggtheme.Rd
+++ b/man/ggtheme.Rd
@@ -84,7 +84,7 @@ theme_test(
 )
 }
 \arguments{
-\item{base_size}{base font size; text size in pts.}
+\item{base_size}{base font size, given in pts.}
 
 \item{base_family}{base font family}
 


### PR DESCRIPTION
Fixes a typo and a missing word in the documentation for `has_flipped_aes()`. Rendering the .Rd files also turned up a roxygen/Rd mismatch from #3787. It's just a tiny change, so I've included it here.