### PR TITLE
Minor documentation fixes.

### DIFF
--- a/R/geom-text.r
+++ b/R/geom-text.r
@@ -43,7 +43,7 @@
 #'   displayed as described in `?plotmath`.
 #' @param nudge_x,nudge_y Horizontal and vertical adjustment to nudge labels by.
 #'   Useful for offsetting text from points, particularly on discrete scales.
-#'   Cannot be jointy specified with `position`.
+#'   Cannot be jointly specified with `position`.
 #' @param position Position adjustment, either as a string, or the result of
 #'  a call to a position adjustment function. Cannot be jointy specified with
 #'  `nudge_x` or `nudge_y`.

--- a/R/scale-hue.r
+++ b/R/scale-hue.r
@@ -82,7 +82,6 @@ scale_fill_hue <- function(..., h = c(0, 360) + 15, c = 100, l = 65, h.start = 0
 #'   * A function that returns a discrete colour/fill scale (e.g., [scale_fill_hue()],
 #'   [scale_fill_brewer()], etc).
 #' @export
-#' @rdname
 #' @examples
 #' # Template function for creating densities grouped by a variable
 #' cty_by_var <- function(var) {

--- a/man/geom_text.Rd
+++ b/man/geom_text.Rd
@@ -75,7 +75,7 @@ displayed as described in \code{?plotmath}.}
 
 \item{nudge_x, nudge_y}{Horizontal and vertical adjustment to nudge labels by.
 Useful for offsetting text from points, particularly on discrete scales.
-Cannot be jointy specified with \code{position}.}
+Cannot be jointly specified with \code{position}.}
 
 \item{label.padding}{Amount of padding around label. Defaults to 0.25 lines.}
 

--- a/man/ggsf.Rd
+++ b/man/ggsf.Rd
@@ -190,11 +190,11 @@ displayed as described in \code{?plotmath}.}
 
 \item{nudge_x}{Horizontal and vertical adjustment to nudge labels by.
 Useful for offsetting text from points, particularly on discrete scales.
-Cannot be jointy specified with \code{position}.}
+Cannot be jointly specified with \code{position}.}
 
 \item{nudge_y}{Horizontal and vertical adjustment to nudge labels by.
 Useful for offsetting text from points, particularly on discrete scales.
-Cannot be jointy specified with \code{position}.}
+Cannot be jointly specified with \code{position}.}
 
 \item{label.padding}{Amount of padding around label. Defaults to 0.25 lines.}
 


### PR DESCRIPTION
Fix a typo in the `geom_text()` documentation and a roxygen2 bug introduced in recent PR #3833.