### PR TITLE
Revert "Add missing US spellings for “scale_grey” (#4299)"

### DIFF
--- a/R/zxx.r
+++ b/R/zxx.r
@@ -193,16 +193,6 @@ scale_color_stepsn <- scale_colour_stepsn
 scale_color_grey <- scale_colour_grey
 
 #' @export
-#' @rdname scale_grey
-#' @usage NULL
-scale_color_gray <- scale_colour_grey
-
-#' @export
-#' @rdname scale_grey
-#' @usage NULL
-scale_fill_gray <- scale_fill_grey
-
-#' @export
 #' @rdname scale_hue
 #' @usage NULL
 scale_color_hue <- scale_colour_hue


### PR DESCRIPTION
This reverts commit a8352072a048249224f6e517e817e6ac72477c47.

As discussed, adding the additional spelling is more trouble than it is worth so this PR reverts it