### PR TITLE
Handle when `geometry` is not a symbol

### DIFF
--- a/R/layer-sf.R
+++ b/R/layer-sf.R
@@ -52,7 +52,7 @@ LayerSf <- ggproto("LayerSf", Layer,
       self$geom_params$legend <- "polygon"
 
       # now check if the type should not be polygon
-      if (!is.null(self$mapping$geometry)) {
+      if (!is.null(self$mapping$geometry) && quo_is_symbol(self$mapping$geometry)) {
         geometry_column <- as_name(self$mapping$geometry)
         if (inherits(data[[geometry_column]], "sfc")) {
           sf_type <- detect_sf_type(data[[geometry_column]])

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -76,6 +76,13 @@ test_that("geom_sf() determines the legend type from mapped geometry column", {
     ggplot(d_sf) + geom_sf(aes(geometry = g_line, colour = "a"))
   )
   expect_identical(p$plot$layers[[1]]$geom_params$legend, "line")
+
+  # If `geometry` is not a symbol, layer_sf() gives up guessing the legend type,
+  # and falls back to "polygon"
+  p <- ggplot_build(
+    ggplot(d_sf) + geom_sf(aes(geometry = identity(g_point), colour = "a"))
+  )
+  expect_identical(p$plot$layers[[1]]$geom_params$legend, "polygon")
 })
 
 test_that("geom_sf() removes rows containing missing aes", {

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -77,8 +77,8 @@ test_that("geom_sf() determines the legend type from mapped geometry column", {
   )
   expect_identical(p$plot$layers[[1]]$geom_params$legend, "line")
 
-  # If `geometry` is not a symbol, layer_sf() gives up guessing the legend type,
-  # and falls back to "polygon"
+  # If `geometry` is not a symbol, `LayerSf$setup_layer()` gives up guessing
+  # the legend type, and falls back to "polygon"
   p <- ggplot_build(
     ggplot(d_sf) + geom_sf(aes(geometry = identity(g_point), colour = "a"))
   )


### PR DESCRIPTION
Fix #4122 

Currently, `LayerSf$setup_layer()` uses `as_name(self$mapping$geometry)` in the assumption that `geometry` is a quosure of a symbol, which is not always the case. Possible fix would be

1. actually evaluate it
2. give up guessing the type nicely

and I chose option 2. because option 1. seems too much for this rare use case.

``` r
devtools::load_all("~/repo/ggplot2")
#> Loading ggplot2

nc <- sf::st_read(system.file("shape/nc.shp", package = "sf"), quiet = TRUE)
ggplot(nc) +
  geom_sf(aes(fill = AREA, geometry = sf::st_centroid(geometry)))
#> Warning in st_centroid.sfc(geometry): st_centroid does not give correct
#> centroids for longitude/latitude data

#> Warning in st_centroid.sfc(geometry): st_centroid does not give correct
#> centroids for longitude/latitude data
```

![](https://i.imgur.com/8ZZOvYX.png)

<sup>Created on 2020-07-10 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>