### PR TITLE
Construct time_trans with the given timezone

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Fix bug in `scale_[x|y]_datetime()` where a specified timezone would be 
+  ignored by the scale (@thomasp85, #4007)
+
 * Fix bug in `guide_coloursteps()` that would repeat the terminal bins if the
   breaks coincided with the limits of the scale (@thomasp85, #4019)
   

--- a/R/scale-date.r
+++ b/R/scale-date.r
@@ -342,13 +342,13 @@ datetime_scale <- function(aesthetics, trans, palette,
 ScaleContinuousDatetime <- ggproto("ScaleContinuousDatetime", ScaleContinuous,
   secondary.axis = waiver(),
   timezone = NULL,
-  train = function(self, x) {
+  transform = function(self, x) {
     tz <- attr(x, "tzone")
     if (is.null(self$timezone) && !is.null(tz)) {
       self$timezone <- tz
       self$trans <- time_trans(self$timezone)
     }
-    ggproto_parent(ScaleContinuous, self)$train(x)
+    ggproto_parent(ScaleContinuous, self)$transform(x)
   },
   map = function(self, x, limits = self$get_limits()) {
     self$oob(x, limits)

--- a/R/scale-date.r
+++ b/R/scale-date.r
@@ -314,6 +314,11 @@ datetime_scale <- function(aesthetics, trans, palette,
     scale_class <- ScaleContinuous
   }
 
+  trans <- switch(trans,
+    date = date_trans(),
+    time = time_trans(timezone)
+  )
+
   sc <- continuous_scale(
     aesthetics,
     name,
@@ -337,13 +342,13 @@ datetime_scale <- function(aesthetics, trans, palette,
 ScaleContinuousDatetime <- ggproto("ScaleContinuousDatetime", ScaleContinuous,
   secondary.axis = waiver(),
   timezone = NULL,
-  transform = function(self, x) {
+  train = function(self, x) {
     tz <- attr(x, "tzone")
     if (is.null(self$timezone) && !is.null(tz)) {
       self$timezone <- tz
       self$trans <- time_trans(self$timezone)
     }
-    ggproto_parent(ScaleContinuous, self)$transform(x)
+    ggproto_parent(ScaleContinuous, self)$train(x)
   },
   map = function(self, x, limits = self$get_limits()) {
     self$oob(x, limits)


### PR DESCRIPTION
Fix #4007 

Currently the timezone argument in `scale_[x|y]_datetime()` is ignored. This PR rectifies that