### PR TITLE
follow tidyverse recycling rules for aesthetics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Aesthetics of length 1 are now recycled to 0 if the length of the data is 0 
+  (@thomasp85, #4588)
+
 * Setting `stroke` to `NA` in `geom_point()` will no longer impair the sizing of
   the points (@thomasp85, #4624)
 

--- a/R/geom-.r
+++ b/R/geom-.r
@@ -208,7 +208,7 @@ NULL
 .stroke <- 96 / 25.4
 
 check_aesthetics <- function(x, n) {
-  ns <- vapply(x, length, numeric(1))
+  ns <- vapply(x, length, integer(1))
   good <- ns == 1L | ns == n
 
   if (all(good)) {

--- a/R/layer.r
+++ b/R/layer.r
@@ -264,7 +264,8 @@ Layer <- ggproto("Layer", NULL,
       if (length(evaled) == 0) {
         n <- 0
       } else {
-        n <- max(vapply(evaled, length, integer(1)))
+        aes_n <- vapply(evaled, length, integer(1))
+        n <- if (min(aes_n) == 0) 0L else max(aes_n)
       }
     }
     check_aesthetics(evaled, n)

--- a/tests/testthat/test-aes-setting.r
+++ b/tests/testthat/test-aes-setting.r
@@ -13,6 +13,17 @@ test_that("aesthetic parameters match length of data", {
   set_colours(rep("red", 5))
 })
 
+test_that("Length 1 aesthetics are recycled to 0", {
+  p <- ggplot(data.frame(x = numeric(), y = numeric())) +
+    geom_point(aes(x, y, colour = "red"))
+
+  expect_silent(plot(p))
+
+  data <- layer_data(p)
+
+  expect_equal(nrow(data), 0)
+})
+
 test_that("legend filters out aesthetics not of length 1", {
   df <- data_frame(x = 1:5, y = 1:5)
   p <- ggplot(df, aes(x, y, colour = factor(x))) +


### PR DESCRIPTION
Fix #4588 

This PR allows mix of 0-length and 1-length vectors (recycled to 0) in aesthetics... It both puts ggplot2 in line with our decided recycling rules and makes it less error-prone to set aesthetics to scalars as these values can now be mixed with all sizes of data (even 0)