### PR TITLE
Compare facet params instead of the whole objects in tests

### DIFF
--- a/tests/testthat/test-facet-.r
+++ b/tests/testthat/test-facet-.r
@@ -125,10 +125,10 @@ test_that("facet_grid() accepts vars()", {
   expect_identical(grid$params$rows, quos(foo = foo))
   expect_identical(grid$params$cols, quos(bar = bar))
 
-  expect_equal(facet_grid(vars(am, vs)), facet_grid(am + vs ~ .))
-  expect_equal(facet_grid(vars(am, vs), vars(cyl)), facet_grid(am + vs ~ cyl))
-  expect_equal(facet_grid(NULL, vars(cyl)), facet_grid(. ~ cyl))
-  expect_equal(facet_grid(vars(am, vs), TRUE), facet_grid(am + vs ~ ., margins = TRUE))
+  expect_equal(facet_grid(vars(am, vs))$params, facet_grid(am + vs ~ .)$params)
+  expect_equal(facet_grid(vars(am, vs), vars(cyl))$params, facet_grid(am + vs ~ cyl)$params)
+  expect_equal(facet_grid(NULL, vars(cyl))$params, facet_grid(. ~ cyl)$params)
+  expect_equal(facet_grid(vars(am, vs), TRUE)$params, facet_grid(am + vs ~ ., margins = TRUE)$params)
 })
 
 test_that("facet_grid() fails if passed both a formula and a vars()", {


### PR DESCRIPTION
(As probably some of you also got the email about this,) `all.equal()` now compares environments on R-devel. And actually the GitHub Action runner on R-devel kept failing from some days ago. This pull request fixes it by narrowing the comparing from the whole ggproto objects to only the meaningful elements.

Note that, this behavior is consistent with that of `expect_equal()` in testthat 3rd edition, which uses `waldo::compare()` and it has no option to ignore the environment generally. If we stick with 2nd edition, we can use `check.environment = FALSE` as a workaround, but probably we will want to move to 3rd edition at some point, so I didn't choose `check.environment`.