### PR TITLE
Clear cache to handle R-devel change

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -10,7 +10,7 @@ name: R-CMD-check
 
 # Increment this version when we want to clear cache
 env:
-  cache-version: v2
+  cache-version: v3
 
 jobs:
   R-CMD-check:


### PR DESCRIPTION
Close #4116 

Googling the error message "Graphics API version mismatch" led me to the possibility that the version of R devel might be bumped up. Clearing the cache seems solve the problem. 

c.f. https://github.com/davidgohel/ReporteRs/issues/126#issuecomment-226176502