### PR TITLE
Use parentheses

### DIFF
--- a/R/aes.r
+++ b/R/aes.r
@@ -217,10 +217,10 @@ is_position_aes <- function(vars) {
 #' evaluation to capture the variable names. `aes_` and `aes_string`
 #' require you to explicitly quote the inputs either with `""` for
 #' `aes_string()`, or with `quote` or `~` for `aes_()`.
-#' (`aes_q` is an alias to `aes_`). This makes `aes_` and
-#' `aes_string` easy to program with.
+#' (`aes_q()` is an alias to `aes_()`). This makes `aes_()` and
+#' `aes_string()` easy to program with.
 #'
-#' `aes_string` and `aes_` are particularly useful when writing
+#' `aes_string()` and `aes_()` are particularly useful when writing
 #' functions that create plots because you can use strings or quoted
 #' names/calls to define the aesthetic mappings, rather than having to use
 #' [substitute()] to generate a call to `aes()`.

--- a/R/autolayer.r
+++ b/R/autolayer.r
@@ -1,6 +1,6 @@
 #' Create a ggplot layer appropriate to a particular data type
 #'
-#' `autolayer` uses ggplot2 to draw a particular layer for an object of a
+#' `autolayer()` uses ggplot2 to draw a particular layer for an object of a
 #' particular class in a single command. This defines the S3 generic that
 #' other classes and packages can extend.
 #'

--- a/R/autoplot.r
+++ b/R/autoplot.r
@@ -1,6 +1,6 @@
 #' Create a complete ggplot appropriate to a particular data type
 #'
-#' `autoplot` uses ggplot2 to draw a particular plot for an object of a
+#' `autoplot()` uses ggplot2 to draw a particular plot for an object of a
 #' particular class in a single command. This defines the S3 generic that
 #' other classes and packages can extend.
 #'

--- a/R/axis-secondary.R
+++ b/R/axis-secondary.R
@@ -24,12 +24,12 @@
 #'   the axis on the plot. Usually this is [guide_axis()].
 #'
 #' @details
-#' `sec_axis` is used to create the specifications for a secondary axis.
+#' `sec_axis()` is used to create the specifications for a secondary axis.
 #' Except for the `trans` argument any of the arguments can be set to
 #' `derive()` which would result in the secondary axis inheriting the
 #' settings from the primary axis.
 #'
-#' `dup_axis` is provide as a shorthand for creating a secondary axis that
+#' `dup_axis()` is provide as a shorthand for creating a secondary axis that
 #' is a duplication of the primary axis, effectively mirroring the primary axis.
 #'
 #' As of v3.1, date and datetime scales have limited secondary axis capabilities.

--- a/R/coord-map.r
+++ b/R/coord-map.r
@@ -1,6 +1,6 @@
 #' Map projections
 #'
-#' `coord_map` projects a portion of the earth, which is approximately
+#' `coord_map()` projects a portion of the earth, which is approximately
 #' spherical, onto a flat 2D plane using any projection defined by the
 #' `mapproj` package. Map projections do not, in general, preserve straight
 #' lines, so this requires considerable computation. `coord_quickmap` is a
@@ -15,7 +15,7 @@
 #' 0. For regions that span only a few degrees and are not too close to the
 #' poles, setting the aspect ratio of the plot to the appropriate lat/lon ratio
 #' approximates the usual mercator projection. This is what
-#' `coord_quickmap` does, and is much faster (particularly for complex
+#' `coord_quickmap()` does, and is much faster (particularly for complex
 #' plots like [geom_tile()]) at the expense of correctness.
 #'
 #' @param projection projection to use, see

--- a/R/coord-transform.r
+++ b/R/coord-transform.r
@@ -1,6 +1,6 @@
 #' Transformed Cartesian coordinate system
 #'
-#' `coord_trans` is different to scale transformations in that it occurs after
+#' `coord_trans()` is different to scale transformations in that it occurs after
 #' statistical transformation and will affect the visual appearance of geoms - there is
 #' no guarantee that straight lines will continue to be straight.
 #'

--- a/R/facet-wrap.r
+++ b/R/facet-wrap.r
@@ -3,7 +3,7 @@ NULL
 
 #' Wrap a 1d ribbon of panels into 2d
 #'
-#' `facet_wrap` wraps a 1d sequence of panels into 2d. This is generally
+#' `facet_wrap()` wraps a 1d sequence of panels into 2d. This is generally
 #' a better use of screen space than [facet_grid()] because most
 #' displays are roughly rectangular.
 #'

--- a/R/geom-.r
+++ b/R/geom-.r
@@ -14,7 +14,7 @@ NULL
 #' Compared to `Stat` and `Position`, `Geom` is a little
 #' different because the execution of the setup and compute functions is
 #' split up. `setup_data` runs before position adjustments, and
-#' `draw_layer` is not run until render time, much later. This
+#' `draw_layer()` is not run until render time, much later. This
 #' means there is no `setup_params` because it's hard to communicate
 #' the changes.
 #'

--- a/R/geom-ribbon.r
+++ b/R/geom-ribbon.r
@@ -2,7 +2,7 @@
 #'
 #' For each x value, `geom_ribbon()` displays a y interval defined
 #' by `ymin` and `ymax`. `geom_area()` is a special case of
-#' `geom_ribbon`, where the `ymin` is fixed to 0 and `y` is used instead
+#' `geom_ribbon()`, where the `ymin` is fixed to 0 and `y` is used instead
 #' of `ymax`.
 #'
 #' An area plot is the continuous analogue of a stacked bar chart (see

--- a/R/geom-segment.r
+++ b/R/geom-segment.r
@@ -1,6 +1,6 @@
 #' Line segments and curves
 #'
-#' `geom_segment` draws a straight line between points (x, y) and
+#' `geom_segment()` draws a straight line between points (x, y) and
 #' (xend, yend). `geom_curve` draws a curved line. See the underlying
 #' drawing function [grid::curveGrob()] for the parameters that
 #' control the curve.

--- a/R/geom-tile.r
+++ b/R/geom-tile.r
@@ -1,9 +1,9 @@
 #' Rectangles
 #'
-#' `geom_rect` and `geom_tile` do the same thing, but are
-#' parameterised differently: `geom_rect` uses the locations of the four
+#' `geom_rect()` and `geom_tile()` do the same thing, but are
+#' parameterised differently: `geom_rect()` uses the locations of the four
 #' corners (`xmin`, `xmax`, `ymin` and `ymax`), while
-#' `geom_tile` uses the center of the tile and its size (`x`,
+#' `geom_tile()` uses the center of the tile and its size (`x`,
 #' `y`, `width`, `height`). `geom_raster` is a high
 #' performance special case for when all the tiles are the same size.
 #'

--- a/R/position-dodge.r
+++ b/R/position-dodge.r
@@ -1,10 +1,10 @@
 #' Dodge overlapping objects side-to-side
 #'
 #' Dodging preserves the vertical position of an geom while adjusting the
-#' horizontal position. `position_dodge` requires the grouping variable to be
-#' be specified in the global or `geom_*` layer. Unlike `position_dodge`,
-#' `position_dodge2` works without a grouping variable in a layer.
-#' `position_dodge2` works with bars and rectangles, but is
+#' horizontal position. `position_dodge()` requires the grouping variable to be
+#' be specified in the global or `geom_*` layer. Unlike `position_dodge()`,
+#' `position_dodge2()` works without a grouping variable in a layer.
+#' `position_dodge2()` works with bars and rectangles, but is
 #' particulary useful for arranging box plots, which
 #' can have variable widths.
 #'

--- a/R/position-nudge.R
+++ b/R/position-nudge.R
@@ -1,6 +1,6 @@
 #' Nudge points a fixed distance
 #'
-#' `position_nudge` is generally useful for adjusting the position of
+#' `position_nudge()` is generally useful for adjusting the position of
 #' items on discrete scales by a small amount. Nudging is built in to
 #' [geom_text()] because it's so useful for moving labels a small
 #' distance from what they're labelling.

--- a/R/quick-plot.r
+++ b/R/quick-plot.r
@@ -1,6 +1,6 @@
 #' Quick plot
 #'
-#' `qplot` is a shortcut designed to be familiar if you're used to base
+#' `qplot()` is a shortcut designed to be familiar if you're used to base
 #' [plot()]. It's a convenient wrapper for creating a number of
 #' different types of plots using a consistent calling scheme. It's great
 #' for allowing you to produce plots quickly, but I highly recommend

--- a/R/scale-alpha.r
+++ b/R/scale-alpha.r
@@ -2,7 +2,7 @@
 #'
 #' Alpha-transparency scales are not tremendously useful, but can be a
 #' convenient way to visually down-weight less important observations.
-#' `scale_alpha` is an alias for `scale_alpha_continuous` since
+#' `scale_alpha()` is an alias for `scale_alpha_continuous()` since
 #' that is the most common use of alpha, and it saves a bit of typing.
 #'
 #' @param ... Other arguments passed on to [continuous_scale()], [binned_scale],

--- a/R/scale-discrete-.r
+++ b/R/scale-discrete-.r
@@ -1,6 +1,6 @@
 #' Position scales for discrete data
 #'
-#' `scale_x_discrete` and `scale_y_discrete` are used to set the values for
+#' `scale_x_discrete()` and `scale_y_discrete()` are used to set the values for
 #' discrete x and y scale aesthetics. For simple manipulation of scale labels
 #' and limits, you may wish to use [labs()] and [lims()] instead.
 #'

--- a/R/scale-shape.r
+++ b/R/scale-shape.r
@@ -1,11 +1,11 @@
 #' Scales for shapes, aka glyphs
 #'
-#' `scale_shape` maps discrete variables to six easily discernible shapes.
+#' `scale_shape()` maps discrete variables to six easily discernible shapes.
 #' If you have more than six levels, you will get a warning message, and the
 #' seventh and subsequence levels will not appear on the plot. Use
 #' [scale_shape_manual()] to supply your own values. You can not map
 #' a continuous variable to shape unless `scale_shape_binned()` is used. Still,
-#' as shape has no inherent order, this use is not advised..
+#' as shape has no inherent order, this use is not advised.
 #'
 #' @param solid Should the shapes be solid, `TRUE`, or hollow,
 #'   `FALSE`?

--- a/R/scale-size.r
+++ b/R/scale-size.r
@@ -1,12 +1,12 @@
 #' Scales for area or radius
 #'
-#' `scale_size` scales area, `scale_radius` scales radius. The size
+#' `scale_size()` scales area, `scale_radius()` scales radius. The size
 #' aesthetic is most commonly used for points and text, and humans perceive
 #' the area of points (not their radius), so this provides for optimal
-#' perception. `scale_size_area` ensures that a value of 0 is mapped
-#' to a size of 0. `scale_size_binned` is a binned version of `scale_size` that
+#' perception. `scale_size_area()` ensures that a value of 0 is mapped
+#' to a size of 0. `scale_size_binned()` is a binned version of `scale_size()` that
 #' scales by area (but does not ensure 0 equals an area of zero). For a binned
-#' equivalent of `scale_size_area` use `scale_size_binned_area`.
+#' equivalent of `scale_size_area()` use `scale_size_binned_area()`.
 #'
 #' @name scale_size
 #' @inheritParams continuous_scale

--- a/R/stat-qq.r
+++ b/R/stat-qq.r
@@ -1,7 +1,7 @@
 #' A quantile-quantile plot
 #'
-#' `geom_qq` and `stat_qq` produce quantile-quantile plots. `geom_qq_line` and
-#' `stat_qq_line` compute the slope and intercept of the line connecting the
+#' `geom_qq()` and `stat_qq()` produce quantile-quantile plots. `geom_qq_line()` and
+#' `stat_qq_line()` compute the slope and intercept of the line connecting the
 #' points at specified quartiles of the theoretical and sample distributions.
 #'
 #' @eval rd_aesthetics("stat", "qq")

--- a/R/stat-summary-2d.r
+++ b/R/stat-summary-2d.r
@@ -1,7 +1,7 @@
 #' Bin and summarise in 2d (rectangle & hexagons)
 #'
-#' `stat_summary_2d` is a 2d variation of [stat_summary()].
-#' `stat_summary_hex` is a hexagonal variation of
+#' `stat_summary_2d()` is a 2d variation of [stat_summary()].
+#' `stat_summary_hex()` is a hexagonal variation of
 #' [stat_summary_2d()]. The data are divided into bins defined
 #' by `x` and `y`, and then the values of `z` in each cell is
 #' are summarised with `fun`.

--- a/R/stat-summary.r
+++ b/R/stat-summary.r
@@ -1,6 +1,6 @@
 #' Summarise y values at unique/binned x
 #'
-#' `stat_summary` operates on unique `x` or `y`; `stat_summary_bin`
+#' `stat_summary()` operates on unique `x` or `y`; `stat_summary_bin()`
 #' operates on binned `x` or `y`. They are more flexible versions of
 #' [stat_bin()]: instead of just counting, they can compute any
 #' aggregate.

--- a/R/utilities-break.r
+++ b/R/utilities-break.r
@@ -1,8 +1,8 @@
 #' Discretise numeric data into categorical
 #'
-#' `cut_interval` makes `n` groups with equal range, `cut_number`
+#' `cut_interval()` makes `n` groups with equal range, `cut_number()`
 #' makes `n` groups with (approximately) equal numbers of observations;
-#' `cut_width` makes groups of width `width`.
+#' `cut_width()` makes groups of width `width`.
 #'
 #' @author Randall Prium contributed most of the implementation of
 #'    `cut_width`.

--- a/man/aes_.Rd
+++ b/man/aes_.Rd
@@ -22,11 +22,11 @@ properties (aesthetics) of geoms. \code{\link[=aes]{aes()}} uses non-standard
 evaluation to capture the variable names. \code{aes_} and \code{aes_string}
 require you to explicitly quote the inputs either with \code{""} for
 \code{aes_string()}, or with \code{quote} or \code{~} for \code{aes_()}.
-(\code{aes_q} is an alias to \code{aes_}). This makes \code{aes_} and
-\code{aes_string} easy to program with.
+(\code{aes_q()} is an alias to \code{aes_()}). This makes \code{aes_()} and
+\code{aes_string()} easy to program with.
 }
 \details{
-\code{aes_string} and \code{aes_} are particularly useful when writing
+\code{aes_string()} and \code{aes_()} are particularly useful when writing
 functions that create plots because you can use strings or quoted
 names/calls to define the aesthetic mappings, rather than having to use
 \code{\link[=substitute]{substitute()}} to generate a call to \code{aes()}.

--- a/man/autolayer.Rd
+++ b/man/autolayer.Rd
@@ -15,7 +15,7 @@ autolayer(object, ...)
 a ggplot layer
 }
 \description{
-\code{autolayer} uses ggplot2 to draw a particular layer for an object of a
+\code{autolayer()} uses ggplot2 to draw a particular layer for an object of a
 particular class in a single command. This defines the S3 generic that
 other classes and packages can extend.
 }

