### PR TITLE
Add options to guide_colourstep

### DIFF
--- a/R/guide-colorsteps.R
+++ b/R/guide-colorsteps.R
@@ -10,6 +10,12 @@
 #'   Default is `NULL` which makes the guide use the setting from the scale
 #' @param ticks A logical specifying if tick marks on the colourbar should be
 #'   visible.
+#' @param nbin A numeric specifying the number of bins for drawing the
+#'   colourbar. A smoother colourbar results from a larger value.
+#' @param raster A logical. If `TRUE` then the colourbar is rendered as a
+#'   raster object. If `FALSE` then the colourbar is rendered as a set of
+#'   rectangles. Note that not all graphics devices are capable of rendering
+#'   raster image.
 #' @inheritDotParams guide_colourbar -nbin -raster -ticks -available_aes
 #'
 #' @inheritSection guide_bins Use with discrete scale
@@ -43,8 +49,8 @@
 #' # (can also be set in the scale)
 #' p + scale_fill_binned(show.limits = TRUE)
 #'
-guide_coloursteps <- function(even.steps = TRUE, show.limits = NULL, ticks = FALSE, ...) {
-  guide <- guide_colourbar(raster = FALSE, ticks = ticks, nbin = 100, ...)
+guide_coloursteps <- function(even.steps = TRUE, raster= FALSE, nbin = 100, show.limits = NULL, ticks = FALSE, ...) {
+  guide <- guide_colourbar(raster = raster, ticks = ticks, nbin = , ...)
   guide$even.steps <- even.steps
   guide$show.limits <- show.limits
   class(guide) <- c('colorsteps', class(guide))

--- a/man/geom_bin_2d.Rd
+++ b/man/geom_bin_2d.Rd
@@ -100,6 +100,7 @@ in the presence of overplotting.
 \item \strong{\code{y}}
 \item \code{fill}
 \item \code{group}
+\item \code{weight}
 }
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 }

--- a/man/guide_coloursteps.Rd
+++ b/man/guide_coloursteps.Rd
@@ -5,13 +5,35 @@
 \alias{guide_colorsteps}
 \title{Discretized colourbar guide}
 \usage{
-guide_coloursteps(even.steps = TRUE, show.limits = NULL, ticks = FALSE, ...)
+guide_coloursteps(
+  even.steps = TRUE,
+  raster = FALSE,
+  nbin = 100,
+  show.limits = NULL,
+  ticks = FALSE,
+  ...
+)
 
-guide_colorsteps(even.steps = TRUE, show.limits = NULL, ticks = FALSE, ...)
+guide_colorsteps(
+  even.steps = TRUE,
+  raster = FALSE,
+  nbin = 100,
+  show.limits = NULL,
+  ticks = FALSE,
+  ...
+)
 }
 \arguments{
 \item{even.steps}{Should the rendered size of the bins be equal, or should
 they be proportional to their length in the data space? Defaults to \code{TRUE}}
+
+\item{raster}{A logical. If \code{TRUE} then the colourbar is rendered as a
+raster object. If \code{FALSE} then the colourbar is rendered as a set of
+rectangles. Note that not all graphics devices are capable of rendering
+raster image.}
+
+\item{nbin}{A numeric specifying the number of bins for drawing the
+colourbar. A smoother colourbar results from a larger value.}
 
 \item{show.limits}{Should labels for the outer limits of the bins be printed?
 Default is \code{NULL} which makes the guide use the setting from the scale}

--- a/man/hmisc.Rd
+++ b/man/hmisc.Rd
@@ -29,10 +29,10 @@ These are wrappers around functions from \pkg{Hmisc} designed to make them
 easier to use with \code{\link[=stat_summary]{stat_summary()}}. See the Hmisc documentation
 for more details:
 \itemize{
-\item \code{\link[Hmisc:smean.sd]{Hmisc::smean.cl.boot()}}
-\item \code{\link[Hmisc:smean.sd]{Hmisc::smean.cl.normal()}}
-\item \code{\link[Hmisc:smean.sd]{Hmisc::smean.sdl()}}
-\item \code{\link[Hmisc:smean.sd]{Hmisc::smedian.hilow()}}
+\item \code{\link[Hmisc:smean.cl.boot]{Hmisc::smean.cl.boot()}}
+\item \code{\link[Hmisc:smean.cl.normal]{Hmisc::smean.cl.normal()}}
+\item \code{\link[Hmisc:smean.sdl]{Hmisc::smean.sdl()}}
+\item \code{\link[Hmisc:smedian.hilow]{Hmisc::smedian.hilow()}}
 }
 }
 \examples{


### PR DESCRIPTION
The guide_coloursteps function does not pass on raster or nbin options to the guide_colourbar function which work correctly (with ragg) when passed on. I'm not entirely sure if there is a reason why they aren't passed on but I thought it made sense to include them as options. 

I also updated the associated documentation for guide_colourbar to include explainers of the nbin and raster params, (taken from guide-colorbar).