### PR TITLE
set.seed() before sample()

### DIFF
--- a/R/position-jitterdodge.R
+++ b/R/position-jitterdodge.R
@@ -13,6 +13,7 @@
 #' @inheritParams position_jitter
 #' @export
 #' @examples
+#' set.seed(596)
 #' dsub <- diamonds[sample(nrow(diamonds), 1000), ]
 #' ggplot(dsub, aes(x = cut, y = carat, fill = clarity)) +
 #'   geom_boxplot(outlier.size = 0) +

--- a/R/scale-brewer.r
+++ b/R/scale-brewer.r
@@ -40,6 +40,7 @@
 #' @rdname scale_brewer
 #' @export
 #' @examples
+#' set.seed(596)
 #' dsamp <- diamonds[sample(nrow(diamonds), 1000), ]
 #' (d <- ggplot(dsamp, aes(carat, price)) +
 #'   geom_point(aes(colour = clarity)))

--- a/R/scale-hue.r
+++ b/R/scale-hue.r
@@ -15,6 +15,7 @@
 #' @family colour scales
 #' @examples
 #' \donttest{
+#' set.seed(596)
 #' dsamp <- diamonds[sample(nrow(diamonds), 1000), ]
 #' (d <- ggplot(dsamp, aes(carat, price)) + geom_point(aes(colour = clarity)))
 #'

--- a/R/scale-shape.r
+++ b/R/scale-shape.r
@@ -14,6 +14,7 @@
 #' @rdname scale_shape
 #' @export
 #' @examples
+#' set.seed(596)
 #' dsmall <- diamonds[sample(nrow(diamonds), 100), ]
 #'
 #' (d <- ggplot(dsmall, aes(carat, price)) + geom_point(aes(shape = cut)))

--- a/R/scale-viridis.r
+++ b/R/scale-viridis.r
@@ -20,6 +20,7 @@
 #' @export
 #' @examples
 #' # viridis is the default colour/fill scale for ordered factors
+#' set.seed(596)
 #' dsamp <- diamonds[sample(nrow(diamonds), 1000), ]
 #' ggplot(dsamp, aes(carat, price)) +
 #'   geom_point(aes(colour = clarity))

--- a/man/position_jitterdodge.Rd
+++ b/man/position_jitterdodge.Rd
@@ -35,6 +35,7 @@ This is primarily used for aligning points generated through
 a fill aesthetic supplied).
 }
 \examples{
+set.seed(596)
 dsub <- diamonds[sample(nrow(diamonds), 1000), ]
 ggplot(dsub, aes(x = cut, y = carat, fill = clarity)) +
   geom_boxplot(outlier.size = 0) +

--- a/man/scale_brewer.Rd
+++ b/man/scale_brewer.Rd
@@ -134,6 +134,7 @@ Modify the palette through the \code{palette} argument.
 }
 
 \examples{
+set.seed(596)
 dsamp <- diamonds[sample(nrow(diamonds), 1000), ]
 (d <- ggplot(dsamp, aes(carat, price)) +
   geom_point(aes(colour = clarity)))

--- a/man/scale_hue.Rd
+++ b/man/scale_hue.Rd
@@ -113,6 +113,7 @@ It does not generate colour-blind safe palettes.
 }
 \examples{
 \donttest{
+set.seed(596)
 dsamp <- diamonds[sample(nrow(diamonds), 1000), ]
 (d <- ggplot(dsamp, aes(carat, price)) + geom_point(aes(colour = clarity)))
 

--- a/man/scale_shape.Rd
+++ b/man/scale_shape.Rd
@@ -80,6 +80,7 @@ a continuous variable to shape unless \code{scale_shape_binned()} is used. Still
 as shape has no inherent order, this use is not advised.
 }
 \examples{
+set.seed(596)
 dsmall <- diamonds[sample(nrow(diamonds), 100), ]
 
 (d <- ggplot(dsmall, aes(carat, price)) + geom_point(aes(shape = cut)))

--- a/man/scale_viridis.Rd
+++ b/man/scale_viridis.Rd
@@ -136,6 +136,7 @@ with common forms of colour blindness. See also
 }
 \examples{
 # viridis is the default colour/fill scale for ordered factors
+set.seed(596)
 dsamp <- diamonds[sample(nrow(diamonds), 1000), ]
 ggplot(dsamp, aes(carat, price)) +
   geom_point(aes(colour = clarity))


### PR DESCRIPTION
This code is heavily used in our examples. Shouldn't we set a seed to make this deterministic?

```r
dsub <- diamonds[sample(nrow(diamonds), 1000), ]
```