### PR TITLE
Replace coord_equal in scale-identity.r

### DIFF
--- a/R/scale-identity.r
+++ b/R/scale-identity.r
@@ -25,7 +25,7 @@
 #' ggplot(luv_colours, aes(u, v)) +
 #'   geom_point(aes(colour = col), size = 3) +
 #'   scale_color_identity() +
-#'   coord_equal()
+#'   coord_fixed()
 #'
 #' df <- data.frame(
 #'   x = 1:4,

--- a/man/scale_identity.Rd
+++ b/man/scale_identity.Rd
@@ -59,7 +59,7 @@ argument.
 ggplot(luv_colours, aes(u, v)) +
   geom_point(aes(colour = col), size = 3) +
   scale_color_identity() +
-  coord_equal()
+  coord_fixed()
 
 df <- data.frame(
   x = 1:4,


### PR DESCRIPTION
Replace the old `coord_equal()` function, mentioned in the example code, with `coord_fixed()`