--- a/man/autoplot.Rd
+++ b/man/autoplot.Rd
@@ -15,7 +15,7 @@ autoplot(object, ...)
 a ggplot object
 }
 \description{
-\code{autoplot} uses ggplot2 to draw a particular plot for an object of a
+\code{autoplot()} uses ggplot2 to draw a particular plot for an object of a
 particular class in a single command. This defines the S3 generic that
 other classes and packages can extend.
 }

--- a/man/coord_map.Rd
+++ b/man/coord_map.Rd
@@ -43,7 +43,7 @@ the limits to ensure that data and axes don't overlap. If \code{FALSE},
 limits are taken exactly from the data or \code{xlim}/\code{ylim}.}
 }
 \description{
-\code{coord_map} projects a portion of the earth, which is approximately
+\code{coord_map()} projects a portion of the earth, which is approximately
 spherical, onto a flat 2D plane using any projection defined by the
 \code{mapproj} package. Map projections do not, in general, preserve straight
 lines, so this requires considerable computation. \code{coord_quickmap} is a
@@ -59,7 +59,7 @@ towards infinity because the length of one degree of longitude tends towards
 0. For regions that span only a few degrees and are not too close to the
 poles, setting the aspect ratio of the plot to the appropriate lat/lon ratio
 approximates the usual mercator projection. This is what
-\code{coord_quickmap} does, and is much faster (particularly for complex
+\code{coord_quickmap()} does, and is much faster (particularly for complex
 plots like \code{\link[=geom_tile]{geom_tile()}}) at the expense of correctness.
 }
 \examples{

--- a/man/coord_trans.Rd
+++ b/man/coord_trans.Rd
@@ -38,7 +38,7 @@ the limits to ensure that data and axes don't overlap. If \code{FALSE},
 limits are taken exactly from the data or \code{xlim}/\code{ylim}.}
 }
 \description{
-\code{coord_trans} is different to scale transformations in that it occurs after
+\code{coord_trans()} is different to scale transformations in that it occurs after
 statistical transformation and will affect the visual appearance of geoms - there is
 no guarantee that straight lines will continue to be straight.
 }

