### PR TITLE
Drop support for R 3.2

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,7 +30,6 @@ jobs:
           - {os: ubuntu-16.04,   r: '3.5',   vdiffr: false, xref: true,   rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.4',   vdiffr: false, xref: true,   rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.3',   vdiffr: false, xref: true,   rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.2',   vdiffr: false, xref: false,  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Authors@R: c(
     person("RStudio", role = c("cph", "fnd"))
     )
 Depends:
-    R (>= 3.2)
+    R (>= 3.3)
 Imports: 
     digest,
     glue,

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@
 
 * `stat_bin()`'s computed variable `width` is now documented (#3522).
 
+* ggplot2 now requires R >= 3.3 (#4247).
+
 # ggplot2 3.3.2
 This is a small release focusing on fixing regressions introduced in 3.3.1.
 


### PR DESCRIPTION
Fix #4247

digest package now requires R >= 3.3, and it seems there's no handy alternatives for it at the moment. We might eventually restore the support in future, but let's drop it for now.