### PR TITLE
Document flipped computed variables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -263,6 +263,6 @@ Collate:
     'zxx.r'
     'zzz.r'
 VignetteBuilder: knitr
-RoxygenNote: 7.1.0.9000
+RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8

--- a/R/stat-boxplot.r
+++ b/R/stat-boxplot.r
@@ -4,13 +4,13 @@
 #' @section Computed variables:
 #' \describe{
 #'   \item{width}{width of boxplot}
-#'   \item{ymin}{lower whisker = smallest observation greater than or equal to lower hinge - 1.5 * IQR}
-#'   \item{lower}{lower hinge, 25% quantile}
+#'   \item{ymin or xmin}{lower whisker = smallest observation greater than or equal to lower hinge - 1.5 * IQR}
+#'   \item{lower or xlower}{lower hinge, 25% quantile}
 #'   \item{notchlower}{lower edge of notch = median - 1.58 * IQR / sqrt(n)}
-#'   \item{middle}{median, 50% quantile}
+#'   \item{middle or xmiddle}{median, 50% quantile}
 #'   \item{notchupper}{upper edge of notch = median + 1.58 * IQR / sqrt(n)}
-#'   \item{upper}{upper hinge, 75% quantile}
-#'   \item{ymax}{upper whisker = largest observation less than or equal to upper hinge + 1.5 * IQR}
+#'   \item{upper or xupper}{upper hinge, 75% quantile}
+#'   \item{ymax or xmin}{upper whisker = largest observation less than or equal to upper hinge + 1.5 * IQR}
 #' }
 #' @export
 stat_boxplot <- function(mapping = NULL, data = NULL,

--- a/R/stat-boxplot.r
+++ b/R/stat-boxplot.r
@@ -2,6 +2,7 @@
 #' @param coef Length of the whiskers as multiple of IQR. Defaults to 1.5.
 #' @inheritParams stat_identity
 #' @section Computed variables:
+#' `stat_boxplot()` provides the following variables, some of which depend on the orientation:
 #' \describe{
 #'   \item{width}{width of boxplot}
 #'   \item{ymin or xmin}{lower whisker = smallest observation greater than or equal to lower hinge - 1.5 * IQR}
@@ -10,7 +11,7 @@
 #'   \item{middle or xmiddle}{median, 50% quantile}
 #'   \item{notchupper}{upper edge of notch = median + 1.58 * IQR / sqrt(n)}
 #'   \item{upper or xupper}{upper hinge, 75% quantile}
-#'   \item{ymax or xmin}{upper whisker = largest observation less than or equal to upper hinge + 1.5 * IQR}
+#'   \item{ymax or xmax}{upper whisker = largest observation less than or equal to upper hinge + 1.5 * IQR}
 #' }
 #' @export
 stat_boxplot <- function(mapping = NULL, data = NULL,

--- a/R/stat-boxplot.r
+++ b/R/stat-boxplot.r
@@ -5,13 +5,13 @@
 #' `stat_boxplot()` provides the following variables, some of which depend on the orientation:
 #' \describe{
 #'   \item{width}{width of boxplot}
-#'   \item{ymin or xmin}{lower whisker = smallest observation greater than or equal to lower hinge - 1.5 * IQR}
-#'   \item{lower or xlower}{lower hinge, 25% quantile}
+#'   \item{ymin *or* xmin}{lower whisker = smallest observation greater than or equal to lower hinge - 1.5 * IQR}
+#'   \item{lower *or* xlower}{lower hinge, 25% quantile}
 #'   \item{notchlower}{lower edge of notch = median - 1.58 * IQR / sqrt(n)}
-#'   \item{middle or xmiddle}{median, 50% quantile}
+#'   \item{middle *or* xmiddle}{median, 50% quantile}
 #'   \item{notchupper}{upper edge of notch = median + 1.58 * IQR / sqrt(n)}
-#'   \item{upper or xupper}{upper hinge, 75% quantile}
-#'   \item{ymax or xmax}{upper whisker = largest observation less than or equal to upper hinge + 1.5 * IQR}
+#'   \item{upper *or* xupper}{upper hinge, 75% quantile}
+#'   \item{ymax *or* xmax}{upper whisker = largest observation less than or equal to upper hinge + 1.5 * IQR}
 #' }
 #' @export
 stat_boxplot <- function(mapping = NULL, data = NULL,

--- a/R/stat-smooth.r
+++ b/R/stat-smooth.r
@@ -32,9 +32,9 @@
 #' @section Computed variables:
 #' `stat_smooth()` provides the following variables, some of which depend on the orientation:
 #' \describe{
-#'   \item{y or x}{predicted value}
-#'   \item{ymin or xmin}{lower pointwise confidence interval around the mean}
-#'   \item{ymax or xmax}{upper pointwise confidence interval around the mean}
+#'   \item{y *or* x}{predicted value}
+#'   \item{ymin *or* xmin}{lower pointwise confidence interval around the mean}
+#'   \item{ymax *or* xmax}{upper pointwise confidence interval around the mean}
 #'   \item{se}{standard error}
 #' }
 #' @export

--- a/R/stat-smooth.r
+++ b/R/stat-smooth.r
@@ -31,9 +31,9 @@
 #'   function defined by `method`.
 #' @section Computed variables:
 #' \describe{
-#'   \item{y}{predicted value}
-#'   \item{ymin}{lower pointwise confidence interval around the mean}
-#'   \item{ymax}{upper pointwise confidence interval around the mean}
+#'   \item{y or x}{predicted value}
+#'   \item{ymin or xmin}{lower pointwise confidence interval around the mean}
+#'   \item{ymax or xmax}{upper pointwise confidence interval around the mean}
 #'   \item{se}{standard error}
 #' }
 #' @export

--- a/R/stat-smooth.r
+++ b/R/stat-smooth.r
@@ -30,6 +30,7 @@
 #' @param method.args List of additional arguments passed on to the modelling
 #'   function defined by `method`.
 #' @section Computed variables:
+#' `stat_smooth()` provides the following variables, some of which depend on the orientation:
 #' \describe{
 #'   \item{y or x}{predicted value}
 #'   \item{ymin or xmin}{lower pointwise confidence interval around the mean}

--- a/man/geom_boxplot.Rd
+++ b/man/geom_boxplot.Rd
@@ -174,13 +174,13 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \describe{
 \item{width}{width of boxplot}
-\item{ymin}{lower whisker = smallest observation greater than or equal to lower hinge - 1.5 * IQR}
-\item{lower}{lower hinge, 25\% quantile}
+\item{ymin or xmin}{lower whisker = smallest observation greater than or equal to lower hinge - 1.5 * IQR}
+\item{lower or xlower}{lower hinge, 25\% quantile}
 \item{notchlower}{lower edge of notch = median - 1.58 * IQR / sqrt(n)}
-\item{middle}{median, 50\% quantile}
+\item{middle or xmiddle}{median, 50\% quantile}
 \item{notchupper}{upper edge of notch = median + 1.58 * IQR / sqrt(n)}
-\item{upper}{upper hinge, 75\% quantile}
-\item{ymax}{upper whisker = largest observation less than or equal to upper hinge + 1.5 * IQR}
+\item{upper or xupper}{upper hinge, 75\% quantile}
+\item{ymax or xmin}{upper whisker = largest observation less than or equal to upper hinge + 1.5 * IQR}
 }
 }
 

--- a/man/geom_boxplot.Rd
+++ b/man/geom_boxplot.Rd
@@ -175,13 +175,13 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 \code{stat_boxplot()} provides the following variables, some of which depend on the orientation:
 \describe{
 \item{width}{width of boxplot}
-\item{ymin or xmin}{lower whisker = smallest observation greater than or equal to lower hinge - 1.5 * IQR}
-\item{lower or xlower}{lower hinge, 25\% quantile}
+\item{ymin \emph{or} xmin}{lower whisker = smallest observation greater than or equal to lower hinge - 1.5 * IQR}
+\item{lower \emph{or} xlower}{lower hinge, 25\% quantile}
 \item{notchlower}{lower edge of notch = median - 1.58 * IQR / sqrt(n)}
-\item{middle or xmiddle}{median, 50\% quantile}
+\item{middle \emph{or} xmiddle}{median, 50\% quantile}
 \item{notchupper}{upper edge of notch = median + 1.58 * IQR / sqrt(n)}
-\item{upper or xupper}{upper hinge, 75\% quantile}
-\item{ymax or xmax}{upper whisker = largest observation less than or equal to upper hinge + 1.5 * IQR}
+\item{upper \emph{or} xupper}{upper hinge, 75\% quantile}
+\item{ymax \emph{or} xmax}{upper whisker = largest observation less than or equal to upper hinge + 1.5 * IQR}
 }
 }
 

--- a/man/geom_boxplot.Rd
+++ b/man/geom_boxplot.Rd
@@ -172,6 +172,7 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
+\code{stat_boxplot()} provides the following variables, some of which depend on the orientation:
 \describe{
 \item{width}{width of boxplot}
 \item{ymin or xmin}{lower whisker = smallest observation greater than or equal to lower hinge - 1.5 * IQR}
@@ -180,7 +181,7 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 \item{middle or xmiddle}{median, 50\% quantile}
 \item{notchupper}{upper edge of notch = median + 1.58 * IQR / sqrt(n)}
 \item{upper or xupper}{upper hinge, 75\% quantile}
-\item{ymax or xmin}{upper whisker = largest observation less than or equal to upper hinge + 1.5 * IQR}
+\item{ymax or xmax}{upper whisker = largest observation less than or equal to upper hinge + 1.5 * IQR}
 }
 }
 

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -172,9 +172,9 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \code{stat_smooth()} provides the following variables, some of which depend on the orientation:
 \describe{
-\item{y or x}{predicted value}
-\item{ymin or xmin}{lower pointwise confidence interval around the mean}
-\item{ymax or xmax}{upper pointwise confidence interval around the mean}
+\item{y \emph{or} x}{predicted value}
+\item{ymin \emph{or} xmin}{lower pointwise confidence interval around the mean}
+\item{ymax \emph{or} xmax}{upper pointwise confidence interval around the mean}
 \item{se}{standard error}
 }
 }

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -170,6 +170,7 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
+\code{stat_smooth()} provides the following variables, some of which depend on the orientation:
 \describe{
 \item{y or x}{predicted value}
 \item{ymin or xmin}{lower pointwise confidence interval around the mean}

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -171,9 +171,9 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 \section{Computed variables}{
 
 \describe{
-\item{y}{predicted value}
-\item{ymin}{lower pointwise confidence interval around the mean}
-\item{ymax}{upper pointwise confidence interval around the mean}
+\item{y or x}{predicted value}
+\item{ymin or xmin}{lower pointwise confidence interval around the mean}
+\item{ymax or xmax}{upper pointwise confidence interval around the mean}
 \item{se}{standard error}
 }
 }


### PR DESCRIPTION
Fix #4124

These four stat have variables whose names differ depending on the orientation.

- `stat_boxplot()`: `middle`, `lower`, and `upper`. This feels a bit tricky at least in two points; the flipped names are asynmetric (e.g. `middle` vs `xmiddle`, not `ymiddle` vs `xmiddle`), and `notchlower` and `notchupper` doesn't have their flipped form.
- `stat_smooth()`: `y`, `ymin`, and `ymax`
- `stat_function()` ~~`stat_ecdf()`~~ : these generate both `x` and `y`, so the documentation would be cryptic like below, so I don't address them in this pull request (at least they don't have undocumented computed variables)

```
#' `stat_function()` computes the following variables:
#' \describe{
#'   \item{x or y}{x or y values along a grid}
#'   \item{y or x}{value of the function evaluated at corresponding x or y}
#' }
```

edit: I just remembered `stat_ecdf()` doesn't support flipping (c.f. #4005)