--- a/man/cut_interval.Rd
+++ b/man/cut_interval.Rd
@@ -58,9 +58,9 @@ To center on integers, \code{width = 1} and \code{center = 0}.
 or left edges of bins are included in the bin.}
 }
 \description{
-\code{cut_interval} makes \code{n} groups with equal range, \code{cut_number}
+\code{cut_interval()} makes \code{n} groups with equal range, \code{cut_number()}
 makes \code{n} groups with (approximately) equal numbers of observations;
-\code{cut_width} makes groups of width \code{width}.
+\code{cut_width()} makes groups of width \code{width}.
 }
 \examples{
 table(cut_interval(1:100, 10))

--- a/man/facet_wrap.Rd
+++ b/man/facet_wrap.Rd
@@ -71,7 +71,7 @@ either of the four sides by setting \code{strip.position = c("top",
   "bottom", "left", "right")}}
 }
 \description{
-\code{facet_wrap} wraps a 1d sequence of panels into 2d. This is generally
+\code{facet_wrap()} wraps a 1d sequence of panels into 2d. This is generally
 a better use of screen space than \code{\link[=facet_grid]{facet_grid()}} because most
 displays are roughly rectangular.
 }

--- a/man/geom_qq.Rd
+++ b/man/geom_qq.Rd
@@ -120,8 +120,8 @@ that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 }
 \description{
-\code{geom_qq} and \code{stat_qq} produce quantile-quantile plots. \code{geom_qq_line} and
-\code{stat_qq_line} compute the slope and intercept of the line connecting the
+\code{geom_qq()} and \code{stat_qq()} produce quantile-quantile plots. \code{geom_qq_line()} and
+\code{stat_qq_line()} compute the slope and intercept of the line connecting the
 points at specified quartiles of the theoretical and sample distributions.
 }
 \section{Aesthetics}{

--- a/man/geom_ribbon.Rd
+++ b/man/geom_ribbon.Rd
@@ -89,7 +89,7 @@ upper and lower lines, \code{"upper"}/\code{"lower"} draws the respective lines 
 \description{
 For each x value, \code{geom_ribbon()} displays a y interval defined
 by \code{ymin} and \code{ymax}. \code{geom_area()} is a special case of
-\code{geom_ribbon}, where the \code{ymin} is fixed to 0 and \code{y} is used instead
+\code{geom_ribbon()}, where the \code{ymin} is fixed to 0 and \code{y} is used instead
 of \code{ymax}.
 }
 \details{

--- a/man/geom_segment.Rd
+++ b/man/geom_segment.Rd
@@ -106,7 +106,7 @@ the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
     More control points creates a smoother curve.}
 }
 \description{
-\code{geom_segment} draws a straight line between points (x, y) and
+\code{geom_segment()} draws a straight line between points (x, y) and
 (xend, yend). \code{geom_curve} draws a curved line. See the underlying
 drawing function \code{\link[grid:curveGrob]{grid::curveGrob()}} for the parameters that
 control the curve.

--- a/man/geom_tile.Rd
+++ b/man/geom_tile.Rd
@@ -100,10 +100,10 @@ the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 \item{linejoin}{Line join style (round, mitre, bevel).}
 }
 \description{
-\code{geom_rect} and \code{geom_tile} do the same thing, but are
-parameterised differently: \code{geom_rect} uses the locations of the four
+\code{geom_rect()} and \code{geom_tile()} do the same thing, but are
+parameterised differently: \code{geom_rect()} uses the locations of the four
 corners (\code{xmin}, \code{xmax}, \code{ymin} and \code{ymax}), while
-\code{geom_tile} uses the center of the tile and its size (\code{x},
+\code{geom_tile()} uses the center of the tile and its size (\code{x},
 \code{y}, \code{width}, \code{height}). \code{geom_raster} is a high
 performance special case for when all the tiles are the same size.
 }

--- a/man/ggplot2-ggproto.Rd
+++ b/man/ggplot2-ggproto.Rd
@@ -152,7 +152,7 @@ fields.
 Compared to \code{Stat} and \code{Position}, \code{Geom} is a little
 different because the execution of the setup and compute functions is
 split up. \code{setup_data} runs before position adjustments, and
-\code{draw_layer} is not run until render time, much later. This
+\code{draw_layer()} is not run until render time, much later. This
 means there is no \code{setup_params} because it's hard to communicate
 the changes.
 

--- a/man/position_dodge.Rd
+++ b/man/position_dodge.Rd
@@ -30,10 +30,10 @@ This is useful if you're rotating both the plot and legend.}
 }
 \description{
 Dodging preserves the vertical position of an geom while adjusting the
-horizontal position. \code{position_dodge} requires the grouping variable to be
-be specified in the global or \verb{geom_*} layer. Unlike \code{position_dodge},
-\code{position_dodge2} works without a grouping variable in a layer.
-\code{position_dodge2} works with bars and rectangles, but is
+horizontal position. \code{position_dodge()} requires the grouping variable to be
+be specified in the global or \verb{geom_*} layer. Unlike \code{position_dodge()},
+\code{position_dodge2()} works without a grouping variable in a layer.
+\code{position_dodge2()} works with bars and rectangles, but is
 particulary useful for arranging box plots, which
 can have variable widths.
 }

