### PR TITLE
Make coord_sf() default use projected coords

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,10 +1,12 @@
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+#on:
+#  push:
+#    branches:
+#      - master
+#  pull_request:
+#    branches:
+#      - master
+
+on: [push, pull_request]
 
 name: R-CMD-check
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,14 +9,13 @@ small selection of feature refinements.
   
 * `coord_sf()` now has an argument `default_crs` that specifies the coordinate
   reference system (CRS) for non-sf layers and scale/coord limits. This argument
-  defaults to the World Geodetic System 1984 (WGS84), which means x and y 
-  positions are interpreted as longitude and latitude. This is a potentially 
-  breaking change for users who use projected coordinates in non-sf layers or in 
-  limits. Setting `default_crs = NULL` recovers the old behavior. Further, 
-  authors of extension packages implementing `stat_sf()`-like functionality are 
-  encouraged to look at the source code of `stat_sf()`'s `compute_group()` 
-  function to see how to provide scale-limit hints to `coord_sf()` 
-  (@clauswilke, #3659).
+  defaults to `NULL`, which means non-sf layers are assumed to be in projected
+  coordinates, as in prior ggplot2 versions. Setting `default_crs = sf::st_crs(4326)`
+  provides a simple way to interpret x and y positions as longitude and latitude,
+  regardless of the CRS used by `coord_sf()`. Authors of extension packages
+  implementing `stat_sf()`-like functionality are encouraged to look at the source
+  code of `stat_sf()`'s `compute_group()` function to see how to provide scale-limit
+  hints to `coord_sf()` (@clauswilke, #3659).
 
 * `ggsave()` now uses ragg to render raster output if ragg is available. It also
   handles custom devices that sets a default unit (e.g. `ragg::agg_png`) 

--- a/R/annotation-map.r
+++ b/R/annotation-map.r
@@ -42,6 +42,7 @@ NULL
 #' p +
 #'   coord_sf(
 #'     crs = st_crs(3347),
+#'     default_crs = st_crs(4326),  # data is provided as long-lat
 #'     xlim = c(-84, -76),
 #'     ylim = c(34, 37.2)
 #'   )
@@ -53,7 +54,7 @@ NULL
 #'     data = nc, inherit.aes = FALSE,
 #'     fill = NA, color = "black", size = 0.1
 #'   ) +
-#'   coord_sf(crs = st_crs(3347))
+#'   coord_sf(crs = st_crs(3347), default_crs = st_crs(4326))
 #' }}}
 annotation_map <- function(map, ...) {
   # Get map input into correct form

--- a/R/coord-sf.R
+++ b/R/coord-sf.R
@@ -268,7 +268,8 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
   is_free = function() FALSE,
 
   # for regular geoms (such as geom_path, geom_polygon, etc.), CoordSf is non-linear
-  is_linear = function() FALSE,
+  # if the default_crs option is being used, i.e., not set to NULL
+  is_linear = function(self) is.null(self$get_default_crs()),
 
   distance = function(self, x, y, panel_params) {
     d <- self$backtransform_range(panel_params)
@@ -588,12 +589,12 @@ calc_limits_bbox <- function(method, xlim, ylim, crs, default_crs) {
 #'   be projected before plotting. If not specified, will use the CRS defined
 #'   in the first sf layer of the plot.
 #' @param default_crs The default CRS to be used for non-sf layers (which
-#'   don't carry any CRS information) and scale limits. If not specified, this
-#'   defaults to the World Geodetic System 1984 (WGS84), which means x and y
-#'   positions are interpreted as longitude and latitude, respectively. If
-#'   set to `NULL`, uses the setting for `crs`, which means that then all
+#'   don't carry any CRS information) and scale limits. The default value of
+#'   `NULL` means that the setting for `crs` is used. This implies that all
 #'   non-sf layers and scale limits are assumed to be specified in projected
-#'   coordinates.
+#'   coordinates. A useful alternative setting is `default_crs = sf::st_crs(4326)`,
+#'   which means x and y positions are interpreted as longitude and latitude,
+#'   respectively, in the World Geodetic System 1984 (WGS84).
 #' @param xlim,ylim Limits for the x and y axes. These limits are specified
 #'   in the units of the default CRS. To specify limits in projected coordinates,
 #'   set `default_crs = NULL`. How limit specifications translate into the exact
@@ -655,7 +656,7 @@ calc_limits_bbox <- function(method, xlim, ylim, crs, default_crs) {
 #' @export
 #' @rdname ggsf
 coord_sf <- function(xlim = NULL, ylim = NULL, expand = TRUE,
-                     crs = NULL, default_crs = sf::st_crs(4326),
+                     crs = NULL, default_crs = NULL,
                      datum = sf::st_crs(4326),
                      label_graticule = waiver(),
                      label_axes = waiver(), lims_method = c("cross", "box", "orthogonal", "geometry_bbox"),

--- a/R/coord-sf.R
+++ b/R/coord-sf.R
@@ -596,22 +596,19 @@ calc_limits_bbox <- function(method, xlim, ylim, crs, default_crs) {
 #'   which means x and y positions are interpreted as longitude and latitude,
 #'   respectively, in the World Geodetic System 1984 (WGS84).
 #' @param xlim,ylim Limits for the x and y axes. These limits are specified
-#'   in the units of the default CRS. To specify limits in projected coordinates,
-#'   set `default_crs = NULL`. How limit specifications translate into the exact
+#'   in the units of the default CRS. By default, this means projected coordinates
+#'   (`default_crs = NULL`). How limit specifications translate into the exact
 #'   region shown on the plot can be confusing when non-linear or rotated coordinate
-#'   systems are used. First, different methods can be preferable under different
-#'   conditions. See parameter `lims_method` for details. Second, specifying limits
-#'   along only one direction can affect the automatically generated limits along the
-#'   other direction. Therefore, it is best to always specify limits for both x and y.
-#'   Third, specifying limits via position scales or `xlim()`/`ylim()` is strongly
-#'   discouraged, as it can result in data points being dropped from the plot even
-#'   though they would be visible in the final plot region. Finally, specifying limits
-#'   that cross the international date boundary is not possible with WGS84 as the default
-#'   crs. All these issues can be avoided by working in projected coordinates,
-#'   via `default_crs = NULL`, but at the cost of having to provide less intuitive
-#'   numeric values for the limit parameters.
+#'   systems are used as the default crs. First, different methods can be preferable
+#'   under different conditions. See parameter `lims_method` for details. Second,
+#'   specifying limits along only one direction can affect the automatically generated
+#'   limits along the other direction. Therefore, it is best to always specify limits
+#'   for both x and y. Third, specifying limits via position scales or `xlim()`/`ylim()`
+#'   is strongly discouraged, as it can result in data points being dropped from the plot even
+#'   though they would be visible in the final plot region.
 #' @param lims_method Method specifying how scale limits are converted into
-#'   limits on the plot region. For a very non-linear CRS (e.g., a perspective centered
+#'   limits on the plot region. Has no effect when `default_crs = NULL`.
+#'   For a very non-linear CRS (e.g., a perspective centered
 #'   around the North pole), the available methods yield widely differing results, and
 #'   you may want to try various options. Methods currently implemented include `"cross"`
 #'   (the default), `"box"`, `"orthogonal"`, and `"geometry_bbox"`. For method `"cross"`,

--- a/R/geom-sf.R
+++ b/R/geom-sf.R
@@ -24,7 +24,7 @@
 #'
 #' @section CRS:
 #' `coord_sf()` ensures that all layers use a common CRS. You can
-#' either specify it using the `CRS` param, or `coord_sf()` will
+#' either specify it using the `crs` param, or `coord_sf()` will
 #' take it from the first layer that defines a CRS.
 #'
 #' @section Combining sf layers and regular geoms:
@@ -33,21 +33,24 @@
 #' when using these geoms, two problems arise. First, what CRS should be used
 #' for the x and y coordinates used by these non-sf geoms? The CRS applied to
 #' non-sf geoms is set by the `default_crs` parameter, and it defaults to
-#' the World Geodetic System 1984 (WGS84). This means that x and y
-#' positions are interpreted as longitude and latitude, respectively. You can
-#' also specify any other valid CRS as the default CRS for non-sf geoms. Moreover,
-#' if you set `default_crs = NULL`, then positions for non-sf geoms are
-#' interpreted as projected coordinates. This setting allows you complete control
-#' over where exactly items are placed on the plot canvas.
+#' `NULL`, which means positions for non-sf geoms are interpreted as projected
+#' coordinates in the coordinate system set by the `crs` parameter. This setting
+#' allows you complete control over where exactly items are placed on the plot
+#' canvas, but it may require some understanding of how projections work and how
+#' to generate data in projected coordinates. As an alternative, you can set
+#' `default_crs = sf::st_crs(4326)`, the World Geodetic System 1984 (WGS84).
+#' This means that x and y positions are interpreted as longitude and latitude,
+#' respectively. You can also specify any other valid CRS as the default CRS for
+#' non-sf geoms.
 #'
 #' The second problem that arises for non-sf geoms is how straight lines
-#' should be interpreted in projected space. The approach `coord_sf()` takes is
-#' to break straight lines into small pieces (i.e., segmentize them) and
-#' then transform the pieces into projected coordinates. For the default setting
-#' where x and y are interpreted as longitude and latitude, this approach means
-#' that horizontal lines follow the parallels and vertical lines follow the
-#' meridians. If you need a different approach to handling straight lines, then
-#' you should manually segmentize and project coordinates and generate the plot
+#' should be interpreted in projected space when `default_crs` is not set to `NULL`.
+#' The approach `coord_sf()` takes is to break straight lines into small pieces
+#' (i.e., segmentize them) and then transform the pieces into projected coordinates.
+#' For the default setting where x and y are interpreted as longitude and latitude,
+#' this approach means that horizontal lines follow the parallels and vertical lines
+#' follow the meridians. If you need a different approach to handling straight lines,
+#' then you should manually segmentize and project coordinates and generate the plot
 #' in projected coordinates.
 #'
 #' @param show.legend logical. Should this layer be included in the legends?
@@ -78,11 +81,12 @@
 #'   geom_sf(colour = "white") +
 #'   geom_sf(aes(geometry = mid, size = AREA), show.legend = "point")
 #'
-#' # You can also use layers with x and y aesthetics: these are
-#' # assumed to already be in the common CRS.
-#' ggplot(nc) +
+#' # You can also use layers with x and y aesthetics. To have these interpreted
+#' # as longitude/latitude you need to set the default CRS in coord_sf()
+#' ggplot(nc_3857) +
 #'   geom_sf() +
-#'   annotate("point", x = -80, y = 35, colour = "red", size = 4)
+#'   annotate("point", x = -80, y = 35, colour = "red", size = 4) +
+#'   coord_sf(default_crs = sf::st_crs(4326))
 #'
 #' # Thanks to the power of sf, a geom_sf nicely handles varying projections
 #' # setting the aspect ratio correctly.

--- a/man/annotation_map.Rd
+++ b/man/annotation_map.Rd
@@ -48,6 +48,7 @@ if (requireNamespace("sf", quietly = TRUE)) {
 p +
   coord_sf(
     crs = st_crs(3347),
+    default_crs = st_crs(4326),  # data is provided as long-lat
     xlim = c(-84, -76),
     ylim = c(34, 37.2)
   )
@@ -59,6 +60,6 @@ p +
     data = nc, inherit.aes = FALSE,
     fill = NA, color = "black", size = 0.1
   ) +
-  coord_sf(crs = st_crs(3347))
+  coord_sf(crs = st_crs(3347), default_crs = st_crs(4326))
 }}}
 }

--- a/man/ggsf.Rd
+++ b/man/ggsf.Rd
@@ -18,7 +18,7 @@ coord_sf(
   ylim = NULL,
   expand = TRUE,
   crs = NULL,
-  default_crs = sf::st_crs(4326),
+  default_crs = NULL,
   datum = sf::st_crs(4326),
   label_graticule = waiver(),
   label_axes = waiver(),
@@ -110,12 +110,12 @@ be projected before plotting. If not specified, will use the CRS defined
 in the first sf layer of the plot.}
 
 \item{default_crs}{The default CRS to be used for non-sf layers (which
-don't carry any CRS information) and scale limits. If not specified, this
-defaults to the World Geodetic System 1984 (WGS84), which means x and y
-positions are interpreted as longitude and latitude, respectively. If
-set to \code{NULL}, uses the setting for \code{crs}, which means that then all
+don't carry any CRS information) and scale limits. The default value of
+\code{NULL} means that the setting for \code{crs} is used. This implies that all
 non-sf layers and scale limits are assumed to be specified in projected
-coordinates.}
+coordinates. A useful alternative setting is \code{default_crs = sf::st_crs(4326)},
+which means x and y positions are interpreted as longitude and latitude,
+respectively, in the World Geodetic System 1984 (WGS84).}
 
 \item{datum}{CRS that provides datum to use when generating graticules.}
 
@@ -284,7 +284,7 @@ the plot.
 \section{CRS}{
 
 \code{coord_sf()} ensures that all layers use a common CRS. You can
-either specify it using the \code{CRS} param, or \code{coord_sf()} will
+either specify it using the \code{crs} param, or \code{coord_sf()} will
 take it from the first layer that defines a CRS.
 }
 
@@ -295,21 +295,24 @@ Most regular geoms, such as \code{\link[=geom_point]{geom_point()}}, \code{\link
 when using these geoms, two problems arise. First, what CRS should be used
 for the x and y coordinates used by these non-sf geoms? The CRS applied to
 non-sf geoms is set by the \code{default_crs} parameter, and it defaults to
-the World Geodetic System 1984 (WGS84). This means that x and y
-positions are interpreted as longitude and latitude, respectively. You can
-also specify any other valid CRS as the default CRS for non-sf geoms. Moreover,
-if you set \code{default_crs = NULL}, then positions for non-sf geoms are
-interpreted as projected coordinates. This setting allows you complete control
-over where exactly items are placed on the plot canvas.
+\code{NULL}, which means positions for non-sf geoms are interpreted as projected
+coordinates in the coordinate system set by the \code{crs} parameter. This setting
+allows you complete control over where exactly items are placed on the plot
+canvas, but it may require some understanding of how projections work and how
+to generate data in projected coordinates. As an alternative, you can set
+\code{default_crs = sf::st_crs(4326)}, the World Geodetic System 1984 (WGS84).
+This means that x and y positions are interpreted as longitude and latitude,
+respectively. You can also specify any other valid CRS as the default CRS for
+non-sf geoms.
 
 The second problem that arises for non-sf geoms is how straight lines
-should be interpreted in projected space. The approach \code{coord_sf()} takes is
-to break straight lines into small pieces (i.e., segmentize them) and
-then transform the pieces into projected coordinates. For the default setting
-where x and y are interpreted as longitude and latitude, this approach means
-that horizontal lines follow the parallels and vertical lines follow the
-meridians. If you need a different approach to handling straight lines, then
-you should manually segmentize and project coordinates and generate the plot
+should be interpreted in projected space when \code{default_crs} is not set to \code{NULL}.
+The approach \code{coord_sf()} takes is to break straight lines into small pieces
+(i.e., segmentize them) and then transform the pieces into projected coordinates.
+For the default setting where x and y are interpreted as longitude and latitude,
+this approach means that horizontal lines follow the parallels and vertical lines
+follow the meridians. If you need a different approach to handling straight lines,
+then you should manually segmentize and project coordinates and generate the plot
 in projected coordinates.
 }
 
@@ -334,11 +337,12 @@ ggplot(nc_3857) +
   geom_sf(colour = "white") +
   geom_sf(aes(geometry = mid, size = AREA), show.legend = "point")
 
-# You can also use layers with x and y aesthetics: these are
-# assumed to already be in the common CRS.
-ggplot(nc) +
+# You can also use layers with x and y aesthetics. To have these interpreted
+# as longitude/latitude you need to set the default CRS in coord_sf()
+ggplot(nc_3857) +
   geom_sf() +
-  annotate("point", x = -80, y = 35, colour = "red", size = 4)
+  annotate("point", x = -80, y = 35, colour = "red", size = 4) +
+  coord_sf(default_crs = sf::st_crs(4326))
 
 # Thanks to the power of sf, a geom_sf nicely handles varying projections
 # setting the aspect ratio correctly.

--- a/man/ggsf.Rd
+++ b/man/ggsf.Rd
@@ -86,20 +86,16 @@ stat_sf(
 }
 \arguments{
 \item{xlim, ylim}{Limits for the x and y axes. These limits are specified
-in the units of the default CRS. To specify limits in projected coordinates,
-set \code{default_crs = NULL}. How limit specifications translate into the exact
+in the units of the default CRS. By default, this means projected coordinates
+(\code{default_crs = NULL}). How limit specifications translate into the exact
 region shown on the plot can be confusing when non-linear or rotated coordinate
-systems are used. First, different methods can be preferable under different
-conditions. See parameter \code{lims_method} for details. Second, specifying limits
-along only one direction can affect the automatically generated limits along the
-other direction. Therefore, it is best to always specify limits for both x and y.
-Third, specifying limits via position scales or \code{xlim()}/\code{ylim()} is strongly
-discouraged, as it can result in data points being dropped from the plot even
-though they would be visible in the final plot region. Finally, specifying limits
-that cross the international date boundary is not possible with WGS84 as the default
-crs. All these issues can be avoided by working in projected coordinates,
-via \code{default_crs = NULL}, but at the cost of having to provide less intuitive
-numeric values for the limit parameters.}
+systems are used as the default crs. First, different methods can be preferable
+under different conditions. See parameter \code{lims_method} for details. Second,
+specifying limits along only one direction can affect the automatically generated
+limits along the other direction. Therefore, it is best to always specify limits
+for both x and y. Third, specifying limits via position scales or \code{xlim()}/\code{ylim()}
+is strongly discouraged, as it can result in data points being dropped from the plot even
+though they would be visible in the final plot region.}
 
 \item{expand}{If \code{TRUE}, the default, adds a small expansion factor to
 the limits to ensure that data and axes don't overlap. If \code{FALSE},
@@ -146,7 +142,8 @@ specified with \code{list(bottom = "E", left = "N")}.
 This parameter can be used alone or in combination with \code{label_graticule}.}
 
 \item{lims_method}{Method specifying how scale limits are converted into
-limits on the plot region. For a very non-linear CRS (e.g., a perspective centered
+limits on the plot region. Has no effect when \code{default_crs = NULL}.
+For a very non-linear CRS (e.g., a perspective centered
 around the North pole), the available methods yield widely differing results, and
 you may want to try various options. Methods currently implemented include \code{"cross"}
 (the default), \code{"box"}, \code{"orthogonal"}, and \code{"geometry_bbox"}. For method \code{"cross"},

--- a/tests/figs/coord-sf/non-sf-geoms-using-long-lat.svg
+++ b/tests/figs/coord-sf/non-sf-geoms-using-long-lat.svg
@@ -86,5 +86,5 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='506.64' y='555.95' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='8.30px' lengthAdjust='spacingAndGlyphs'>W</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='375.73' y='568.24' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(152.52,286.62) rotate(-90)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='181.92' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='151.64px' lengthAdjust='spacingAndGlyphs'>non-sf geoms use long-lat</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='181.92' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='161.91px' lengthAdjust='spacingAndGlyphs'>non-sf geoms using long-lat</text></g>
 </svg>

--- a/tests/figs/coord-sf/non-sf-geoms-using-projected-coords.svg
+++ b/tests/figs/coord-sf/non-sf-geoms-using-projected-coords.svg
@@ -86,5 +86,5 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='506.64' y='555.95' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='8.30px' lengthAdjust='spacingAndGlyphs'>W</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='375.73' y='568.24' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text transform='translate(152.52,286.62) rotate(-90)' style='font-size: 11.00px; font-family: Liberation Sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='181.92' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='119.88px' lengthAdjust='spacingAndGlyphs'>default crs turned off</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='181.92' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='216.11px' lengthAdjust='spacingAndGlyphs'>non-sf geoms using projected coords</text></g>
 </svg>

--- a/tests/figs/deps.txt
+++ b/tests/figs/deps.txt
@@ -1,3 +1,3 @@
 - vdiffr-svg-engine: 1.0
 - vdiffr: 0.3.3
-- freetypeharfbuzz: 0.2.6
+- freetypeharfbuzz: 0.2.5

--- a/tests/testthat/test-coord_sf.R
+++ b/tests/testthat/test-coord_sf.R
@@ -221,28 +221,28 @@ test_that("default crs works", {
 
   p <- ggplot(polygon) + geom_sf(fill = NA)
 
-  # projected sf objects can be mixed with regular geoms using non-projected data
-  expect_doppelganger(
-    "non-sf geoms use long-lat",
-    p + geom_point(data = points, aes(x, y))
-  )
-
-  # default crs can be turned off
+  # by default, regular geoms are interpreted to use projected data
   points_trans <- sf_transform_xy(points, 3347, 4326)
   expect_doppelganger(
-    "default crs turned off",
-    p + geom_point(data = points_trans, aes(x, y)) +
-    coord_sf(default_crs = NULL)
+    "non-sf geoms using projected coords",
+    p + geom_point(data = points_trans, aes(x, y))
   )
 
-  # by default, coord limits are specified in long-lat
+  # projected sf objects can be mixed with regular geoms using non-projected data
+  expect_doppelganger(
+    "non-sf geoms using long-lat",
+    p + geom_point(data = points, aes(x, y)) +
+      coord_sf(default_crs = 4326)
+  )
+
+  # coord limits can be specified in long-lat
   expect_doppelganger(
     "limits specified in long-lat",
     p + geom_point(data = points, aes(x, y)) +
-      coord_sf(xlim = c(-80.5, -76), ylim = c(36, 41))
+      coord_sf(xlim = c(-80.5, -76), ylim = c(36, 41), default_crs = 4326)
   )
 
-  # when default crs is off, limits are specified in projected coords
+  # by default limits are specified in projected coords
   lims <- sf_transform_xy(
     list(x = c(-80.5, -76, -78.25, -78.25), y = c(38.5, 38.5, 36, 41)),
     3347, 4326
@@ -250,7 +250,7 @@ test_that("default crs works", {
   expect_doppelganger(
     "limits specified in projected coords",
     p + geom_point(data = points_trans, aes(x, y)) +
-      coord_sf(xlim = lims$x[1:2], ylim = lims$y[3:4], default_crs = NULL)
+      coord_sf(xlim = lims$x[1:2], ylim = lims$y[3:4])
   )
 })
 


### PR DESCRIPTION
Set `default_crs = NULL`, as discussed in #4494.