### PR TITLE
Don't allow stroke = NA to mess up point sizing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Setting `stroke` to `NA` in `geom_point()` will no longer impair the sizing of
+  the points (@thomasp85, #4624)
+
 * All geoms now have consistent exposure of linejoin and lineend parameters, and
   the guide keys will now respect these settings (@thomasp85, #4653)
 

--- a/R/geom-point.r
+++ b/R/geom-point.r
@@ -122,6 +122,8 @@ GeomPoint <- ggproto("GeomPoint", Geom,
     }
 
     coords <- coord$transform(data, panel_params)
+    stroke_size <- coords$stroke
+    stroke_size[is.na(stroke_size)] <- 0
     ggname("geom_point",
       pointsGrob(
         coords$x, coords$y,
@@ -130,7 +132,7 @@ GeomPoint <- ggproto("GeomPoint", Geom,
           col = alpha(coords$colour, coords$alpha),
           fill = alpha(coords$fill, coords$alpha),
           # Stroke is added around the outside of the point
-          fontsize = coords$size * .pt + coords$stroke * .stroke / 2,
+          fontsize = coords$size * .pt + stroke_size * .stroke / 2,
           lwd = coords$stroke * .stroke / 2
         )
       )


### PR DESCRIPTION
Fix #4624 by treating ´NA` as `0` when calculating point size