### PR TITLE
Fix failures on test coverage CI

### DIFF
--- a/tests/testthat/test-prohibited-functions.R
+++ b/tests/testthat/test-prohibited-functions.R
@@ -47,6 +47,9 @@ R_paths <- c(
 R_files <- list.files(R_paths, pattern = ".*\\.(R|r)$", full.names = TRUE)
 
 test_that("list up R files properly", {
+  skip_on_covr()
+  skip_on_cran()
+
   expect_true(length(R_files) > 0)
 })
 


### PR DESCRIPTION
(Fix https://github.com/tidyverse/ggplot2/pull/4446#issuecomment-826799440)

Tests in `tests/testthat/test-prohibited-functions.R` needs to parse R files to do static analysis. But, files are not always available, so this test might fail and `covr::coverage()` is the case.

https://github.com/tidyverse/ggplot2/blob/bb8f960356a55fe2e72cfd0569179835818f00d8/tests/testthat/test-prohibited-functions.R#L49-L51

This pull requests let the test skip on `covr::coverage()`, and also on CRAN for safety.