### PR TITLE
Fix extended bins in `guide_coloursteps()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* Fix bug in `guide_coloursteps()` that would repeat the terminal bins if the
+  breaks coincided with the limits of the scale (@thomasp85, #4019)
 
 * Make sure that default labels from default mappings doesn't overwrite default
   labels from explicit mappings (@thomasp85, #2406)

--- a/R/guide-colorsteps.R
+++ b/R/guide-colorsteps.R
@@ -64,6 +64,7 @@ guide_train.colorsteps <- function(guide, scale, aesthetic = NULL) {
     }
     if (is.numeric(breaks)) {
       limits <- scale$get_limits()
+      breaks <- breaks[!breaks %in% limits]
       all_breaks <- c(limits[1], breaks, limits[2])
       bin_at <- all_breaks[-1] - diff(all_breaks) / 2
     } else {


### PR DESCRIPTION
Fix #4019 

This PR fixes the issue with extended terminal bins in `guide_coloursteps()` by removing breaks if they coincide