### PR TITLE
Update pkgdown GitHub Action

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: master
+    branches:
       - master
   release:
     types: [published]

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,6 +1,9 @@
 on:
   push:
     branches: master
+      - master
+  release:
+    types: [published]
 
 name: pkgdown
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -36,7 +36,8 @@ jobs:
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE, type = "binary")
-          install.packages("pkgdown")
+          remotes::install_github("tidyverse/tidytemplate")
+          remotes::install_dev("pkgdown")
         shell: Rscript {0}
 
       - name: Install package

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,28 +1,46 @@
 on:
   push:
-    branches:
-      - master
-  release:
-    types: [published]
+    branches: master
 
 name: pkgdown
 
 jobs:
   pkgdown:
     runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
+
       - uses: r-lib/actions/setup-r@master
+
       - uses: r-lib/actions/setup-pandoc@master
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
       - name: Install dependencies
         run: |
-          install.packages("remotes")
           remotes::install_deps(dependencies = TRUE, type = "binary")
-          remotes::install_github("tidyverse/tidytemplate")
-          remotes::install_dev("pkgdown")
+          install.packages("pkgdown")
         shell: Rscript {0}
+
       - name: Install package
         run: R CMD INSTALL .
+
       - name: Deploy package
-        run: pkgdown::deploy_to_branch(new_process = FALSE)
-        shell: Rscript {0}
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'


### PR DESCRIPTION
pkgdown action now fails with the following error. It seems we now need to configure username and email explicitly (c.f. https://github.com/r-lib/actions/issues/135). Since [the latest `pkgdown.yml`](https://github.com/r-lib/actions/blob/e9e2c876f3578ce790f0242ba27e67a85b3a9081/examples/pkgdown.yaml) already handles this and it contains some other improvements, I copied it and added some tweaks (including `publish` event, installing binary packages, and installing tidytemplate).

<https://github.com/tidyverse/ggplot2/runs/921163458#step:7:520>:
```
── Commiting updated site ──────────────────────────────────────────────────────
Running git add -A .
Running git commit --allow-empty -m \
  'Built site for ggplot2: 3.3.2.9000@8f7b03c'

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'runner@Mac-1595979566438.(none)')

Error: System command 'git' failed, exit status: 128, stdout & stderr were printed
```