### PR TITLE
Use pak in R-CMD-check.yaml

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,9 +33,9 @@ jobs:
           - {os: ubuntu-18.04,   r: '3.3',   vdiffr: false, xref: false}
 
     env:
-      # R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       # don't treat missing suggested packages as error
-      _R_CHECK_FORCE_SUGGESTS_: false
+      # _R_CHECK_FORCE_SUGGESTS_: false
       # Some packages might unavailable on the older versions, so let's ignore xref warnings
       _R_CHECK_RD_XREFS_: ${{ matrix.config.xref }}
       # Runs vdiffr test only on the latest version of R

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -35,7 +35,7 @@ jobs:
     env:
       # R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       # don't treat missing suggested packages as error
-      # _R_CHECK_FORCE_SUGGESTS_: false
+      _R_CHECK_FORCE_SUGGESTS_: false
       # Some packages might unavailable on the older versions, so let's ignore xref warnings
       _R_CHECK_RD_XREFS_: ${{ matrix.config.xref }}
       # Runs vdiffr test only on the latest version of R

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,9 +45,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
@@ -61,11 +61,11 @@ jobs:
           # Use only binary packages
           echo 'options(pkgType = "binary")' >> ~/.Rprofile
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck, survival=?ignore-before-r=3.5.0, maps=?ignore-before-r=3.5.0
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2
         env:
           _R_CHECK_FORCE_SUGGESTS_: false
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,7 +30,6 @@ jobs:
           - {os: ubuntu-18.04,   r: '3.6',   vdiffr: false, xref: true}
           - {os: ubuntu-18.04,   r: '3.5',   vdiffr: false, xref: true}
           - {os: ubuntu-18.04,   r: '3.4',   vdiffr: false, xref: false}
-          - {os: ubuntu-18.04,   r: '3.3',   vdiffr: false, xref: false}
 
     env:
       # Some packages might unavailable on the older versions, so let's ignore xref warnings
@@ -60,7 +59,6 @@ jobs:
             multcomp=?ignore-before-r=3.5.0
             quantreg=?ignore-before-r=3.5.0
             interp=?ignore-before-r=3.5.0
-            sf=?ignore-before-r=3.4.0
 
       - uses: r-lib/actions/check-r-package@v2
         env:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -49,14 +49,6 @@ jobs:
           r-version: ${{ matrix.config.r }}
           use-public-rspm: true
 
-      - name: Install system dependencies on macOS
-        if: runner.os == 'macOS'
-        run: |
-          # XQuartz is needed by vdiffr
-          brew install xquartz
-          # Use only binary packages
-          echo 'options(pkgType = "binary")' >> ~/.Rprofile
-
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           cache-version: 7

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,7 +33,7 @@ jobs:
           - {os: ubuntu-18.04,   r: '3.3',   vdiffr: false, xref: false}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      # R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       # don't treat missing suggested packages as error
       # _R_CHECK_FORCE_SUGGESTS_: false
       # Some packages might unavailable on the older versions, so let's ignore xref warnings
@@ -60,6 +60,11 @@ jobs:
           brew install xquartz
           # Use only binary packages
           echo 'options(pkgType = "binary")' >> ~/.Rprofile
+
+      - name: Install pak
+        run: |
+          install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev/")
+        shell: Rscript {0}
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,10 +12,6 @@ on:
 
 name: R-CMD-check
 
-# Increment this version when we want to clear cache
-env:
-  cache-version: v6
-
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
@@ -29,18 +25,17 @@ jobs:
           - {os: windows-latest, r: '4.1',   vdiffr: true,  xref: true}
           - {os: macOS-latest,   r: '4.1',   vdiffr: true,  xref: true}
           - {os: ubuntu-18.04,   r: 'devel', vdiffr: false, xref: true}
