### PR TITLE
Warn too many breaks before doing `seq()`

### DIFF
--- a/R/bin.R
+++ b/R/bin.R
@@ -85,14 +85,16 @@ bin_breaks_width <- function(x_range, width = NULL, center = NULL,
   # Small correction factor so that we don't get an extra bin when, for
   # example, origin = 0, max(x) = 20, width = 10.
   max_x <- x_range[2] + (1 - 1e-08) * width
+
+  if (isTRUE((max_x - origin) / width > 1e6)) {
+    abort("The number of histogram bins must be less than 1,000,000.\nDid you make `binwidth` too small?")
+  }
   breaks <- seq(origin, max_x, width)
 
   if (length(breaks) == 1) {
     # In exceptionally rare cases, the above can fail and produce only a
     # single break (see issue #3606). We fix this by adding a second break.
     breaks <- c(breaks, breaks + width)
-  } else if (length(breaks) > 1e6) {
-    abort("The number of histogram bins must be less than 1,000,000.\nDid you make `binwidth` too small?")
   }
 
   bin_breaks(breaks, closed = closed)


### PR DESCRIPTION
Fix #4131

``` r
devtools::load_all("~/repo/ggplot2")
#> Loading ggplot2

ggplot(tibble::tibble(x=c(1, 1e12)), aes(x)) + geom_histogram(binwidth=1)
#> Warning: Computation failed in `stat_bin()`:
#> The number of histogram bins must be less than 1,000,000.
#> Did you make `binwidth` too small?
```

![](https://i.imgur.com/jq7QCMX.png)

<sup>Created on 2020-07-11 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
