### PR TITLE
Ignore missing facet specs

### DIFF
--- a/R/facet-.r
+++ b/R/facet-.r
@@ -318,8 +318,8 @@ as_facets_list <- function(x) {
 # Flatten a list of quosures objects to a quosures object, and compact it
 compact_facets <- function(x) {
   x <- flatten_if(x, is_list)
-  null <- vapply(x, quo_is_null, logical(1))
-  new_quosures(x[!null])
+  null_or_missing <- vapply(x, function(x) quo_is_null(x) || quo_is_missing(x), logical(1))
+  new_quosures(x[!null_or_missing])
 }
 
 # Compatibility with plyr::as.quoted()

--- a/tests/testthat/test-facet-.r
+++ b/tests/testthat/test-facet-.r
@@ -52,13 +52,25 @@ test_that("facets reject aes()", {
 test_that("wrap_as_facets_list() returns a quosures object with compacted", {
   expect_identical(wrap_as_facets_list(vars(foo)), quos(foo = foo))
   expect_identical(wrap_as_facets_list(~foo + bar), quos(foo = foo, bar = bar))
-  expect_identical(wrap_as_facets_list(vars(foo, NULL, bar)), quos(foo = foo, bar = bar))
+
+  f <- function(x) {
+    expect_identical(wrap_as_facets_list(vars(foo, {{ x }}, bar)), quos(foo = foo, bar = bar))
+  }
+
+  f(NULL)
+  f()
 })
 
 test_that("grid_as_facets_list() returns a list of quosures objects with compacted", {
   expect_identical(grid_as_facets_list(vars(foo), NULL), list(rows = quos(foo = foo), cols = quos()))
   expect_identical(grid_as_facets_list(~foo, NULL), list(rows = quos(), cols = quos(foo = foo)))
-  expect_identical(grid_as_facets_list(vars(foo, NULL, bar), NULL), list(rows = quos(foo = foo, bar = bar), cols = quos()))
+
+  f <- function(x) {
+    expect_identical(grid_as_facets_list(vars(foo, {{ x }}, bar), NULL), list(rows = quos(foo = foo, bar = bar), cols = quos()))
+  }
+
+  f(NULL)
+  f()
 })
 
 test_that("wrap_as_facets_list() and grid_as_facets_list() accept empty specs", {


### PR DESCRIPTION
Fix #4319 

This is a follow-up of #3162; at that time I considered only `NULL`, but probably missing arguments should be ignored as well. Here's the use case:

``` r
devtools::load_all("~/repo/ggplot2")
#> ℹ Loading ggplot2

f <- function(facet) {
  ggplot(mpg, aes(displ, hwy)) +
    geom_point() +
    facet_wrap(vars({{ facet }}))
}

f()
```

![](https://i.imgur.com/1uu1mtZ.png)

``` r
f(cyl)
```

![](https://i.imgur.com/VZEbzKw.png)

<sup>Created on 2021-03-19 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>