### PR TITLE
Ensure all keys in `guide_bins(..., reverse = TRUE)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Fix a bug in `guide_bins()` where keys would disappear if the guide was 
+  reversed (@thomasp85, #4210)
+
 * Fix a bug in legend justification where justification was lost of the legend
   dimensions exceeded the available size (@thomasp85, #3635)
 

--- a/R/guide-bins.R
+++ b/R/guide-bins.R
@@ -144,6 +144,7 @@ guide_train.bins <- function(guide, scale, aesthetic = NULL) {
 
   if (is.numeric(breaks)) {
     limits <- scale$get_limits()
+    breaks <- breaks[!breaks %in% limits]
     all_breaks <- c(limits[1], breaks, limits[2])
     bin_at <- all_breaks[-1] - diff(all_breaks) / 2
   } else {
@@ -163,7 +164,12 @@ guide_train.bins <- function(guide, scale, aesthetic = NULL) {
   key$.label <- scale$get_labels(all_breaks)
   guide$show.limits <- guide$show.limits %||% scale$show_limits %||% FALSE
 
-  if (guide$reverse) key <- key[nrow(key):1, ]
+  if (guide$reverse) {
+    key <- key[rev(seq_len(nrow(key))), ]
+    # Move last row back to last
+    aesthetics <- setdiff(names(key), ".label")
+    key[, aesthetics] <- key[c(seq_len(nrow(key))[-1], 1), aesthetics]
+  }
 
   guide$key <- key
   guide$hash <- with(


### PR DESCRIPTION
Fix #4210 

This fixes a bug when reversing the bin guide because the terminal row that held irrelevant `NA` values ended up as the first row