### PR TITLE
Only apply limits if they are not NA in plot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Fix a bug in `qplot()` when supplying `c(NA, NA)` as axis limits 
+  (@thomasp85, #4027)
+
 * Fix bug in `geom_dotplot()` where dots would be positioned wrong with 
   `stackgroups = TRUE` (@thomasp85, #1745)
 

--- a/R/quick-plot.r
+++ b/R/quick-plot.r
@@ -166,8 +166,8 @@ qplot <- function(x, y, ..., data, facets = NULL, margins = FALSE,
   if (!missing(xlab)) p <- p + xlab(xlab)
   if (!missing(ylab)) p <- p + ylab(ylab)
 
-  if (!missing(xlim)) p <- p + xlim(xlim)
-  if (!missing(ylim)) p <- p + ylim(ylim)
+  if (!missing(xlim) && !all(is.na(xlim))) p <- p + xlim(xlim)
+  if (!missing(ylim) && !all(is.na(ylim))) p <- p + ylim(ylim)
 
   p
 }


### PR DESCRIPTION
Fix #4027 

This PR simply catches the case where the user supplies `c(NA, NA)` as limits and ignores it