### PR TITLE
Fix a typo in changelog (wrong issue number)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,7 +87,7 @@ small selection of feature refinements.
 * It is now deprecated to specify `guides(<scale> = FALSE)` or
   `scale_*(guide = FALSE)` to remove a guide. Please use 
   `guides(<scale> = "none")` or `scale_*(guide = "none")` instead 
-  (@yutannihilation, #4094).
+  (@yutannihilation, #4097)
   
 * Fix a bug in `guide_bins()` where keys would disappear if the guide was 
   reversed (@thomasp85, #4210)


### PR DESCRIPTION
Just fixing a typo discovered when looking at this entry find out what was the reason for deprecation and whether there are some ramifications, so having a correct link might be helpful to others too (if you agree, please also consider updating it manually in the release notes on GitHub).

The correct issue is #4097 but #4094 was referenced in the changelog.