### PR TITLE
Regenerate document and add a test to ensure no missing scale_color_*()

### DIFF
--- a/man/scale_viridis.Rd
+++ b/man/scale_viridis.Rd
@@ -12,6 +12,7 @@
 \alias{scale_fill_ordinal}
 \alias{scale_color_viridis_d}
 \alias{scale_color_viridis_c}
+\alias{scale_color_viridis_b}
 \title{Viridis colour scales from viridisLite}
 \usage{
 scale_colour_viridis_d(

--- a/tests/testthat/test-scales.r
+++ b/tests/testthat/test-scales.r
@@ -370,3 +370,15 @@ test_that("scale_apply preserves class and attributes", {
   expect_false(inherits(out, "foobar"))
   expect_null(attributes(out))
 })
+
+test_that("All scale_colour_*() have their American versions", {
+  # In testthat, the package env contains non-exported functions as well so we
+  # need to parse NAMESPACE file by ourselves
+  exports <- readLines(system.file("NAMESPACE", package = "ggplot2"))
+  colour_scale_exports <- grep("scale_.*colour", exports, value = TRUE)
+  color_scale_exports <- grep("scale_.*color", exports, value = TRUE)
+  expect_equal(
+    colour_scale_exports,
+    sub("color", "colour", color_scale_exports)
+  )
+})

--- a/tests/testthat/test-scales.r
+++ b/tests/testthat/test-scales.r
@@ -375,8 +375,8 @@ test_that("All scale_colour_*() have their American versions", {
   # In testthat, the package env contains non-exported functions as well so we
   # need to parse NAMESPACE file by ourselves
   exports <- readLines(system.file("NAMESPACE", package = "ggplot2"))
-  colour_scale_exports <- grep("scale_.*colour", exports, value = TRUE)
-  color_scale_exports <- grep("scale_.*color", exports, value = TRUE)
+  colour_scale_exports <- grep("export\\(scale_colour_.*\\)", exports, value = TRUE)
+  color_scale_exports <- grep("export\\(scale_color_.*\\)", exports, value = TRUE)
   expect_equal(
     colour_scale_exports,
     sub("color", "colour", color_scale_exports)


### PR DESCRIPTION
Followup of #4048

* Regenerate the document to fix the build failure (it complains because there's no alias of `scale_color_viridis_b`)
* Add a test to check if all `scale_colour_*()` have their corresponding `scale_color_*()`.