### PR TITLE
Fix CI by skipping visual tests when vdiffr is not available

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -49,6 +49,7 @@ jobs:
       - uses: r-lib/actions/setup-r@master
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - uses: r-lib/actions/setup-pandoc@master
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,17 +24,17 @@ jobs:
         config:
           - {os: windows-latest, r: '4.0',   vdiffr: true,  xref: true}
           - {os: macOS-latest,   r: '4.0',   vdiffr: true,  xref: true}
-          - {os: ubuntu-16.04,   r: 'devel', vdiffr: false, xref: true,  cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '4.0',   vdiffr: true,  xref: true,  cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.6',   vdiffr: false, xref: true,  cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.5',   vdiffr: false, xref: true,  cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.4',   vdiffr: false, xref: true,  cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.3',   vdiffr: false, xref: true,  cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.2',   vdiffr: false, xref: false, cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: 'devel', vdiffr: false, xref: true,   rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest", http-user-agent: "R/4.0.0 (ubuntu-16.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions"}
+          - {os: ubuntu-16.04,   r: '4.0',   vdiffr: true,  xref: true,   rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: '3.6',   vdiffr: false, xref: true,   rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: '3.5',   vdiffr: false, xref: true,   rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: '3.4',   vdiffr: false, xref: true,   rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: '3.3',   vdiffr: false, xref: true,   rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: '3.2',   vdiffr: false, xref: false,  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      CRAN: ${{ matrix.config.cran }}
+      RSPM: ${{ matrix.config.rspm }}
       # don't treat missing suggested packages as error
       _R_CHECK_FORCE_SUGGESTS_: false
       # Some packages might unavailable on the older versions, so let's ignore xref warnings
@@ -68,12 +68,11 @@ jobs:
 
       - name: Install system dependencies on Linux
         if: runner.os == 'Linux'
-        env:
-          RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
         run: |
-          Rscript -e "remotes::install_github('r-hub/sysreqs')"
-          sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
-          sudo -s eval "$sysreqs"
+          while read -r cmd
+          do
+            eval sudo $cmd
+          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "16.04"))')
 
       - name: Install system dependencies on macOS
         if: runner.os == 'macOS'

--- a/tests/testthat/helper-vdiffr.R
+++ b/tests/testthat/helper-vdiffr.R
@@ -2,4 +2,9 @@
 #   - VDIFFR_RUN_TESTS is "false" (on Travis CI with older versions and dev version of R)
 #   - CI is not set (on CRAN)
 
-expect_doppelganger <- vdiffr::expect_doppelganger
+if (requireNamespace("vdiffr", quietly = TRUE)) {
+  expect_doppelganger <- vdiffr::expect_doppelganger
+} else {
+  # If vdiffr is not available, assign a dummy function
+  expect_doppelganger <- function(...) skip("vdiffr is not installed.")
+}

--- a/tests/testthat/helper-vdiffr.R
+++ b/tests/testthat/helper-vdiffr.R
@@ -5,6 +5,11 @@
 if (requireNamespace("vdiffr", quietly = TRUE)) {
   expect_doppelganger <- vdiffr::expect_doppelganger
 } else {
-  # If vdiffr is not available, assign a dummy function
+  # If vdiffr is not available and visual tests are not explicitly disabled, raise error.
+  if (!identical(Sys.getenv("VDIFFR_RUN_TESTS"), "false")) {
+    abort("vdiffr is not installed")
+  }
+
+  # Otherwise, assign a dummy function
   expect_doppelganger <- function(...) skip("vdiffr is not installed.")
 }

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -30,7 +30,7 @@ test_that("ggsave restores previous graphics device", {
 
 test_that("ggsave uses theme background as image background", {
   # FIXME: This should check svglite, but, at the time of writing this, there's already a binary
-  #        package of svglite, and it can be installed even the dependency is not available, surprisingly...
+  #        package of svglite, and it can be installed even if the dependency is not available, surprisingly...
   skip_if_not_installed("systemfonts")
 
   path <- tempfile()

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -29,6 +29,10 @@ test_that("ggsave restores previous graphics device", {
 })
 
 test_that("ggsave uses theme background as image background", {
+  # FIXME: This should check svglite, but, at the time of writing this, there's already a binary
+  #        package of svglite, and it can be installed even the dependency is not available, surprisingly...
+  skip_if_not_installed("systemfonts")
+
   path <- tempfile()
   on.exit(unlink(path))
   p <- ggplot(mtcars, aes(disp, mpg)) +


### PR DESCRIPTION
I'm not sure if systemfonts will be available again on R 3.3 and 3.2 (if we follow the 5 version policy, the support for 3.2 might be dropped), but I think the tests should handle this gracefully anyway, as vdiffr is not actually used for testing on the versions. It seems we also need to skip the ggsave test newly added by #4164 as svglite also depends on systemfonts.

Also, this PR reflects some changes on [r-lib/action's check.full.yaml](https://github.com/r-lib/actions/blob/master/examples/check-full.yaml) (Use RStudio package manager, and use binary packages on R-devel as well).