### PR TITLE
Make sure jitter is only calculated once

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Fix a bug in `position_jitter()` where different jitters would be applied to 
+  different position aesthetics of the same axis (@thomasp85, #2941)
+
 * `coord_sf()` now has an argument `default_crs` that specifies the coordinate
   reference system (CRS) for non-sf layers and scale/coord limits. This argument
   defaults to the World Geodetic System 1984 (WGS84), which means x and y positions

--- a/R/position-jitter.r
+++ b/R/position-jitter.r
@@ -77,9 +77,9 @@ PositionJitter <- ggproto("PositionJitter", Position,
     trans_y <- if (params$height > 0) function(x) jitter(x, amount = params$height)
 
     # Make sure x and y jitter is only calculated once for all position aesthetics
-    x_aes <- intersect(names(data), ggplot_global$x_aes)
+    x_aes <- intersect(ggplot_global$x_aes, names(data))
     x <- if (length(x_aes) == 0) 0 else data[[x_aes[1]]]
-    y_aes <- intersect(names(data), ggplot_global$y_aes)
+    y_aes <- intersect(ggplot_global$y_aes, names(data))
     y <- if (length(y_aes) == 0) 0 else data[[y_aes[1]]]
     dummy_data <- new_data_frame(list(x = x, y = y), nrow(data))
     fixed_jitter <- with_seed_null(params$seed, transform_position(dummy_data, trans_x, trans_y))

--- a/R/position-jitter.r
+++ b/R/position-jitter.r
@@ -77,10 +77,16 @@ PositionJitter <- ggproto("PositionJitter", Position,
     trans_y <- if (params$height > 0) function(x) jitter(x, amount = params$height)
 
     # Make sure x and y jitter is only calculated once for all position aesthetics
-    dummy_data <- data.frame(x = rep(0, nrow(data)), y = rep(0, nrow(data)))
+    x_aes <- intersect(names(data), ggplot_global$x_aes)
+    x <- if (length(x_aes) == 0) 0 else data[[x_aes[1]]]
+    y_aes <- intersect(names(data), ggplot_global$y_aes)
+    y <- if (length(y_aes) == 0) 0 else data[[y_aes[1]]]
+    dummy_data <- new_data_frame(list(x = x, y = y), nrow(data))
     fixed_jitter <- with_seed_null(params$seed, transform_position(dummy_data, trans_x, trans_y))
+    x_jit <- fixed_jitter$x - x
+    y_jit <- fixed_jitter$y - y
 
     # Apply jitter
-    transform_position(data, function(x) x + fixed_jitter$x, function(x) x + fixed_jitter$y)
+    transform_position(data, function(x) x + x_jit, function(x) x + y_jit)
   }
 )

--- a/R/position-jitter.r
+++ b/R/position-jitter.r
@@ -76,6 +76,11 @@ PositionJitter <- ggproto("PositionJitter", Position,
     trans_x <- if (params$width > 0) function(x) jitter(x, amount = params$width)
     trans_y <- if (params$height > 0) function(x) jitter(x, amount = params$height)
 
-    with_seed_null(params$seed, transform_position(data, trans_x, trans_y))
+    # Make sure x and y jitter is only calculated once for all position aesthetics
+    dummy_data <- data.frame(x = rep(0, nrow(data)), y = rep(0, nrow(data)))
+    fixed_jitter <- with_seed_null(params$seed, transform_position(dummy_data, trans_x, trans_y))
+
+    # Apply jitter
+    transform_position(data, function(x) x + fixed_jitter$x, function(x) x + fixed_jitter$y)
   }
 )


### PR DESCRIPTION
Fix #2941 

This PR changes the jitter position implementation to calculate a jitter once for `x` and `y` and then apply that to all position aesthetics