### PR TITLE
Add description of undocumented parameters

### DIFF
--- a/R/stat-density-2d.r
+++ b/R/stat-density-2d.r
@@ -5,6 +5,7 @@
 #' @param contour_var Character string identifying the variable to contour
 #'   by. Can be one of `"density"`, `"ndensity"`, or `"count"`. See the section
 #'   on computed variables for details.
+#' @inheritDotParams geom_contour bins binwidth breaks
 #' @param n Number of grid points in each direction.
 #' @param h Bandwidth (vector of length two). If `NULL`, estimated
 #'   using [MASS::bandwidth.nrd()].

--- a/man/geom_density_2d.Rd
+++ b/man/geom_density_2d.Rd
@@ -94,10 +94,15 @@ from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 \item{position}{Position adjustment, either as a string, or the result of
 a call to a position adjustment function.}
 
-\item{...}{Other arguments passed on to \code{\link[=layer]{layer()}}. These are
-often aesthetics, used to set an aesthetic to a fixed value, like
-\code{colour = "red"} or \code{size = 3}. They may also be parameters
-to the paired geom/stat.}
+\item{...}{
+  Arguments passed on to \code{\link[=geom_contour]{geom_contour}}
+  \describe{
+    \item{\code{bins}}{Number of contour bins. Overridden by \code{binwidth}.}
+    \item{\code{binwidth}}{The width of the contour bins. Overridden by \code{breaks}.}
+    \item{\code{breaks}}{Numeric vector to set the contour breaks.
+Overrides \code{binwidth} and \code{bins}. By default, this is a vector of
+length ten with \code{\link[=pretty]{pretty()}} breaks.}
+  }}
 
 \item{contour_var}{Character string identifying the variable to contour
 by. Can be one of \code{"density"}, \code{"ndensity"}, or \code{"count"}. See the section


### PR DESCRIPTION
Close #3946

I have borrowed the parameter description from [geom-contour](https://github.com/tidyverse/ggplot2/blob/2b03e4723f0b91875667ffb4f952ad6e471ac9f8/R/geom-contour.r#L16).

(This is my first pull request for ggplot2, and I'm not familiar with roxygen2, so apologies if I have missed something obvious.)