--- a/man/position_nudge.Rd
+++ b/man/position_nudge.Rd
@@ -10,7 +10,7 @@ position_nudge(x = 0, y = 0)
 \item{x, y}{Amount of vertical and horizontal distance to move.}
 }
 \description{
-\code{position_nudge} is generally useful for adjusting the position of
+\code{position_nudge()} is generally useful for adjusting the position of
 items on discrete scales by a small amount. Nudging is built in to
 \code{\link[=geom_text]{geom_text()}} because it's so useful for moving labels a small
 distance from what they're labelling.

--- a/man/qplot.Rd
+++ b/man/qplot.Rd
@@ -70,7 +70,7 @@ x axis label, and y axis label respectively.}
 \item{stat, position}{DEPRECATED.}
 }
 \description{
-\code{qplot} is a shortcut designed to be familiar if you're used to base
+\code{qplot()} is a shortcut designed to be familiar if you're used to base
 \code{\link[=plot]{plot()}}. It's a convenient wrapper for creating a number of
 different types of plots using a consistent calling scheme. It's great
 for allowing you to produce plots quickly, but I highly recommend

--- a/man/scale_alpha.Rd
+++ b/man/scale_alpha.Rd
@@ -30,7 +30,7 @@ breaks, labels and so forth.}
 \description{
 Alpha-transparency scales are not tremendously useful, but can be a
 convenient way to visually down-weight less important observations.
-\code{scale_alpha} is an alias for \code{scale_alpha_continuous} since
+\code{scale_alpha()} is an alias for \code{scale_alpha_continuous()} since
 that is the most common use of alpha, and it saves a bit of typing.
 }
 \examples{

--- a/man/scale_discrete.Rd
+++ b/man/scale_discrete.Rd
@@ -74,7 +74,7 @@ expand the scale by 5\% on each side for continuous variables, and by
 \code{left} or \code{right} for y axes, \code{top} or \code{bottom} for x axes.}
 }
 \description{
-\code{scale_x_discrete} and \code{scale_y_discrete} are used to set the values for
+\code{scale_x_discrete()} and \code{scale_y_discrete()} are used to set the values for
 discrete x and y scale aesthetics. For simple manipulation of scale labels
 and limits, you may wish to use \code{\link[=labs]{labs()}} and \code{\link[=lims]{lims()}} instead.
 }

