### PR TITLE
Deprecate guides(... = FALSE)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
   
 * Updated style for example code (@rjake, #4092)
 
+* Using `guides(<aes> = FALSE)` to suppress legends is now deprecated. Please
+  use `guides(<aes> = "none")` instead (@yutannihilation, #4094).
+
 # ggplot2 3.3.2
 This is a small release focusing on fixing regressions introduced in 3.3.1.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,8 +7,10 @@
 
 * Only drop groups in `stat_ydensity()` when there are fewer than two data points and throw a warning (@andrewwbutler, #4111).
 
-* Using `guides(<scale> = FALSE)` to remove a guide is now deprecated. Please
-  use `guides(<scale> = "none")` instead (@yutannihilation, #4094).
+* It is not deprecated to specify `guides(<scale> = FALSE)` or
+  `scale_*(guide = FALSE)` to remove a guide. Please use 
+  `guides(<scale> = "none")` or `scale_*(guide = "none")` instead 
+  (@yutannihilation, #4094).
 
 # ggplot2 3.3.2
 This is a small release focusing on fixing regressions introduced in 3.3.1.

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,8 +5,8 @@
   
 * Updated style for example code (@rjake, #4092)
 
-* Using `guides(<aes> = FALSE)` to suppress legends is now deprecated. Please
-  use `guides(<aes> = "none")` instead (@yutannihilation, #4094).
+* Using `guides(<scale> = FALSE)` to remove a guide is now deprecated. Please
+  use `guides(<scale> = "none")` instead (@yutannihilation, #4094).
 
 # ggplot2 3.3.2
 This is a small release focusing on fixing regressions introduced in 3.3.1.

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 
 * Only drop groups in `stat_ydensity()` when there are fewer than two data points and throw a warning (@andrewwbutler, #4111).
 
-* It is not deprecated to specify `guides(<scale> = FALSE)` or
+* It is now deprecated to specify `guides(<scale> = FALSE)` or
   `scale_*(guide = FALSE)` to remove a guide. Please use 
   `guides(<scale> = "none")` or `scale_*(guide = "none")` instead 
   (@yutannihilation, #4094).

--- a/R/guides-.r
+++ b/R/guides-.r
@@ -71,7 +71,7 @@ guides <- function(...) {
   }
 
   idx_false <- vapply(args, isFALSE, FUN.VALUE = logical(1L))
-  if (any(idx_false)) {
+  if (isTRUE(any(idx_false))) {
     warn('`guides(<scale> = FALSE)` is deprecated. Please use `guides(<scale> = "none")` instead.')
     args[idx_false] <- "none"
   }

--- a/R/guides-.r
+++ b/R/guides-.r
@@ -184,10 +184,15 @@ guides_train <- function(scales, theme, guides, labels) {
       #   + guides(XXX) > + scale_ZZZ(guide=XXX) > default(i.e., legend)
       guide <- resolve_guide(output, scale, guides)
 
-      # this should be changed to testing guide == "none"
-      # scale$legend is backward compatibility
-      # if guides(XXX=FALSE), then scale_ZZZ(guides=XXX) is discarded.
-      if (identical(guide, "none") || isFALSE(guide) || inherits(guide, "guide_none")) next
+      if (identical(guide, "none") || inherits(guide, "guide_none")) next
+
+      if (isFALSE(guide)) {
+        warn(glue(
+          "`guides({scale$aesthetics} = FALSE)` is deprecated. ",
+          'Please use `guides({scale$aesthetics} = "none")` instead.'
+        ))
+        next
+      }
 
       # check the validity of guide.
       # if guide is character, then find the guide object

--- a/R/guides-.r
+++ b/R/guides-.r
@@ -69,6 +69,13 @@ guides <- function(...) {
     if (is.list(args[[1]]) && !inherits(args[[1]], "guide")) args <- args[[1]]
     args <- rename_aes(args)
   }
+
+  idx_false <- vapply(args, isFALSE, FUN.VALUE = logical(1L))
+  if (any(idx_false)) {
+    warn('`guides(<scale> = FALSE)` is deprecated. Please use `guides(<scale> = "none")` instead.')
+    args[idx_false] <- "none"
+  }
+
   structure(args, class = "guides")
 }
 
@@ -193,10 +200,7 @@ guides_train <- function(scales, theme, guides, labels) {
       if (identical(guide, "none") || inherits(guide, "guide_none")) next
 
       if (isFALSE(guide)) {
-        warn(glue(
-          "`guides({scale$aesthetics} = FALSE)` is deprecated. ",
-          'Please use `guides({scale$aesthetics} = "none")` instead.'
-        ))
+        warn('It is deprecated to specify `FALSE` to remove a guide. Please use `"none"` instead.')
         next
       }
 

--- a/R/guides-.r
+++ b/R/guides-.r
@@ -200,7 +200,7 @@ guides_train <- function(scales, theme, guides, labels) {
       if (identical(guide, "none") || inherits(guide, "guide_none")) next
 
       if (isFALSE(guide)) {
-        warn('It is deprecated to specify `FALSE` to remove a guide. Please use `"none"` instead.')
+        warn('It is deprecated to specify `guide = FALSE` to remove a guide. Please use `guide = "none"` instead.')
         next
       }
 

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -529,13 +529,12 @@ test_that("a warning is generated when guides(<scale> = FALSE) is specified", {
   df <- data_frame(x = c(1, 2, 4),
                    y = c(6, 5, 7))
 
+  # warn on guide(<scale> = FALSE)
   expect_warning(g <- guides(colour = FALSE), "`guides(<scale> = FALSE)` is deprecated.", fixed = TRUE)
   expect_equal(g[["colour"]], "none")
 
-  # manually create a invalid guide
-  g[["colour"]] <- FALSE
-
-  p <- ggplot(df, aes(x, y, colour = x)) + g
+  # warn on scale_*(guide = FALSE)
+  p <- ggplot(df, aes(x, y, colour = x)) + scale_colour_continuous(guide = FALSE)
   built <- expect_silent(ggplot_build(p))
-  expect_warning(ggplot_gtable(built), "It is deprecated to specify `FALSE`")
+  expect_warning(ggplot_gtable(built), "It is deprecated to specify `guide = FALSE`")
 })

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -524,3 +524,14 @@ test_that("coloursteps guide can be styled correctly", {
     p + guides(colour = guide_coloursteps(ticks = TRUE))
   )
 })
+
+test_that("a warning is generated when guides(... = FALSE) is specified", {
+  df <- data_frame(x = c(1, 2, 4),
+                   y = c(6, 5, 7))
+
+  p <- ggplot(df, aes(x, y, colour = x)) +
+    geom_point() +
+    guides(colour = FALSE)
+  built <- expect_silent(ggplot_build(p))
+  expect_warning(ggplot_gtable(built), "`guides(colour = FALSE)` is deprecated.", fixed = TRUE)
+})

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -525,13 +525,17 @@ test_that("coloursteps guide can be styled correctly", {
   )
 })
 
-test_that("a warning is generated when guides(... = FALSE) is specified", {
+test_that("a warning is generated when guides(<scale> = FALSE) is specified", {
   df <- data_frame(x = c(1, 2, 4),
                    y = c(6, 5, 7))
 
-  p <- ggplot(df, aes(x, y, colour = x)) +
-    geom_point() +
-    guides(colour = FALSE)
+  expect_warning(g <- guides(colour = FALSE), "`guides(<scale> = FALSE)` is deprecated.", fixed = TRUE)
+  expect_equal(g[["colour"]], "none")
+
+  # manually create a invalid guide
+  g[["colour"]] <- FALSE
+
+  p <- ggplot(df, aes(x, y, colour = x)) + g
   built <- expect_silent(ggplot_build(p))
-  expect_warning(ggplot_gtable(built), "`guides(colour = FALSE)` is deprecated.", fixed = TRUE)
+  expect_warning(ggplot_gtable(built), "It is deprecated to specify `FALSE`")
 })


### PR DESCRIPTION
Fix #4097

`guides(... = FALSE)` was a very old syntax and is not mentioned in any documentations. This should be deprecated to inform the users about the recommended way (`guides(... = "none")`).