### PR TITLE
Set file background from plot theme

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,7 +63,8 @@ Suggests:
     sf (>= 0.7-3),
     svglite (>= 1.2.0.9001),
     testthat (>= 2.1.0),
-    vdiffr (>= 0.3.0)
+    vdiffr (>= 0.3.0),
+    xml2
 Enhances: sp
 License: GPL-2 | file LICENSE
 URL: http://ggplot2.tidyverse.org, https://github.com/tidyverse/ggplot2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* `ggsave()` now sets the default background to match the fill value of the
+  `plot.background` theme element (@karawoo, #4057)
+
 * Extended `stat_ecdf()` to calculate the cdf from either x or y instead from y only (@jgjl, #4005).
 
 * Fixed a bug in `labeller()` so that `.default` is passed to `as_labeller()`

--- a/R/save.r
+++ b/R/save.r
@@ -38,6 +38,8 @@
 #' @param limitsize When `TRUE` (the default), `ggsave()` will not
 #'   save images larger than 50x50 inches, to prevent the common error of
 #'   specifying dimensions in pixels.
+#' @param bg Background colour. If `NULL`, uses the `plot.background` fill value
+#'   from the plot theme.
 #' @param ... Other arguments passed on to the graphics device function,
 #'   as specified by `device`.
 #' @export
@@ -74,7 +76,7 @@
 ggsave <- function(filename, plot = last_plot(),
                    device = NULL, path = NULL, scale = 1,
                    width = NA, height = NA, units = c("in", "cm", "mm"),
-                   dpi = 300, limitsize = TRUE, ...) {
+                   dpi = 300, limitsize = TRUE, bg = NULL, ...) {
 
   dpi <- parse_dpi(dpi)
   dev <- plot_dev(device, filename, dpi = dpi)
@@ -84,8 +86,11 @@ ggsave <- function(filename, plot = last_plot(),
   if (!is.null(path)) {
     filename <- file.path(path, filename)
   }
+  if (is_null(bg)) {
+    bg <- calc_element("plot.background", plot_theme(plot))$fill
+  }
   old_dev <- grDevices::dev.cur()
-  dev(filename = filename, width = dim[1], height = dim[2], ...)
+  dev(filename = filename, width = dim[1], height = dim[2], bg = bg, ...)
   on.exit(utils::capture.output({
     grDevices::dev.off()
     if (old_dev > 1) grDevices::dev.set(old_dev) # restore old device unless null device

--- a/man/ggsave.Rd
+++ b/man/ggsave.Rd
@@ -15,6 +15,7 @@ ggsave(
   units = c("in", "cm", "mm"),
   dpi = 300,
   limitsize = TRUE,
+  bg = NULL,
   ...
 )
 }
@@ -42,6 +43,9 @@ If not supplied, uses the size of current graphics device.}
 \item{limitsize}{When \code{TRUE} (the default), \code{ggsave()} will not
 save images larger than 50x50 inches, to prevent the common error of
 specifying dimensions in pixels.}
+
+\item{bg}{Background colour. If \code{NULL}, uses the \code{plot.background} fill value
+from the plot theme.}
 
 \item{...}{Other arguments passed on to the graphics device function,
 as specified by \code{device}.}

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -28,6 +28,20 @@ test_that("ggsave restores previous graphics device", {
   expect_identical(old_dev, dev.cur())
 })
 
+test_that("ggsave uses theme background as image background", {
+  path <- tempfile()
+  on.exit(unlink(path))
+  p <- ggplot(mtcars, aes(disp, mpg)) +
+    geom_point() +
+    coord_fixed() +
+    theme(plot.background = element_rect(fill = "#00CCCC"))
+  ggsave(path, p, device = "svg", width = 5, height = 5)
+  img <- xml2::read_xml(path)
+  # Find background rect in svg
+  bg <- as.character(xml2::xml_find_first(img, xpath = "d1:rect/@style"))
+  expect_true(grepl("fill: #00CCCC", bg))
+})
+
 # plot_dim ---------------------------------------------------------------
 
 test_that("guesses and informs if dim not specified", {


### PR DESCRIPTION
Closes #4057. @clauswilke I took your proposed approach and calculated the theme element to get the background color. I imagine people will still typically want to edit their theme to remove the plot border.

I'm opening this as a draft because I think it needs a test but I'm not sure how best to write one. Is there a way to have vdiffr compare two files rather than comparing a plot object against a file? I imagine there is and that vdiffr is doing this under the hood normally, but I tinkered with it a bit and couldn't figure it out.

``` r
library("ggplot2")

p <- ggplot(mtcars, aes(disp, mpg)) +
  geom_point() +
  coord_fixed() + # using coord_fixed() just to emphasize what's the plot and what's the image background
  theme(plot.background = element_rect(fill = "forestgreen"))

ggsave("~/p_new.png", p)
#> Saving 7 x 5 in image
knitr::include_graphics("~/p_new.png")
```

![](https://i.imgur.com/C7YTYYF.png)

``` r

ggsave("~/p_override.png", p, bg = "cyan")
#> Saving 7 x 5 in image
knitr::include_graphics("~/p_override.png")
```

![](https://i.imgur.com/NkFBbQE.png)
