### PR TITLE
remove stringsAsFactor for the mapped_discrete as.data.frame method

### DIFF
--- a/R/scale-discrete-.r
+++ b/R/scale-discrete-.r
@@ -170,6 +170,6 @@ c.mapped_discrete <- function(..., recursive = FALSE) {
   new_mapped_discrete(NextMethod())
 }
 #' @export
-as.data.frame.mapped_discrete <- function (x, ..., stringsAsFactors = default.stringsAsFactors()) {
-  as.data.frame.vector(x = unclass(x), ..., stringsAsFactors = stringsAsFactors)
+as.data.frame.mapped_discrete <- function (x, ...) {
+  as.data.frame.vector(x = unclass(x), ...)
 }


### PR DESCRIPTION
Fix #4746 

This PR should not affect anything at all, but prepare for the deprecation of `default.stringsAsFactors()` in the next major release of R