### PR TITLE
Toggle the logic of skipping visual tests

### DIFF
--- a/tests/testthat/helper-vdiffr.R
+++ b/tests/testthat/helper-vdiffr.R
@@ -1,12 +1,12 @@
-# vdiffr ignores failures when
-#   - VDIFFR_RUN_TESTS is "false" (on Travis CI with older versions and dev version of R)
-#   - CI is not set (on CRAN)
+# By default, if vdiffr is not installed, all visual tests are skipped unless
+# VDIFFR_RUN_TESTS is explicitly set to "true", which should be the case only on
+# a GitHub Actions CI runner with stable version of R.
 
 if (requireNamespace("vdiffr", quietly = TRUE)) {
   expect_doppelganger <- vdiffr::expect_doppelganger
 } else {
-  # If vdiffr is not available and visual tests are not explicitly disabled, raise error.
-  if (!identical(Sys.getenv("VDIFFR_RUN_TESTS"), "false")) {
+  # If vdiffr is not available and visual tests are explicitly required, raise error.
+  if (identical(Sys.getenv("VDIFFR_RUN_TESTS"), "true")) {
     abort("vdiffr is not installed")
   }
 


### PR DESCRIPTION
Fix #4293

At the time of implementing #4192, I was afraid that visual tests would be silently ignored on the CI (and we would oversight some bugs), so I chose the following logic:

* When vdiffr is not available, do raise an error unless `VDIFFR_RUN_TESTS` envvar is explicitly set to *`false`*

but this ends up failure on CRAN checks. So, this pull request toggle the logic to the following for safety. This should fix the CRAN checks.

* When vdiffr is not available, do NOT raise an error unless `VDIFFR_RUN_TESTS` envvar is explicitly set to *`true`*