### PR TITLE
Do not use RStudio Package Manager for R-devel

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -10,7 +10,7 @@ name: R-CMD-check
 
 # Increment this version when we want to clear cache
 env:
-  cache-version: v3
+  cache-version: v4
 
 jobs:
   R-CMD-check:
@@ -24,7 +24,7 @@ jobs:
         config:
           - {os: windows-latest, r: '4.0',   vdiffr: true,  xref: true}
           - {os: macOS-latest,   r: '4.0',   vdiffr: true,  xref: true}
-          - {os: ubuntu-16.04,   r: 'devel', vdiffr: false, xref: true,   rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest", http-user-agent: "R/4.0.0 (ubuntu-16.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions"}
+          - {os: ubuntu-16.04,   r: 'devel', vdiffr: false, xref: true}
           - {os: ubuntu-16.04,   r: '4.0',   vdiffr: true,  xref: true,   rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.6',   vdiffr: false, xref: true,   rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.5',   vdiffr: false, xref: true,   rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -32,6 +32,7 @@ test_that("ggsave uses theme background as image background", {
   # FIXME: This should check svglite, but, at the time of writing this, there's already a binary
   #        package of svglite, and it can be installed even if the dependency is not available, surprisingly...
   skip_if_not_installed("systemfonts")
+  skip_if_not_installed("xml2")
 
   path <- tempfile()
   on.exit(unlink(path))

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -29,9 +29,6 @@ test_that("ggsave restores previous graphics device", {
 })
 
 test_that("ggsave uses theme background as image background", {
-  # FIXME: This should check svglite, but, at the time of writing this, there's already a binary
-  #        package of svglite, and it can be installed even if the dependency is not available, surprisingly...
-  skip_if_not_installed("systemfonts")
   skip_if_not_installed("xml2")
 
   path <- tempfile()


### PR DESCRIPTION
All visual tests fail on R-devel with this error:

```
 > test_check("ggplot2")
── 1. Error: aesthetics are drawn correctly (@test-aes.r#160)  ─────────────────
Graphics API version mismatch
Backtrace:
 1. vdiffr::expect_doppelganger(...)
 2. vdiffr:::writer(fig, testcase, title)
 3. vdiffr:::svglite(file, user_fonts = get_aliases())
 4. vdiffr:::svglite_(...)
```
(<https://github.com/tidyverse/ggplot2/pull/4227/checks?check_run_id=1239216870#step:10:132>)

I tried clearing cache, but it still failed. I bet this is because some binary on RStudio package manager is outdated. This might be solved by just waiting for some package to get rebuilt, but it kept failing at least for this 2 weeks, so I think there's little hope. This pull request removes RStudio Package Manager on R-devel runner and clears cache.

This pull request adds these changes:

* Stop using RStudio Public Package Manager on R-devel runner
* Remove workaround for systemfonts package as it's available again
* Add a workaround for xml2 (it seems not available on R 3.2)