### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -90,7 +90,7 @@ jobs:
           # Since sf dependencies are a bit heavy, install them only when they are needed
           SF_NEEDS_UPDATED=$(Rscript -e 'if (!"sf" %in% installed.packages()[,"Package"] || "sf" %in% old.packages()[,"Package"]) cat("yes")')
           if [ "${SF_NEEDS_UPDATED}" == "yes" ]; then
-            brew install udunits gdal
+            # brew install udunits gdal
           fi
 
       - name: Install dependencies

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -89,8 +89,10 @@ jobs:
 
           # Since sf dependencies are a bit heavy, install them only when they are needed
           SF_NEEDS_UPDATED=$(Rscript -e 'if (!"sf" %in% installed.packages()[,"Package"] || "sf" %in% old.packages()[,"Package"]) cat("yes")')
-          if [ "${SF_NEEDS_UPDATED}" == "yes" ]; then
-            # brew install udunits gdal
+          SF_BINARY_VERSION=$(Rscript -e 'x <- available.packages(type = "binary"); cat(x[x[,"Package"]  == "sf","Version"])')
+          SF_SOURCE_VERSION=$(Rscript -e 'x <- available.packages(type = "source"); cat(x[x[,"Package"]  == "sf","Version"])')
+          if [ "${SF_NEEDS_UPDATED}" = "yes" && "${SF_BINARY_VERSION}" != "${SF_SOURCE_VERSION}" ]; then
+            brew install udunits gdal
           fi
 
       - name: Install dependencies

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,7 +24,7 @@ jobs:
         config:
           - {os: windows-latest, r: '4.0',   vdiffr: true,  xref: true}
           - {os: macOS-latest,   r: '4.0',   vdiffr: true,  xref: true}
