### PR TITLE
Fix misalignment in geom_dotplot when stackratio != 1 and stackdir != "up"

### DIFF
--- a/R/geom-dotplot.r
+++ b/R/geom-dotplot.r
@@ -288,7 +288,7 @@ GeomDotplot <- ggproto("GeomDotplot", Geom,
 
     ggname("geom_dotplot",
       dotstackGrob(stackaxis = stackaxis, x = tdata$x, y = tdata$y, dotdia = dotdianpc,
-                  stackposition = tdata$stackpos, stackratio = stackratio,
+                  stackposition = tdata$stackpos, stackdir = stackdir, stackratio = stackratio,
                   default.units = "npc",
                   gp = gpar(col = alpha(tdata$colour, tdata$alpha),
                             fill = alpha(tdata$fill, tdata$alpha),

--- a/tests/testthat/_snaps/geom-dotplot/stack-center-stackratio-0-5.svg
+++ b/tests/testthat/_snaps/geom-dotplot/stack-center-stackratio-0-5.svg
@@ -1,0 +1,77 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDMuMDZ8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='43.06' y='22.78' width='671.46' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDMuMDZ8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='43.06' y='22.78' width='671.46' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='100.33' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='197.21' cy='310.70' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='197.21' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='197.21' cy='257.20' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='253.56' cy='310.70' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='253.56' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='253.56' cy='257.20' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='324.07' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='297.32' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='270.57' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='243.82' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='377.51' cy='310.70' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='377.51' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='377.51' cy='257.20' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='423.19' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='509.15' cy='310.70' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='509.15' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='509.15' cy='257.20' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='586.19' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='657.25' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<rect x='43.06' y='22.78' width='671.46' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='38.13' y='524.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-0.50</text>
+<text x='38.13' y='405.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-0.25</text>
+<text x='38.13' y='286.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='38.13' y='168.26' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='38.13' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.50</text>
+<polyline points='40.32,521.37 43.06,521.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,402.66 43.06,402.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,283.95 43.06,283.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,165.24 43.06,165.24 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,46.53 43.06,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='68.32,547.85 68.32,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='202.06,547.85 202.06,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='335.81,547.85 335.81,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='469.55,547.85 469.55,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='603.30,547.85 603.30,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='68.32' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='202.06' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='335.81' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='469.55' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='603.30' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='378.79' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
+<text x='43.06' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='168.42px' lengthAdjust='spacingAndGlyphs'>stack center, stackratio = 0.5</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/geom-dotplot/stack-center-stackratio-1-5.svg
+++ b/tests/testthat/_snaps/geom-dotplot/stack-center-stackratio-1-5.svg
@@ -1,0 +1,77 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDMuMDZ8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='43.06' y='22.78' width='671.46' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDMuMDZ8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='43.06' y='22.78' width='671.46' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='100.33' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='197.21' cy='364.20' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='197.21' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='197.21' cy='203.70' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='253.56' cy='364.20' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='253.56' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='253.56' cy='203.70' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='404.32' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='324.07' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='243.82' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='163.58' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='377.51' cy='364.20' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='377.51' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='377.51' cy='203.70' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='423.19' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='509.15' cy='364.20' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='509.15' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='509.15' cy='203.70' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='586.19' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='657.25' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<rect x='43.06' y='22.78' width='671.46' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='38.13' y='524.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-0.50</text>
+<text x='38.13' y='405.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-0.25</text>
+<text x='38.13' y='286.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='38.13' y='168.26' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='38.13' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.50</text>
+<polyline points='40.32,521.37 43.06,521.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,402.66 43.06,402.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,283.95 43.06,283.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,165.24 43.06,165.24 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,46.53 43.06,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='68.32,547.85 68.32,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='202.06,547.85 202.06,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='335.81,547.85 335.81,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='469.55,547.85 469.55,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='603.30,547.85 603.30,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='68.32' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='202.06' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='335.81' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='469.55' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='603.30' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='378.79' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
+<text x='43.06' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='168.42px' lengthAdjust='spacingAndGlyphs'>stack center, stackratio = 1.5</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/geom-dotplot/stack-centerwhole-stackratio-0-5.svg
+++ b/tests/testthat/_snaps/geom-dotplot/stack-centerwhole-stackratio-0-5.svg
@@ -1,0 +1,77 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDMuMDZ8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='43.06' y='22.78' width='671.46' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDMuMDZ8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='43.06' y='22.78' width='671.46' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='100.33' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='197.21' cy='310.70' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='197.21' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='197.21' cy='257.20' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='253.56' cy='310.70' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='253.56' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='253.56' cy='257.20' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='310.70' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='257.20' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='230.45' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='377.51' cy='310.70' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='377.51' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='377.51' cy='257.20' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='423.19' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='509.15' cy='310.70' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='509.15' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='509.15' cy='257.20' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='586.19' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='657.25' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<rect x='43.06' y='22.78' width='671.46' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='38.13' y='524.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-0.50</text>
+<text x='38.13' y='405.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-0.25</text>
+<text x='38.13' y='286.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='38.13' y='168.26' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='38.13' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.50</text>
+<polyline points='40.32,521.37 43.06,521.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,402.66 43.06,402.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,283.95 43.06,283.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,165.24 43.06,165.24 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,46.53 43.06,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='68.32,547.85 68.32,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='202.06,547.85 202.06,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='335.81,547.85 335.81,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='469.55,547.85 469.55,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='603.30,547.85 603.30,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='68.32' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='202.06' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='335.81' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='469.55' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='603.30' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='378.79' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
+<text x='43.06' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='202.91px' lengthAdjust='spacingAndGlyphs'>stack centerwhole, stackratio = 0.5</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/geom-dotplot/stack-centerwhole-stackratio-1-5.svg
+++ b/tests/testthat/_snaps/geom-dotplot/stack-centerwhole-stackratio-1-5.svg
@@ -1,0 +1,77 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDMuMDZ8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='43.06' y='22.78' width='671.46' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDMuMDZ8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='43.06' y='22.78' width='671.46' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='100.33' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='197.21' cy='364.20' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='197.21' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='197.21' cy='203.70' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='253.56' cy='364.20' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='253.56' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='253.56' cy='203.70' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='364.20' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='203.70' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='123.45' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='377.51' cy='364.20' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='377.51' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='377.51' cy='203.70' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='423.19' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='509.15' cy='364.20' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='509.15' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='509.15' cy='203.70' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='586.19' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='657.25' cy='283.95' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<rect x='43.06' y='22.78' width='671.46' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='38.13' y='524.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-0.50</text>
+<text x='38.13' y='405.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-0.25</text>
+<text x='38.13' y='286.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='38.13' y='168.26' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='38.13' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.50</text>
+<polyline points='40.32,521.37 43.06,521.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,402.66 43.06,402.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,283.95 43.06,283.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,165.24 43.06,165.24 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,46.53 43.06,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='68.32,547.85 68.32,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='202.06,547.85 202.06,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='335.81,547.85 335.81,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='469.55,547.85 469.55,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='603.30,547.85 603.30,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='68.32' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='202.06' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='335.81' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='469.55' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='603.30' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='378.79' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
+<text x='43.06' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='202.91px' lengthAdjust='spacingAndGlyphs'>stack centerwhole, stackratio = 1.5</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/geom-dotplot/stack-down-stackratio-0-5.svg
+++ b/tests/testthat/_snaps/geom-dotplot/stack-down-stackratio-0-5.svg
@@ -1,0 +1,77 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDMuMDZ8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='43.06' y='22.78' width='671.46' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDMuMDZ8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='43.06' y='22.78' width='671.46' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='100.33' cy='73.27' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='197.21' cy='73.27' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='197.21' cy='100.02' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='197.21' cy='126.77' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='253.56' cy='73.27' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='253.56' cy='100.02' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='253.56' cy='126.77' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='73.27' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='100.02' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='126.77' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='153.52' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='377.51' cy='73.27' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='377.51' cy='100.02' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='377.51' cy='126.77' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='423.19' cy='73.27' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='509.15' cy='73.27' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='509.15' cy='100.02' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='509.15' cy='126.77' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='586.19' cy='73.27' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='657.25' cy='73.27' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<rect x='43.06' y='22.78' width='671.46' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='38.13' y='524.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-1.00</text>
+<text x='38.13' y='405.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-0.75</text>
+<text x='38.13' y='286.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-0.50</text>
+<text x='38.13' y='168.26' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-0.25</text>
+<text x='38.13' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<polyline points='40.32,521.37 43.06,521.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,402.66 43.06,402.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,283.95 43.06,283.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,165.24 43.06,165.24 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,46.53 43.06,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='68.32,547.85 68.32,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='202.06,547.85 202.06,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='335.81,547.85 335.81,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='469.55,547.85 469.55,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='603.30,547.85 603.30,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='68.32' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='202.06' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='335.81' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='469.55' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='603.30' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='378.79' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
+<text x='43.06' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='163.29px' lengthAdjust='spacingAndGlyphs'>stack down, stackratio = 0.5</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/geom-dotplot/stack-down-stackratio-1-5.svg
+++ b/tests/testthat/_snaps/geom-dotplot/stack-down-stackratio-1-5.svg
@@ -1,0 +1,77 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDMuMDZ8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='43.06' y='22.78' width='671.46' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDMuMDZ8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='43.06' y='22.78' width='671.46' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='100.33' cy='73.27' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='197.21' cy='73.27' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='197.21' cy='153.52' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='197.21' cy='233.77' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='253.56' cy='73.27' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='253.56' cy='153.52' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='253.56' cy='233.77' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='73.27' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='153.52' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='233.77' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='304.44' cy='314.02' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='377.51' cy='73.27' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='377.51' cy='153.52' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='377.51' cy='233.77' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='423.19' cy='73.27' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='509.15' cy='73.27' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='509.15' cy='153.52' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='509.15' cy='233.77' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='586.19' cy='73.27' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='657.25' cy='73.27' r='26.75' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<rect x='43.06' y='22.78' width='671.46' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='38.13' y='524.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-1.00</text>
+<text x='38.13' y='405.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-0.75</text>
+<text x='38.13' y='286.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-0.50</text>
+<text x='38.13' y='168.26' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='20.06px' lengthAdjust='spacingAndGlyphs'>-0.25</text>
+<text x='38.13' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<polyline points='40.32,521.37 43.06,521.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,402.66 43.06,402.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,283.95 43.06,283.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,165.24 43.06,165.24 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.32,46.53 43.06,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='68.32,547.85 68.32,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='202.06,547.85 202.06,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='335.81,547.85 335.81,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='469.55,547.85 469.55,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='603.30,547.85 603.30,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='68.32' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='202.06' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='335.81' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='469.55' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='603.30' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='378.79' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
+<text x='43.06' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='163.29px' lengthAdjust='spacingAndGlyphs'>stack down, stackratio = 1.5</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/geom-dotplot/stack-up-stackratio-0-5.svg
+++ b/tests/testthat/_snaps/geom-dotplot/stack-up-stackratio-0-5.svg
@@ -1,0 +1,77 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDAuMTN8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='40.13' y='22.78' width='674.39' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDAuMTN8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='40.13' y='22.78' width='674.39' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='97.65' cy='494.50' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='194.95' cy='494.50' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='194.95' cy='467.64' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='194.95' cy='440.77' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='251.55' cy='494.50' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='251.55' cy='467.64' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='251.55' cy='440.77' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='302.65' cy='494.50' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='302.65' cy='467.64' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='302.65' cy='440.77' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='302.65' cy='413.91' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='376.04' cy='494.50' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='376.04' cy='467.64' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='376.04' cy='440.77' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='421.92' cy='494.50' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='508.25' cy='494.50' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='508.25' cy='467.64' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='508.25' cy='440.77' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='585.63' cy='494.50' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='657.00' cy='494.50' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<rect x='40.13' y='22.78' width='674.39' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='35.20' y='524.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='35.20' y='405.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='35.20' y='286.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.50</text>
+<text x='35.20' y='168.26' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.75</text>
+<text x='35.20' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>1.00</text>
+<polyline points='37.39,521.37 40.13,521.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.39,402.66 40.13,402.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.39,283.95 40.13,283.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.39,165.24 40.13,165.24 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.39,46.53 40.13,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='65.50,547.85 65.50,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='199.83,547.85 199.83,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='334.16,547.85 334.16,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='468.49,547.85 468.49,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='602.82,547.85 602.82,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='65.50' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='199.83' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='334.16' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='468.49' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='602.82' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='377.33' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
+<text x='40.13' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='146.41px' lengthAdjust='spacingAndGlyphs'>stack up, stackratio = 0.5</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/geom-dotplot/stack-up-stackratio-1-5.svg
+++ b/tests/testthat/_snaps/geom-dotplot/stack-up-stackratio-1-5.svg
@@ -1,0 +1,77 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDAuMTN8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='40.13' y='22.78' width='674.39' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDAuMTN8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='40.13' y='22.78' width='674.39' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='97.65' cy='494.50' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='194.95' cy='494.50' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='194.95' cy='413.91' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='194.95' cy='333.31' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='251.55' cy='494.50' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='251.55' cy='413.91' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='251.55' cy='333.31' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='302.65' cy='494.50' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='302.65' cy='413.91' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='302.65' cy='333.31' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='302.65' cy='252.71' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='376.04' cy='494.50' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='376.04' cy='413.91' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='376.04' cy='333.31' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='421.92' cy='494.50' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='508.25' cy='494.50' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='508.25' cy='413.91' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='508.25' cy='333.31' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='585.63' cy='494.50' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='657.00' cy='494.50' r='26.87' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<rect x='40.13' y='22.78' width='674.39' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='35.20' y='524.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='35.20' y='405.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='35.20' y='286.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.50</text>
+<text x='35.20' y='168.26' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>0.75</text>
+<text x='35.20' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>1.00</text>
+<polyline points='37.39,521.37 40.13,521.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.39,402.66 40.13,402.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.39,283.95 40.13,283.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.39,165.24 40.13,165.24 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.39,46.53 40.13,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='65.50,547.85 65.50,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='199.83,547.85 199.83,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='334.16,547.85 334.16,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='468.49,547.85 468.49,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='602.82,547.85 602.82,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='65.50' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='199.83' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='334.16' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='468.49' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='602.82' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='377.33' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>count</text>
+<text x='40.13' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='146.41px' lengthAdjust='spacingAndGlyphs'>stack up, stackratio = 1.5</text>
+</g>
+</svg>

--- a/tests/testthat/test-geom-dotplot.R
+++ b/tests/testthat/test-geom-dotplot.R
@@ -125,6 +125,34 @@ test_that("geom_dotplot draws correctly", {
     ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, stackdir = "centerwhole") + coord_flip()
   )
 
+  # Stacking methods with stackratio < 1
+  expect_doppelganger("stack up, stackratio = 0.5",
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, stackdir = "up", stackratio = 0.5)
+  )
+  expect_doppelganger("stack down, stackratio = 0.5",
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, stackdir = "down", stackratio = 0.5)
+  )
+  expect_doppelganger("stack center, stackratio = 0.5",
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, stackdir = "center", stackratio = 0.5)
+  )
+  expect_doppelganger("stack centerwhole, stackratio = 0.5",
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, stackdir = "centerwhole", stackratio = 0.5)
+  )
+
+  # Stacking methods with stackratio > 1
+  expect_doppelganger("stack up, stackratio = 1.5",
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, stackdir = "up", stackratio = 1.5)
+  )
+  expect_doppelganger("stack down, stackratio = 1.5",
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, stackdir = "down", stackratio = 1.5)
+  )
+  expect_doppelganger("stack center, stackratio = 1.5",
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, stackdir = "center", stackratio = 1.5)
+  )
+  expect_doppelganger("stack centerwhole, stackratio = 1.5",
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, stackdir = "centerwhole", stackratio = 1.5)
+  )
+
   # Binning along x, with groups
   expect_doppelganger("multiple groups, bins not aligned",
     ggplot(dat, aes(x, fill = g)) + geom_dotplot(binwidth = .4, alpha = .4)


### PR DESCRIPTION
This PR fixes #4614.

## The problem

For `geom_dotplot()` / the `dotstack` grob, the `(1 - x$stackratio) / 2` adjustment on these lines...

https://github.com/tidyverse/ggplot2/blob/c89c265a57fd71f8a0288ce81037296aadc0a012/R/grob-dotstack.r#L34-L42

...is there because otherwise when `stackratio != 1` and `stackdir = "up"`, the base of the first dot in a stack will no longer touch the baseline. This is because `stackratio` will expand (or contract) the dot stack away (or towards) the origin. 

However, currently this adjustment only works correctly for `stackdir = "up"`. For example, here is `stackdir = "down"` (for other examples, see #4614):

```r
ggplot(data.frame(x = c(rep(1, 3), rep(2, 2))), aes(x)) +
  geom_dotplot(binwidth = 0.5, alpha = 0.5, stackdir = "down", stackratio = 1.5) +
  coord_fixed() +
  ylim(-2, 2) +
  xlim(0, 6)
```
![image](https://user-images.githubusercontent.com/6345019/153695945-90243584-8c56-4b7e-8015-9720c00f68d8.png)

Notice how the top dot in each stack does not touch `y = 0` as it should.

## The solution

The solution is that the `(1 - x$stackratio) / 2` adjustment needs to depend on `stackdir`:

- For `"up"`, it should remain `(1 - x$stackratio) / 2`
- For `"down"`, it should be reversed: `-(1 - x$stackratio) / 2`
- For `"center"` and `"centerwhole"`, it is unnecessary, and should be `0`.

This PR implements that change, and includes test cases to ensure the adjustment is correct when `stackratio < 1` and when `stackratio > 1`.