### PR TITLE
Pass on binwidth and height to geom

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* `geom_hex()` will now use the binwidth from `stat_bin_hex()` if present, 
+  instead of deriving it (@thomasp85, #4580)
+
 * Setting `stroke` to `NA` in `geom_point()` will no longer impair the sizing of
   the points (@thomasp85, #4624)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * `geom_hex()` will now use the binwidth from `stat_bin_hex()` if present, 
   instead of deriving it (@thomasp85, #4580)
+  
+* `geom_hex()` now works on non-linear coordinate systems (@thomasp85)
 
 * Setting `stroke` to `NA` in `geom_point()` will no longer impair the sizing of
   the points (@thomasp85, #4624)

--- a/R/geom-hex.r
+++ b/R/geom-hex.r
@@ -66,6 +66,9 @@ GeomHex <- ggproto("GeomHex", Geom,
     } else {
       dx <- resolution(data$x, FALSE)
     }
+    # Adjust for difference in width and height of regular hexagon. 1.15 adjusts
+    # for the effect of the overlapping range in y-direction on the resolution
+    # calculation
     if (!is.null(data$height)) {
       dy <- data$height[1] /  sqrt(3) / 2
     } else {

--- a/R/geom-hex.r
+++ b/R/geom-hex.r
@@ -59,28 +59,31 @@ GeomHex <- ggproto("GeomHex", Geom,
     if (empty(data)) {
       return(zeroGrob())
     }
-    if (!inherits(coord, "CoordCartesian")) {
-      abort("geom_hex() only works with Cartesian coordinates")
-    }
-    # Extract binwidth and height from data if possible
+
+    # Get hex sizes
     if (!is.null(data$width)) {
-      data$xend <- data$x + data$width
+      dx <- data$width[1] / 2
+    } else {
+      dx <- resolution(data$x, FALSE)
     }
     if (!is.null(data$height)) {
-      data$yend <- data$y + data$height
+      dy <- data$height[1] /  sqrt(3) / 2
+    } else {
+      dy <- resolution(data$y, FALSE) / sqrt(3) / 2 * 1.15
     }
+
+    hexC <- hexbin::hexcoords(dx, dy, n = 1)
+
+    n <- nrow(data)
+
+    data <- data[rep(seq_len(n), each = 6), ]
+    data$x <- rep.int(hexC$x, n) + data$x
+    data$y <- rep.int(hexC$y, n) + data$y
 
     coords <- coord$transform(data, panel_params)
 
-    binwidth <- c(NA, NA)
-    if (!is.null(data$width)) {
-      binwidth[1] <- coords$xend[1] - coords$x[1]
-    }
-    if (!is.null(data$height)) {
-      binwidth[2] <- coords$yend[1] - coords$y[1]
-    }
-    ggname("geom_hex", hexGrob(
-      coords$x, coords$y, binwidth,
+    ggname("geom_hex", polygonGrob(
+      coords$x, coords$y,
       gp = gpar(
         col = coords$colour,
         fill = alpha(coords$fill, coords$alpha),
@@ -89,7 +92,9 @@ GeomHex <- ggproto("GeomHex", Geom,
         lineend = lineend,
         linejoin = linejoin,
         linemitre = linemitre
-      )
+      ),
+      default.units = "native",
+      id.lengths = rep.int(6, n)
     ))
   },
 
@@ -115,11 +120,13 @@ GeomHex <- ggproto("GeomHex", Geom,
 # @param size vector of hex sizes
 # @param gp graphical parameters
 # @keyword internal
-hexGrob <- function(x, y, binwidth, size = rep(1, length(x)), gp = gpar()) {
+#
+# THIS IS NO LONGER USED BUT LEFT IF CODE SOMEWHERE ELSE RELIES ON IT
+hexGrob <- function(x, y, size = rep(1, length(x)), gp = gpar()) {
   if (length(y) != length(x)) abort("`x` and `y` must have the same length")
 
-  dx <- if (is.na(binwidth[1])) resolution(x, FALSE) else binwidth[1]/2
-  dy <- if (is.na(binwidth[2])) resolution(y, FALSE) / sqrt(3) / 2 * 1.15 else binwidth[2]/ sqrt(3) / 2
+  dx <- resolution(x, FALSE)
+  dy <- resolution(y, FALSE) / sqrt(3) / 2 * 1.15
 
   hexC <- hexbin::hexcoords(dx, dy, n = 1)
 

--- a/R/hexbin.R
+++ b/R/hexbin.R
@@ -36,6 +36,8 @@ hexBinSummarise <- function(x, y, z, binwidth, fun = mean, fun.args = list(), dr
   # Convert to data frame
   out <- new_data_frame(hexbin::hcell2xy(hb))
   out$value <- as.vector(value)
+  out$width <- binwidth[1]
+  out$height <- binwidth[2]
 
   if (drop) out <- stats::na.omit(out)
   out

--- a/tests/testthat/_snaps/geom-hex/hex-bin-plot-in-polar-coordinates.svg
+++ b/tests/testthat/_snaps/geom-hex/hex-bin-plot-in-polar-coordinates.svg
@@ -1,0 +1,183 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTEuMjV8NjY4Ljc1fDAuMDB8NTc2LjAw'>
+    <rect x='51.25' y='0.00' width='617.50' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTEuMjV8NjY4Ljc1fDAuMDB8NTc2LjAw)'>
+<rect x='51.25' y='0.00' width='617.50' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpODQuMDR8NjEyLjQzfDIyLjc4fDU1MS4xNw=='>
+    <rect x='84.04' y='22.78' width='528.39' height='528.39' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODQuMDR8NjEyLjQzfDIyLjc4fDU1MS4xNw==)'>
+<rect x='84.04' y='22.78' width='528.39' height='528.39' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polygon points='347.05,288.60 349.42,285.35 350.25,283.49 349.05,285.14 347.42,288.81 346.22,290.46 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #2F638E;' />
+<polygon points='337.76,277.55 340.75,280.24 341.72,282.24 339.52,281.94 336.03,279.93 335.21,277.51 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #2F638E;' />
+<polygon points='338.17,304.41 340.18,300.92 342.50,299.85 343.26,302.29 342.01,306.12 339.23,307.20 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #2F638E;' />
+<polygon points='328.54,291.16 332.48,290.32 334.83,291.33 333.52,293.53 329.85,295.16 327.18,293.82 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #2F638E;' />
+<polygon points='328.54,282.79 332.48,283.63 334.22,285.50 332.13,286.98 328.10,286.98 326.21,284.66 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #2F638E;' />
+<polygon points='353.67,312.57 352.84,308.63 354.45,306.12 357.24,307.20 358.88,310.88 356.94,313.78 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #2F638E;' />
+<polygon points='332.85,308.15 335.22,304.89 338.17,304.41 339.23,307.20 337.59,310.88 334.14,311.38 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='323.35,295.06 327.18,293.82 329.85,295.16 329.06,298.05 325.57,300.06 322.49,298.44 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='322.21,289.71 326.21,289.29 328.54,291.16 327.18,293.82 323.35,295.06 320.67,292.84 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='325.57,273.89 329.06,275.91 329.85,278.79 327.18,280.13 323.35,278.89 322.49,275.51 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='332.13,314.87 334.14,311.38 337.59,310.88 339.53,313.78 338.28,317.61 334.32,318.24 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='326.68,310.91 329.38,307.92 332.85,308.15 334.14,311.38 332.13,314.87 328.12,314.66 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='318.81,300.08 322.49,298.44 325.57,300.06 325.44,303.54 322.18,305.91 318.60,304.09 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='381.35,306.10 377.87,304.09 377.66,300.08 380.78,297.55 384.61,298.79 385.01,303.35 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='376.66,312.57 373.66,309.87 374.29,305.91 377.87,304.09 381.35,306.10 380.80,310.64 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='356.19,324.39 355.35,320.45 358.19,317.61 362.15,318.24 363.79,321.91 360.67,325.26 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='348.23,325.22 348.23,321.20 351.60,319.01 355.35,320.45 356.19,324.39 352.44,327.01 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='325.75,317.92 328.12,314.66 332.13,314.87 334.32,318.24 332.68,321.91 328.10,321.84 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='315.11,306.10 318.60,304.09 322.18,305.91 322.80,309.87 319.81,312.57 315.66,310.64 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='311.86,298.79 315.69,297.55 318.81,300.08 318.60,304.09 315.11,306.10 311.46,303.35 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='310.20,290.97 314.20,290.55 316.73,293.67 315.69,297.55 311.86,298.79 308.86,295.35 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='311.86,275.16 315.69,276.40 316.73,280.28 314.20,283.40 310.20,282.98 308.86,278.61 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='315.11,267.85 318.60,269.87 318.81,273.88 315.69,276.40 311.86,275.16 311.46,270.60 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='332.68,252.04 334.32,255.72 332.13,259.08 328.12,259.29 325.75,256.04 328.10,252.11 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='370.38,325.33 368.36,321.84 370.71,317.92 375.17,316.89 377.87,319.89 375.45,324.43 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='352.86,331.02 352.44,327.01 356.19,324.39 360.67,325.26 361.92,329.09 357.86,332.26 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='343.60,331.02 344.03,327.01 348.23,325.22 352.44,327.01 352.86,331.02 348.23,333.27 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='334.55,329.09 335.79,325.26 340.28,324.39 344.03,327.01 343.60,331.02 338.61,332.26 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='303.95,286.98 307.98,286.98 310.20,290.97 308.86,295.35 304.92,296.18 302.19,291.82 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='304.92,277.77 308.86,278.61 310.20,282.98 307.98,286.98 303.95,286.98 302.19,282.14 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='385.63,320.65 382.64,317.95 384.06,313.01 388.33,310.12 391.81,312.14 390.57,317.74 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='368.70,332.95 367.06,329.27 370.38,325.33 375.45,324.43 377.81,327.69 374.40,332.30 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='358.70,336.20 357.86,332.26 361.92,329.09 367.06,329.27 368.70,332.95 364.41,336.75 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='318.65,327.69 321.02,324.43 326.09,325.33 329.40,329.27 327.77,332.95 322.07,332.30 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='300.37,302.53 304.20,301.28 307.78,304.99 308.14,310.12 304.65,312.14 300.42,308.26 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='404.59,286.98 400.57,286.98 398.28,281.72 399.43,276.09 403.36,275.26 406.29,280.87 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='354.13,343.03 353.70,339.02 358.70,336.20 364.41,336.75 365.65,340.58 360.37,344.07 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='293.10,298.69 297.04,297.86 300.37,302.53 300.42,308.26 296.75,309.90 292.72,305.01 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='291.87,286.98 295.90,286.98 298.19,292.24 297.04,297.86 293.10,298.69 290.18,293.08 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='373.61,343.98 371.98,340.30 376.41,335.79 382.55,334.20 384.91,337.46 380.44,342.76 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='311.56,337.46 313.92,334.20 320.05,335.79 324.49,340.30 322.85,343.98 316.03,342.76 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='416.67,286.98 412.65,286.98 410.29,280.45 411.24,273.58 415.18,272.75 418.30,279.61 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='415.18,301.21 411.24,300.37 410.29,293.50 412.65,286.98 416.67,286.98 418.30,294.34 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='403.60,327.20 400.34,324.84 402.27,318.18 407.08,313.18 410.76,314.81 409.25,322.20 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='369.38,352.06 368.14,348.24 373.61,343.98 380.44,342.76 382.45,346.25 376.89,351.34 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='314.01,346.25 316.03,342.76 322.85,343.98 328.33,348.24 327.09,352.06 319.58,351.34 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='419.07,263.96 415.24,265.21 410.76,259.14 409.25,251.75 412.73,249.74 418.11,255.86 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='422.30,294.76 418.30,294.34 416.67,286.98 418.30,279.61 422.30,279.19 424.72,286.98 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='378.53,355.01 376.89,351.34 382.45,346.25 389.64,343.97 392.01,347.23 386.48,353.22 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='363.72,359.83 362.88,355.89 369.38,352.06 376.89,351.34 378.53,355.01 371.87,359.72 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='348.23,361.45 348.23,357.43 355.39,355.04 362.88,355.89 363.72,359.83 356.23,363.05 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='304.46,347.23 306.82,343.97 314.01,346.25 319.58,351.34 317.94,355.01 309.99,353.22 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='277.40,263.96 281.23,265.21 281.29,272.75 278.17,279.61 274.16,279.19 273.42,271.07 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='421.79,254.23 418.11,255.86 412.73,249.74 410.12,242.02 413.37,239.65 419.71,245.71 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='428.75,286.98 424.72,286.98 422.30,279.19 423.05,271.07 426.99,270.24 430.31,278.35 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='426.99,303.72 423.05,302.88 422.30,294.76 424.72,286.98 428.75,286.98 430.31,295.60 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='413.37,334.30 410.12,331.94 412.73,324.21 418.11,318.09 421.79,319.72 419.71,328.24 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='356.65,367.05 356.23,363.05 363.72,359.83 371.87,359.72 373.11,363.55 365.39,367.70 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='356.65,206.90 356.23,210.91 348.23,212.50 340.24,210.91 339.82,206.90 348.23,204.45 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='383.44,207.90 381.80,211.58 373.11,210.40 365.39,206.25 366.23,202.31 375.60,202.74 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='430.55,260.23 426.72,261.47 421.79,254.23 419.71,245.71 423.19,243.70 429.14,250.95 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='434.31,296.02 430.31,295.60 428.75,286.98 430.31,278.35 434.31,277.93 436.80,286.98 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='430.55,313.72 426.72,312.48 426.99,303.72 430.31,295.60 434.31,296.02 434.87,305.39 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='412.56,344.89 409.56,342.20 413.37,334.30 419.71,328.24 423.19,330.25 419.89,339.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='383.44,366.05 381.80,362.37 388.49,356.70 396.74,353.74 399.11,357.00 392.52,363.68 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='265.92,313.72 269.74,312.48 274.68,319.72 276.76,328.24 273.28,330.25 267.32,323.00 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='283.91,229.06 286.90,231.75 283.10,239.65 276.76,245.71 273.28,243.70 276.58,234.92 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='423.14,232.55 419.89,234.92 412.56,229.06 407.50,221.16 410.19,218.17 418.54,223.67 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='432.82,249.31 429.14,250.95 423.19,243.70 419.89,234.92 423.14,232.55 430.17,239.67 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='440.83,286.98 436.80,286.98 434.31,277.93 434.87,268.56 438.80,267.72 442.32,277.09 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='438.80,306.23 434.87,305.39 434.31,296.02 436.80,286.98 440.83,286.98 442.32,296.87 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='432.82,324.64 429.14,323.00 430.55,313.72 434.87,305.39 438.80,306.23 438.21,316.21 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='410.19,355.79 407.50,352.79 412.56,344.89 419.89,339.03 423.14,341.40 418.54,350.28 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='357.91,379.06 357.49,375.06 366.23,371.64 375.60,371.21 376.85,375.04 367.90,379.51 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='257.66,267.72 261.60,268.56 262.15,277.93 259.67,286.98 255.64,286.98 254.15,277.09 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='286.28,218.17 288.97,221.16 283.91,229.06 276.58,234.92 273.32,232.55 277.93,223.67 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='388.35,196.87 386.71,200.55 376.85,198.91 367.90,194.44 368.74,190.50 379.33,191.26 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='406.21,207.18 403.84,210.44 394.53,206.79 386.71,200.55 388.35,196.87 398.56,199.82 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='442.04,256.50 438.21,257.74 432.82,249.31 430.17,239.67 433.65,237.66 440.18,246.04 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #214667;' />
+<polygon points='406.21,366.77 403.84,363.51 410.19,355.79 418.54,350.28 421.53,352.97 415.58,361.77 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #214667;' />
+<polygon points='388.35,377.08 386.71,373.40 394.53,367.16 403.84,363.51 406.21,366.77 398.56,374.14 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #214667;' />
+<polygon points='432.91,225.45 429.66,227.82 421.53,220.98 415.58,212.18 418.27,209.19 427.52,215.59 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #214667;' />
+<polygon points='443.86,244.40 440.18,246.04 433.65,237.66 429.66,227.82 432.91,225.45 440.62,233.63 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #214667;' />
+<polygon points='443.86,329.55 440.18,327.91 442.04,317.45 446.68,307.90 450.62,308.74 449.70,319.94 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #214667;' />
+<polygon points='432.91,348.50 429.66,346.13 433.65,336.29 440.18,327.91 443.86,329.55 440.62,340.32 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='418.27,364.76 415.58,361.77 421.53,352.97 429.66,346.13 432.91,348.50 427.52,358.36 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='413.31,197.41 410.94,200.67 400.57,196.33 391.63,189.52 393.26,185.84 404.59,189.36 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='453.52,252.77 449.70,254.01 443.86,244.40 440.62,233.63 444.11,231.62 451.21,241.13 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='444.11,342.33 440.62,340.32 443.86,329.55 449.70,319.94 453.52,321.19 451.21,332.82 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='393.26,388.11 391.63,384.44 400.57,377.62 410.94,373.28 413.31,376.54 404.59,384.60 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='360.44,170.87 360.02,174.87 348.23,176.27 336.45,174.87 336.03,170.87 348.23,168.22 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #3772A2;' />
+<polygon points='406.61,185.87 404.59,189.36 393.26,185.84 383.07,179.77 384.31,175.94 396.54,178.48 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #3772A2;' />
+<polygon points='426.35,200.22 423.66,203.21 413.31,197.41 404.59,189.36 406.61,185.87 418.04,190.90 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #3772A2;' />
+<polygon points='442.68,218.35 439.43,220.72 430.51,212.90 423.66,203.21 426.35,200.22 436.49,207.51 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #3772A2;' />
+<polygon points='454.89,239.49 451.21,241.13 444.11,231.62 439.43,220.72 442.68,218.35 451.08,227.60 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #3772A2;' />
+<polygon points='426.35,373.74 423.66,370.74 430.51,361.06 439.43,353.23 442.68,355.60 436.49,366.44 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #3772A2;' />
+<polygon points='398.18,174.80 396.54,178.48 384.31,175.94 372.93,170.81 373.76,166.87 386.80,168.28 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='420.41,187.64 418.04,190.90 406.61,185.87 396.54,178.48 398.18,174.80 410.63,178.90 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='454.57,225.58 451.08,227.60 442.68,218.35 436.49,207.51 439.48,204.82 449.20,213.62 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='434.43,191.24 431.74,194.23 420.41,187.64 410.63,178.90 412.65,175.41 425.14,181.13 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='465.92,234.58 462.24,236.22 454.57,225.58 449.20,213.62 452.46,211.25 461.54,221.56 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='376.27,155.06 375.44,159.00 361.70,158.86 348.23,156.14 348.23,152.11 362.54,150.85 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='476.50,245.30 472.67,246.54 465.92,234.58 461.54,221.56 465.03,219.54 473.28,231.30 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4691CC;' />
+<polygon points='362.96,146.85 362.54,150.85 348.23,152.11 333.93,150.85 333.51,146.85 348.23,144.06 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4691CC;' />
+<polygon points='418.69,164.95 416.67,168.44 403.09,163.77 390.53,156.80 391.78,152.97 406.36,156.42 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4691CC;' />
+<polygon points='408.00,152.74 406.36,156.42 391.78,152.97 377.95,147.18 378.78,143.25 394.26,145.31 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4691CC;' />
+<polygon points='424.72,154.49 422.71,157.98 408.00,152.74 394.26,145.31 395.51,141.48 411.28,145.38 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4691CC;' />
+<polygon points='412.91,141.71 411.28,145.38 395.51,141.48 380.46,135.37 381.30,131.43 398.00,133.83 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4691CC;' />
+<polygon points='417.82,130.67 416.19,134.35 399.24,130.00 382.97,123.56 383.81,119.62 401.73,122.34 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='463.00,129.01 460.63,132.27 442.84,123.11 426.01,112.28 427.65,108.61 446.87,116.14 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='454.92,102.19 452.90,105.68 432.56,97.57 412.92,87.88 414.17,84.05 435.84,90.22 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<text x='471.88' y='86.91' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='583.69' y='323.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='411.11' y='519.31' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='162.58' y='438.56' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='138.29' y='178.38' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<rect x='84.04' y='22.78' width='528.39' height='528.39' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='79.11' y='235.96' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='79.11' y='170.59' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='79.11' y='105.22' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>40</text>
+<polyline points='81.30,232.94 84.04,232.94 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='81.30,167.57 84.04,167.57 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='81.30,102.19 84.04,102.19 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='348.23' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='22.62px' lengthAdjust='spacingAndGlyphs'>displ</text>
+<text transform='translate(64.30,286.98) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='19.57px' lengthAdjust='spacingAndGlyphs'>hwy</text>
+<rect x='623.39' y='236.11' width='39.89' height='101.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<image width='17.28' height='86.40' x='623.39' y='251.44' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAmElEQVQ4ja2UQRLDMAgDd3hk/tnX5agcknFaCoa0vnkMCEnGsL12GQhDYDpPwoDrpBFlRDWi/9Wu6AHC9FkLYLrzlhD3oJ3mDvRHRYy7IC8A7bCK8gpWKYDzeQVArDcDyD2YAnSofZvzaOA6Q7Oahp/dmRuVTQ0xU5TGP2o8Waool1obVuv1q8qP9xPvg633XlGLDtfIhNUBcBeA5ss0BXMAAAAASUVORK5CYII='/>
+<text x='646.14' y='326.37' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='646.14' y='302.45' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text x='646.14' y='278.53' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
+<text x='646.14' y='254.61' style='font-size: 8.80px; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<text x='623.39' y='244.82' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
+<line x1='623.39' y1='323.35' x2='626.84' y2='323.35' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='623.39' y1='299.43' x2='626.84' y2='299.43' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='623.39' y1='275.51' x2='626.84' y2='275.51' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='623.39' y1='251.59' x2='626.84' y2='251.59' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='637.21' y1='323.35' x2='640.67' y2='323.35' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='637.21' y1='299.43' x2='640.67' y2='299.43' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='637.21' y1='275.51' x2='640.67' y2='275.51' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='637.21' y1='251.59' x2='640.67' y2='251.59' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='84.04' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='186.40px' lengthAdjust='spacingAndGlyphs'>hex bin plot in polar coordinates</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/geom-hex/hex-bin-plot-with-sqrt-transformed-y.svg
+++ b/tests/testthat/_snaps/geom-hex/hex-bin-plot-with-sqrt-transformed-y.svg
@@ -1,0 +1,181 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzIuNzl8NjYzLjY3fDIyLjc4fDU0NS4xMQ=='>
+    <rect x='32.79' y='22.78' width='630.88' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzIuNzl8NjYzLjY3fDIyLjc4fDU0NS4xMQ==)'>
+<rect x='32.79' y='22.78' width='630.88' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polygon points='405.59,514.77 405.59,528.06 396.03,534.84 386.47,528.06 386.47,514.77 396.03,508.25 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #2F638E;' />
+<polygon points='558.53,476.83 558.53,489.18 548.97,495.46 539.41,489.18 539.41,476.83 548.97,470.76 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #2F638E;' />
+<polygon points='396.03,458.80 396.03,470.76 386.47,476.83 376.91,470.76 376.91,458.80 386.47,452.92 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #2F638E;' />
+<polygon points='472.50,458.80 472.50,470.76 462.94,476.83 453.38,470.76 453.38,458.80 462.94,452.92 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #2F638E;' />
+<polygon points='510.73,458.80 510.73,470.76 501.17,476.83 491.62,470.76 491.62,458.80 501.17,452.92 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #2F638E;' />
+<polygon points='329.12,441.34 329.12,452.92 319.56,458.80 310.00,452.92 310.00,441.34 319.56,435.63 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #2F638E;' />
+<polygon points='405.59,441.34 405.59,452.92 396.03,458.80 386.47,452.92 386.47,441.34 396.03,435.63 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='462.94,441.34 462.94,452.92 453.38,458.80 443.82,452.92 443.82,441.34 453.38,435.63 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='482.06,441.34 482.06,452.92 472.50,458.80 462.94,452.92 462.94,441.34 472.50,435.63 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='539.41,441.34 539.41,452.92 529.85,458.80 520.29,452.92 520.29,441.34 529.85,435.63 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='396.03,424.37 396.03,435.63 386.47,441.34 376.91,435.63 376.91,424.37 386.47,418.82 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='415.15,424.37 415.15,435.63 405.59,441.34 396.03,435.63 396.03,424.37 405.59,418.82 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='453.38,424.37 453.38,435.63 443.82,441.34 434.26,435.63 434.26,424.37 443.82,418.82 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='252.65,407.87 252.65,418.82 243.09,424.37 233.53,418.82 233.53,407.87 243.09,402.47 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='271.76,407.87 271.76,418.82 262.20,424.37 252.65,418.82 252.65,407.87 262.20,402.47 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='329.12,407.87 329.12,418.82 319.56,424.37 310.00,418.82 310.00,407.87 319.56,402.47 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='348.23,407.87 348.23,418.82 338.67,424.37 329.12,418.82 329.12,407.87 338.67,402.47 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='405.59,407.87 405.59,418.82 396.03,424.37 386.47,418.82 386.47,407.87 396.03,402.47 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='443.82,407.87 443.82,418.82 434.26,424.37 424.70,418.82 424.70,407.87 434.26,402.47 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='462.94,407.87 462.94,418.82 453.38,424.37 443.82,418.82 443.82,407.87 453.38,402.47 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='482.06,407.87 482.06,418.82 472.50,424.37 462.94,418.82 462.94,407.87 472.50,402.47 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='520.29,407.87 520.29,418.82 510.73,424.37 501.17,418.82 501.17,407.87 510.73,402.47 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='539.41,407.87 539.41,418.82 529.85,424.37 520.29,418.82 520.29,407.87 529.85,402.47 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='596.76,407.87 596.76,418.82 587.20,424.37 577.64,418.82 577.64,407.87 587.20,402.47 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='300.44,391.80 300.44,402.47 290.88,407.87 281.32,402.47 281.32,391.80 290.88,386.53 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='338.67,391.80 338.67,402.47 329.12,407.87 319.56,402.47 319.56,391.80 329.12,386.53 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='357.79,391.80 357.79,402.47 348.23,407.87 338.67,402.47 338.67,391.80 348.23,386.53 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='376.91,391.80 376.91,402.47 367.35,407.87 357.79,402.47 357.79,391.80 367.35,386.53 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='491.62,391.80 491.62,402.47 482.06,407.87 472.50,402.47 472.50,391.80 482.06,386.53 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='510.73,391.80 510.73,402.47 501.17,407.87 491.62,402.47 491.62,391.80 501.17,386.53 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='271.76,376.13 271.76,386.53 262.20,391.80 252.65,386.53 252.65,376.13 262.20,370.98 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='310.00,376.13 310.00,386.53 300.44,391.80 290.88,386.53 290.88,376.13 300.44,370.98 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='329.12,376.13 329.12,386.53 319.56,391.80 310.00,386.53 310.00,376.13 319.56,370.98 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='405.59,376.13 405.59,386.53 396.03,391.80 386.47,386.53 386.47,376.13 396.03,370.98 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='462.94,376.13 462.94,386.53 453.38,391.80 443.82,386.53 443.82,376.13 453.38,370.98 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='204.85,360.82 204.85,370.98 195.29,376.13 185.73,370.98 185.73,360.82 195.29,355.80 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='338.67,360.82 338.67,370.98 329.12,376.13 319.56,370.98 319.56,360.82 329.12,355.80 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='472.50,360.82 472.50,370.98 462.94,376.13 453.38,370.98 453.38,360.82 462.94,355.80 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='491.62,360.82 491.62,370.98 482.06,376.13 472.50,370.98 472.50,360.82 482.06,355.80 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='310.00,345.86 310.00,355.80 300.44,360.82 290.88,355.80 290.88,345.86 300.44,340.94 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='405.59,345.86 405.59,355.80 396.03,360.82 386.47,355.80 386.47,345.86 396.03,340.94 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='204.85,331.22 204.85,340.94 195.29,345.86 185.73,340.94 185.73,331.22 195.29,326.40 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #132B43;' />
+<polygon points='223.97,331.22 223.97,340.94 214.41,345.86 204.85,340.94 204.85,331.22 214.41,326.40 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='262.20,331.22 262.20,340.94 252.65,345.86 243.09,340.94 243.09,331.22 252.65,326.40 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='319.56,331.22 319.56,340.94 310.00,345.86 300.44,340.94 300.44,331.22 310.00,326.40 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='396.03,331.22 396.03,340.94 386.47,345.86 376.91,340.94 376.91,331.22 386.47,326.40 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='176.18,316.87 176.18,326.40 166.62,331.22 157.06,326.40 157.06,316.87 166.62,312.16 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='214.41,316.87 214.41,326.40 204.85,331.22 195.29,326.40 195.29,316.87 204.85,312.16 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='310.00,316.87 310.00,326.40 300.44,331.22 290.88,326.40 290.88,316.87 300.44,312.16 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='329.12,316.87 329.12,326.40 319.56,331.22 310.00,326.40 310.00,316.87 319.56,312.16 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='348.23,316.87 348.23,326.40 338.67,331.22 329.12,326.40 329.12,316.87 338.67,312.16 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='405.59,316.87 405.59,326.40 396.03,331.22 386.47,326.40 386.47,316.87 396.03,312.16 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='520.29,316.87 520.29,326.40 510.73,331.22 501.17,326.40 501.17,316.87 510.73,312.16 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='166.62,302.82 166.62,312.16 157.06,316.87 147.50,312.16 147.50,302.82 157.06,298.19 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='204.85,302.82 204.85,312.16 195.29,316.87 185.73,312.16 185.73,302.82 195.29,298.19 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='223.97,302.82 223.97,312.16 214.41,316.87 204.85,312.16 204.85,302.82 214.41,298.19 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='262.20,302.82 262.20,312.16 252.65,316.87 243.09,312.16 243.09,302.82 252.65,298.19 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='338.67,302.82 338.67,312.16 329.12,316.87 319.56,312.16 319.56,302.82 329.12,298.19 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='644.56,302.82 644.56,312.16 635.00,316.87 625.44,312.16 625.44,302.82 635.00,298.19 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='99.71,289.03 99.71,298.19 90.15,302.82 80.59,298.19 80.59,289.03 90.15,284.49 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='176.18,289.03 176.18,298.19 166.62,302.82 157.06,298.19 157.06,289.03 166.62,284.49 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='214.41,289.03 214.41,298.19 204.85,302.82 195.29,298.19 195.29,289.03 204.85,284.49 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='233.53,289.03 233.53,298.19 223.97,302.82 214.41,298.19 214.41,289.03 223.97,284.49 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='271.76,289.03 271.76,298.19 262.20,302.82 252.65,298.19 252.65,289.03 262.20,284.49 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='310.00,289.03 310.00,298.19 300.44,302.82 290.88,298.19 290.88,289.03 300.44,284.49 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='462.94,289.03 462.94,298.19 453.38,302.82 443.82,298.19 443.82,289.03 453.38,284.49 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='558.53,289.03 558.53,298.19 548.97,302.82 539.41,298.19 539.41,289.03 548.97,284.49 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='147.50,275.49 147.50,284.49 137.94,289.03 128.38,284.49 128.38,275.49 137.94,271.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='166.62,275.49 166.62,284.49 157.06,289.03 147.50,284.49 147.50,275.49 157.06,271.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='204.85,275.49 204.85,284.49 195.29,289.03 185.73,284.49 185.73,275.49 195.29,271.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='223.97,275.49 223.97,284.49 214.41,289.03 204.85,284.49 204.85,275.49 214.41,271.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='243.09,275.49 243.09,284.49 233.53,289.03 223.97,284.49 223.97,275.49 233.53,271.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='281.32,275.49 281.32,284.49 271.76,289.03 262.20,284.49 262.20,275.49 271.76,271.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='338.67,275.49 338.67,284.49 329.12,289.03 319.56,284.49 319.56,275.49 329.12,271.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='510.73,275.49 510.73,284.49 501.17,289.03 491.62,284.49 491.62,275.49 501.17,271.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='568.09,275.49 568.09,284.49 558.53,289.03 548.97,284.49 548.97,275.49 558.53,271.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='99.71,262.20 99.71,271.03 90.15,275.49 80.59,271.03 80.59,262.20 90.15,257.81 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='118.82,262.20 118.82,271.03 109.26,275.49 99.71,271.03 99.71,262.20 109.26,257.81 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='176.18,262.20 176.18,271.03 166.62,275.49 157.06,271.03 157.06,262.20 166.62,257.81 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #214667;' />
+<polygon points='290.88,262.20 290.88,271.03 281.32,275.49 271.76,271.03 271.76,262.20 281.32,257.81 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #214667;' />
+<polygon points='310.00,262.20 310.00,271.03 300.44,275.49 290.88,271.03 290.88,262.20 300.44,257.81 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #214667;' />
+<polygon points='147.50,249.13 147.50,257.81 137.94,262.20 128.38,257.81 128.38,249.13 137.94,244.82 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #214667;' />
+<polygon points='166.62,249.13 166.62,257.81 157.06,262.20 147.50,257.81 147.50,249.13 157.06,244.82 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #214667;' />
+<polygon points='243.09,249.13 243.09,257.81 233.53,262.20 223.97,257.81 223.97,249.13 233.53,244.82 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #214667;' />
+<polygon points='262.20,249.13 262.20,257.81 252.65,262.20 243.09,257.81 243.09,249.13 252.65,244.82 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='281.32,249.13 281.32,257.81 271.76,262.20 262.20,257.81 262.20,249.13 271.76,244.82 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='118.82,236.27 118.82,244.82 109.26,249.13 99.71,244.82 99.71,236.27 109.26,232.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='176.18,236.27 176.18,244.82 166.62,249.13 157.06,244.82 157.06,236.27 166.62,232.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='252.65,236.27 252.65,244.82 243.09,249.13 233.53,244.82 233.53,236.27 243.09,232.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='310.00,236.27 310.00,244.82 300.44,249.13 290.88,244.82 290.88,236.27 300.44,232.03 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='71.03,223.62 71.03,232.03 61.47,236.27 51.91,232.03 51.91,223.62 61.47,219.45 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #3772A2;' />
+<polygon points='109.26,223.62 109.26,232.03 99.71,236.27 90.15,232.03 90.15,223.62 99.71,219.45 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #3772A2;' />
+<polygon points='128.38,223.62 128.38,232.03 118.82,236.27 109.26,232.03 109.26,223.62 118.82,219.45 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #3772A2;' />
+<polygon points='147.50,223.62 147.50,232.03 137.94,236.27 128.38,232.03 128.38,223.62 137.94,219.45 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #3772A2;' />
+<polygon points='166.62,223.62 166.62,232.03 157.06,236.27 147.50,232.03 147.50,223.62 157.06,219.45 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #3772A2;' />
+<polygon points='281.32,223.62 281.32,232.03 271.76,236.27 262.20,232.03 262.20,223.62 271.76,219.45 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #3772A2;' />
+<polygon points='99.71,211.17 99.71,219.45 90.15,223.62 80.59,219.45 80.59,211.17 90.15,207.06 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='118.82,211.17 118.82,219.45 109.26,223.62 99.71,219.45 99.71,211.17 109.26,207.06 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='157.06,211.17 157.06,219.45 147.50,223.62 137.94,219.45 137.94,211.17 147.50,207.06 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='128.38,198.91 128.38,207.06 118.82,211.17 109.26,207.06 109.26,198.91 118.82,194.86 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='166.62,198.91 166.62,207.06 157.06,211.17 147.50,207.06 147.50,198.91 157.06,194.86 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='80.59,186.82 80.59,194.86 71.03,198.91 61.47,194.86 61.47,186.82 71.03,182.83 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='176.18,186.82 176.18,194.86 166.62,198.91 157.06,194.86 157.06,186.82 166.62,182.83 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4691CC;' />
+<polygon points='71.03,174.90 71.03,182.83 61.47,186.82 51.91,182.83 51.91,174.90 61.47,170.97 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4691CC;' />
+<polygon points='109.26,174.90 109.26,182.83 99.71,186.82 90.15,182.83 90.15,174.90 99.71,170.97 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4691CC;' />
+<polygon points='99.71,163.15 99.71,170.97 90.15,174.90 80.59,170.97 80.59,163.15 90.15,159.27 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4691CC;' />
+<polygon points='109.26,151.56 109.26,159.27 99.71,163.15 90.15,159.27 90.15,151.56 99.71,147.73 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4691CC;' />
+<polygon points='99.71,140.12 99.71,147.73 90.15,151.56 80.59,147.73 80.59,140.12 90.15,136.34 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4691CC;' />
+<polygon points='99.71,117.66 99.71,125.09 90.15,128.82 80.59,125.09 80.59,117.66 90.15,113.98 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='118.82,74.34 118.82,81.43 109.26,84.99 99.71,81.43 99.71,74.34 109.26,70.82 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<polygon points='109.26,43.10 109.26,49.96 99.71,53.41 90.15,49.96 90.15,43.10 99.71,39.69 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #1A3855;' />
+<rect x='32.79' y='22.78' width='630.88' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='27.86' y='369.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='27.86' y='221.14' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='27.86' y='95.90' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>40</text>
+<polyline points='30.05,366.66 32.79,366.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,218.11 32.79,218.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,92.87 32.79,92.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='111.39,547.85 111.39,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='217.60,547.85 217.60,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='323.81,547.85 323.81,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='430.01,547.85 430.01,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='536.22,547.85 536.22,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='642.43,547.85 642.43,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='111.39' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='217.60' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='323.81' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='430.01' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='536.22' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='642.43' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>7</text>
+<text x='348.23' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='22.62px' lengthAdjust='spacingAndGlyphs'>displ</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='19.57px' lengthAdjust='spacingAndGlyphs'>hwy</text>
+<rect x='674.63' y='233.08' width='39.89' height='101.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<image width='17.28' height='86.40' x='674.63' y='248.41' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAmElEQVQ4ja2UQRLDMAgDd3hk/tnX5agcknFaCoa0vnkMCEnGsL12GQhDYDpPwoDrpBFlRDWi/9Wu6AHC9FkLYLrzlhD3oJ3mDvRHRYy7IC8A7bCK8gpWKYDzeQVArDcDyD2YAnSofZvzaOA6Q7Oahp/dmRuVTQ0xU5TGP2o8Waool1obVuv1q8qP9xPvg633XlGLDtfIhNUBcBeA5ss0BXMAAAAASUVORK5CYII='/>
+<text x='697.39' y='323.35' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='697.39' y='299.43' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text x='697.39' y='275.51' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
+<text x='697.39' y='251.59' style='font-size: 8.80px; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<text x='674.63' y='241.79' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
+<line x1='674.63' y1='320.32' x2='678.09' y2='320.32' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='674.63' y1='296.40' x2='678.09' y2='296.40' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='674.63' y1='272.48' x2='678.09' y2='272.48' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='674.63' y1='248.56' x2='678.09' y2='248.56' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='688.46' y1='320.32' x2='691.91' y2='320.32' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='688.46' y1='296.40' x2='691.91' y2='296.40' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='688.46' y1='272.48' x2='691.91' y2='272.48' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='688.46' y1='248.56' x2='691.91' y2='248.56' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='32.79' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='205.44px' lengthAdjust='spacingAndGlyphs'>hex bin plot with sqrt-transformed y</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/geom-hex/single-hex-bin-with-width-and-height-of-0-1.svg
+++ b/tests/testthat/_snaps/geom-hex/single-hex-bin-with-width-and-height-of-0-1.svg
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzguMTd8Njc1LjkxfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='38.17' y='22.78' width='637.74' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzguMTd8Njc1LjkxfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='38.17' y='22.78' width='637.74' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polygon points='371.53,277.09 371.53,290.80 357.04,297.66 342.54,290.80 342.54,277.09 357.04,270.24 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #336A98;' />
+<rect x='38.17' y='22.78' width='637.74' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='33.24' y='524.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text x='33.24' y='405.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='33.24' y='286.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='33.24' y='168.26' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='33.24' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<polyline points='35.43,521.37 38.17,521.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='35.43,402.66 38.17,402.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='35.43,283.95 38.17,283.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='35.43,165.24 38.17,165.24 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='35.43,46.53 38.17,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='67.16,547.85 67.16,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='212.10,547.85 212.10,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='357.04,547.85 357.04,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='501.98,547.85 501.98,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='646.92,547.85 646.92,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='67.16' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text x='212.10' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='357.04' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='501.98' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='646.92' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='357.04' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
+<rect x='686.87' y='233.08' width='27.65' height='101.73' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<image width='17.28' height='86.40' x='686.87' y='248.41' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAHUlEQVQ4jWMwzprxn4mBgYFhlBglRolRYpQYLgQAwNIEi4uZL9UAAAAASUVORK5CYII='/>
+<text x='709.63' y='294.64' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='686.87' y='241.79' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
+<line x1='686.87' y1='291.61' x2='690.32' y2='291.61' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='700.69' y1='291.61' x2='704.15' y2='291.61' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='38.17' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='244.37px' lengthAdjust='spacingAndGlyphs'>single hex bin with width and height of 0.1</text>
+</g>
+</svg>

--- a/tests/testthat/test-geom-hex.R
+++ b/tests/testthat/test-geom-hex.R
@@ -18,3 +18,11 @@ test_that("size and linetype are applied", {
   expect_equal(gpar$lwd, c(4, 4) * .pt, tolerance = 1e-7)
   expect_equal(gpar$lty, c(2, 2), tolerance = 1e-7)
 })
+
+test_that("bin size are picked up from stat", {
+  expect_doppelganger("single hex bin with width and height of 0.1",
+    ggplot(data.frame(x = 0, y = 0)) +
+      geom_hex(aes(x = x, y = y), binwidth = c(0.1, 0.1)) +
+      coord_cartesian(xlim = c(-1, 1), ylim = c(-1, 1))
+  )
+})

--- a/tests/testthat/test-geom-hex.R
+++ b/tests/testthat/test-geom-hex.R
@@ -15,8 +15,8 @@ test_that("size and linetype are applied", {
     geom_hex(color = "red", size = 4, linetype = 2)
 
   gpar <- layer_grob(plot)[[1]]$children[[1]]$gp
-  expect_equal(gpar$lwd, c(4, 4) * .pt, tolerance = 1e-7)
-  expect_equal(gpar$lty, c(2, 2), tolerance = 1e-7)
+  expect_equal(gpar$lwd, rep(4, 12) * .pt, tolerance = 1e-7)
+  expect_equal(gpar$lty, rep(2, 12), tolerance = 1e-7)
 })
 
 test_that("bin size are picked up from stat", {
@@ -24,5 +24,16 @@ test_that("bin size are picked up from stat", {
     ggplot(data.frame(x = 0, y = 0)) +
       geom_hex(aes(x = x, y = y), binwidth = c(0.1, 0.1)) +
       coord_cartesian(xlim = c(-1, 1), ylim = c(-1, 1))
+  )
+})
+
+test_that("geom_hex works in non-linear coordinate systems", {
+  p <- ggplot(mpg, aes(displ, hwy)) + geom_hex()
+
+  expect_doppelganger("hex bin plot with sqrt-transformed y",
+    p + coord_trans(y = "sqrt")
+  )
+  expect_doppelganger("hex bin plot in polar coordinates",
+                      p + coord_polar()
   )
 })


### PR DESCRIPTION
Fix #4580 

This PR makes `stat_bin_hex()` write `width` and `height` to the data which `geom_hex()` can pick up instead of deriving the resolution from data. This fixes issues with very sparse data where the bin resolution is not obvious from the bin centers