### PR TITLE
Create the requested number of bins in `bin2d_breaks()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Fix a bug in `stat_summary_bin()` where one more than the requested number of
+  bins would be created (@thomasp85, #3824)
+
 * Fix bug in `guide_coloursteps()` that would repeat the terminal bins if the
   breaks coincided with the limits of the scale (@thomasp85, #4019)
   

--- a/R/stat-bin2d.r
+++ b/R/stat-bin2d.r
@@ -132,6 +132,12 @@ bin2d_breaks <- function(scale, breaks = NULL, origin = NULL, binwidth = NULL,
   if (!(is.numeric(origin) && length(origin) == 1)) abort("`origin` must be a numeric scalar")
 
   breaks <- seq(origin, range[2] + binwidth, binwidth)
+
+  # Check if the last bin lies fully outside the range
+  if (length(breaks) > 1 && breaks[length(breaks) - 1] >= range[2]) {
+    breaks <- breaks[-length(breaks)]
+  }
+
   adjust_breaks(breaks, right)
 }
 


### PR DESCRIPTION
Fix #3824 

This PR fixes the reported bug by removing the last bin if it lies completely outside the the scale range