### PR TITLE
Clarify that span is only used for loess in stat_smooth

### DIFF
--- a/R/stat-smooth.r
+++ b/R/stat-smooth.r
@@ -25,8 +25,8 @@
 #' @param level Level of confidence interval to use (0.95 by default).
 #' @param span Controls the amount of smoothing for the default loess smoother.
 #'   Smaller numbers produce wigglier lines, larger numbers produce smoother
-#'   lines. Only used with loess, i.e. when `method="loess"`,
-#'   or when `method=NULL` (the default) and there are fewer than 1,000
+#'   lines. Only used with loess, i.e. when `method = "loess"`,
+#'   or when `method = NULL` (the default) and there are fewer than 1,000
 #'   observations.
 #' @param n Number of points at which to evaluate smoother.
 #' @param method.args List of additional arguments passed on to the modelling

--- a/R/stat-smooth.r
+++ b/R/stat-smooth.r
@@ -25,7 +25,9 @@
 #' @param level Level of confidence interval to use (0.95 by default).
 #' @param span Controls the amount of smoothing for the default loess smoother.
 #'   Smaller numbers produce wigglier lines, larger numbers produce smoother
-#'   lines.
+#'   lines. Only used with loess, i.e. when `method="loess"`,
+#'   or when `method=NULL` (the default) and there are fewer than 1,000
+#'   observations.
 #' @param n Number of points at which to evaluate smoother.
 #' @param method.args List of additional arguments passed on to the modelling
 #'   function defined by `method`.

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -120,7 +120,7 @@ the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 
 \item{span}{Controls the amount of smoothing for the default loess smoother.
 Smaller numbers produce wigglier lines, larger numbers produce smoother
-lines. Only used when loess is used, i.e. when \code{method="loess"}
+lines. Only used with loess, i.e. when \code{method="loess"},
 or when \code{method=NULL} (the default) and there are fewer than 1,000
 observations.}
 

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -120,7 +120,9 @@ the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 
 \item{span}{Controls the amount of smoothing for the default loess smoother.
 Smaller numbers produce wigglier lines, larger numbers produce smoother
-lines.}
+lines. Only used when loess is used, i.e. when \code{method="loess"}
+or when \code{method=NULL} (the default) and there are fewer than 1,000
+observations.}
 
 \item{fullrange}{Should the fit span the full range of the plot, or just
 the data?}

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -120,8 +120,8 @@ the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 
 \item{span}{Controls the amount of smoothing for the default loess smoother.
 Smaller numbers produce wigglier lines, larger numbers produce smoother
-lines. Only used with loess, i.e. when \code{method="loess"},
-or when \code{method=NULL} (the default) and there are fewer than 1,000
+lines. Only used with loess, i.e. when \code{method = "loess"},
+or when \code{method = NULL} (the default) and there are fewer than 1,000
 observations.}
 
 \item{fullrange}{Should the fit span the full range of the plot, or just


### PR DESCRIPTION
It can be surprising that `span` argument has no effect when number of observations is large (cf. https://github.com/tidyverse/ggplot2/issues/3174).