### PR TITLE
Fix geom_ribbon() on non-cartesian Coords

### DIFF
--- a/R/geom-ribbon.r
+++ b/R/geom-ribbon.r
@@ -128,19 +128,31 @@ GeomRibbon <- ggproto("GeomRibbon", Geom,
     ids[missing_pos] <- NA
 
     data <- unclass(data) #for faster indexing
-    positions <- new_data_frame(list(
-      x = c(data$x, rev(data$x)),
-      y = c(data$ymax, rev(data$ymin)),
-      id = c(ids, rev(ids))
+
+    # The upper line and lower line need to processed separately (#4023)
+    positions_upper <- new_data_frame(list(
+      x = data$x,
+      y = data$ymax,
+      id = ids
     ))
 
-    positions <- flip_data(positions, flipped_aes)
+    positions_lower <- new_data_frame(list(
+      x = rev(data$x),
+      y = rev(data$ymin),
+      id = rev(ids)
+    ))
 
-    munched <- coord_munch(coord, positions, panel_params)
+    positions_upper <- flip_data(positions_upper, flipped_aes)
+    positions_lower <- flip_data(positions_lower, flipped_aes)
+
+    munched_upper <- coord_munch(coord, positions_upper, panel_params)
+    munched_lower <- coord_munch(coord, positions_lower, panel_params)
+
+    munched_poly <- rbind(munched_upper, munched_lower)
 
     is_full_outline <- identical(outline.type, "full")
     g_poly <- polygonGrob(
-      munched$x, munched$y, id = munched$id,
+      munched_poly$x, munched_poly$y, id = munched_poly$id,
       default.units = "native",
       gp = gpar(
         fill = alpha(aes$fill, aes$alpha),
@@ -154,12 +166,13 @@ GeomRibbon <- ggproto("GeomRibbon", Geom,
       return(ggname("geom_ribbon", g_poly))
     }
 
-    munched_lines <- munched
-    # increment the IDs of the lower line
-    munched_lines$id <- switch(outline.type,
-      both = munched_lines$id + rep(c(0, max(ids, na.rm = TRUE)), each = length(ids)),
-      upper = munched_lines$id + rep(c(0, NA), each = length(ids)),
-      lower = munched_lines$id + rep(c(NA, 0), each = length(ids)),
+    # Increment the IDs of the lower line so that they will be drawn as separate lines
+    munched_lower$id <- munched_lower$id + max(ids, na.rm = TRUE)
+
+    munched_lines <- switch(outline.type,
+      both = rbind(munched_upper, munched_lower),
+      upper = munched_upper,
+      lower = munched_lower,
       abort(glue("invalid outline.type: {outline.type}"))
     )
     g_lines <- polylineGrob(

--- a/tests/testthat/test-geom-ribbon.R
+++ b/tests/testthat/test-geom-ribbon.R
@@ -46,12 +46,12 @@ test_that("outline.type option works", {
   # upper
   expect_s3_class(g_ribbon_upper$children[[1]]$children[[1]], "polygon")
   expect_s3_class(g_ribbon_upper$children[[1]]$children[[2]], "polyline")
-  expect_equal(g_ribbon_upper$children[[1]]$children[[2]]$id, rep(c(1L, NA), each = 4))
+  expect_equal(g_ribbon_upper$children[[1]]$children[[2]]$id, rep(1L, each = 4))
 
   # lower
   expect_s3_class(g_ribbon_lower$children[[1]]$children[[1]], "polygon")
   expect_s3_class(g_ribbon_lower$children[[1]]$children[[2]], "polyline")
-  expect_equal(g_ribbon_lower$children[[1]]$children[[2]]$id, rep(c(NA, 1L), each = 4))
+  expect_equal(g_ribbon_lower$children[[1]]$children[[2]]$id, rep(2L, each = 4))
 
   # full
   expect_s3_class(g_ribbon_full$children[[1]], "polygon")
@@ -59,5 +59,5 @@ test_that("outline.type option works", {
   # geom_area()'s default is upper
   expect_s3_class(g_area_default$children[[1]]$children[[1]], "polygon")
   expect_s3_class(g_area_default$children[[1]]$children[[2]], "polyline")
-  expect_equal(g_area_default$children[[1]]$children[[2]]$id, rep(c(1L, NA), each = 4))
+  expect_equal(g_area_default$children[[1]]$children[[2]]$id, rep(1L, each = 4))
 })


### PR DESCRIPTION
Fix #4023

The current implementation squashes the upper and lower lines together and tweaks the lower one's `id` on the assumption that the upper and the lower has the same number of rows as the original data. But, it's not true when the Coord is non-cartesian.

<details>

https://github.com/tidyverse/ggplot2/blob/48268385c414702bc343e46d51144846d39232fa/R/geom-ribbon.r#L131-L135

https://github.com/tidyverse/ggplot2/blob/48268385c414702bc343e46d51144846d39232fa/R/geom-ribbon.r#L139

https://github.com/tidyverse/ggplot2/blob/48268385c414702bc343e46d51144846d39232fa/R/geom-ribbon.r#L158-L164

</details>

This PR fixes this issue by processing the upper and the lower separately.

``` r
devtools::load_all("~/repo/ggplot2/")
#> Loading ggplot2

d <- base::data.frame(x = c(1, 2), y = c(3, 4))

ggplot(d) +
  geom_area(aes(x, y), colour = "black", fill = "pink") +
  coord_polar()
```

![](https://i.imgur.com/scpKe0m.png)

<sup>Created on 2020-05-24 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
