### PR TITLE
compute the correct interval for locfit smoothers 

### DIFF
--- a/R/stat-smooth-methods.r
+++ b/R/stat-smooth-methods.r
@@ -47,7 +47,7 @@ predictdf.loess <- function(model, xseq, se, level) {
 
   if (se) {
     y = pred$fit
-    ci <- pred$se.fit * stats::qt(level / 2 + .5, pred$df)
+    ci = pred$se.fit * stats::qt(level / 2 + .5, pred$df)
     ymin = y - ci
     ymax = y + ci
     base::data.frame(x = xseq, y, ymin, ymax, se = pred$se.fit)
@@ -62,8 +62,9 @@ predictdf.locfit <- function(model, xseq, se, level) {
 
   if (se) {
     y = pred$fit
-    ymin = y - pred$se.fit
-    ymax = y + pred$se.fit
+    ci = pred$se.fit * stats::qt(level / 2 + .5, model$dp["df2"])
+    ymin = y - ci
+    ymax = y + ci
     base::data.frame(x = xseq, y, ymin, ymax, se = pred$se.fit)
   } else {
     base::data.frame(x = xseq, y = as.vector(pred))


### PR DESCRIPTION
Closes #3806

``` r
library(ggplot2)
library(locfit)
#> locfit 1.5-9.4    2020-03-24

mtcars$x <- mtcars$disp
grid <- seq(71, 470, length.out = 100)
fit <- locfit::locfit(mpg ~ x, data = mtcars)
prd <- predict(fit, data.frame(x = grid), se.fit = TRUE)
resid_df <- fit$dp["df2"]

lower_95 <- prd$fit + qt(0.025, df = resid_df) * prd$se.fit
upper_95 <- prd$fit + qt(0.975, df = resid_df) * prd$se.fit
res_95 <- ggplot2:::predictdf(fit, xseq = grid, se = TRUE, level = 0.95)
all.equal(res_95$ymin, lower_95, tolerance = 0.0001)
#> [1] TRUE
all.equal(res_95$ymax, upper_95, tolerance = 0.0001)
#> [1] TRUE

lower_99 <- prd$fit + qt(0.005, df = resid_df) * prd$se.fit
upper_99 <- prd$fit + qt(0.995, df = resid_df) * prd$se.fit
res_99 <- ggplot2:::predictdf(fit, xseq = grid, se = TRUE, level = 0.99)
all.equal(res_99$ymin, lower_99, tolerance = 0.0001)
#> [1] TRUE
all.equal(res_99$ymax, upper_99, tolerance = 0.0001)
#> [1] TRUE
```

<sup>Created on 2021-04-19 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0.9000)</sup>