-          - {os: macOS-latest,   r: 'devel', vdiffr: false, xref: true}
+          - {os: ubuntu-16.04,   r: 'devel', vdiffr: false, xref: true,  cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '4.0',   vdiffr: true,  xref: true,  cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.6',   vdiffr: false, xref: true,  cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.5',   vdiffr: false, xref: true,  cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
@@ -81,19 +81,8 @@ jobs:
           # XQuartz is needed by vdiffr
           brew cask install xquartz
 
-          # To install vdiffr, these three libraries/tools are needed in addition to XQuartz
-          # - freetype (already installed, needed by systemfonts)
-          # - cairo (not installed, needed by gdtools)
-          # - pkg-config (not installed, needed to set proper build settings)
-          brew install pkg-config cairo
-
-          # Since sf dependencies are a bit heavy, install them only when they are needed
-          SF_NEEDS_UPDATED=$(Rscript -e 'if (!"sf" %in% installed.packages()[,"Package"] || "sf" %in% old.packages()[,"Package"]) cat("yes")')
-          SF_BINARY_VERSION=$(Rscript -e 'x <- available.packages(type = "binary"); cat(x[x[,"Package"]  == "sf","Version"])')
-          SF_SOURCE_VERSION=$(Rscript -e 'x <- available.packages(type = "source"); cat(x[x[,"Package"]  == "sf","Version"])')
-          if [ "${SF_NEEDS_UPDATED}" = "yes" && "${SF_BINARY_VERSION}" != "${SF_SOURCE_VERSION}" ]; then
-            brew install udunits gdal
-          fi
+          # Use only binary packages
+          echo 'options(pkgType = "binary")' >> ~/.Rprofile
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -71,10 +71,6 @@ jobs:
         env:
           RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
         run: |
-          # Use cran:libgit2 PPA to avoid conflicts of libcurl4-gnutls-dev
-          # Remove this after https://github.com/r-lib/actions/pull/97 gets merged
-          sudo add-apt-repository ppa:cran/libgit2
-
           Rscript -e "remotes::install_github('r-hub/sysreqs')"
           sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
           sudo -s eval "$sysreqs"

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           install.packages("remotes")
-          remotes::install_deps(dependencies = TRUE)
+          remotes::install_deps(dependencies = TRUE, type = "binary")
           remotes::install_github("tidyverse/tidytemplate")
           remotes::install_dev("pkgdown")
         shell: Rscript {0}

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -14,7 +14,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: r-lib/actions/setup-r@master
       - name: Install dependencies
-        run: Rscript -e 'install.packages(c("remotes", "roxygen2"))' -e 'remotes::install_deps(dependencies = TRUE)'
+        run: Rscript -e 'install.packages(c("remotes", "roxygen2"))' -e 'remotes::install_deps(dependencies = TRUE, type = "binary"'
       - name: Document
         run: Rscript -e 'roxygen2::roxygenise()'
       - name: commit

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -53,7 +53,7 @@ jobs:
           # Since sf dependencies are a bit heavy, install them only when they are needed
           SF_NEEDS_UPDATED=$(Rscript -e 'if (!"sf" %in% installed.packages()[,"Package"] || "sf" %in% old.packages()[,"Package"]) cat("yes")')
           if [ "${SF_NEEDS_UPDATED}" == "yes" ]; then
-            brew install udunits gdal
+            # brew install udunits gdal
           fi
 
       - name: Install dependencies

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -52,8 +52,10 @@ jobs:
 
           # Since sf dependencies are a bit heavy, install them only when they are needed
           SF_NEEDS_UPDATED=$(Rscript -e 'if (!"sf" %in% installed.packages()[,"Package"] || "sf" %in% old.packages()[,"Package"]) cat("yes")')
-          if [ "${SF_NEEDS_UPDATED}" == "yes" ]; then
-            # brew install udunits gdal
+          SF_BINARY_VERSION=$(Rscript -e 'x <- available.packages(type = "binary"); cat(x[x[,"Package"]  == "sf","Version"])')
+          SF_SOURCE_VERSION=$(Rscript -e 'x <- available.packages(type = "source"); cat(x[x[,"Package"]  == "sf","Version"])')
+          if [ "${SF_NEEDS_UPDATED}" = "yes" && "${SF_BINARY_VERSION}" != "${SF_SOURCE_VERSION}" ]; then
+            brew install udunits gdal
           fi
 
       - name: Install dependencies

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -39,29 +39,14 @@ jobs:
           restore-keys: ${{ env.cache-version }}-macOS-r-${{ env.r-version }}-
 
       - name: Install system dependencies on macOS
-        if: runner.os == 'macOS'
         run: |
           # XQuartz is needed by vdiffr
           brew cask install xquartz
 
-          # To install vdiffr, these three libraries/tools are needed in addition to XQuartz
-          # - freetype (already installed, needed by systemfonts)
-          # - cairo (not installed, needed by gdtools)
-          # - pkg-config (not installed, needed to set proper build settings)
-          brew install pkg-config cairo
-
-          # Since sf dependencies are a bit heavy, install them only when they are needed
-          SF_NEEDS_UPDATED=$(Rscript -e 'if (!"sf" %in% installed.packages()[,"Package"] || "sf" %in% old.packages()[,"Package"]) cat("yes")')
-          SF_BINARY_VERSION=$(Rscript -e 'x <- available.packages(type = "binary"); cat(x[x[,"Package"]  == "sf","Version"])')
-          SF_SOURCE_VERSION=$(Rscript -e 'x <- available.packages(type = "source"); cat(x[x[,"Package"]  == "sf","Version"])')
-          if [ "${SF_NEEDS_UPDATED}" = "yes" && "${SF_BINARY_VERSION}" != "${SF_SOURCE_VERSION}" ]; then
-            brew install udunits gdal
-          fi
-
       - name: Install dependencies
         run: |
           install.packages(c("remotes"))
-          remotes::install_deps(dependencies = TRUE)
+          remotes::install_deps(dependencies = TRUE, type = "binary")
           remotes::install_cran("covr")
         shell: Rscript {0}
 

--- a/tests/testthat/test-geom-quantile.R
+++ b/tests/testthat/test-geom-quantile.R
@@ -1,6 +1,8 @@
 context("geom-quantile")
 
 test_that("geom_quantile matches quantile regression", {
+  skip_if_not_installed("quantreg")
+
   set.seed(6531)
   x <- rnorm(10)
   df <- tibble::tibble(


### PR DESCRIPTION
## Summary of the changes

* Skip some tests if quantreg package is not available
* Replace macOS + R-devel runner and with Ubuntu-16.04 + R-devel runner
* Install binary packages only on macOS
* Remove the step to add libgit PPA

## Details of the problems

### quantreg on R < 3.6

As of version 5.61 (released on July 7, 2020), quantreg package imports [conquer package](https://cran.r-project.org/web/packages/conquer/index.html), which requires R >= 3.6. So, quantreg now virtually requires R >= 3.6.

Diff: https://github.com/cran/quantreg/commit/16f49417c4f7ce6308ba660aba56ee70319cd396#diff-35ba4a2677442e210c23a00a5601aba3R31

### macOS

#### R-devel

It fails to setup R for an unknown error. Now that r-lib/actions provide R-devel also to Linux runners, let's use `ubuntu-16.04` for R-devel. I feel the toolchain of macOS is too franky, and as ggplot2 is not a package that needs compilation, I feel the macOS + R-devel is not worth keeping.

https://github.com/r-lib/actions/issues/49#issuecomment-665047147

#### R 4.0

`brew install gdal` fails with the following error. I set the `pkgType` option on macOS to avoid building packages at all.

```
==> Installing gdal dependency: gcc
==> Pouring gcc-10.1.0.catalina.bottle.tar.gz
##[error]Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/gfortran
Target /usr/local/bin/gfortran
already exists. You may want to remove it:
  rm '/usr/local/bin/gfortran'

To force the link and overwrite all conflicting files:
  brew link --overwrite gcc

To list all files that would be deleted:
  brew link --overwrite --dry-run gcc

Possible conflicting files are:
/usr/local/bin/gfortran -> /usr/local/gfortran/bin/gfortran
```

### libgit2 PPA

(This is not about failures, just for cleanup)

As https://github.com/r-lib/actions/pull/97 is already merged, we can just remove this from the YAML.
