### PR TITLE
make sure linetype and linewidth is passed on to the polygongrob

### DIFF
--- a/R/geom-ribbon.r
+++ b/R/geom-ribbon.r
@@ -138,16 +138,19 @@ GeomRibbon <- ggproto("GeomRibbon", Geom,
 
     munched <- coord_munch(coord, positions, panel_params)
 
+    is_full_outline <- identical(outline.type, "full")
     g_poly <- polygonGrob(
       munched$x, munched$y, id = munched$id,
       default.units = "native",
       gp = gpar(
         fill = alpha(aes$fill, aes$alpha),
-        col = if (identical(outline.type, "full")) aes$colour else NA
+        col = if (is_full_outline) aes$colour else NA,
+        lwd = if (is_full_outline) aes$size * .pt else 0,
+        lty = if (is_full_outline) aes$linetype else 1
       )
     )
 
-    if (identical(outline.type, "full")) {
+    if (is_full_outline) {
       return(ggname("geom_ribbon", g_poly))
     }
 

--- a/tests/figs/geom-smooth/ribbon-turned-on-in-geom-smooth.svg
+++ b/tests/figs/geom-smooth/ribbon-turned-on-in-geom-smooth.svg
@@ -19,11 +19,11 @@
   </clipPath>
 </defs>
 <rect x='35.21' y='22.77' width='639.71' height='522.36' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMzUuMjF8Njc0LjkzfDU0NS4xM3wyMi43Nw==)' />
-<polygon points='64.29,283.95 645.85,46.52 645.85,283.95 64.29,521.39 ' style='stroke-width: 0.75; stroke: none; fill: #F8766D; fill-opacity: 0.40;' clip-path='url(#cpMzUuMjF8Njc0LjkzfDU0NS4xM3wyMi43Nw==)' />
+<polygon points='64.29,283.95 645.85,46.52 645.85,283.95 64.29,521.39 ' style='stroke-width: 0.00; stroke: none; fill: #F8766D; fill-opacity: 0.40;' clip-path='url(#cpMzUuMjF8Njc0LjkzfDU0NS4xM3wyMi43Nw==)' />
 <polyline points='64.29,283.95 645.85,46.52 ' style='stroke-width: 2.13; stroke: none;' clip-path='url(#cpMzUuMjF8Njc0LjkzfDU0NS4xM3wyMi43Nw==)' />
 <polyline points='645.85,283.95 64.29,521.39 ' style='stroke-width: 2.13; stroke: none;' clip-path='url(#cpMzUuMjF8Njc0LjkzfDU0NS4xM3wyMi43Nw==)' />
 <polyline points='64.29,402.67 645.85,165.23 ' style='stroke-width: 2.13; stroke: #F8766D; stroke-linecap: butt;' clip-path='url(#cpMzUuMjF8Njc0LjkzfDU0NS4xM3wyMi43Nw==)' />
-<polygon points='64.29,46.52 645.85,283.95 645.85,521.39 64.29,283.95 ' style='stroke-width: 0.75; stroke: none; fill: #00BFC4; fill-opacity: 0.40;' clip-path='url(#cpMzUuMjF8Njc0LjkzfDU0NS4xM3wyMi43Nw==)' />
+<polygon points='64.29,46.52 645.85,283.95 645.85,521.39 64.29,283.95 ' style='stroke-width: 0.00; stroke: none; fill: #00BFC4; fill-opacity: 0.40;' clip-path='url(#cpMzUuMjF8Njc0LjkzfDU0NS4xM3wyMi43Nw==)' />
 <polyline points='64.29,46.52 645.85,283.95 ' style='stroke-width: 2.13; stroke: none;' clip-path='url(#cpMzUuMjF8Njc0LjkzfDU0NS4xM3wyMi43Nw==)' />
 <polyline points='645.85,521.39 64.29,283.95 ' style='stroke-width: 2.13; stroke: none;' clip-path='url(#cpMzUuMjF8Njc0LjkzfDU0NS4xM3wyMi43Nw==)' />
 <polyline points='64.29,165.23 645.85,402.67 ' style='stroke-width: 2.13; stroke: #00BFC4; stroke-linecap: butt;' clip-path='url(#cpMzUuMjF8Njc0LjkzfDU0NS4xM3wyMi43Nw==)' />

--- a/tests/figs/position-stack/area-stacking.svg
+++ b/tests/figs/position-stack/area-stacking.svg
@@ -19,9 +19,9 @@
   </clipPath>
 </defs>
 <rect x='27.89' y='22.77' width='633.46' height='522.36' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMjcuODl8NjYxLjM0fDU0NS4xM3wyMi43Nw==)' />
-<polygon points='56.68,375.27 248.64,265.69 440.59,46.52 632.55,521.39 632.55,375.27 440.59,156.10 248.64,338.74 56.68,375.27 ' style='stroke-width: 0.75; stroke: none; fill: #F8766D;' clip-path='url(#cpMjcuODl8NjYxLjM0fDU0NS4xM3wyMi43Nw==)' />
+<polygon points='56.68,375.27 248.64,265.69 440.59,46.52 632.55,521.39 632.55,375.27 440.59,156.10 248.64,338.74 56.68,375.27 ' style='stroke-width: 0.00; stroke: none; fill: #F8766D;' clip-path='url(#cpMjcuODl8NjYxLjM0fDU0NS4xM3wyMi43Nw==)' />
 <polyline points='56.68,375.27 248.64,265.69 440.59,46.52 632.55,521.39 ' style='stroke-width: 1.07; stroke: none;' clip-path='url(#cpMjcuODl8NjYxLjM0fDU0NS4xM3wyMi43Nw==)' />
-<polygon points='56.68,375.27 248.64,338.74 440.59,156.10 632.55,265.69 632.55,375.27 440.59,375.27 248.64,375.27 56.68,375.27 ' style='stroke-width: 0.75; stroke: none; fill: #00BFC4;' clip-path='url(#cpMjcuODl8NjYxLjM0fDU0NS4xM3wyMi43Nw==)' />
+<polygon points='56.68,375.27 248.64,338.74 440.59,156.10 632.55,265.69 632.55,375.27 440.59,375.27 248.64,375.27 56.68,375.27 ' style='stroke-width: 0.00; stroke: none; fill: #00BFC4;' clip-path='url(#cpMjcuODl8NjYxLjM0fDU0NS4xM3wyMi43Nw==)' />
 <polyline points='56.68,375.27 248.64,338.74 440.59,156.10 632.55,265.69 ' style='stroke-width: 1.07; stroke: none;' clip-path='url(#cpMjcuODl8NjYxLjM0fDU0NS4xM3wyMi43Nw==)' />
 <rect x='27.89' y='22.77' width='633.46' height='522.36' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpMjcuODl8NjYxLjM0fDU0NS4xM3wyMi43Nw==)' />
 <defs>


### PR DESCRIPTION
Fix #3891 This PR fixes the oversight of adding the line aesthetics to the polygonGrob for `outline.type = 'full'`