### PR TITLE
Add `trans` option in `annotation_logticks()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -266,7 +266,7 @@ Collate:
     'zxx.r'
     'zzz.r'
 VignetteBuilder: knitr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8
 Config/Needs/website:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Allow transformations inside `annotate_logticks()`, which is useful for
+  secondary axes (@benjaminrich, #4636)
+
 * `scale_*_manual()` no longer displays extra legend keys, or changes their 
   order, when a named `values` argument has more items than the data. To display
   all `values` on the legend instead, use

--- a/R/annotation-logticks.r
+++ b/R/annotation-logticks.r
@@ -20,6 +20,7 @@
 #'   (default) when the data is already transformed with `log10()` or when
 #'   using `scale_y_log10()`. It should be `FALSE` when using
 #'   `coord_trans(y = "log10")`.
+#' @param trans A function (or formula in rlang lambda notation).
 #' @param colour Colour of the tick marks.
 #' @param size Thickness of tick marks, in mm.
 #' @param linetype Linetype of tick marks (`solid`, `dashed`, etc.)
@@ -79,7 +80,7 @@
 #'   mid = unit(3,"mm"),
 #'   long = unit(4,"mm")
 #' )
-annotation_logticks <- function(base = 10, sides = "bl", outside = FALSE, scaled = TRUE,
+annotation_logticks <- function(base = 10, sides = "bl", outside = FALSE, scaled = TRUE, trans = ~.,
     short = unit(0.1, "cm"), mid = unit(0.2, "cm"), long = unit(0.3, "cm"),
     colour = "black", size = 0.5, linetype = 1, alpha = 1, color = NULL, ...)
 {
@@ -99,6 +100,7 @@ annotation_logticks <- function(base = 10, sides = "bl", outside = FALSE, scaled
       sides = sides,
       outside = outside,
       scaled = scaled,
+      trans = trans,
       short = short,
       mid = mid,
       long = long,
@@ -122,7 +124,7 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
   },
 
   draw_panel = function(data, panel_params, coord, base = 10, sides = "bl",
-                        outside = FALSE, scaled = TRUE, short = unit(0.1, "cm"),
+                        outside = FALSE, scaled = TRUE, trans = ~., short = unit(0.1, "cm"),
                         mid = unit(0.2, "cm"), long = unit(0.3, "cm"))
   {
     ticks <- list()
@@ -150,6 +152,9 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
 
       if (scaled)
         xticks$value <- log(xticks$value, base)
+
+      trans <- as_function(trans)
+      xticks$value <- trans(xticks$value)
 
       names(xticks)[names(xticks) == "value"] <- x_name   # Rename to 'x' for coordinates$transform
       xticks <- coord$transform(xticks, panel_params)
@@ -188,6 +193,9 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
 
       if (scaled)
         yticks$value <- log(yticks$value, base)
+
+      trans <- as_function(trans)
+      yticks$value <- trans(yticks$value)
 
       names(yticks)[names(yticks) == "value"] <- y_name   # Rename to 'y' for coordinates$transform
       yticks <- coord$transform(yticks, panel_params)

--- a/man/annotation_logticks.Rd
+++ b/man/annotation_logticks.Rd
@@ -9,6 +9,7 @@ annotation_logticks(
   sides = "bl",
   outside = FALSE,
   scaled = TRUE,
+  trans = ~.,
   short = unit(0.1, "cm"),
   mid = unit(0.2, "cm"),
   long = unit(0.3, "cm"),
@@ -35,6 +36,8 @@ of the plot area. Default is off (\code{FALSE}). You will also need to use
 (default) when the data is already transformed with \code{log10()} or when
 using \code{scale_y_log10()}. It should be \code{FALSE} when using
 \code{coord_trans(y = "log10")}.}
+
+\item{trans}{A function (or formula in rlang lambda notation).}
 
 \item{short}{a \code{\link[grid:unit]{grid::unit()}} object specifying the length of the
 short tick marks}


### PR DESCRIPTION
This is intended to address #4636.

I could really use some help with this, as I've never contributed to ggplot2 before, and I'm not really sure of the best way to do this.

It's a simple enough change, should not break anything, and it does solve the problem described in #4636 if you add `trans= ~ f(.)` inside `annotation_logticks()`, like this:

```r
df1 <- data.frame(x=0:10, y=seq(10, 0, len=11))
df2 <- data.frame(x=0:10, y=seq(0.1, 1000, len=11))

ylim1 <- c(0, 10)
ylim2 <- log10(c(0.1, 1000))

f <- function(y) (diff(ylim1)/diff(ylim2))*(y - min(ylim2)) + min(ylim1)
g <- function(y) (diff(ylim2)/diff(ylim1))*(y - min(ylim1)) + min(ylim2)


ggplot() +
  geom_col(data=df1, aes(x=x, y=y, color="linear scale"), alpha=0.2) +
  geom_line(data=df2, aes(x=x, y=f(log10(y)), color="log scale"), size=2) +
  scale_y_continuous("Linear Scale",
    sec.axis=sec_axis(~ g(.), name="Log Scale", labels=function(x) 10^x)) +
  annotation_logticks(sides="r", color="red", trans= ~ f(.)) +
  scale_color_manual(breaks=c("linear scale", "log scale"), values=c("blue", "red")) +
  theme_classic() +
  theme(
    axis.title.y       = element_text(color="blue"),
    axis.text.y        = element_text(color="blue"),
    axis.ticks.y       = element_line(color="blue"),
    axis.title.y.right = element_text(color="red"),
    axis.text.y.right  = element_text(color="red"),
    axis.ticks.y.right = element_line(color="red"))
```
![image](https://user-images.githubusercontent.com/17572252/136455192-d5c5b093-e21d-4bf3-b2e5-28ff49953d1b.png)
