### PR TITLE
Followup after v3.3.4 release

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,12 +1,10 @@
-#on:
-#  push:
-#    branches:
-#      - master
-#  pull_request:
-#    branches:
-#      - master
-
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 name: R-CMD-check
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: ggplot2
-Version: 3.3.4
+Version: 3.3.4.9000
 Title: Create Elegant Data Visualisations Using the Grammar of Graphics
 Description: A system for 'declaratively' creating graphics,
     based on "The Grammar of Graphics". You provide the data, tell 'ggplot2'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# ggplot2 (development version)
+
 # ggplot2 3.3.4
 This is a larger patch release fixing a huge number of bugs and introduces a 
 small selection of feature refinements.

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,8 @@ small selection of feature refinements.
   correctly (@thomasp85, #4388)
 
 * `ggsave()` now returns the saved file location invisibly (#3379, @eliocamp).
+  Note that, as a side effect, an unofficial hack `<ggplot object> + ggsave()`
+  no longer works (#4513).
 
 * The scale arguments `limits`, `breaks`, `minor_breaks`, `labels`, `rescaler`
   and `oob` now accept purrr style lambda notation (@teunbrand, #4427). The same 


### PR DESCRIPTION
* Use the dev version
* Revert the tweaked settings for GitHub Actions CI
* Add a note that `+ ggsave()` no longer works, fix #4513