### PR TITLE
Update pr-commnads.yaml to the latest

### DIFF
--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -7,6 +7,8 @@ jobs:
     if: startsWith(github.event.comment.body, '/document')
     name: document
     runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - uses: r-lib/actions/pr-fetch@master
@@ -19,6 +21,8 @@ jobs:
         run: Rscript -e 'roxygen2::roxygenise()'
       - name: commit
         run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
           git add man/\* NAMESPACE
           git commit -m 'Document'
       - uses: r-lib/actions/pr-push@master
@@ -28,6 +32,8 @@ jobs:
     if: startsWith(github.event.comment.body, '/style')
     name: style
     runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - uses: r-lib/actions/pr-fetch@master
@@ -40,13 +46,10 @@ jobs:
         run: Rscript -e 'styler::style_pkg()'
       - name: commit
         run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
           git add \*.R
           git commit -m 'Style'
       - uses: r-lib/actions/pr-push@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-  # A mock job just to ensure we have a successful build status
-  finish:
-    runs-on: ubuntu-latest
-    steps:
-      - run: true


### PR DESCRIPTION
Sorry, I found I needed to add `git config` also to pr-commands.yaml... This PR updates pr-commands.yaml to [the latest one on r-lib/actions](https://github.com/r-lib/actions/blob/9b0e9a42c639483e129d48f25f338015ef243b3a/examples/pr-commands.yaml). This time, I confirmed `/document` works on my forked repo: https://github.com/r-lib/actions/blob/9b0e9a42c639483e129d48f25f338015ef243b3a/examples/pr-commands.yaml