-          - {os: ubuntu-18.04,   r: '4.1',   vdiffr: true,  xref: true, rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
-          - {os: ubuntu-18.04,   r: '4.0',   vdiffr: false, xref: true, rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
-          - {os: ubuntu-18.04,   r: '3.6',   vdiffr: false, xref: true, rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
-          - {os: ubuntu-18.04,   r: '3.5',   vdiffr: false, xref: true, rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
-          - {os: ubuntu-18.04,   r: '3.4',   vdiffr: false, xref: false, rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
-          - {os: ubuntu-18.04,   r: '3.3',   vdiffr: false, xref: false, rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
+          - {os: ubuntu-18.04,   r: '4.1',   vdiffr: true,  xref: true}
+          - {os: ubuntu-18.04,   r: '4.0',   vdiffr: false, xref: true}
+          - {os: ubuntu-18.04,   r: '3.6',   vdiffr: false, xref: true}
+          - {os: ubuntu-18.04,   r: '3.5',   vdiffr: false, xref: true}
+          - {os: ubuntu-18.04,   r: '3.4',   vdiffr: false, xref: false}
+          - {os: ubuntu-18.04,   r: '3.3',   vdiffr: false, xref: false}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
+      # R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       # don't treat missing suggested packages as error
-      _R_CHECK_FORCE_SUGGESTS_: false
+      # _R_CHECK_FORCE_SUGGESTS_: false
       # Some packages might unavailable on the older versions, so let's ignore xref warnings
       _R_CHECK_RD_XREFS_: ${{ matrix.config.xref }}
       # Runs vdiffr test only on the latest version of R
@@ -50,34 +45,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-pandoc@v1
+
+      - uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@master
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), "depends.Rds", version = 2)
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v1
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ env.cache-version }}-${{ runner.os }}-r-${{ matrix.config.r }}-${{ hashFiles('depends.Rds') }}
-          restore-keys: ${{ env.cache-version }}-${{ runner.os }}-r-${{ matrix.config.r }}-
-
-      - name: Install system dependencies on Linux
-        if: runner.os == 'Linux'
-        run: |
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "18.04"))')
       - name: Install system dependencies on macOS
         if: runner.os == 'macOS'
         run: |
@@ -85,19 +60,23 @@ jobs:
           brew install xquartz
           # Use only binary packages
           echo 'options(pkgType = "binary")' >> ~/.Rprofile
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
 
-      - name: Check
-        run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
+      - uses: r-lib/actions/setup-r-dependencies@v1
+        with:
+          extra-packages: rcmdcheck, survival=?ignore-before-r=3.5.0, maps=?ignore-before-r=3.5.0
+
+      - uses: r-lib/actions/check-r-package@v1
+        env:
+          _R_CHECK_FORCE_SUGGESTS_: false
+
+      - name: Show testthat output
+        if: always()
+        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@main
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,9 +33,6 @@ jobs:
           - {os: ubuntu-18.04,   r: '3.3',   vdiffr: false, xref: false}
 
     env:
-      # R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      # don't treat missing suggested packages as error
-      # _R_CHECK_FORCE_SUGGESTS_: false
       # Some packages might unavailable on the older versions, so let's ignore xref warnings
       _R_CHECK_RD_XREFS_: ${{ matrix.config.xref }}
       # Runs vdiffr test only on the latest version of R
@@ -50,7 +47,6 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
-          http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
       - name: Install system dependencies on macOS
@@ -61,14 +57,13 @@ jobs:
           # Use only binary packages
           echo 'options(pkgType = "binary")' >> ~/.Rprofile
 
-      - name: Install pak
-        run: |
-          install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev/")
-        shell: Rscript {0}
-
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: rcmdcheck, survival=?ignore-before-r=3.5.0, maps=?ignore-before-r=3.5.0
+          cache-version: 7
+          extra-packages: |<
+            rcmdcheck
+            survival=?ignore-before-r=3.5.0
+            maps=?ignore-before-r=3.5.0
 
       - uses: r-lib/actions/check-r-package@v2
         env:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -60,10 +60,15 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           cache-version: 7
-          extra-packages: |<
-            rcmdcheck
-            survival=?ignore-before-r=3.5.0
+          extra-packages: |
+            any::rcmdcheck
             maps=?ignore-before-r=3.5.0
+            Hmisc=?ignore-before-r=3.6.0
+            mapproj=?ignore-before-r=3.5.0
+            multcomp=?ignore-before-r=3.5.0
+            quantreg=?ignore-before-r=3.5.0
+            interp=?ignore-before-r=3.5.0
+            sf=?ignore-before-r=3.4.0
 
       - uses: r-lib/actions/check-r-package@v2
         env:


### PR DESCRIPTION
It seems pak-based workflow is ready to use now. Let's see if this works...

> > This is now possible with `?ignore` and `?ignore-before-r`: see some GHA oriented docs here-ish: https://github.com/r-lib/actions/tree/v2/setup-r-dependencies#ignoring-optional-dependencies-that-need-a-newer-r-version
https://github.com/r-lib/pak/issues/290#issuecomment-992400476