### PR TITLE
Fix discrete orientation example in stat_summary

### DIFF
--- a/R/stat-summary.r
+++ b/R/stat-summary.r
@@ -53,7 +53,7 @@
 #' d + stat_summary(fun.data = "mean_cl_boot", colour = "red", size = 2)
 #'
 #' # Orientation follows the discrete axis
-#' ggplot(mtcars, aes(mpg, cyl)) +
+#' ggplot(mtcars, aes(mpg, factor(cyl))) +
 #'   geom_point() +
 #'   stat_summary(fun.data = "mean_cl_boot", colour = "red", size = 2)
 #'

--- a/man/stat_summary.Rd
+++ b/man/stat_summary.Rd
@@ -186,7 +186,7 @@ d <- ggplot(mtcars, aes(cyl, mpg)) + geom_point()
 d + stat_summary(fun.data = "mean_cl_boot", colour = "red", size = 2)
 
 # Orientation follows the discrete axis
-ggplot(mtcars, aes(mpg, cyl)) +
+ggplot(mtcars, aes(mpg, factor(cyl))) +
   geom_point() +
   stat_summary(fun.data = "mean_cl_boot", colour = "red", size = 2)
 


### PR DESCRIPTION
Fix #4150 

Replace cyl with factor(cyl) in discrete orientation example of stat_summary