### PR TITLE
Add example showing how to use the fill argument in stat_function()

### DIFF
--- a/R/geom-function.R
+++ b/R/geom-function.R
@@ -32,6 +32,8 @@
 #'
 #' base + stat_function(fun = dnorm, geom = "point", n = 20)
 #'
+#' base + stat_function(fun = dnorm, geom = "density", color = "blue", fill = "blue", alpha = 0.5)
+#'
 #' base + geom_function(fun = dnorm, n = 20)
 #'
 #' # Two functions on the same plot

--- a/R/geom-function.R
+++ b/R/geom-function.R
@@ -32,7 +32,7 @@
 #'
 #' base + stat_function(fun = dnorm, geom = "point", n = 20)
 #'
-#' base + stat_function(fun = dnorm, geom = "density", color = "blue", fill = "blue", alpha = 0.5)
+#' base + stat_function(fun = dnorm, geom = "polygon", color = "blue", fill = "blue", alpha = 0.5)
 #'
 #' base + geom_function(fun = dnorm, n = 20)
 #'

--- a/man/geom_function.Rd
+++ b/man/geom_function.Rd
@@ -130,6 +130,8 @@ base + stat_function(fun = dnorm, geom = "point")
 
 base + stat_function(fun = dnorm, geom = "point", n = 20)
 
+base + stat_function(fun = dnorm, geom = "density", color = "blue", fill = "blue", alpha = 0.5)
+
 base + geom_function(fun = dnorm, n = 20)
 
 # Two functions on the same plot

--- a/man/geom_function.Rd
+++ b/man/geom_function.Rd
@@ -130,7 +130,7 @@ base + stat_function(fun = dnorm, geom = "point")
 
 base + stat_function(fun = dnorm, geom = "point", n = 20)
 
-base + stat_function(fun = dnorm, geom = "density", color = "blue", fill = "blue", alpha = 0.5)
+base + stat_function(fun = dnorm, geom = "polygon", color = "blue", fill = "blue", alpha = 0.5)
 
 base + geom_function(fun = dnorm, n = 20)
 


### PR DESCRIPTION
Output:

![image](https://user-images.githubusercontent.com/10783929/114730323-0ce98e00-9d41-11eb-97c5-56e09477f839.png)

I believe this new example is useful because it might not be straightforward how to use the `fill` aesthetic with `geom_function()`/`stat_function()`.

My first try was to simply add `fill = "blue"` but it doesn't work because the `geom_line()` doesn't understand `fill`.