### PR TITLE
Use rlang::check_installed()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     isoband,
     MASS,
     mgcv,
-    rlang (>= 0.3.0),
+    rlang (>= 0.4.10),
     scales (>= 0.5.0),
     stats,
     tibble,

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,10 @@
 
 * ggplot2 now requires R >= 3.3 (#4247).
 
+* ggplot2 now uses `rlang::check_installed()` to check if a suggested package is
+  installed, which will offer to install the package before continuing (#4375, 
+  @malcolmbarrett)
+
 # ggplot2 3.3.3
 This is a small patch release mainly intended to address changes in R and CRAN.
 It further changes the licensing model of ggplot2 to an MIT license.

--- a/R/coord-map.r
+++ b/R/coord-map.r
@@ -318,7 +318,7 @@ CoordMap <- ggproto("CoordMap", Coord,
 
 
 mproject <- function(coord, x, y, orientation) {
-  check_installed("mapproj")
+  check_installed("mapproj", reason = "for `coord_map()`")
   suppressWarnings(mapproj::mapproject(x, y,
     projection = coord$projection,
     parameters  = coord$params,

--- a/R/coord-map.r
+++ b/R/coord-map.r
@@ -318,6 +318,7 @@ CoordMap <- ggproto("CoordMap", Coord,
 
 
 mproject <- function(coord, x, y, orientation) {
+  check_installed("mapproj")
   suppressWarnings(mapproj::mapproject(x, y,
     projection = coord$projection,
     parameters  = coord$params,

--- a/R/fortify-map.r
+++ b/R/fortify-map.r
@@ -75,7 +75,7 @@ fortify.map <- function(model, data, ...) {
 #'   coord_map("albers",  lat0 = 45.5, lat1 = 29.5)
 #' }
 map_data <- function(map, region = ".", exact = FALSE, ...) {
-  try_require("maps", "map_data")
+  check_installed("maps")
   map_obj <- maps::map(map, region, exact = exact, plot = FALSE, fill = TRUE, ...)
   fortify(map_obj)
 }

--- a/R/fortify-map.r
+++ b/R/fortify-map.r
@@ -75,7 +75,7 @@ fortify.map <- function(model, data, ...) {
 #'   coord_map("albers",  lat0 = 45.5, lat1 = 29.5)
 #' }
 map_data <- function(map, region = ".", exact = FALSE, ...) {
-  check_installed("maps")
+  check_installed("maps", reason = "for `map_data()`")
   map_obj <- maps::map(map, region, exact = exact, plot = FALSE, fill = TRUE, ...)
   fortify(map_obj)
 }

--- a/R/fortify.r
+++ b/R/fortify.r
@@ -17,9 +17,7 @@ fortify.data.frame <- function(model, data, ...) model
 fortify.tbl_df <- function(model, data, ...) model
 #' @export
 fortify.tbl <- function(model, data, ...) {
-  if (!requireNamespace("dplyr", quietly = TRUE)) {
-    abort("dplyr must be installed to work with tbl objects")
-  }
+  check_installed("dplyr")
   dplyr::collect(model)
 }
 #' @export
@@ -31,9 +29,7 @@ fortify.function <- function(model, data, ...) model
 fortify.formula <- function(model, data, ...) as_function(model)
 #' @export
 fortify.grouped_df <- function(model, data, ...) {
-  if (!requireNamespace("dplyr", quietly = TRUE)) {
-    abort("dplyr must be installed to work with grouped_df objects")
-  }
+  check_installed("dplyr")
   model$.group <- dplyr::group_indices(model)
   model
 }

--- a/R/fortify.r
+++ b/R/fortify.r
@@ -17,7 +17,7 @@ fortify.data.frame <- function(model, data, ...) model
 fortify.tbl_df <- function(model, data, ...) model
 #' @export
 fortify.tbl <- function(model, data, ...) {
-  check_installed("dplyr")
+  check_installed("dplyr", reason = "to work with `tbl` objects")
   dplyr::collect(model)
 }
 #' @export
@@ -29,7 +29,7 @@ fortify.function <- function(model, data, ...) model
 fortify.formula <- function(model, data, ...) as_function(model)
 #' @export
 fortify.grouped_df <- function(model, data, ...) {
-  check_installed("dplyr")
+  check_installed("dplyr", reason = "to work with `grouped_df` objects")
   model$.group <- dplyr::group_indices(model)
   model
 }

--- a/R/stat-binhex.r
+++ b/R/stat-binhex.r
@@ -49,7 +49,7 @@ StatBinhex <- ggproto("StatBinhex", Stat,
 
   compute_group = function(data, scales, binwidth = NULL, bins = 30,
                            na.rm = FALSE) {
-    try_require("hexbin", "stat_binhex")
+    check_installed("hexbin")
 
     binwidth <- binwidth %||% hex_binwidth(bins, scales)
     wt <- data$weight %||% rep(1L, nrow(data))

--- a/R/stat-binhex.r
+++ b/R/stat-binhex.r
@@ -49,7 +49,7 @@ StatBinhex <- ggproto("StatBinhex", Stat,
 
   compute_group = function(data, scales, binwidth = NULL, bins = 30,
                            na.rm = FALSE) {
-    check_installed("hexbin")
+    check_installed("hexbin", reason = "for `stat_binhex()`")
 
     binwidth <- binwidth %||% hex_binwidth(bins, scales)
     wt <- data$weight %||% rep(1L, nrow(data))

--- a/R/stat-quantile.r
+++ b/R/stat-quantile.r
@@ -50,7 +50,7 @@ StatQuantile <- ggproto("StatQuantile", Stat,
   compute_group = function(data, scales, quantiles = c(0.25, 0.5, 0.75),
                            formula = NULL, xseq = NULL, method = "rq",
                            method.args = list(), lambda = 1, na.rm = FALSE) {
-    try_require("quantreg", "stat_quantile")
+    check_installed("quantreg")
 
     if (is.null(formula)) {
       if (method == "rqss") {

--- a/R/stat-quantile.r
+++ b/R/stat-quantile.r
@@ -50,7 +50,7 @@ StatQuantile <- ggproto("StatQuantile", Stat,
   compute_group = function(data, scales, quantiles = c(0.25, 0.5, 0.75),
                            formula = NULL, xseq = NULL, method = "rq",
                            method.args = list(), lambda = 1, na.rm = FALSE) {
-    check_installed("quantreg")
+    check_installed("quantreg", reason = "for `stat_quantile()`")
 
     if (is.null(formula)) {
       if (method == "rqss") {

--- a/R/stat-summary-hex.r
+++ b/R/stat-summary-hex.r
@@ -43,7 +43,7 @@ StatSummaryHex <- ggproto("StatSummaryHex", Stat,
 
   compute_group = function(data, scales, binwidth = NULL, bins = 30, drop = TRUE,
                            fun = "mean", fun.args = list()) {
-    check_installed("hexbin")
+    check_installed("hexbin", reason = "for `stat_summary_hex()`")
 
     binwidth <- binwidth %||% hex_binwidth(bins, scales)
     fun <- as_function(fun)

--- a/R/stat-summary-hex.r
+++ b/R/stat-summary-hex.r
@@ -43,7 +43,7 @@ StatSummaryHex <- ggproto("StatSummaryHex", Stat,
 
   compute_group = function(data, scales, binwidth = NULL, bins = 30, drop = TRUE,
                            fun = "mean", fun.args = list()) {
-    try_require("hexbin", "stat_summary_hex")
+    check_installed("hexbin")
 
     binwidth <- binwidth %||% hex_binwidth(bins, scales)
     fun <- as_function(fun)

--- a/R/stat-summary.r
+++ b/R/stat-summary.r
@@ -245,8 +245,7 @@ NULL
 wrap_hmisc <- function(fun) {
 
   function(x, ...) {
-    if (!requireNamespace("Hmisc", quietly = TRUE))
-      abort("Hmisc package required for this function")
+    check_installed("Hmisc")
 
     fun <- getExportedValue("Hmisc", fun)
     result <- do.call(fun, list(x = quote(x), ...))

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -56,22 +56,6 @@ clist <- function(l) {
   paste(paste(names(l), l, sep = " = ", collapse = ", "), sep = "")
 }
 
-
-# Test whether package `package` is available. `fun` provides
-# the name of the ggplot2 function that uses this package, and is
-# used only to produce a meaningful error message if the
-# package is not available.
-try_require <- function(package, fun) {
-  if (requireNamespace(package, quietly = TRUE)) {
-    return(invisible())
-  }
-
-  abort(glue("
-    Package `{package}` required for `{fun}`.
-    Please install and try again.
-  "))
-}
-
 # Return unique columns
 # This is used for figuring out which columns are constant within a group
 #


### PR DESCRIPTION
This PR replaces various `requireNamespace()` + `abort()` checks with the new rlang function `check_installed()`, which offers to install the suggested package then proceeds or aborts. This PR also bumps the rlang dependency to 0.4.10

<img width="656" alt="Screen Shot 2021-03-17 at 3 23 00 PM" src="https://user-images.githubusercontent.com/23123711/111546650-39f05400-8735-11eb-9f13-1e211610090d.png">

I didn't use the `reason` argument in any `check_installed()` calls, which can add a bit of context. I'd be happy to add that, if desired.

Closes #4370, fixes #4344