### PR TITLE
Move seed setup in `position_jitter()` to `setup_params()` from the constructor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Make sure position_jitter creates the same jittering independent of whether it
+  is called by name or with constructor (@thomasp85, #2507)
+
 * Fix a bug in `position_dodge2()` where `NA` values in thee data would cause an
   error (@thomasp85, #2905)
 

--- a/R/position-jitter.r
+++ b/R/position-jitter.r
@@ -46,10 +46,6 @@
 #'   geom_point(position = jitter) +
 #'   geom_point(position = jitter, color = "red", aes(am + 0.2, vs + 0.2))
 position_jitter <- function(width = NULL, height = NULL, seed = NA) {
-  if (!is.null(seed) && is.na(seed)) {
-    seed <- sample.int(.Machine$integer.max, 1L)
-  }
-
   ggproto(NULL, PositionJitter,
     width = width,
     height = height,
@@ -62,13 +58,19 @@ position_jitter <- function(width = NULL, height = NULL, seed = NA) {
 #' @usage NULL
 #' @export
 PositionJitter <- ggproto("PositionJitter", Position,
+  seed = NA,
   required_aes = c("x", "y"),
 
   setup_params = function(self, data) {
+    if (!is.null(self$seed) && is.na(self$seed)) {
+      seed <- sample.int(.Machine$integer.max, 1L)
+    } else {
+      seed <- self$seed
+    }
     list(
       width = self$width %||% (resolution(data$x, zero = FALSE) * 0.4),
       height = self$height %||% (resolution(data$y, zero = FALSE) * 0.4),
-      seed = self$seed
+      seed = seed
     )
   },
 


### PR DESCRIPTION
Fix #2507 

This PR implements @paleolimbot suggested fix. I think it is brittle to rely on calling the constructor, because it is also valid (but weird) to pass in PositionJitter directly

I think we should aim for all ggproto objects to be self-sufficient, i.e. have next to no logic in the constructors