### PR TITLE
Add arrow to line params

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* `geom_sf()` now respects `arrow` parameter for lines (@jakeruss, #4659)
+
 * Updated documentation for `print.ggplot` to reflect that it returns
   the original plot, not the result of `ggplot_build()`. (@r2evans, #4390)
 

--- a/R/geom-sf.R
+++ b/R/geom-sf.R
@@ -128,14 +128,15 @@ GeomSf <- ggproto("GeomSf", Geom,
 
   draw_panel = function(data, panel_params, coord, legend = NULL,
                         lineend = "butt", linejoin = "round", linemitre = 10,
-                        na.rm = TRUE) {
+                        arrow = NULL, na.rm = TRUE) {
     if (!inherits(coord, "CoordSf")) {
       abort("geom_sf() must be used with coord_sf()")
     }
 
     # Need to refactor this to generate one grob per geometry type
     coord <- coord$transform(data, panel_params)
-    sf_grob(coord, lineend = lineend, linejoin = linejoin, linemitre = linemitre, na.rm = na.rm)
+    sf_grob(coord, lineend = lineend, linejoin = linejoin, linemitre = linemitre,
+            arrow = arrow, na.rm = na.rm)
   },
 
   draw_key = function(data, params, size) {
@@ -160,7 +161,8 @@ default_aesthetics <- function(type) {
   }
 }
 
-sf_grob <- function(x, lineend = "butt", linejoin = "round", linemitre = 10, na.rm = TRUE) {
+sf_grob <- function(x, lineend = "butt", linejoin = "round", linemitre = 10,
+                    arrow = NULL, na.rm = TRUE) {
   type <- sf_types[sf::st_geometry_type(x$geometry)]
   is_point <- type == "point"
   is_line <- type == "line"
@@ -208,7 +210,8 @@ sf_grob <- function(x, lineend = "butt", linejoin = "round", linemitre = 10, na.
   lty <- x$linetype %||% defaults$linetype[type_ind]
   gp <- gpar(
     col = col, fill = fill, fontsize = fontsize, lwd = lwd, lty = lty,
-    lineend = lineend, linejoin = linejoin, linemitre = linemitre
+    lineend = lineend, linejoin = linejoin, linemitre = linemitre,
+    arrow = arrow
   )
   sf::st_as_grob(x$geometry, pch = pch, gp = gp)
 }

--- a/R/geom-sf.R
+++ b/R/geom-sf.R
@@ -210,10 +210,9 @@ sf_grob <- function(x, lineend = "butt", linejoin = "round", linemitre = 10,
   lty <- x$linetype %||% defaults$linetype[type_ind]
   gp <- gpar(
     col = col, fill = fill, fontsize = fontsize, lwd = lwd, lty = lty,
-    lineend = lineend, linejoin = linejoin, linemitre = linemitre,
-    arrow = arrow
+    lineend = lineend, linejoin = linejoin, linemitre = linemitre
   )
-  sf::st_as_grob(x$geometry, pch = pch, gp = gp)
+  sf::st_as_grob(x$geometry, pch = pch, gp = gp, arrow = arrow)
 }
 
 #' @export

--- a/tests/testthat/_snaps/geom-sf/north-carolina-county-boundaries-with-arrow.svg
+++ b/tests/testthat/_snaps/geom-sf/north-carolina-county-boundaries-with-arrow.svg
@@ -20,52 +20,53 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMC4wMHw3MjAuMDB8MzMuNzh8NTQyLjIy'>
-    <rect x='0.00' y='33.78' width='720.00' height='508.45' />
+  <clipPath id='cpMC4wMHw3MjAuMDB8MjUuMTJ8NTUwLjg4'>
+    <rect x='0.00' y='25.12' width='720.00' height='525.75' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MzMuNzh8NTQyLjIy)'>
-<rect x='0.00' y='33.78' width='720.00' height='508.45' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MjUuMTJ8NTUwLjg4)'>
+<rect x='0.00' y='25.12' width='720.00' height='525.75' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzIuNDN8NzE0LjUyfDM5LjI1fDUyMy45Mw=='>
-    <rect x='32.43' y='39.25' width='682.09' height='484.68' />
+  <clipPath id='cpMzIuNDN8NzE0LjUyfDQ3LjkxfDUzMi41OA=='>
+    <rect x='32.43' y='47.91' width='682.09' height='484.68' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzIuNDN8NzE0LjUyfDM5LjI1fDUyMy45Mw==)'>
-<rect x='32.43' y='39.25' width='682.09' height='484.68' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='395.14,501.90 63.44,306.35 151.31,61.29 553.56,82.33 651.34,250.65 683.52,339.76 395.14,501.90 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='404.31,486.42 395.14,501.90 413.14,502.11 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<rect x='32.43' y='39.25' width='682.09' height='484.68' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMzIuNDN8NzE0LjUyfDQ3LjkxfDUzMi41OA==)'>
+<rect x='32.43' y='47.91' width='682.09' height='484.68' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='395.14,510.55 63.44,315.00 151.31,69.94 553.56,90.98 651.34,259.30 683.52,348.42 395.14,510.55 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='404.31,495.07 395.14,510.55 413.14,510.76 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='32.43' y='47.91' width='682.09' height='484.68' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='27.50' y='485.13' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.25</text>
-<text x='27.50' y='423.24' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.30</text>
-<text x='27.50' y='361.36' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.35</text>
-<text x='27.50' y='299.47' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.40</text>
-<text x='27.50' y='237.59' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.45</text>
-<text x='27.50' y='175.70' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.50</text>
-<text x='27.50' y='113.82' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.55</text>
-<text x='27.50' y='51.94' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.60</text>
-<polyline points='29.69,482.10 32.43,482.10 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='29.69,420.21 32.43,420.21 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='29.69,358.33 32.43,358.33 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='29.69,296.44 32.43,296.44 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='29.69,234.56 32.43,234.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='29.69,172.68 32.43,172.68 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='29.69,110.79 32.43,110.79 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='29.69,48.91 32.43,48.91 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='114.18,526.67 114.18,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='237.95,526.67 237.95,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='361.72,526.67 361.72,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='485.49,526.67 485.49,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='609.26,526.67 609.26,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='114.18' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.7</text>
-<text x='237.95' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.6</text>
-<text x='361.72' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.5</text>
-<text x='485.49' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.4</text>
-<text x='609.26' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.3</text>
+<text x='27.50' y='493.78' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.25</text>
+<text x='27.50' y='431.89' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.30</text>
+<text x='27.50' y='370.01' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.35</text>
+<text x='27.50' y='308.13' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.40</text>
+<text x='27.50' y='246.24' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.45</text>
+<text x='27.50' y='184.36' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.50</text>
+<text x='27.50' y='122.47' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.55</text>
+<text x='27.50' y='60.59' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.60</text>
+<polyline points='29.69,490.75 32.43,490.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,428.87 32.43,428.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,366.98 32.43,366.98 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,305.10 32.43,305.10 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,243.21 32.43,243.21 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,181.33 32.43,181.33 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,119.44 32.43,119.44 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,57.56 32.43,57.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='114.18,535.32 114.18,532.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='237.95,535.32 237.95,532.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='361.72,535.32 361.72,532.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='485.49,535.32 485.49,532.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='609.26,535.32 609.26,532.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='114.18' y='543.57' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.7</text>
+<text x='237.95' y='543.57' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.6</text>
+<text x='361.72' y='543.57' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.5</text>
+<text x='485.49' y='543.57' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.4</text>
+<text x='609.26' y='543.57' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.3</text>
+<text x='32.43' y='39.69' style='font-size: 13.20px; font-family: sans;' textLength='260.49px' lengthAdjust='spacingAndGlyphs'>North Carolina county boundaries with arrow</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/geom-sf/north-carolina-county-boundaries-with-arrow.svg
+++ b/tests/testthat/_snaps/geom-sf/north-carolina-county-boundaries-with-arrow.svg
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MzMuNzh8NTQyLjIy'>
+    <rect x='0.00' y='33.78' width='720.00' height='508.45' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MzMuNzh8NTQyLjIy)'>
+<rect x='0.00' y='33.78' width='720.00' height='508.45' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzIuNDN8NzE0LjUyfDM5LjI1fDUyMy45Mw=='>
+    <rect x='32.43' y='39.25' width='682.09' height='484.68' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzIuNDN8NzE0LjUyfDM5LjI1fDUyMy45Mw==)'>
+<rect x='32.43' y='39.25' width='682.09' height='484.68' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='395.14,501.90 63.44,306.35 151.31,61.29 553.56,82.33 651.34,250.65 683.52,339.76 395.14,501.90 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='404.31,486.42 395.14,501.90 413.14,502.11 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='32.43' y='39.25' width='682.09' height='484.68' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='27.50' y='485.13' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.25</text>
+<text x='27.50' y='423.24' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.30</text>
+<text x='27.50' y='361.36' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.35</text>
+<text x='27.50' y='299.47' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.40</text>
+<text x='27.50' y='237.59' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.45</text>
+<text x='27.50' y='175.70' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.50</text>
+<text x='27.50' y='113.82' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.55</text>
+<text x='27.50' y='51.94' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.60</text>
+<polyline points='29.69,482.10 32.43,482.10 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,420.21 32.43,420.21 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,358.33 32.43,358.33 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,296.44 32.43,296.44 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,234.56 32.43,234.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,172.68 32.43,172.68 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,110.79 32.43,110.79 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,48.91 32.43,48.91 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='114.18,526.67 114.18,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='237.95,526.67 237.95,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='361.72,526.67 361.72,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='485.49,526.67 485.49,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='609.26,526.67 609.26,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='114.18' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.7</text>
+<text x='237.95' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.6</text>
+<text x='361.72' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.5</text>
+<text x='485.49' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.4</text>
+<text x='609.26' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.3</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/geom-sf/north-carolina-county-boundaries-with-more-than-one-arrow.svg
+++ b/tests/testthat/_snaps/geom-sf/north-carolina-county-boundaries-with-more-than-one-arrow.svg
@@ -20,62 +20,63 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMC4wMHw3MjAuMDB8MzMuNzh8NTQyLjIy'>
-    <rect x='0.00' y='33.78' width='720.00' height='508.45' />
+  <clipPath id='cpMC4wMHw3MjAuMDB8MjUuMTJ8NTUwLjg4'>
+    <rect x='0.00' y='25.12' width='720.00' height='525.75' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MzMuNzh8NTQyLjIy)'>
-<rect x='0.00' y='33.78' width='720.00' height='508.45' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MjUuMTJ8NTUwLjg4)'>
+<rect x='0.00' y='25.12' width='720.00' height='525.75' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzIuNDN8NzE0LjUyfDM5LjI1fDUyMy45Mw=='>
-    <rect x='32.43' y='39.25' width='682.09' height='484.68' />
+  <clipPath id='cpMzIuNDN8NzE0LjUyfDQ3LjkxfDUzMi41OA=='>
+    <rect x='32.43' y='47.91' width='682.09' height='484.68' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzIuNDN8NzE0LjUyfDM5LjI1fDUyMy45Mw==)'>
-<rect x='32.43' y='39.25' width='682.09' height='484.68' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='395.14,501.90 63.44,306.35 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='81.44,306.51 63.44,306.35 72.30,322.02 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='63.44,306.35 151.31,61.29 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='154.52,79.00 151.31,61.29 137.58,72.92 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='151.31,61.29 553.56,82.33 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='537.52,90.50 553.56,82.33 538.46,72.52 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='553.56,82.33 651.34,250.65 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='635.72,241.69 651.34,250.65 651.29,232.65 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='651.34,250.65 683.52,339.76 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='669.76,328.16 683.52,339.76 686.69,322.05 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='683.52,339.76 395.14,501.90 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polyline points='404.31,486.42 395.14,501.90 413.14,502.11 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<rect x='32.43' y='39.25' width='682.09' height='484.68' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpMzIuNDN8NzE0LjUyfDQ3LjkxfDUzMi41OA==)'>
+<rect x='32.43' y='47.91' width='682.09' height='484.68' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='395.14,510.55 63.44,315.00 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='81.44,315.16 63.44,315.00 72.30,330.67 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='63.44,315.00 151.31,69.94 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='154.52,87.65 151.31,69.94 137.58,81.57 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='151.31,69.94 553.56,90.98 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='537.52,99.15 553.56,90.98 538.46,81.18 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='553.56,90.98 651.34,259.30 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='635.72,250.34 651.34,259.30 651.29,241.30 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='651.34,259.30 683.52,348.42 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='669.76,336.81 683.52,348.42 686.69,330.70 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='683.52,348.42 395.14,510.55 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='404.31,495.07 395.14,510.55 413.14,510.76 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='32.43' y='47.91' width='682.09' height='484.68' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='27.50' y='485.13' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.25</text>
-<text x='27.50' y='423.24' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.30</text>
-<text x='27.50' y='361.36' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.35</text>
-<text x='27.50' y='299.47' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.40</text>
-<text x='27.50' y='237.59' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.45</text>
-<text x='27.50' y='175.70' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.50</text>
-<text x='27.50' y='113.82' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.55</text>
-<text x='27.50' y='51.94' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.60</text>
-<polyline points='29.69,482.10 32.43,482.10 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='29.69,420.21 32.43,420.21 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='29.69,358.33 32.43,358.33 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='29.69,296.44 32.43,296.44 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='29.69,234.56 32.43,234.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='29.69,172.68 32.43,172.68 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='29.69,110.79 32.43,110.79 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='29.69,48.91 32.43,48.91 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='114.18,526.67 114.18,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='237.95,526.67 237.95,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='361.72,526.67 361.72,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='485.49,526.67 485.49,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='609.26,526.67 609.26,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='114.18' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.7</text>
-<text x='237.95' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.6</text>
-<text x='361.72' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.5</text>
-<text x='485.49' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.4</text>
-<text x='609.26' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.3</text>
+<text x='27.50' y='493.78' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.25</text>
+<text x='27.50' y='431.89' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.30</text>
+<text x='27.50' y='370.01' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.35</text>
+<text x='27.50' y='308.13' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.40</text>
+<text x='27.50' y='246.24' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.45</text>
+<text x='27.50' y='184.36' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.50</text>
+<text x='27.50' y='122.47' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.55</text>
+<text x='27.50' y='60.59' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.60</text>
+<polyline points='29.69,490.75 32.43,490.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,428.87 32.43,428.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,366.98 32.43,366.98 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,305.10 32.43,305.10 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,243.21 32.43,243.21 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,181.33 32.43,181.33 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,119.44 32.43,119.44 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,57.56 32.43,57.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='114.18,535.32 114.18,532.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='237.95,535.32 237.95,532.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='361.72,535.32 361.72,532.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='485.49,535.32 485.49,532.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='609.26,535.32 609.26,532.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='114.18' y='543.57' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.7</text>
+<text x='237.95' y='543.57' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.6</text>
+<text x='361.72' y='543.57' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.5</text>
+<text x='485.49' y='543.57' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.4</text>
+<text x='609.26' y='543.57' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.3</text>
+<text x='32.43' y='39.69' style='font-size: 13.20px; font-family: sans;' textLength='349.29px' lengthAdjust='spacingAndGlyphs'>North Carolina county boundaries with more than one arrow</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/geom-sf/north-carolina-county-boundaries-with-more-than-one-arrow.svg
+++ b/tests/testthat/_snaps/geom-sf/north-carolina-county-boundaries-with-more-than-one-arrow.svg
@@ -1,0 +1,81 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MzMuNzh8NTQyLjIy'>
+    <rect x='0.00' y='33.78' width='720.00' height='508.45' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MzMuNzh8NTQyLjIy)'>
+<rect x='0.00' y='33.78' width='720.00' height='508.45' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzIuNDN8NzE0LjUyfDM5LjI1fDUyMy45Mw=='>
+    <rect x='32.43' y='39.25' width='682.09' height='484.68' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzIuNDN8NzE0LjUyfDM5LjI1fDUyMy45Mw==)'>
+<rect x='32.43' y='39.25' width='682.09' height='484.68' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='395.14,501.90 63.44,306.35 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='81.44,306.51 63.44,306.35 72.30,322.02 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='63.44,306.35 151.31,61.29 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='154.52,79.00 151.31,61.29 137.58,72.92 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='151.31,61.29 553.56,82.33 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='537.52,90.50 553.56,82.33 538.46,72.52 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='553.56,82.33 651.34,250.65 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='635.72,241.69 651.34,250.65 651.29,232.65 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='651.34,250.65 683.52,339.76 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='669.76,328.16 683.52,339.76 686.69,322.05 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='683.52,339.76 395.14,501.90 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='404.31,486.42 395.14,501.90 413.14,502.11 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<rect x='32.43' y='39.25' width='682.09' height='484.68' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='27.50' y='485.13' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.25</text>
+<text x='27.50' y='423.24' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.30</text>
+<text x='27.50' y='361.36' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.35</text>
+<text x='27.50' y='299.47' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.40</text>
+<text x='27.50' y='237.59' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.45</text>
+<text x='27.50' y='175.70' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.50</text>
+<text x='27.50' y='113.82' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.55</text>
+<text x='27.50' y='51.94' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>36.60</text>
+<polyline points='29.69,482.10 32.43,482.10 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,420.21 32.43,420.21 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,358.33 32.43,358.33 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,296.44 32.43,296.44 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,234.56 32.43,234.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,172.68 32.43,172.68 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,110.79 32.43,110.79 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='29.69,48.91 32.43,48.91 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='114.18,526.67 114.18,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='237.95,526.67 237.95,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='361.72,526.67 361.72,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='485.49,526.67 485.49,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='609.26,526.67 609.26,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='114.18' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.7</text>
+<text x='237.95' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.6</text>
+<text x='361.72' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.5</text>
+<text x='485.49' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.4</text>
+<text x='609.26' y='534.92' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-81.3</text>
+</g>
+</svg>

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -207,7 +207,7 @@ test_that("geom_sf draws arrows correctly", {
   skip_if_not_installed("sf")
   if (packageVersion("sf") < "0.5.3") skip("Need sf 0.5.3")
 
-  nc_tiny_coords <- data_frame(
+  nc_tiny_coords <- tibble::data_frame(
     x = c(-81.473, -81.741, -81.67, -81.345, -81.266, -81.24, -81.473),
     y = c(36.234, 36.392, 36.59, 36.573, 36.437, 36.365, 36.234)
   )

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -202,3 +202,38 @@ test_that("geom_sf_text() and geom_sf_label() draws correctly", {
     ggplot() + geom_sf_label(data = nc_3857, aes(label = NAME))
   )
 })
+
+test_that("geom_sf draws arrows correctly", {
+  skip_if_not_installed("sf")
+  if (packageVersion("sf") < "0.5.3") skip("Need sf 0.5.3")
+
+  nc_tiny_coords <- data_frame(
+    x = c(-81.473, -81.741, -81.67, -81.345, -81.266, -81.24, -81.473),
+    y = c(36.234, 36.392, 36.59, 36.573, 36.437, 36.365, 36.234)
+  )
+
+  nc <- sf::st_linestring(
+      sf::st_coordinates(sf::st_as_sf(nc_tiny_coords, coords = c("x", "y"), crs = 4326))
+    )
+
+  nc2 <- sf::st_cast(
+    sf::st_sfc(
+      sf::st_multilinestring(lapply(
+        1:(length(st_coordinates(nc)[, 1]) - 1),
+          function(x) rbind(
+            as.numeric(st_coordinates(nc)[x, 1:2]),
+            as.numeric(st_coordinates(nc)[x + 1, 1:2])
+            )
+        )
+      ), sf::st_crs(nc)
+    ), "LINESTRING"
+  )
+
+  expect_doppelganger("North Carolina county boundaries with arrow",
+                      ggplot() + geom_sf(data = nc, arrow = arrow()) + coord_sf(datum = 4326)
+  )
+
+  expect_doppelganger("North Carolina county boundaries with more than one arrow",
+                      ggplot() + geom_sf(data = nc2, arrow = arrow()) + coord_sf(datum = 4326)
+  )
+})

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -207,7 +207,7 @@ test_that("geom_sf draws arrows correctly", {
   skip_if_not_installed("sf")
   if (packageVersion("sf") < "0.5.3") skip("Need sf 0.5.3")
 
-  nc_tiny_coords <- tibble::data_frame(
+  nc_tiny_coords <- data_frame(
     x = c(-81.473, -81.741, -81.67, -81.345, -81.266, -81.24, -81.473),
     y = c(36.234, 36.392, 36.59, 36.573, 36.437, 36.365, 36.234)
   )
@@ -230,10 +230,10 @@ test_that("geom_sf draws arrows correctly", {
   )
 
   expect_doppelganger("North Carolina county boundaries with arrow",
-                      ggplot() + geom_sf(data = nc, arrow = arrow()) + coord_sf(datum = 4326)
+    ggplot() + geom_sf(data = nc, arrow = arrow()) + coord_sf(datum = 4326)
   )
 
   expect_doppelganger("North Carolina county boundaries with more than one arrow",
-                      ggplot() + geom_sf(data = nc2, arrow = arrow()) + coord_sf(datum = 4326)
+    ggplot() + geom_sf(data = nc2, arrow = arrow()) + coord_sf(datum = 4326)
   )
 })

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -219,10 +219,10 @@ test_that("geom_sf draws arrows correctly", {
   nc2 <- sf::st_cast(
     sf::st_sfc(
       sf::st_multilinestring(lapply(
-        1:(length(st_coordinates(nc)[, 1]) - 1),
+        1:(length(sf::st_coordinates(nc)[, 1]) - 1),
           function(x) rbind(
-            as.numeric(st_coordinates(nc)[x, 1:2]),
-            as.numeric(st_coordinates(nc)[x + 1, 1:2])
+            as.numeric(sf::st_coordinates(nc)[x, 1:2]),
+            as.numeric(sf::st_coordinates(nc)[x + 1, 1:2])
             )
         )
       ), sf::st_crs(nc)


### PR DESCRIPTION
My vague recollection when I opened #4391, was I thought adding arrow was basically adding it to the list. As you can see from this commit it doesn't work. 

I expected the following to work, but no. 
````
library(sf)
library(ggplot2)

coords <- tibble::tibble(lat = c(26.562855, 28.538336), 
                         lon = c(-81.949532, -81.379234)) %>%
  st_as_sf(coords = c("lon", "lat"),  crs = 4326, remove = FALSE) %>%
  st_coordinates() %>%
  st_linestring()

ggplot() + 
  geom_sf(data = coords, size = 2, 
          arrow = arrow(angle = 45, ends = "last", type = "open", length = unit(0.5, "inches")))
````

I'm not sure I understand enough to complete this task 