### PR TITLE
Remove a workaround about rmarkdown on R <3.6

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -77,11 +77,6 @@ jobs:
           sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
           sudo -s eval "$sysreqs"
 
-      # Remove this when the new rmarkdown is released on CRAN
-      - name: "Workaround for rstudio/rmarkdown#1831"
-        if: runner.os == 'Linux' && matrix.config.r < '3.6'
-        run: Rscript -e "remotes::install_github('rstudio/rmarkdown')"
-
       - name: Install system dependencies on macOS
         if: runner.os == 'macOS'
         run: |


### PR DESCRIPTION
The new version of rmarkdown was released on CRAN and it now contains the fix for `tools::vignetteInfo()` errors.  The workaround is no longer needed.