### PR TITLE
Make weight a recognised aesthetic in stat_bin_2d

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* `stat_bin_2d()` now correctly recognises the `weight` aesthetic 
+  (@thomasp85, #4646)
+  
 * All geoms now have consistent exposure of linejoin and lineend parameters, and
   the guide keys will now respect these settings (@thomasp85, #4653)
 

--- a/R/stat-bin2d.r
+++ b/R/stat-bin2d.r
@@ -50,7 +50,7 @@ stat_bin2d <- stat_bin_2d
 #' @usage NULL
 #' @export
 StatBin2d <- ggproto("StatBin2d", Stat,
-  default_aes = aes(fill = after_stat(count)),
+  default_aes = aes(weight = 1, fill = after_stat(count)),
   required_aes = c("x", "y"),
 
   compute_group = function(data, scales, binwidth = NULL, bins = 30,


### PR DESCRIPTION
Fix #4646 - This PR adds a default value to the `weight` aesthetic ensuring that it doesn't emit a warning when given