### PR TITLE
Avoid "<empty>" labels with qplot()

### DIFF
--- a/R/quick-plot.r
+++ b/R/quick-plot.r
@@ -89,10 +89,19 @@ qplot <- function(x, y, ..., data, facets = NULL, margins = FALSE,
 
 
   if (is.null(xlab)) {
-    xlab <- as_label(exprs$x)
+    # Avoid <empty> label (#4170)
+    if (quo_is_missing(exprs$x)) {
+      xlab <- ""
+    } else {
+      xlab <- as_label(exprs$x)
+    }
   }
   if (is.null(ylab)) {
-    ylab <- as_label(exprs$y)
+    if (quo_is_missing(exprs$y)) {
+      ylab <- ""
+    } else {
+      ylab <- as_label(exprs$y)
+    }
   }
 
   if (missing(data)) {


### PR DESCRIPTION
Fix #4170 

    devtools::load_all("~/repo/ggplot2")
    #> Loading ggplot2
    qplot(1:10)
    #> `stat_bin()` using `bins = 30`. Pick better value with `binwidth`.

![](https://i.imgur.com/UNGG5SM.png)

<sup>Created on 2020-09-06 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
