### PR TITLE
Refer to ggplot_global for x and y aesthetics variables

### DIFF
--- a/R/scale-binned.R
+++ b/R/scale-binned.R
@@ -27,7 +27,7 @@ scale_x_binned <- function(name = waiver(), n.breaks = 10, nice.breaks = TRUE,
                            right = TRUE, show.limits = FALSE, trans = "identity",
                            guide = waiver(), position = "bottom") {
   binned_scale(
-    aesthetics = c("x", "xmin", "xmax", "xend", "xintercept", "xmin_final", "xmax_final", "xlower", "xmiddle", "xupper"),
+    ggplot_global$x_aes,
     scale_name = "position_b", palette = identity, name = name, breaks = breaks,
     labels = labels, limits = limits, expand = expand, oob = oob, na.value = na.value,
     n.breaks = n.breaks, nice.breaks = nice.breaks, right = right, trans = trans,
@@ -44,7 +44,7 @@ scale_y_binned <- function(name = waiver(), n.breaks = 10, nice.breaks = TRUE,
                            right = TRUE, show.limits = FALSE, trans = "identity",
                            guide = waiver(), position = "left") {
   binned_scale(
-    aesthetics = c("y", "ymin", "ymax", "yend", "yintercept", "ymin_final", "ymax_final", "lower", "middle", "upper"),
+    ggplot_global$y_aes,
     scale_name = "position_b", palette = identity, name = name, breaks = breaks,
     labels = labels, limits = limits, expand = expand, oob = oob, na.value = na.value,
     n.breaks = n.breaks, nice.breaks = nice.breaks, right = right, trans = trans,

--- a/R/scale-continuous.r
+++ b/R/scale-continuous.r
@@ -81,7 +81,7 @@ scale_x_continuous <- function(name = waiver(), breaks = waiver(),
                                guide = waiver(), position = "bottom",
                                sec.axis = waiver()) {
   sc <- continuous_scale(
-    c("x", "xmin", "xmax", "xend", "xintercept", "xmin_final", "xmax_final", "xlower", "xmiddle", "xupper", "x0"),
+    ggplot_global$x_aes,
     "position_c", identity, name = name, breaks = breaks, n.breaks = n.breaks,
     minor_breaks = minor_breaks, labels = labels, limits = limits,
     expand = expand, oob = oob, na.value = na.value, trans = trans,
@@ -102,7 +102,7 @@ scale_y_continuous <- function(name = waiver(), breaks = waiver(),
                                guide = waiver(), position = "left",
                                sec.axis = waiver()) {
   sc <- continuous_scale(
-    c("y", "ymin", "ymax", "yend", "yintercept", "ymin_final", "ymax_final", "lower", "middle", "upper", "y0"),
+    ggplot_global$y_aes,
     "position_c", identity, name = name, breaks = breaks, n.breaks = n.breaks,
     minor_breaks = minor_breaks, labels = labels, limits = limits,
     expand = expand, oob = oob, na.value = na.value, trans = trans,


### PR DESCRIPTION
I happened to find `scale_{x,y}_binned()` doesn't include `x0` and `y0`, which I think is unintended. Probably we should refer to `ggplot_global` directly in these cases. Hard coding the same list on 4 places is a bit hard to maintain.