### PR TITLE
Allow trailing commas in guides() and labs()

### DIFF
--- a/R/guides-.r
+++ b/R/guides-.r
@@ -64,7 +64,7 @@
 #'  )
 #' }
 guides <- function(...) {
-  args <- list(...)
+  args <- list2(...)
   if (length(args) > 0) {
     if (is.list(args[[1]]) && !inherits(args[[1]], "guide")) args <- args[[1]]
     args <- rename_aes(args)

--- a/R/labels.r
+++ b/R/labels.r
@@ -68,7 +68,8 @@ update_labels <- function(p, labels) {
 #'  labs(title = "title") +
 #'  labs(title = NULL)
 labs <- function(..., title = waiver(), subtitle = waiver(), caption = waiver(), tag = waiver()) {
-  args <- list2(..., title = title, subtitle = subtitle, caption = caption, tag = tag)
+  # .ignore_empty = "all" is needed to allow trailing commas, which is NOT a trailing comma for dots_list() as it's in ...
+  args <- dots_list(..., title = title, subtitle = subtitle, caption = caption, tag = tag, .ignore_empty = "all")
 
   is_waive <- vapply(args, is.waive, logical(1))
   args <- args[!is_waive]


### PR DESCRIPTION
Fix #4237 

    devtools::load_all("~/repo/ggplot2")
    #> Loading ggplot2

    labs(x = "x", )
    #> $x
    #> [1] "x"
    #> 
    #> attr(,"class")
    #> [1] "labels"
    guides(x = "x", )
    #> $x
    #> [1] "x"
    #> 
    #> attr(,"class")
    #> [1] "guides"

<sup>Created on 2020-10-15 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
