### PR TITLE
Remove filename from the call to custom devices if file is present in the formals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Better compatibility of custom device functions in `ggsave()` 
+  (@thomasp85, #4539)
+
 * Strip padding in `facet_grid()` is now only in effect if `strip.placement = "outside"`
   _and_ an axis is present between the strip and the panel (@thomasp85, #4610)
 

--- a/R/save.r
+++ b/R/save.r
@@ -162,6 +162,7 @@ plot_dev <- function(device, filename = NULL, dpi = 300) {
     call_args <- list()
     if ("file" %in% names(args)) {
       call_args$file <- filename
+      call_args["filename"] <- list(NULL)
     }
     if ("res" %in% names(args)) {
       call_args$res <- dpi


### PR DESCRIPTION
Fix #4539 

This PR make it so that only file _or_ filename is passed on as argument to the custom device