### PR TITLE
Allow scale_{colour/fill}_ordinal() to be configured via new ggplot2.ordinal.{colour/fill} global options. 

### DIFF
--- a/R/zxx.r
+++ b/R/zxx.r
@@ -3,7 +3,15 @@
 #' @export
 #' @rdname scale_viridis
 #' @usage NULL
-scale_colour_ordinal <- scale_colour_viridis_d
+scale_colour_ordinal <- function(..., type = getOption("ggplot2.ordinal.colour", getOption("ggplot2.ordinal.fill"))) {
+  type <- type %||% scale_colour_viridis_d
+  if (is.function(type)) {
+    type(...)
+  } else {
+    discrete_scale("colour", "ordinal", ordinal_pal(type), ...)
+  }
+}
+
 
 #' @export
 #' @rdname scale_viridis
@@ -62,7 +70,21 @@ scale_color_date <- scale_colour_date
 #' @export
 #' @rdname scale_viridis
 #' @usage NULL
-scale_fill_ordinal <- scale_fill_viridis_d
+scale_fill_ordinal <- function(..., type = getOption("ggplot2.ordinal.fill", getOption("ggplot2.ordinal.colour"))) {
+  type <- type %||% scale_fill_viridis_d
+  if (is.function(type)) {
+    type(...)
+  } else {
+    discrete_scale("fill", "ordinal", ordinal_pal(type), ...)
+  }
+}
+
+ordinal_pal <- function(colours, na.color = "grey50", alpha = TRUE) {
+  pal <- scales::colour_ramp(colours, na.color = na.color, alpha = alpha)
+  function(n) {
+    pal(seq(0, 1, length.out = n))
+  }
+}
 
 #' @export
 #' @rdname scale_gradient


### PR DESCRIPTION
Closes #4148. 

Could be seen as a follow-up of sorts to #3833, which added the ability to configure qualitative (i.e., non-ordinal) colourscale defaults. This PR adds a similar ability to configure ordinal colourscale defaults via new `ggplot2.ordinal.{colour/fill}` options:

```r
library(ggplot2)

p <- ggplot(diamonds, aes(price, colour = cut, fill = cut)) + geom_density()
p
```

![image](https://user-images.githubusercontent.com/1365941/100668437-87c98380-3321-11eb-89a5-65d16f6a0fe9.png)


```r
withr::with_options(
  list(ggplot2.ordinal.fill = viridisLite::cividis(10)), p
)
```

![image](https://user-images.githubusercontent.com/1365941/100668406-7aac9480-3321-11eb-91c7-b1a42633ab1c.png)
