### PR TITLE
Add non_missing_aes to geom_tile

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # ggplot2 (development version)
 
 * `geom_tile()` now correctly recognises missing data in `xmin`, `xmax`, `ymin`,
-  and `ymax` (@thomasp85, #4495)
+  and `ymax` (@thomasp85 and @sigmapi, #4495)
 
 * Axes are now added correctly in `facet_wrap()` when `as.table = FALSE`
   (@thomasp85, #4553)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* `geom_tile()` now correctly recognises missing data in `xmin`, `xmax`, `ymin`,
+  and `ymax` (@thomasp85, #4495)
+
 * Axes are now added correctly in `facet_wrap()` when `as.table = FALSE`
   (@thomasp85, #4553)
 

--- a/R/geom-tile.r
+++ b/R/geom-tile.r
@@ -113,5 +113,10 @@ GeomTile <- ggproto("GeomTile", GeomRect,
 
   required_aes = c("x", "y"),
 
+  # These aes columns are created by setup_data(). They need to be listed here so
+  # that GeomRect$handle_na() properly removes any bars that fall outside the defined
+  # limits, not just those for which x and y are outside the limits
+  non_missing_aes = c("xmin", "xmax", "ymin", "ymax"),
+
   draw_key = draw_key_polygon
 )


### PR DESCRIPTION
Fix #4495

Correctly declare min, xmax, ymin, and ymax as aes needing values