### PR TITLE
Round down breaks in scale_date to avoid misalignment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Fix bug in `scale_[x|y]_date()` where custom breaks functions that resulted in
+  fracional dates would get misaligned (@thomasp85, #3965)
+
 * Fix bug in `guide_coloursteps()` that would repeat the terminal bins if the
   breaks coincided with the limits of the scale (@thomasp85, #4019)
   

--- a/R/scale-date.r
+++ b/R/scale-date.r
@@ -382,6 +382,11 @@ ScaleContinuousDate <- ggproto("ScaleContinuousDate", ScaleContinuous,
   map = function(self, x, limits = self$get_limits()) {
     self$oob(x, limits)
   },
+  get_breaks = function(self, limits = self$get_limits()) {
+    breaks <- ggproto_parent(ScaleContinuous, self)$get_breaks(limits)
+    breaks <- floor(breaks)
+    breaks[breaks >= limits[1] & breaks <= limits[2]]
+  },
   break_info = function(self, range = NULL) {
     breaks <- ggproto_parent(ScaleContinuous, self)$break_info(range)
     if (!(is.waive(self$secondary.axis) || self$secondary.axis$empty())) {

--- a/R/scale-date.r
+++ b/R/scale-date.r
@@ -384,6 +384,9 @@ ScaleContinuousDate <- ggproto("ScaleContinuousDate", ScaleContinuous,
   },
   get_breaks = function(self, limits = self$get_limits()) {
     breaks <- ggproto_parent(ScaleContinuous, self)$get_breaks(limits)
+    if (is.null(breaks)) {
+      return(NULL)
+    }
     breaks <- floor(breaks)
     breaks[breaks >= limits[1] & breaks <= limits[2]]
   },


### PR DESCRIPTION
Fix #3965 

This PR implements a fix for the misalignment by calling `floor()` on the breaks returned in `get_breaks()`