### PR TITLE
Doesn't try to combine labels if labels are NULL

### DIFF
--- a/R/coord-polar.r
+++ b/R/coord-polar.r
@@ -281,7 +281,7 @@ CoordPolar <- ggproto("CoordPolar", Coord,
     # Combine the two ends of the scale if they are close
     theta <- theta[!is.na(theta)]
     ends_apart <- (theta[length(theta)] - theta[1]) %% (2*pi)
-    if (length(theta) > 0 && ends_apart < 0.05) {
+    if (length(theta) > 0 && ends_apart < 0.05 & !is.null(labels)) {
       n <- length(labels)
       if (is.expression(labels)) {
         combined <- substitute(paste(a, "/", b),

--- a/R/coord-polar.r
+++ b/R/coord-polar.r
@@ -281,7 +281,7 @@ CoordPolar <- ggproto("CoordPolar", Coord,
     # Combine the two ends of the scale if they are close
     theta <- theta[!is.na(theta)]
     ends_apart <- (theta[length(theta)] - theta[1]) %% (2*pi)
-    if (length(theta) > 0 && ends_apart < 0.05 & !is.null(labels)) {
+    if (length(theta) > 0 && ends_apart < 0.05 && !is.null(labels)) {
       n <- length(labels)
       if (is.expression(labels)) {
         combined <- substitute(paste(a, "/", b),


### PR DESCRIPTION
I encountered this strange error. It took me a while to get a reprex because it is incredibly elusive. 

``` r
library(ggplot2)

grid <- expand.grid(x = seq(0, 360, by = 2.5), y = seq(-90, -20, by = 2.5))
grid$z <- with(grid, x^2*y)

ggplot(grid, aes(x, y)) +
  geom_contour(aes(z = z)) +
  coord_polar() +
  scale_x_continuous(breaks = seq(0, 360, by = 30), labels = NULL)
#> Error in labels[[n]] <- combined: attempt to select less than one element in integerOneIndex
```

The issue was that `coord_polar()` tries to combine labels even if they are `NULL`. I added a check. All tests succeed and the bug is fixed. 