### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -77,6 +77,11 @@ jobs:
           sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
           sudo -s eval "$sysreqs"
 
+      # Remove this when the new rmarkdown is released on CRAN
+      - name: "Workaround for rstudio/rmarkdown#1831"
+        if: runner.os == 'Linux' && runner.r < '3.6'
+        run: Rscript -e "remotes::install_github('rstudio/rmarkdown')"
+
       - name: Install system dependencies on macOS
         if: runner.os == 'macOS'
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -79,7 +79,7 @@ jobs:
 
       # Remove this when the new rmarkdown is released on CRAN
       - name: "Workaround for rstudio/rmarkdown#1831"
-        if: runner.os == 'Linux' && runner.r < '3.6'
+        if: runner.os == 'Linux' && matrix.config.r < '3.6'
         run: Rscript -e "remotes::install_github('rstudio/rmarkdown')"
 
       - name: Install system dependencies on macOS

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -10,7 +10,7 @@ name: R-CMD-check
 
 # Increment this version when we want to clear cache
 env:
-  cache-version: v1
+  cache-version: v2
 
 jobs:
   R-CMD-check:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ env:
   # switch off vdiffr by default
   - VDIFFR_RUN_TESTS=false
 
+# Workaround for rstudio/rmarkdown#1831
+r_github_packages: rstudio/rmarkdown
+
 after_success:
   - Rscript -e 'covr::codecov()'
 


### PR DESCRIPTION
Fix #4045 

We need two fixes here:

* For the macOS (devel) runner, bump cache version to clear the cache
* For the Linux (<3.6) runner, install the dev version of rmarkdown package. This will be unnecessary after the next version of rmarkdown is released on CRAN.