### PR TITLE
Use the dev version of pkgdown

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Install dependencies
         run: |
           pak::local_install_dev_deps(upgrade = TRUE, dependencies = c("all", "Config/Needs/website"))
-          pak::pkg_install("pkgdown")
+          pak::pkg_install("r-lib/pkgdown")
         shell: Rscript {0}
 
       - name: Install package

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -118,6 +118,7 @@ reference:
   - expand_limits
   - expansion
   - starts_with("scale_")
+  - get_alt_text
 
 - title: "Guides: axes and legends"
   desc: >


### PR DESCRIPTION
Fix #4540

Currently the CRAN version of pkgdown seems to have a bug on linking topics. @maelle adviced me to use the dev version of pkgdown (c.f. https://github.com/r-lib/pkgdown/issues/1733), and I confirmed it works as expected on my forked repo: https://yutannihilation.github.io/ggplot2/dev/reference/theme.html