### PR TITLE
Add details to start parameter of coord_polar (#3893).

### DIFF
--- a/R/coord-polar.r
+++ b/R/coord-polar.r
@@ -4,7 +4,8 @@
 #' are a stacked bar chart in polar coordinates.
 #'
 #' @param theta variable to map angle to (`x` or `y`)
-#' @param start offset of starting point from 12 o'clock in radians
+#' @param start offset of starting point from 12 o'clock in radians. Offset
+#'   is applied clockwise or anticlockwise depending on value of `direction`.
 #' @param direction 1, clockwise; -1, anticlockwise
 #' @param clip Should drawing be clipped to the extent of the plot panel? A
 #'   setting of `"on"` (the default) means yes, and a setting of `"off"`

--- a/R/coord-polar.r
+++ b/R/coord-polar.r
@@ -4,7 +4,7 @@
 #' are a stacked bar chart in polar coordinates.
 #'
 #' @param theta variable to map angle to (`x` or `y`)
-#' @param start offset of starting point from 12 o'clock in radians. Offset
+#' @param start Offset of starting point from 12 o'clock in radians. Offset
 #'   is applied clockwise or anticlockwise depending on value of `direction`.
 #' @param direction 1, clockwise; -1, anticlockwise
 #' @param clip Should drawing be clipped to the extent of the plot panel? A

--- a/man/coord_polar.Rd
+++ b/man/coord_polar.Rd
@@ -9,7 +9,8 @@ coord_polar(theta = "x", start = 0, direction = 1, clip = "on")
 \arguments{
 \item{theta}{variable to map angle to (\code{x} or \code{y})}
 
-\item{start}{offset of starting point from 12 o'clock in radians}
+\item{start}{Offset of starting point from 12 o'clock in radians. Offset
+is applied clockwise or anticlockwise depending on value of \code{direction}.}
 
 \item{direction}{1, clockwise; -1, anticlockwise}
 


### PR DESCRIPTION
Motivation: current documentation for coord_polar() does not mention that 'start' offset can be applied either clockwise or anticlockwise. Added note in docs that the offset is applied depending on orientation specified by 'direction' parameter (1 = clockwise, -1 = anticlockwise).