### PR TITLE
Export `add()` as alias for `+`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@
 
 * ggplot2 now requires R >= 3.3 (#4247).
 
+* Export `add()` as a alias for `+`, to facilitate ggplot2 usage with the native R pipe `|>` (@bmwiernik, #4357)
+
 # ggplot2 3.3.3
 This is a small patch release mainly intended to address changes in R and CRAN.
 It further changes the licensing model of ggplot2 to an MIT license.

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -618,3 +618,18 @@ split_with_index <- function(x, f, n = max(f)) {
   attributes(f) <- list(levels = as.character(seq_len(n)), class = "factor")
   unname(split(x, f))
 }
+
+#' Add a layer to a ggplot
+#'
+#' `add()` is an alias for `+`.
+#' `add()` can be used with the base R pipe `|>`, which prohibits `+`.
+#' Its functionality is otherwise identical to `+`.
+#'
+#' @export
+#' @examples
+#' \dontrun{
+#' ggplot(diamonds, aes(carat, price)) |>
+#'   add(geom_point()) |>
+#'   add(geom_smooth(method = "lm", colour = "blue"))
+#' }
+add <- `+`


### PR DESCRIPTION
This facilitates ggplot2 usage with the R 4.1 native pipe `|>`, which prohibits `+` on the RHS.

```r
diamonds |>
  ggplot(diamonds, aes(carat, price)) |>
  add(geom_point())
```

Also enables a workflow involving the magrittr pipe:

```r
diamonds %>%
  ggplot(diamonds, aes(carat, price)) %>%
  add(geom_point())
```

cf. https://github.com/tidyverse/ggplot2/issues/4357
cf. https://github.com/tidyverse/ggplot2/pull/4359