### PR TITLE
Do not pass bg arg to grDevices::win.metafile()

### DIFF
--- a/R/save.r
+++ b/R/save.r
@@ -192,8 +192,9 @@ plot_dev <- function(device, filename = NULL, dpi = 300) {
     tex =  function(filename, ...) grDevices::pictex(file = filename, ...),
     pdf =  function(filename, ..., version = "1.4") grDevices::pdf(file = filename, ..., version = version),
     svg =  function(filename, ...) svglite::svglite(file = filename, ...),
-    emf =  function(...) grDevices::win.metafile(...),
-    wmf =  function(...) grDevices::win.metafile(...),
+    # win.metafile() doesn't have `bg` arg so we need to absorb it before passing `...`
+    emf =  function(..., bg = NULL) grDevices::win.metafile(...),
+    wmf =  function(..., bg = NULL) grDevices::win.metafile(...),
     png =  function(...) png_dev(..., res = dpi, units = "in"),
     jpg =  function(...) jpeg_dev(..., res = dpi, units = "in"),
     jpeg = function(...) jpeg_dev(..., res = dpi, units = "in"),


### PR DESCRIPTION
Fix #4521 

#4164 adds `bg` arg to `ggsave()`, but `grDevices::win.metafile()` is the exception in that it doesn't have `bg` argument. We need to absorb it in the wrapper function.