### PR TITLE
Make sure that expressions are reencoded as expressions when collapsed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Fix bug in `labeller()` where parsing was turned off if `.multiline = FALSE`
+  (@thomasp85, #4084)
+
 * Fix bug in `geom_dotplot()` where dots would be positioned wrong with 
   `stackgroups = TRUE` (@thomasp85, #1745)
 

--- a/R/labeller.r
+++ b/R/labeller.r
@@ -91,7 +91,7 @@ collapse_labels_lines <- function(labels) {
   is_exp <- vapply(labels, function(l) length(l) > 0 && is.expression(l[[1]]), logical(1))
   out <- do.call("Map", c(list(paste, sep = ", "), labels))
   label <- list(unname(unlist(out)))
-  if (any(is_exp)) {
+  if (all(is_exp)) {
     label <- lapply(label, function(l) list(parse(text = paste0("list(", l, ")"))))
   }
   label

--- a/R/labeller.r
+++ b/R/labeller.r
@@ -88,8 +88,13 @@
 NULL
 
 collapse_labels_lines <- function(labels) {
+  is_exp <- vapply(labels, function(l) length(l) > 0 && is.expression(l[[1]]), logical(1))
   out <- do.call("Map", c(list(paste, sep = ", "), labels))
-  list(unname(unlist(out)))
+  label <- list(unname(unlist(out)))
+  if (any(is_exp)) {
+    label <- lapply(label, function(l) list(parse(text = paste0("list(", l, ")"))))
+  }
+  label
 }
 
 #' @rdname labellers


### PR DESCRIPTION
Fix #4084 

There is one "issue" in that parsing is either, or. Right now it will re-add parsing if *any* label is an expression which could potentially lead to errors if there is a mix of expressions and not (I'm not sure if that is possible) and the non-expressions cannot be parsed...

Alternatively we could only do this if *all* labels are expressions...

``` r
library("ggplot2")

dat <- data.frame(x = 1, y = 1, a = "a", b = 1)

ggplot(dat, aes(x, y)) +
  geom_point() +
  facet_grid(
    ~ a + b,
    labeller = labeller(
      a = c("a" = "a^2"),
      .default = label_parsed,
      .multi_line = FALSE
    )
  )
```

![](https://i.imgur.com/JlFnXyx.png)

<sup>Created on 2021-04-14 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>