### PR TITLE
Use NROW() instead of length() in aesthetics checking.

### DIFF
--- a/R/geom-.r
+++ b/R/geom-.r
@@ -210,7 +210,7 @@ NULL
 .stroke <- 96 / 25.4
 
 check_aesthetics <- function(x, n) {
-  ns <- vapply(x, length, numeric(1))
+  ns <- vapply(x, NROW, numeric(1))
   good <- ns == 1L | ns == n
 
   if (all(good)) {


### PR DESCRIPTION
In response to #4189, I'm creating this PR to see if any checks fail.
They didn't fail when I ran the unit tests locally.

However, there are a few things to note, as just changing `length()` to `NROW()` is not sufficient to allow for tibble aesthetics.
I'll post some details about this in the relevant issue.