### PR TITLE
Remove warning when creating secondary axis with no minor breaks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,9 @@
 * Fix a bug in `stat_summary_bin()` where one more than the requested number of
   bins would be created (@thomasp85, #3824)
   
+* Fix issue in `sec_axis()` that would throw warnings in the absence of any 
+  secondary breaks (@thomasp85, #4368)
+  
 * Fix a bug in `geom_abline()` that resulted in `intercept` not being subjected
   to the transformation of the y scale (@thomasp85, #3741)
   

--- a/R/axis-secondary.R
+++ b/R/axis-secondary.R
@@ -213,30 +213,36 @@ AxisSecondary <- ggproto("AxisSecondary", NULL,
       range_info <- temp_scale$break_info()
 
       # Map the break values back to their correct position on the primary scale
-      old_val <- lapply(range_info$major_source, function(x) which.min(abs(full_range - x)))
-      old_val <- old_range[unlist(old_val)]
-      old_val_trans <- scale$trans$transform(old_val)
+      if (!is.null(range_info$major_source)) {
+        old_val <- lapply(range_info$major_source, function(x) which.min(abs(full_range - x)))
+        old_val <- old_range[unlist(old_val)]
+        old_val_trans <- scale$trans$transform(old_val)
 
-      old_val_minor <- lapply(range_info$minor_source, function(x) which.min(abs(full_range - x)))
-      old_val_minor <- old_range[unlist(old_val_minor)]
-      old_val_minor_trans <- scale$trans$transform(old_val_minor)
+        # rescale values from 0 to 1
+        range_info$major[] <- round(
+          rescale(
+            scale$map(old_val_trans, range(old_val_trans)),
+            from = range
+          ),
+          digits = 3
+        )
+      }
 
-      # rescale values from 0 to 1
-      range_info$major[] <- round(
-        rescale(
-          scale$map(old_val_trans, range(old_val_trans)),
-          from = range
-        ),
-        digits = 3
-      )
+      if (!is.null(range_info$minor_source)) {
+        old_val_minor <- lapply(range_info$minor_source, function(x) which.min(abs(full_range - x)))
+        old_val_minor <- old_range[unlist(old_val_minor)]
+        old_val_minor_trans <- scale$trans$transform(old_val_minor)
 
-      range_info$minor[] <- round(
-        rescale(
-          scale$map(old_val_minor_trans, range(old_val_minor_trans)),
-          from = range
-        ),
-        digits = 3
-      )
+        range_info$minor[] <- round(
+          rescale(
+            scale$map(old_val_minor_trans, range(old_val_minor_trans)),
+            from = range
+          ),
+          digits = 3
+        )
+      } else {
+        old_val_minor_trans <- NULL
+      }
     }
 
     # The _source values should be in (primary) scale_transformed space,

--- a/R/axis-secondary.R
+++ b/R/axis-secondary.R
@@ -226,6 +226,8 @@ AxisSecondary <- ggproto("AxisSecondary", NULL,
           ),
           digits = 3
         )
+      } else {
+        old_val_trans <- NULL
       }
 
       if (!is.null(range_info$minor_source)) {


### PR DESCRIPTION
Fix #4368 

This PR implements the fix proposed by @yutannihilation in the issue