### PR TITLE
Make annotate_logticks coord_flip-aware

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Fix bug in `annotate_logticks()` that would cause an error when used together
+  with `coord_flip()` (@thomasp85, #3954)
+
 * Fix bug in `guide_coloursteps()` that would repeat the terminal bins if the
   breaks coincided with the limits of the scale (@thomasp85, #4019)
   

--- a/R/annotation-logticks.r
+++ b/R/annotation-logticks.r
@@ -126,12 +126,14 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
                         mid = unit(0.2, "cm"), long = unit(0.3, "cm"))
   {
     ticks <- list()
+    flipped <- inherits(coord, "CoordFlip")
+    x_name <- if (flipped) "y" else "x"
+    y_name <- if (flipped) "x" else "y"
 
     # Convert these units to numbers so that they can be put in data frames
     short <- convertUnit(short, "cm", valueOnly = TRUE)
     mid   <- convertUnit(mid,   "cm", valueOnly = TRUE)
     long  <- convertUnit(long,  "cm", valueOnly = TRUE)
-
 
     if (grepl("[b|t]", sides)) {
 
@@ -149,7 +151,7 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
       if (scaled)
         xticks$value <- log(xticks$value, base)
 
-      names(xticks)[names(xticks) == "value"] <- "x"   # Rename to 'x' for coordinates$transform
+      names(xticks)[names(xticks) == "value"] <- x_name   # Rename to 'x' for coordinates$transform
       xticks <- coord$transform(xticks, panel_params)
       xticks = xticks[xticks$x <= 1 & xticks$x >= 0,]
 
@@ -173,7 +175,6 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
       }
     }
 
-
     if (grepl("[l|r]", sides)) {
       yticks <- calc_logticks(
         base = base,
@@ -188,7 +189,7 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
       if (scaled)
         yticks$value <- log(yticks$value, base)
 
-      names(yticks)[names(yticks) == "value"] <- "y"   # Rename to 'y' for coordinates$transform
+      names(yticks)[names(yticks) == "value"] <- y_name   # Rename to 'y' for coordinates$transform
       yticks <- coord$transform(yticks, panel_params)
       yticks = yticks[yticks$y <= 1 & yticks$y >= 0,]
 


### PR DESCRIPTION
Fix #3954 

This PR ensures that `annotate_logticks()` works in the presence of `coord_flip()`. It does so by flipping around the ranges and aesthetic names.

Important notice: With this PR, `sides = "b"` will not get translated to `sides = "l"`. Since the `sides` argument is positional and not tied to aesthetic names it makes sense to me to leave it alone