### PR TITLE
More accurate check for palette names

### DIFF
--- a/R/scale-.r
+++ b/R/scale-.r
@@ -806,7 +806,7 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
       self$n.breaks.cache <- n
     }
 
-    if (is_named(pal)) {
+    if (!is_null(names(pal))) {
       # if pal is named, limit the pal by the names first,
       # then limit the values by the pal
       idx_nomatch <- is.na(match(names(pal), limits))


### PR DESCRIPTION
Closes #4087, specifically the issue where a named palette that didn't match the limits would still get used if too many colors were requested. We now use a more accurate check for whether the palette has names, so if the colors don't match the limits it won't be used. This is the conventional behavior, though as discussed on the issue it can be confusing. This PR makes the behavior consistent, but we might want to separately revisit whether to change the behavior of `scales::manual_pal()`.