### PR TITLE
Check if transformed limits in binning scales are valid before assigning them

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Binning scales are now more resilient to calculated limits that ends up being
+  `NaN` after transformations (@thomasp85, #4510)
+
 * Strip padding in `facet_grid()` is now only in effect if `strip.placement = "outside"`
   _and_ an axis is present between the strip and the panel (@thomasp85, #4610)
 

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -1083,11 +1083,12 @@ ScaleBinned <- ggproto("ScaleBinned", Scale,
             new_limits[1] <- breaks[1]
             breaks <- breaks[-1]
           }
-          limits <- new_limits
         } else {
           bin_size <- max(breaks[1] - limits[1], limits[2] - breaks[1])
-          limits <- c(breaks[1] - bin_size, breaks[1] + bin_size)
+          new_limits <- c(breaks[1] - bin_size, breaks[1] + bin_size)
         }
+        new_limits_trans <- suppressWarnings(self$trans$transform(new_limits))
+        limits[is.finite(new_limits_trans)] <- new_limits[is.finite(new_limits_trans)]
         self$limits <- self$trans$transform(limits)
       }
     } else if (is.function(self$breaks)) {


### PR DESCRIPTION
Fix #4510 

This PR fixes a rare bug when the scale derives new limits to make the terminal bins equal size and these limits ends up being invalid for the given transformation (e.g. `log10`)