### PR TITLE
Bring stat_ydensity behavior in line with stat_density 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
   
 * Updated style for example code (@rjake, #4092)
 
+* Only drop groups in `stat_ydensity` when there are fewer than two data points and throw a warning (@andrewwbutler, #4111).
+
 # ggplot2 3.3.2
 This is a small release focusing on fixing regressions introduced in 3.3.1.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
   
 * Updated style for example code (@rjake, #4092)
 
-* Only drop groups in `stat_ydensity` when there are fewer than two data points and throw a warning (@andrewwbutler, #4111).
+* Only drop groups in `stat_ydensity()` when there are fewer than two data points and throw a warning (@andrewwbutler, #4111).
 
 # ggplot2 3.3.2
 This is a small release focusing on fixing regressions introduced in 3.3.1.

--- a/R/stat-ydensity.r
+++ b/R/stat-ydensity.r
@@ -72,7 +72,7 @@ StatYdensity <- ggproto("StatYdensity", Stat,
   compute_group = function(data, scales, width = NULL, bw = "nrd0", adjust = 1,
                        kernel = "gaussian", trim = TRUE, na.rm = FALSE, flipped_aes = FALSE) {
     if (nrow(data) < 2) {
-      warning("Groups with fewer than two data points have been dropped.", call. = FALSE)
+      warn("Groups with fewer than two data points have been dropped.")
       return(new_data_frame())
     }
     range <- range(data$y, na.rm = TRUE)

--- a/R/stat-ydensity.r
+++ b/R/stat-ydensity.r
@@ -71,7 +71,10 @@ StatYdensity <- ggproto("StatYdensity", Stat,
 
   compute_group = function(data, scales, width = NULL, bw = "nrd0", adjust = 1,
                        kernel = "gaussian", trim = TRUE, na.rm = FALSE, flipped_aes = FALSE) {
-    if (nrow(data) < 3) return(new_data_frame())
+    if (nrow(data) < 2) {
+      warning("Groups with fewer than two data points have been dropped.", call. = FALSE)
+      return(new_data_frame())
+    }
     range <- range(data$y, na.rm = TRUE)
     modifier <- if (trim) 0 else 3
     bw <- calc_bw(data$y, bw)


### PR DESCRIPTION
Addresses https://github.com/tidyverse/ggplot2/issues/4111

`stat_ydensity` now drops groups with fewer than 2 data points (previously 3) and displays a warning.

``` r
library(ggplot2)
table(mtcars$cyl, mtcars$am)
#>    
#>      0  1
#>   4  3  8
#>   6  4  3
#>   8 12  2
ggplot(mtcars, aes(x = factor(cyl), y = mpg, fill = factor(am))) + 
  geom_violin(scale = "width")
```

![](https://i.imgur.com/mhXdAd4.png)

``` r

# warn when fewer than 2 in group
mtcars_sub <- mtcars[-31, ]
table(mtcars_sub$cyl, mtcars_sub$am)
#>    
#>      0  1
#>   4  3  8
#>   6  4  3
#>   8 12  1
ggplot(mtcars_sub, aes(x = factor(cyl), y = mpg, fill = factor(am))) + 
  geom_violin(scale = "width")
#> Warning: Groups with fewer than two data points have been dropped.
```

![](https://i.imgur.com/H5RqCd8.png)

<sup>Created on 2020-07-01 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>