### PR TITLE
Show a function name instead of function call on ggsave's doc

### DIFF
--- a/R/save.r
+++ b/R/save.r
@@ -25,7 +25,7 @@
 #' @param filename File name to create on disk.
 #' @param plot Plot to save, defaults to last plot displayed.
 #' @param device Device to use. Can either be a device function
-#'   (e.g. [png()]), or one of "eps", "ps", "tex" (pictex),
+#'   (e.g. [png]), or one of "eps", "ps", "tex" (pictex),
 #'   "pdf", "jpeg", "tiff", "png", "bmp", "svg" or "wmf" (windows only).
 #' @param path Path of the directory to save plot to: `path` and `filename`
 #'   are combined to create the fully qualified file name. Defaults to the

--- a/man/ggsave.Rd
+++ b/man/ggsave.Rd
@@ -25,7 +25,7 @@ ggsave(
 \item{plot}{Plot to save, defaults to last plot displayed.}
 
 \item{device}{Device to use. Can either be a device function
-(e.g. \code{\link[=png]{png()}}), or one of "eps", "ps", "tex" (pictex),
+(e.g. \link{png}), or one of "eps", "ps", "tex" (pictex),
 "pdf", "jpeg", "tiff", "png", "bmp", "svg" or "wmf" (windows only).}
 
 \item{path}{Path of the directory to save plot to: \code{path} and \code{filename}


### PR DESCRIPTION
Currently the document says

> Can either be a device function (e.g. `png()`), or ...

but we cannot specify `png()`, but `png`. This seems slightly misleading.

c.f. https://github.com/tidyverse/ggplot2/issues/4347#issuecomment-800095723