### PR TITLE
Docs no longer say Geoms don't have setup_params() method

### DIFF
--- a/R/geom-.r
+++ b/R/geom-.r
@@ -11,6 +11,11 @@ NULL
 #' from the top-level `Geom`, and each implements various methods and
 #' fields.
 #'
+#' Compared to `Stat` and `Position`, `Geom` is a little
+#' different because the execution of the setup and compute functions is
+#' split up. `setup_data` runs before position adjustments, and
+#' `draw_layer()` is not run until render time, much later.
+#'
 #' To create a new type of Geom object, you typically will want to
 #' override one or more of the following:
 #'

--- a/R/geom-.r
+++ b/R/geom-.r
@@ -11,13 +11,6 @@ NULL
 #' from the top-level `Geom`, and each implements various methods and
 #' fields.
 #'
-#' Compared to `Stat` and `Position`, `Geom` is a little
-#' different because the execution of the setup and compute functions is
-#' split up. `setup_data` runs before position adjustments, and
-#' `draw_layer()` is not run until render time, much later. This
-#' means there is no `setup_params` because it's hard to communicate
-#' the changes.
-#'
 #' To create a new type of Geom object, you typically will want to
 #' override one or more of the following:
 #'

--- a/man/ggplot2-ggproto.Rd
+++ b/man/ggplot2-ggproto.Rd
@@ -149,6 +149,11 @@ Each of the \verb{Geom*} objects is a \code{\link[=ggproto]{ggproto()}} object, 
 from the top-level \code{Geom}, and each implements various methods and
 fields.
 
+Compared to \code{Stat} and \code{Position}, \code{Geom} is a little
+different because the execution of the setup and compute functions is
+split up. \code{setup_data} runs before position adjustments, and
+\code{draw_layer()} is not run until render time, much later.
+
 To create a new type of Geom object, you typically will want to
 override one or more of the following:
 \itemize{

--- a/man/ggplot2-ggproto.Rd
+++ b/man/ggplot2-ggproto.Rd
@@ -149,13 +149,6 @@ Each of the \verb{Geom*} objects is a \code{\link[=ggproto]{ggproto()}} object, 
 from the top-level \code{Geom}, and each implements various methods and
 fields.
 
-Compared to \code{Stat} and \code{Position}, \code{Geom} is a little
-different because the execution of the setup and compute functions is
-split up. \code{setup_data} runs before position adjustments, and
-\code{draw_layer()} is not run until render time, much later. This
-means there is no \code{setup_params} because it's hard to communicate
-the changes.
-
 To create a new type of Geom object, you typically will want to
 override one or more of the following:
 \itemize{


### PR DESCRIPTION
Per #4158, the docs used to say that Geoms don't have the `setup_params()` method, which is no longer true (#3506). I've deleted this paragraph.