### PR TITLE
subsequence -> subsequent in docs

### DIFF
--- a/R/scale-shape.r
+++ b/R/scale-shape.r
@@ -2,7 +2,7 @@
 #'
 #' `scale_shape()` maps discrete variables to six easily discernible shapes.
 #' If you have more than six levels, you will get a warning message, and the
-#' seventh and subsequence levels will not appear on the plot. Use
+#' seventh and subsequent levels will not appear on the plot. Use
 #' [scale_shape_manual()] to supply your own values. You can not map
 #' a continuous variable to shape unless `scale_shape_binned()` is used. Still,
 #' as shape has no inherent order, this use is not advised.

--- a/man/scale_shape.Rd
+++ b/man/scale_shape.Rd
@@ -71,7 +71,7 @@ as output
 \description{
 \code{scale_shape()} maps discrete variables to six easily discernible shapes.
 If you have more than six levels, you will get a warning message, and the
-seventh and subsequence levels will not appear on the plot. Use
+seventh and subsequent levels will not appear on the plot. Use
 \code{\link[=scale_shape_manual]{scale_shape_manual()}} to supply your own values. You can not map
 a continuous variable to shape unless \code{scale_shape_binned()} is used. Still,
 as shape has no inherent order, this use is not advised.


### PR DESCRIPTION
Fixed typo in scale_shape documentation.