### PR TITLE
Convert size = NA to 0 before rendering guide_legend

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Setting `size = NA` will no longer cause `guide_legend()` to error 
+  (@thomasp85, #4559)
+
 * Setting `stroke` to `NA` in `geom_point()` will no longer impair the sizing of
   the points (@thomasp85, #4624)
 

--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -278,6 +278,10 @@ guide_geom.legend <- function(guide, layers, default_mapping) {
     # override.aes in guide_legend manually changes the geom
     data <- modify_list(data, guide$override.aes)
 
+    if (!is.null(data$size)) {
+      data$size[is.na(data$size)] <- 0
+    }
+
     list(
       draw_key = layer$geom$draw_key,
       data = data,
@@ -383,6 +387,7 @@ guide_gengrob.legend <- function(guide, theme) {
   )
 
   key_size_mat <- do.call("cbind", lapply(guide$geoms, function(g) g$data$size / 10))
+
   if (nrow(key_size_mat) == 0 || ncol(key_size_mat) == 0) {
     key_size_mat <- matrix(0, ncol = 1, nrow = nbreak)
   }

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -182,6 +182,17 @@ test_that("guide merging for guide_legend() works as expected", {
   expect_equal(repeated_identical_labels[[1]]$key$.label, c("label1", "label1", "label2"))
 })
 
+test_that("size = NA doesn't throw rendering errors", {
+  df = data.frame(
+    x = c(1, 2),
+    group = c("a","b")
+  )
+  p <- ggplot(df, aes(x = x, y = 0, colour = group)) +
+    geom_point(size = NA, na.rm = TRUE)
+
+  expect_silent(plot(p))
+})
+
 # Visual tests ------------------------------------------------------------
 
 test_that("axis guides are drawn correctly", {


### PR DESCRIPTION
Fix #4559 

This is a simple fix that converts all instances of `NA` in the size aesthetic to `0`