### PR TITLE
Make sure panels are always set to a positive size

### DIFF
--- a/R/facet-grid-.r
+++ b/R/facet-grid-.r
@@ -333,7 +333,7 @@ FacetGrid <- ggproto("FacetGrid", Facet,
       heights <- vapply(ps, function(i) diff(ranges[[i]]$y.range), numeric(1))
       panel_heights <- unit(heights, "null")
     } else {
-      panel_heights <- rep(unit(1 * aspect_ratio, "null"), nrow)
+      panel_heights <- rep(unit(1 * abs(aspect_ratio), "null"), nrow)
     }
 
     panel_table <- gtable_matrix("layout", panel_table,

--- a/R/facet-null.r
+++ b/R/facet-null.r
@@ -61,7 +61,7 @@ FacetNull <- ggproto("FacetNull", Facet,
     ), ncol = 3, byrow = TRUE)
     z_matrix <- matrix(c(5, 6, 4, 7, 1, 8, 3, 9, 2), ncol = 3, byrow = TRUE)
     grob_widths <- unit.c(grobWidth(axis_v$left), unit(1, "null"), grobWidth(axis_v$right))
-    grob_heights <- unit.c(grobHeight(axis_h$top), unit(aspect_ratio, "null"), grobHeight(axis_h$bottom))
+    grob_heights <- unit.c(grobHeight(axis_h$top), unit(abs(aspect_ratio), "null"), grobHeight(axis_h$bottom))
     grob_names <- c("spacer", "axis-l", "spacer", "axis-t", "panel", "axis-b", "spacer", "axis-r", "spacer")
     grob_clip <- c("off", "off", "off", "off", coord$clip, "off", "off", "off", "off")
 

--- a/R/facet-wrap.r
+++ b/R/facet-wrap.r
@@ -269,7 +269,7 @@ FacetWrap <- ggproto("FacetWrap", Facet,
     empties <- apply(panel_table, c(1,2), function(x) is.zero(x[[1]]))
     panel_table <- gtable_matrix("layout", panel_table,
      widths = unit(rep(1, ncol), "null"),
-     heights = unit(rep(aspect_ratio, nrow), "null"), respect = respect, clip = coord$clip, z = matrix(1, ncol = ncol, nrow = nrow))
+     heights = unit(rep(abs(aspect_ratio), nrow), "null"), respect = respect, clip = coord$clip, z = matrix(1, ncol = ncol, nrow = nrow))
     panel_table$layout$name <- paste0('panel-', rep(seq_len(ncol), nrow), '-', rep(seq_len(nrow), each = ncol))
 
     panel_table <- gtable_add_col_space(panel_table,


### PR DESCRIPTION
When providing a reversed scale along with certain coords the aspect ratio may end up as negative and the panel will get a negative null dimension. This can wreck havoc (see https://github.com/thomasp85/patchwork/issues/195)

This PR fixes it by ensuring the dimension is always positive