### PR TITLE
Transform all the sfc columns independently

### DIFF
--- a/R/coord-sf.R
+++ b/R/coord-sf.R
@@ -62,7 +62,9 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
         return(layer_data)
       }
 
-      sf::st_transform(layer_data, params$crs)
+      idx <- vapply(layer_data, inherits, what = "sfc", FUN.VALUE = logical(1L))
+      layer_data[idx] <- lapply(layer_data[idx], sf::st_transform, crs = params$crs)
+      layer_data
     })
   },
 


### PR DESCRIPTION
Fix #4362

Currently, transformation is done by `sf::st_transform()` on the `sf` data, but in this case only the "active" geometry column is transformed, which is the intended behaviour (c.f., https://github.com/r-spatial/sf/issues/1620#issuecomment-790654565).

https://github.com/tidyverse/ggplot2/blob/4555055ce6e23e5b0630122fd9cc2aaf8cb1f91a/R/coord-sf.R#L55-L67

This pull request applies the transformation on all of the `sfc` columns in the data independently.