### PR TITLE
allow fewer elements in named values vector in manual scales

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # ggplot2 (development version)
 
+* Manual scales now allow named vectors passed to `values` to contain fewer 
+  elements than existing in the data. Elements not present in values will be set
+  to `NA` (@thomasp85, #3451)
+
 * Add support for the BrailleR package for creating descriptions of the plot
   when rendered (@thomasp85, #4459)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -126,6 +126,9 @@
 
 * The scale arguments `limits`, `breaks`, `minor_breaks`, `labels`, `rescaler`
   and `oob` now accept purrr style lambda notation (@teunbrand, #4427).
+  
+* `as_labeller()` (and therefore also `labeller()`) now handles functions in
+  purrr-style lambda notation (@netique, #4188).
 
 # ggplot2 3.3.3
 This is a small patch release mainly intended to address changes in R and CRAN.

--- a/R/labeller.r
+++ b/R/labeller.r
@@ -318,6 +318,8 @@ as_labeller <- function(x, default = label_value, multi_line = TRUE) {
       x(labels)
     } else if (is.function(x)) {
       default(lapply(labels, x))
+    } else if (is.formula(x)) {
+      default(lapply(labels, as_function(x)))
     } else if (is.character(x)) {
       default(lapply(labels, function(label) x[label]))
     } else {

--- a/R/scale-manual.r
+++ b/R/scale-manual.r
@@ -80,38 +80,38 @@ NULL
 
 #' @rdname scale_manual
 #' @export
-scale_colour_manual <- function(..., values, aesthetics = "colour", breaks = waiver()) {
-  manual_scale(aesthetics, values, breaks, ...)
+scale_colour_manual <- function(..., values, aesthetics = "colour", breaks = waiver(), na.value = "grey50") {
+  manual_scale(aesthetics, values, breaks, ..., na.value = na.value)
 }
 
 #' @rdname scale_manual
 #' @export
-scale_fill_manual <- function(..., values, aesthetics = "fill", breaks = waiver()) {
-  manual_scale(aesthetics, values, breaks, ...)
+scale_fill_manual <- function(..., values, aesthetics = "fill", breaks = waiver(), na.value = "grey50") {
+  manual_scale(aesthetics, values, breaks, ..., na.value = na.value)
 }
 
 #' @rdname scale_manual
 #' @export
-scale_size_manual <- function(..., values, breaks = waiver()) {
-  manual_scale("size", values, breaks, ...)
+scale_size_manual <- function(..., values, breaks = waiver(), na.value = NA) {
+  manual_scale("size", values, breaks, ..., na.value = na.value)
 }
 
 #' @rdname scale_manual
 #' @export
-scale_shape_manual <- function(..., values, breaks = waiver()) {
-  manual_scale("shape", values, breaks, ...)
+scale_shape_manual <- function(..., values, breaks = waiver(), na.value = NA) {
+  manual_scale("shape", values, breaks, ..., na.value = na.value)
 }
 
 #' @rdname scale_manual
 #' @export
-scale_linetype_manual <- function(..., values, breaks = waiver()) {
-  manual_scale("linetype", values, breaks, ...)
+scale_linetype_manual <- function(..., values, breaks = waiver(), na.value = "blank") {
+  manual_scale("linetype", values, breaks, ..., na.value = na.value)
 }
 
 #' @rdname scale_manual
 #' @export
-scale_alpha_manual <- function(..., values, breaks = waiver()) {
-  manual_scale("alpha", values, breaks, ...)
+scale_alpha_manual <- function(..., values, breaks = waiver(), na.value = NA) {
+  manual_scale("alpha", values, breaks, ..., na.value = na.value)
 }
 
 #' @rdname scale_manual

--- a/R/scale-manual.r
+++ b/R/scale-manual.r
@@ -121,13 +121,17 @@ scale_discrete_manual <- function(aesthetics, ..., values, breaks = waiver()) {
 }
 
 
-manual_scale <- function(aesthetic, values = NULL, breaks = waiver(), ...) {
+manual_scale <- function(aesthetic, values = NULL, breaks = waiver(), limits = NULL, ...) {
   # check for missing `values` parameter, in lieu of providing
   # a default to all the different scale_*_manual() functions
   if (is_missing(values)) {
     values <- NULL
   } else {
     force(values)
+  }
+
+  if (is.null(limits)) {
+    limits <- names(values)
   }
 
   # order values according to breaks
@@ -141,7 +145,7 @@ manual_scale <- function(aesthetic, values = NULL, breaks = waiver(), ...) {
   }
 
   pal <- function(n) {
-    if (is.null(names(values)) && n > length(values)) {
+    if (n > length(values)) {
       abort(glue("Insufficient values in manual scale. {n} needed but only {length(values)} provided."))
     }
     values

--- a/R/scale-manual.r
+++ b/R/scale-manual.r
@@ -28,6 +28,8 @@
 #'   - A character vector of breaks
 #'   - A function that takes the limits as input and returns breaks
 #'     as output
+#' @param na.value The aesthetic value to use for missing (`NA`) values
+#'
 #' @section Color Blindness:
 #' Many color palettes derived from RGB combinations (like the "rainbow" color
 #' palette) are not suitable to support all viewers, especially those with

--- a/R/scale-manual.r
+++ b/R/scale-manual.r
@@ -141,7 +141,7 @@ manual_scale <- function(aesthetic, values = NULL, breaks = waiver(), ...) {
   }
 
   pal <- function(n) {
-    if (n > length(values)) {
+    if (is.null(names(values)) && n > length(values)) {
       abort(glue("Insufficient values in manual scale. {n} needed but only {length(values)} provided."))
     }
     values

--- a/R/scale-manual.r
+++ b/R/scale-manual.r
@@ -150,5 +150,5 @@ manual_scale <- function(aesthetic, values = NULL, breaks = waiver(), limits = N
     }
     values
   }
-  discrete_scale(aesthetic, "manual", pal, breaks = breaks, ...)
+  discrete_scale(aesthetic, "manual", pal, breaks = breaks, limits = limits, ...)
 }

--- a/man/scale_manual.Rd
+++ b/man/scale_manual.Rd
@@ -11,17 +11,29 @@
 \alias{scale_color_manual}
 \title{Create your own discrete scale}
 \usage{
-scale_colour_manual(..., values, aesthetics = "colour", breaks = waiver())
+scale_colour_manual(
+  ...,
+  values,
+  aesthetics = "colour",
+  breaks = waiver(),
+  na.value = "grey50"
+)
 
-scale_fill_manual(..., values, aesthetics = "fill", breaks = waiver())
+scale_fill_manual(
+  ...,
+  values,
+  aesthetics = "fill",
+  breaks = waiver(),
+  na.value = "grey50"
+)
 
-scale_size_manual(..., values, breaks = waiver())
+scale_size_manual(..., values, breaks = waiver(), na.value = NA)
 
-scale_shape_manual(..., values, breaks = waiver())
+scale_shape_manual(..., values, breaks = waiver(), na.value = NA)
 
-scale_linetype_manual(..., values, breaks = waiver())
+scale_linetype_manual(..., values, breaks = waiver(), na.value = "blank")
 
-scale_alpha_manual(..., values, breaks = waiver())
+scale_alpha_manual(..., values, breaks = waiver(), na.value = NA)
 
 scale_discrete_manual(aesthetics, ..., values, breaks = waiver())
 }

--- a/man/scale_manual.Rd
+++ b/man/scale_manual.Rd
@@ -59,9 +59,6 @@ The default, \code{TRUE}, uses the levels that appear in the data;
     \item{\code{na.translate}}{Unlike continuous scales, discrete scales can easily show
 missing values, and do so by default. If you want to remove missing values
 from a discrete scale, specify \code{na.translate = FALSE}.}
-    \item{\code{na.value}}{If \code{na.translate = TRUE}, what aesthetic value should the
-missing values be displayed as? Does not apply to position scales
-where \code{NA} is always placed at the far right.}
     \item{\code{scale_name}}{The name of the scale that should be used for error messages
 associated with this scale.}
     \item{\code{name}}{The name of the scale. Used as the axis or legend title. If
@@ -102,6 +99,8 @@ same time, via \code{aesthetics = c("colour", "fill")}.}
 \item A function that takes the limits as input and returns breaks
 as output
 }}
+
+\item{na.value}{The aesthetic value to use for missing (\code{NA}) values}
 }
 \description{
 These functions allow you to specify your own set of mappings from levels in the

--- a/tests/testthat/test-scale-manual.r
+++ b/tests/testthat/test-scale-manual.r
@@ -88,12 +88,12 @@ test_that("unnamed values match breaks in manual scales", {
 
 test_that("limits works (#3262)", {
   # named charachter vector
-  s1 <- scale_colour_manual(values = c("8" = "c", "4" = "a", "6" = "b"), limits = c("4", "8"))
+  s1 <- scale_colour_manual(values = c("8" = "c", "4" = "a", "6" = "b"), limits = c("4", "8"), na.value = NA)
   s1$train(c("4", "6", "8"))
   expect_equal(s1$map(c("4", "6", "8")), c("a", NA, "c"))
 
   # named charachter vector
-  s2 <- scale_colour_manual(values = c("c", "a", "b"), limits = c("4", "8"))
+  s2 <- scale_colour_manual(values = c("c", "a", "b"), limits = c("4", "8"), na.value = NA)
   s2$train(c("4", "6", "8"))
   expect_equal(s2$map(c("4", "6", "8")), c("c", NA, "a"))
 })


### PR DESCRIPTION
Fix #3451 

This PR relaxes the requirement on the manual scale `values` vector and allow it to contain fewer elements than the data. Non-existing values are implicitly considered `NA` and mapped to the `na.value` value