### PR TITLE
Allow justification of legends larger than the available space

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # ggplot2 (development version)
 
+* Fix a bug in legend justification where justification was lost of the legend
+  dimensions exceeded the available size (@thomasp85, #3635)
+
+* Fix calculation of confidence interval for locfit smoothing (@topepo, #3806)
+
 * Fix a bug in `geom_abline()` that resulted in `intercept` not being subjected
   to the transformation of the y scale (@thomasp85, #3741)
 

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -199,14 +199,28 @@ ggplot_gtable.ggplot_built <- function(data) {
       ypos <- theme$legend.position[2]
 
       # x and y are specified via theme$legend.position (i.e., coords)
-      legend_box <- editGrob(legend_box,
-        vp = viewport(x = xpos, y = ypos, just = c(xjust, yjust),
-          height = legend_height, width = legend_width))
+      legend_box <- editGrob(
+        legend_box,
+        vp = viewport(
+          x = xpos,
+          y = ypos,
+          just = c(xjust, yjust),
+          height = legend_height,
+          width = legend_width
+        )
+      )
     } else {
       # x and y are adjusted using justification of legend box (i.e., theme$legend.justification)
-      legend_box <- editGrob(legend_box,
-        vp = viewport(x = xjust, y = yjust, just = c(xjust, yjust),
-          height = legend_height, width = legend_width))
+      legend_box <- editGrob(
+        legend_box,
+        vp = viewport(
+          x = xjust,
+          y = yjust,
+          just = c(xjust, yjust),
+          height = legend_height,
+          width = legend_width
+        )
+      )
       legend_box <- gtable_add_rows(legend_box, unit(yjust, 'null'))
       legend_box <- gtable_add_rows(legend_box, unit(1 - yjust, 'null'), 0)
       legend_box <- gtable_add_cols(legend_box, unit(xjust, 'null'), 0)

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -205,7 +205,8 @@ ggplot_gtable.ggplot_built <- function(data) {
     } else {
       # x and y are adjusted using justification of legend box (i.e., theme$legend.justification)
       legend_box <- editGrob(legend_box,
-        vp = viewport(x = xjust, y = yjust, just = c(xjust, yjust)))
+        vp = viewport(x = xjust, y = yjust, just = c(xjust, yjust),
+          height = legend_height, width = legend_width))
       legend_box <- gtable_add_rows(legend_box, unit(yjust, 'null'))
       legend_box <- gtable_add_rows(legend_box, unit(1 - yjust, 'null'), 0)
       legend_box <- gtable_add_cols(legend_box, unit(xjust, 'null'), 0)


### PR DESCRIPTION
Fix #3635 

This PR aims to address the issue of correctly justifying legends if they are larger than the space available. It does so by setting the viewport size to the size of the legend...

re-rendering of the issue example to show it is working

``` r
library(ggplot2)
library(magrittr)

p <- iris %>%
  ggplot(
    aes(x = Sepal.Length, 
        y = Sepal.Width, 
        color = Petal.Length, 
        shape = Species, 
        fill = Petal.Width)
  ) + 
  geom_point() + 
  theme(legend.position = "bottom")

p + theme(legend.justification = "left")
```

![](https://i.imgur.com/iEvU8gw.png)

``` r
p + theme(legend.justification = "right")
```

![](https://i.imgur.com/jH3l8hw.png)

<sup>Created on 2021-04-20 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

(@clauswilke I'm setting you as reviewer as I think you are the other person most familiar with the intricacies of grid. If you don't have time just let me know)