### PR TITLE
Add `oob` arguments to date/datetime position scales.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,9 @@
   `scale_*(guide = FALSE)` to remove a guide. Please use 
   `guides(<scale> = "none")` or `scale_*(guide = "none")` instead 
   (@yutannihilation, #4094).
+  
+* Date and datetime position scales support out-of-bounds (oob) arguments to 
+  control how limits affect data outside those limits (@teunbrand, #4199).
 
 # ggplot2 3.3.2
 This is a small release focusing on fixing regressions introduced in 3.3.1.

--- a/R/scale-date.r
+++ b/R/scale-date.r
@@ -66,6 +66,7 @@ scale_x_date <- function(name = waiver(),
                          date_minor_breaks = waiver(),
                          limits = NULL,
                          expand = waiver(),
+                         oob = censor,
                          guide = waiver(),
                          position = "bottom",
                          sec.axis = waiver()) {
@@ -84,6 +85,7 @@ scale_x_date <- function(name = waiver(),
     guide = guide,
     limits = limits,
     expand = expand,
+    oob = oob,
     position = position
   )
 
@@ -101,6 +103,7 @@ scale_y_date <- function(name = waiver(),
                          date_minor_breaks = waiver(),
                          limits = NULL,
                          expand = waiver(),
+                         oob = censor,
                          guide = waiver(),
                          position = "left",
                          sec.axis = waiver()) {
@@ -119,6 +122,7 @@ scale_y_date <- function(name = waiver(),
     guide = guide,
     limits = limits,
     expand = expand,
+    oob = oob,
     position = position
   )
 
@@ -137,6 +141,7 @@ scale_x_datetime <- function(name = waiver(),
                              timezone = NULL,
                              limits = NULL,
                              expand = waiver(),
+                             oob = censor,
                              guide = waiver(),
                              position = "bottom",
                              sec.axis = waiver()) {
@@ -156,6 +161,7 @@ scale_x_datetime <- function(name = waiver(),
     guide = guide,
     limits = limits,
     expand = expand,
+    oob = oob,
     position = position
   )
 
@@ -175,6 +181,7 @@ scale_y_datetime <- function(name = waiver(),
                              timezone = NULL,
                              limits = NULL,
                              expand = waiver(),
+                             oob = censor,
                              guide = waiver(),
                              position = "left",
                              sec.axis = waiver()) {
@@ -194,6 +201,7 @@ scale_y_datetime <- function(name = waiver(),
     guide = guide,
     limits = limits,
     expand = expand,
+    oob = oob,
     position = position
   )
 

--- a/man/scale_date.Rd
+++ b/man/scale_date.Rd
@@ -19,6 +19,7 @@ scale_x_date(
   date_minor_breaks = waiver(),
   limits = NULL,
   expand = waiver(),
+  oob = censor,
   guide = waiver(),
   position = "bottom",
   sec.axis = waiver()
@@ -34,6 +35,7 @@ scale_y_date(
   date_minor_breaks = waiver(),
   limits = NULL,
   expand = waiver(),
+  oob = censor,
   guide = waiver(),
   position = "left",
   sec.axis = waiver()
@@ -50,6 +52,7 @@ scale_x_datetime(
   timezone = NULL,
   limits = NULL,
   expand = waiver(),
+  oob = censor,
   guide = waiver(),
   position = "bottom",
   sec.axis = waiver()
@@ -66,6 +69,7 @@ scale_y_datetime(
   timezone = NULL,
   limits = NULL,
   expand = waiver(),
+  oob = censor,
   guide = waiver(),
   position = "left",
   sec.axis = waiver()
@@ -163,6 +167,16 @@ to generate the values for the \code{expand} argument. The defaults are to
 expand the scale by 5\% on each side for continuous variables, and by
 0.6 units on each side for discrete variables.}
 
+\item{oob}{One of:
+\itemize{
+\item Function that handles limits outside of the scale limits
+(out of bounds).
+\item The default (\code{\link[scales:oob]{scales::censor()}}) replaces out of
+bounds values with \code{NA}.
+\item \code{\link[scales:oob]{scales::squish()}} for squishing out of bounds values into range.
+\item \code{\link[scales:oob]{scales::squish_infinite()}} for squishing infinite values into range.
+}}
+
 \item{guide}{A function used to create a guide or its name. See
 \code{\link[=guides]{guides()}} for more information.}
 
@@ -173,16 +187,6 @@ expand the scale by 5\% on each side for continuous variables, and by
 
 \item{timezone}{The timezone to use for display on the axes. The default
 (\code{NULL}) uses the timezone encoded in the data.}
-
-\item{oob}{One of:
-\itemize{
-\item Function that handles limits outside of the scale limits
-(out of bounds).
-\item The default (\code{\link[scales:oob]{scales::censor()}}) replaces out of
-bounds values with \code{NA}.
-\item \code{\link[scales:oob]{scales::squish()}} for squishing out of bounds values into range.
-\item \code{\link[scales:oob]{scales::squish_infinite()}} for squishing infinite values into range.
-}}
 
 \item{na.value}{Missing values will be replaced with this value.}
 }


### PR DESCRIPTION
This PR aims to fix #4199 by adding `oob` arguments to date and datetime position scales that are passed along to `ggplot2:::datetime_scale()`.