### PR TITLE
Facets now don't fail if faceting vars are COL, ROW, etc.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* `facet_grid()` and `facet_wrap()` now don't fail when faceting variables are named
+"COL", "ROW", "PANEL", "SCALE_X" or "SCALE_Y". (@eliocamp, #4138)
+
 * `ggsave()` now sets the default background to match the fill value of the
   `plot.background` theme element (@karawoo, #4057)
 

--- a/tests/testthat/test-facet-.r
+++ b/tests/testthat/test-facet-.r
@@ -344,6 +344,32 @@ test_that("eval_facet() is tolerant for missing columns (#2963)", {
   )
 })
 
+
+test_that("facets work with columns named ROW, COL, PANEL, usw...", {
+  data(mtcars)
+
+  mtcars$ROW <- mtcars$cyl
+  mtcars$COL <- mtcars$cyl
+  mtcars$PANEL <- mtcars$cyl
+  mtcars$SCALE_X <- mtcars$cyl
+  mtcars$SCALE_Y <- mtcars$cyl
+
+
+  base <- ggplot(mtcars, aes(hp, mpg)) +
+    geom_point()
+
+  cols <- c("COL", "ROW", "PANEL", "SCALE_X", "SCALE_Y")
+
+  sink <- lapply(cols, function(col) {
+    expect_error(print(base + facet_wrap(as.formula(paste0(col, " ~  am")))), NA)
+  })
+
+  sink <- lapply(cols, function(col) {
+    expect_error(print(base + facet_grid(as.formula(paste0(col, " ~  am")))), NA)
+  })
+
+})
+
 # Visual tests ------------------------------------------------------------
 
 test_that("facet labels respect both justification and margin arguments", {


### PR DESCRIPTION
This will close #4138. 

Works around the issue of duplicated column names by explicitly selecting either data columns or layout columns in the `layout` data.frame when needed. Added tests that pass. 

reprex :)

``` r
library(ggplot2)
mtcars$PANEL <- mtcars$cyl


ggplot(mtcars, aes(hp, mpg)) +
  geom_point() +
  facet_grid(cyl ~  am) 
```

![](https://i.imgur.com/vQ8g8XO.png)

``` r

ggplot(mtcars, aes(hp, mpg)) +
  geom_point() +
  facet_grid(PANEL ~  am) 
```

![](https://i.imgur.com/5euvaDX.png)

<sup>Created on 2021-01-12 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>