### PR TITLE
remove NA breaks before creating the guides

### DIFF
--- a/R/guide-bins.R
+++ b/R/guide-bins.R
@@ -132,6 +132,7 @@ guide_bins <- function(
 #' @export
 guide_train.bins <- function(guide, scale, aesthetic = NULL) {
   breaks <- scale$get_breaks()
+  breaks <- breaks[!is.na(breaks)]
   if (length(breaks) == 0 || all(is.na(breaks))) {
     return()
   }

--- a/R/guide-colorsteps.R
+++ b/R/guide-colorsteps.R
@@ -57,6 +57,7 @@ guide_colorsteps <- guide_coloursteps
 #' @export
 guide_train.colorsteps <- function(guide, scale, aesthetic = NULL) {
   breaks <- scale$get_breaks()
+  breaks <- breaks[!is.na(breaks)]
   if (guide$even.steps || !is.numeric(breaks)) {
     if (length(breaks) == 0 || all(is.na(breaks))) {
       return()


### PR DESCRIPTION
Fix #3876 This PR makes sure NA are not represented in the guide. Whether these guides (and colourbar) should actually represent `NA` (in a more aesthetically pleasing way) is a discussion for later when a guide rewrite is done