### PR TITLE
Allow using optional_aes in Stat

### DIFF
--- a/R/stat-.r
+++ b/R/stat-.r
@@ -61,6 +61,8 @@ Stat <- ggproto("Stat",
 
   non_missing_aes = character(),
 
+  optional_aes = character(),
+
   setup_params = function(data, params) {
     params
   },
@@ -155,7 +157,7 @@ Stat <- ggproto("Stat",
     } else {
       required_aes <- unlist(strsplit(self$required_aes, '|', fixed = TRUE))
     }
-    c(union(required_aes, names(self$default_aes)), "group")
+    c(union(required_aes, names(self$default_aes)), self$optional_aes, "group")
   }
 
 )


### PR DESCRIPTION
This comes out of the discussion in #3860 which surfaced that Stat did not have the same `optional_aes` field as Geom. This PR simply mirrors the Geom implementation so that Stats can declare optional aesthetics.

I'd like to get this into 3.3.1 so I can use it in the book