### PR TITLE
Add missing US spellings for “scale_grey”

### DIFF
--- a/R/zxx.r
+++ b/R/zxx.r
@@ -171,6 +171,16 @@ scale_color_stepsn <- scale_colour_stepsn
 scale_color_grey <- scale_colour_grey
 
 #' @export
+#' @rdname scale_grey
+#' @usage NULL
+scale_color_gray <- scale_colour_grey
+
+#' @export
+#' @rdname scale_grey
+#' @usage NULL
+scale_fill_gray <- scale_fill_grey
+
+#' @export
 #' @rdname scale_hue
 #' @usage NULL
 scale_color_hue <- scale_colour_hue


### PR DESCRIPTION
As per #1901: [“gray” is the predominant US spelling](https://www.merriam-webster.com/dictionary/gray). The purpose of this PR is to increase discoverability for en-US speakers as well as non-native English speakers whose first exposure is to US English spelling rather than UK/AU/NZ.

This PR keeps the existing, less common spelling `scale_color_grey` for backwards compatibility.