### PR TITLE
Throw error with illigal combination of space in facet_grid and aspect.ratio in theme

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Using `theme(aspect.ratio = ...)` together with free space in `facet_grid()`
+  now crrectly throws an error (@thomasp85, #3834)
+  
 * Fix bug in `guide_coloursteps()` that would repeat the terminal bins if the
   breaks coincided with the limits of the scale (@thomasp85, #4019)
   

--- a/R/facet-grid-.r
+++ b/R/facet-grid-.r
@@ -309,6 +309,9 @@ FacetGrid <- ggproto("FacetGrid", Facet,
     strips <- render_strips(col_vars, row_vars, params$labeller, theme)
 
     aspect_ratio <- theme$aspect.ratio
+    if (!is.null(aspect_ratio) && (params$space$x || params$space$y)) {
+      abort("Free scales cannot be mixed with a fixed aspect ratio")
+    }
     if (is.null(aspect_ratio) && !params$free$x && !params$free$y) {
       aspect_ratio <- coord$aspect(ranges[[1]])
     }

--- a/R/facet-grid-.r
+++ b/R/facet-grid-.r
@@ -309,7 +309,7 @@ FacetGrid <- ggproto("FacetGrid", Facet,
     strips <- render_strips(col_vars, row_vars, params$labeller, theme)
 
     aspect_ratio <- theme$aspect.ratio
-    if (!is.null(aspect_ratio) && (params$space$x || params$space$y)) {
+    if (!is.null(aspect_ratio) && (params$space_free$x || params$space_free$y)) {
       abort("Free scales cannot be mixed with a fixed aspect ratio")
     }
     if (is.null(aspect_ratio) && !params$free$x && !params$free$y) {


### PR DESCRIPTION
Fix #3834 

This PR adds a check for when aspect ratio has been set by the theme and free space is requested in facet_grid and throws an error