### PR TITLE
Add missing period at the end of sentence

### DIFF
--- a/R/fortify.r
+++ b/R/fortify.r
@@ -41,7 +41,7 @@ fortify.grouped_df <- function(model, data, ...) {
 fortify.default <- function(model, data, ...) {
   msg <- paste0(
     "`data` must be a data frame, or other object coercible by `fortify()`, ",
-    "not ", obj_desc(model)
+    "not ", obj_desc(model), "."
   )
   if (inherits(model, "uneval")) {
     msg <- paste0(


### PR DESCRIPTION
The error currently reads something like the following:

```
Error: `data` must be a data frame, or other object coercible by `fortify()`, not an S3 object with class uneval
Did you accidentally pass `aes()` to the `data` argument?
```

This PR adds a period at the end of the first sentence.