### PR TITLE
Make guide_bins() respect override.aes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 * Fixed a bug in `labeller()` so that `.default` is passed to `as_labeller()`
   when labellers are specified by naming faceting variables. (@waltersom, #4031)
 
+* Fixed a bug that `guide_bins()` mistakenly ignore `override.aes` argument
+  (@yutannihilation, #4085).
+
 # ggplot2 3.3.2
 This is a small release focusing on fixing regressions introduced in 3.3.1.
 

--- a/R/guide-bins.R
+++ b/R/guide-bins.R
@@ -116,6 +116,7 @@ guide_bins <- function(
 
     # general
     direction = direction,
+    override.aes = rename_aes(override.aes),
     default.unit = default.unit,
     reverse = reverse,
     order = order,


### PR DESCRIPTION
Fix #4085

It seems we simply forgot to pass `override.aes` to the guide object. `guide_merge.bins()` and `guide_geom.bins()` seem to handle `override.aes()` properly.

``` r
devtools::load_all("~/repo/ggplot2")
#> Loading ggplot2

ggplot(mtcars, aes(x = drat, y = wt, size = hp, fill = cyl)) + 
  geom_point(shape = 21) + 
  scale_size_binned(guide = guide_bins(override.aes = list(colour = "red", shape = 21, fill = "blue")))
```

![](https://i.imgur.com/1zIPW5R.png)

<sup>Created on 2020-06-30 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