--- a/man/scale_shape.Rd
+++ b/man/scale_shape.Rd
@@ -69,12 +69,12 @@ as output
 \code{FALSE}?}
 }
 \description{
-\code{scale_shape} maps discrete variables to six easily discernible shapes.
+\code{scale_shape()} maps discrete variables to six easily discernible shapes.
 If you have more than six levels, you will get a warning message, and the
 seventh and subsequence levels will not appear on the plot. Use
 \code{\link[=scale_shape_manual]{scale_shape_manual()}} to supply your own values. You can not map
 a continuous variable to shape unless \code{scale_shape_binned()} is used. Still,
-as shape has no inherent order, this use is not advised..
+as shape has no inherent order, this use is not advised.
 }
 \examples{
 dsmall <- diamonds[sample(nrow(diamonds), 100), ]

--- a/man/scale_size.Rd
+++ b/man/scale_size.Rd
@@ -151,13 +151,13 @@ expand the scale by 5\% on each side for continuous variables, and by
 \item{max_size}{Size of largest points.}
 }
 \description{
-\code{scale_size} scales area, \code{scale_radius} scales radius. The size
+\code{scale_size()} scales area, \code{scale_radius()} scales radius. The size
 aesthetic is most commonly used for points and text, and humans perceive
 the area of points (not their radius), so this provides for optimal
-perception. \code{scale_size_area} ensures that a value of 0 is mapped
-to a size of 0. \code{scale_size_binned} is a binned version of \code{scale_size} that
+perception. \code{scale_size_area()} ensures that a value of 0 is mapped
+to a size of 0. \code{scale_size_binned()} is a binned version of \code{scale_size()} that
 scales by area (but does not ensure 0 equals an area of zero). For a binned
-equivalent of \code{scale_size_area} use \code{scale_size_binned_area}.
+equivalent of \code{scale_size_area()} use \code{scale_size_binned_area()}.
 }
 \examples{
 p <- ggplot(mpg, aes(displ, hwy, size = hwy)) +

--- a/man/sec_axis.Rd
+++ b/man/sec_axis.Rd
@@ -54,12 +54,12 @@ secondary axis, positioned opposite of the primary axis. All secondary
 axes must be based on a one-to-one transformation of the primary axes.
 }
 \details{
-\code{sec_axis} is used to create the specifications for a secondary axis.
+\code{sec_axis()} is used to create the specifications for a secondary axis.
 Except for the \code{trans} argument any of the arguments can be set to
 \code{derive()} which would result in the secondary axis inheriting the
 settings from the primary axis.
 
-\code{dup_axis} is provide as a shorthand for creating a secondary axis that
+\code{dup_axis()} is provide as a shorthand for creating a secondary axis that
 is a duplication of the primary axis, effectively mirroring the primary axis.
 
 As of v3.1, date and datetime scales have limited secondary axis capabilities.

--- a/man/stat_summary.Rd
+++ b/man/stat_summary.Rd
@@ -131,7 +131,7 @@ the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 instead.}
 }
 \description{
-\code{stat_summary} operates on unique \code{x} or \code{y}; \code{stat_summary_bin}
+\code{stat_summary()} operates on unique \code{x} or \code{y}; \code{stat_summary_bin()}
 operates on binned \code{x} or \code{y}. They are more flexible versions of
 \code{\link[=stat_bin]{stat_bin()}}: instead of just counting, they can compute any
 aggregate.

--- a/man/stat_summary_2d.Rd
+++ b/man/stat_summary_2d.Rd
@@ -96,8 +96,8 @@ that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 }
 \description{
-\code{stat_summary_2d} is a 2d variation of \code{\link[=stat_summary]{stat_summary()}}.
-\code{stat_summary_hex} is a hexagonal variation of
+\code{stat_summary_2d()} is a 2d variation of \code{\link[=stat_summary]{stat_summary()}}.
+\code{stat_summary_hex()} is a hexagonal variation of
 \code{\link[=stat_summary_2d]{stat_summary_2d()}}. The data are divided into bins defined
 by \code{x} and \code{y}, and then the values of \code{z} in each cell is
 are summarised with \code{fun}.


### PR DESCRIPTION
when referring to a function in documentation.

Only looked at `` at the start of a line and at surroundings. I can hunt for other instances if you think it's useful.

```sh
sed -r -i "" 's/(^#'"'"' `[a-z_]+[a-z_0-9]*)`/\1()`/' R/*
```