### PR TITLE
Add `bounds` argument to `geom_density()`

### DIFF
--- a/man/geom_density.Rd
+++ b/man/geom_density.Rd
@@ -30,6 +30,7 @@ stat_density(
   n = 512,
   trim = FALSE,
   na.rm = FALSE,
+  bounds = c(-Inf, Inf),
   orientation = NA,
   show.legend = NA,
   inherit.aes = TRUE
@@ -111,6 +112,9 @@ range of that group: this typically means the estimated x values will
 not line-up, and hence you won't be able to stack density values.
 This parameter only matters if you are displaying multiple densities in
 one plot or if you are manually adjusting the scale limits.}
+
+\item{bounds}{Known lower and upper bounds for estimated data. Default
+\code{c(-Inf, Inf)} means that there are no (finite) bounds.}
 }
 \description{
 Computes and draws kernel density estimate, which is a smoothed version of


### PR DESCRIPTION
This is a PR for #3387 and serves as a place for discussion and feedback about possible change.

The goal is to **add `bounds` argument to `geom_density()` and `stat_density()`, which will allow users to specify known constraints on data to obtain more "realistic" density estimation**. Change to computed output of `stats::density()` is made using relatively simple "reflection method of boundary correction" *roughly* taken from "Simple boundary correction for kernel density estimation” by M.C. Jones, 1993 (you can look at free [pdf-file of presentation based on this article](http://www.buch-kromann.dk/tine/nonpar/Simple%20boundary%20correction,%20Jones%201993.pdf), in particular, page 7).

Currently this PR serves two purposes:

- Show that this is a completely non-breaking update. All previous behavior is explicitly preserved.
- Allow everyone to "play" with it.

If agreed that this is a desirable change, at least the following should also be made (which I am happy to do):

- Figure out when and how to notify user about "bad bounds". For example, when some or all data points are outside of `bounds` interval, or simply it doesn't represent a valid interval.
- Add examples of `bounds` usage.