### PR TITLE
Fix pkgdown navbar

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -36,8 +36,8 @@ jobs:
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE, type = "binary")
-          remotes::install_github("tidyverse/tidytemplate")
-          remotes::install_dev("pkgdown")
+          remotes::install_github("tidyverse/tidytemplate", type = "binary")
+          remotes::install_dev("pkgdown", type = "binary")
         shell: Rscript {0}
 
       - name: Install package

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -264,7 +264,7 @@ news:
 
 navbar:
   structure:
-    right: [extensions, github]
+    right: [reference, news, articles, extensions, github]
   components:
     home: ~
     extensions:


### PR DESCRIPTION
Fix  #4376

I'm not sure when the behaviour changed, but it seems pkgdown now requires to list all the topics in `structure`. At least this works fine on my forked repo:

https://yutannihilation.github.io/ggplot2/dev/