### PR TITLE
Capture error with hint when piping plots into facets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,9 @@
   installed, which will offer to install the package before continuing (#4375, 
   @malcolmbarrett)
 
+* Improved error with hint when piping a `ggplot` object into a facet function
+  (#4379, @mitchelloharawild).
+
 # ggplot2 3.3.3
 This is a small patch release mainly intended to address changes in R and CRAN.
 It further changes the licensing model of ggplot2 to an MIT license.

--- a/R/facet-.r
+++ b/R/facet-.r
@@ -276,9 +276,7 @@ df.grid <- function(a, b) {
 # facetting variables.
 
 as_facets_list <- function(x) {
-  if (inherits(x, "uneval")) {
-    abort("Please use `vars()` to supply facet variables")
-  }
+  x <- validate_facets(x)
   if (is_quosures(x)) {
     x <- quos_auto_name(x)
     return(list(x))
@@ -314,6 +312,19 @@ as_facets_list <- function(x) {
 
   x
 }
+
+validate_facets <- function(x) {
+  if (inherits(x, "uneval")) {
+    abort("Please use `vars()` to supply facet variables")
+  }
+  if (inherits(x, "ggplot")) {
+    abort(
+      "Please use `vars()` to supply facet variables\nDid you use %>% instead of +?"
+    )
+  }
+  x
+}
+
 
 # Flatten a list of quosures objects to a quosures object, and compact it
 compact_facets <- function(x) {

--- a/R/facet-grid-.r
+++ b/R/facet-grid-.r
@@ -157,7 +157,14 @@ grid_as_facets_list <- function(rows, cols) {
   is_rows_vars <- is.null(rows) || is_quosures(rows)
   if (!is_rows_vars) {
     if (!is.null(cols)) {
-      abort("`rows` must be `NULL` or a `vars()` list if `cols` is a `vars()` list")
+      msg <- "`rows` must be `NULL` or a `vars()` list if `cols` is a `vars()` list"
+      if(inherits(rows, "ggplot")) {
+        msg <- paste0(
+          msg, "\n",
+          "Did you use %>% instead of +?"
+        )
+      }
+      abort(msg)
     }
     # For backward-compatibility
     facets_list <- as_facets_list(rows)

--- a/R/facet-wrap.r
+++ b/R/facet-wrap.r
@@ -86,6 +86,13 @@ facet_wrap <- function(facets, nrow = NULL, ncol = NULL, scales = "fixed",
     x = any(scales %in% c("free_x", "free")),
     y = any(scales %in% c("free_y", "free"))
   )
+
+  # Check for deprecated labellers
+  labeller <- check_labeller(labeller)
+
+  # Flatten all facets dimensions into a single one
+  facets <- wrap_as_facets_list(facets)
+
   if (!is.null(switch)) {
     .Deprecated("strip.position", old = "switch")
     strip.position <- if (switch == "x") "bottom" else "left"
@@ -101,12 +108,6 @@ facet_wrap <- function(facets, nrow = NULL, ncol = NULL, scales = "fixed",
     nrow <- sanitise_dim(nrow)
     ncol <- sanitise_dim(ncol)
   }
-
-  # Check for deprecated labellers
-  labeller <- check_labeller(labeller)
-
-  # Flatten all facets dimensions into a single one
-  facets <- wrap_as_facets_list(facets)
 
   ggproto(NULL, FacetWrap,
     shrink = shrink,


### PR DESCRIPTION
Resolves #4379

Piping a plot into a `layer()` gives a helpful error with a hint:
``` r
ggplot(diamonds) %>% 
  geom_point(aes(price, carat))
#> Error: `mapping` must be created by `aes()`
#> Did you use %>% instead of +?
```

This pull request adds this hint and better captures the error when piping into facets:

**Before**
``` r
library(ggplot2)
library(magrittr)
ggplot(diamonds) %>% 
  facet_grid(vars(cut))
#> Error: `rows` must be `NULL` or a `vars()` list if `cols` is a `vars()` list
ggplot(diamonds) %>% 
  facet_grid()
#> <ggproto object: Class FacetGrid, Facet, gg>
#>     compute_layout: function
#>     draw_back: function
#>     draw_front: function
#>     draw_labels: function
#>     draw_panels: function
#>     finish_data: function
#>     init_scales: function
#>     map_data: function
#>     params: list
#>     setup_data: function
#>     setup_params: function
#>     shrink: TRUE
#>     train_scales: function
#>     vars: function
#>     super:  <ggproto object: Class FacetGrid, Facet, gg>
ggplot(diamonds) %>% 
  facet_wrap(vars(cut))
#> Warning: Coercing `nrow` to be an integer.
#> Error in sanitise_dim(nrow): 'list' object cannot be coerced to type 'integer'
ggplot(diamonds) %>% 
  facet_wrap()
#> <ggproto object: Class FacetWrap, Facet, gg>
#>     compute_layout: function
#>     draw_back: function
#>     draw_front: function
#>     draw_labels: function
#>     draw_panels: function
#>     finish_data: function
#>     init_scales: function
#>     map_data: function
#>     params: list
#>     setup_data: function
#>     setup_params: function
#>     shrink: TRUE
#>     train_scales: function
#>     vars: function
#>     super:  <ggproto object: Class FacetWrap, Facet, gg>
```

<sup>Created on 2021-03-23 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>

**After**
``` r
library(ggplot2)
library(magrittr)
ggplot(diamonds) %>% 
  facet_grid(vars(cut))
#> Error: `rows` must be `NULL` or a `vars()` list if `cols` is a `vars()` list
#> Did you use %>% instead of +?
ggplot(diamonds) %>% 
  facet_grid()
#> Error: Please use `vars()` to supply facet variables
#> Did you use %>% instead of +?
ggplot(diamonds) %>% 
  facet_wrap(vars(cut))
#> Error: Please use `vars()` to supply facet variables
#> Did you use %>% instead of +?
ggplot(diamonds) %>% 
  facet_wrap()
#> Error: Please use `vars()` to supply facet variables
#> Did you use %>% instead of +?
```

<sup>Created on 2021-03-23 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>