### PR TITLE
Add fontface to GeomPoint aesthetics for more point shapes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,9 @@ precedence between `bins` and `binwidth`. (@eliocamp, #4651)
 
 * Dots in `geom_dotplot()` are now correctly aligned to the baseline when
   `stackratio != 1` and `stackdir != "up"` (@mjskay, #4614)
+  
+* `geom_point()` now accepts the aesthetic `fontface` which allows to use point 
+  shapes in the symbol font. (@mrcaseb, #4762)
 
 # ggplot2 3.3.5
 This is a very small release focusing on fixing a couple of untenable issues 

--- a/R/geom-point.r
+++ b/R/geom-point.r
@@ -113,7 +113,7 @@ GeomPoint <- ggproto("GeomPoint", Geom,
   non_missing_aes = c("size", "shape", "colour"),
   default_aes = aes(
     shape = 19, colour = "black", size = 1.5, fill = NA,
-    alpha = NA, stroke = 0.5
+    alpha = NA, stroke = 0.5, fontface = 1
   ),
 
   draw_panel = function(data, panel_params, coord, na.rm = FALSE) {
@@ -133,7 +133,8 @@ GeomPoint <- ggproto("GeomPoint", Geom,
           fill = alpha(coords$fill, coords$alpha),
           # Stroke is added around the outside of the point
           fontsize = coords$size * .pt + stroke_size * .stroke / 2,
-          lwd = coords$stroke * .stroke / 2
+          lwd = coords$stroke * .stroke / 2,
+          fontface = coords$fontface
         )
       )
     )

--- a/man/geom_count.Rd
+++ b/man/geom_count.Rd
@@ -87,6 +87,7 @@ useful when you have discrete data and overplotting.
 \item \code{alpha}
 \item \code{colour}
 \item \code{fill}
+\item \code{fontface}
 \item \code{group}
 \item \code{shape}
 \item \code{size}

--- a/man/geom_jitter.Rd
+++ b/man/geom_jitter.Rd
@@ -96,6 +96,7 @@ overplotting caused by discreteness in smaller datasets.
 \item \code{alpha}
 \item \code{colour}
 \item \code{fill}
+\item \code{fontface}
 \item \code{group}
 \item \code{shape}
 \item \code{size}

--- a/man/geom_point.Rd
+++ b/man/geom_point.Rd
@@ -100,6 +100,7 @@ Another technique is to make the points transparent (e.g.
 \item \code{alpha}
 \item \code{colour}
 \item \code{fill}
+\item \code{fontface}
 \item \code{group}
 \item \code{shape}
 \item \code{size}

--- a/tests/testthat/test-build.r
+++ b/tests/testthat/test-build.r
@@ -34,7 +34,7 @@ test_that("non-position aesthetics are mapped", {
   expect_named(
     layer_data(l1, 1),
     c(
-      "x", "y", "fill", "group", "colour", "shape", "size", "PANEL",
+      "x", "y", "fill", "fontface", "group", "colour", "shape", "size", "PANEL",
       "alpha", "stroke"
     ),
     ignore.order = TRUE


### PR DESCRIPTION
`grid::pointsGrob` allows shapes via the `pch` argument that is used in `GeomPoint`. Valid values are explained in `?points` where it is also explained that it is possible to use additional symbols when setting `par(font = 5)`. 

This PR adds a `fontface` aesthetic that allows setting the symbol font and activates additional point shapes. See examples below (the output images of the reprex are replaced with higher qualitiy images that are saved with ggsave). 

``` r
library(ggplot2)

df <- tidyr::crossing(x = 0:15, y = 0:15)
df$shape  <- 0:255

# Default fontface ("plain") == 1
ggplot(df, aes(x = x, y = y)) +
  geom_point(shape = df$shape, size = 5, bg = "grey", fontface = 1) +
  geom_text(aes(label = shape), nudge_y = 0.45, size = 3) +
  scale_y_reverse() +
  theme_void()
#> Warning in grid.Call.graphics(C_points, x$x, x$y, x$pch, x$size): unimplemented
#> pch value '26'
#> Warning in grid.Call.graphics(C_points, x$x, x$y, x$pch, x$size): unimplemented
#> pch value '27'
#> Warning in grid.Call.graphics(C_points, x$x, x$y, x$pch, x$size): unimplemented
#> pch value '28'
#> Warning in grid.Call.graphics(C_points, x$x, x$y, x$pch, x$size): unimplemented
#> pch value '29'
#> Warning in grid.Call.graphics(C_points, x$x, x$y, x$pch, x$size): unimplemented
#> pch value '30'
#> Warning in grid.Call.graphics(C_points, x$x, x$y, x$pch, x$size): unimplemented
#> pch value '31'
```

![plot_plain](https://user-images.githubusercontent.com/38586519/158818022-7d2c8bc6-9a14-425d-a3eb-e78aa126c0cc.png)


``` r
# Symbol fontface == 5
ggplot(df, aes(x = x, y = y)) +
  geom_point(shape = df$shape, size = 5, bg = "grey", fontface = 5) +
  geom_text(aes(label = shape), nudge_y = 0.45, size = 3) +
  scale_y_reverse() +
  theme_void()
#> Warning in grid.Call.graphics(C_points, x$x, x$y, x$pch, x$size): unimplemented
#> pch value '26'
#> Warning in grid.Call.graphics(C_points, x$x, x$y, x$pch, x$size): unimplemented
#> pch value '27'
#> Warning in grid.Call.graphics(C_points, x$x, x$y, x$pch, x$size): unimplemented
#> pch value '28'
#> Warning in grid.Call.graphics(C_points, x$x, x$y, x$pch, x$size): unimplemented
#> pch value '29'
#> Warning in grid.Call.graphics(C_points, x$x, x$y, x$pch, x$size): unimplemented
#> pch value '30'
#> Warning in grid.Call.graphics(C_points, x$x, x$y, x$pch, x$size): unimplemented
#> pch value '31'
```

![plot_symbol](https://user-images.githubusercontent.com/38586519/158817995-bec35357-8643-421b-87ae-c1fa917cb1c8.png)


<sup>Created on 2022-03-17 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> - Session info ---------------------------------------------------------------
#>  setting  value
#>  version  R version 4.1.2 (2021-11-01)
#>  os       Windows 10 x64 (build 19042)
#>  system   x86_64, mingw32
#>  ui       RTerm
#>  language en
#>  collate  German_Germany.1252
#>  ctype    German_Germany.1252
#>  tz       Europe/Berlin
#>  date     2022-03-17
#>  pandoc   2.14.0.3 @ C:/Program Files/RStudio/bin/pandoc/ (via rmarkdown)
#> 
#> - Packages -------------------------------------------------------------------
#>  package     * version    date (UTC) lib source
#>  assertthat    0.2.1      2019-03-21 [1] CRAN (R 4.1.0)
#>  backports     1.4.1      2021-12-13 [1] CRAN (R 4.1.2)
#>  cli           3.1.1      2022-01-20 [1] CRAN (R 4.1.2)
#>  colorspace    2.0-3      2022-02-21 [1] CRAN (R 4.1.2)
#>  crayon        1.5.0      2022-02-14 [1] CRAN (R 4.1.2)
#>  curl          4.3.2      2021-06-23 [1] CRAN (R 4.1.0)
#>  DBI           1.1.2      2021-12-20 [1] CRAN (R 4.1.1)
#>  digest        0.6.29     2021-12-01 [1] CRAN (R 4.1.2)
#>  dplyr         1.0.8      2022-02-08 [1] CRAN (R 4.1.2)
#>  ellipsis      0.3.2      2021-04-29 [1] CRAN (R 4.1.0)
#>  evaluate      0.15       2022-02-18 [1] CRAN (R 4.1.2)
#>  fansi         1.0.2      2022-01-14 [1] CRAN (R 4.1.1)
#>  farver        2.1.0      2021-02-28 [1] CRAN (R 4.1.0)
#>  fastmap       1.1.0      2021-01-25 [1] CRAN (R 4.1.0)
#>  fs            1.5.2      2021-12-08 [1] CRAN (R 4.1.1)
#>  generics      0.1.2      2022-01-31 [1] CRAN (R 4.1.2)
#>  ggplot2     * 3.3.5.9000 2022-03-17 [1] local
#>  glue          1.6.2      2022-02-24 [1] CRAN (R 4.1.2)
#>  gtable        0.3.0      2019-03-25 [1] CRAN (R 4.1.0)
#>  highr         0.9        2021-04-16 [1] CRAN (R 4.1.0)
#>  htmltools     0.5.2      2021-08-25 [1] CRAN (R 4.1.1)
#>  httr          1.4.2      2020-07-20 [1] CRAN (R 4.1.0)
#>  knitr         1.37       2021-12-16 [1] CRAN (R 4.1.1)
#>  labeling      0.4.2      2020-10-20 [1] CRAN (R 4.1.0)
#>  lifecycle     1.0.1      2021-09-24 [1] CRAN (R 4.1.1)
#>  magrittr      2.0.2      2022-01-26 [1] CRAN (R 4.1.2)
#>  mime          0.12       2021-09-28 [1] CRAN (R 4.1.1)
#>  munsell       0.5.0      2018-06-12 [1] CRAN (R 4.1.0)
#>  pillar        1.7.0      2022-02-01 [1] CRAN (R 4.1.2)
#>  pkgconfig     2.0.3      2019-09-22 [1] CRAN (R 4.1.0)
#>  purrr         0.3.4      2020-04-17 [1] CRAN (R 4.1.0)
#>  R.cache       0.15.0     2021-04-30 [1] CRAN (R 4.1.0)
#>  R.methodsS3   1.8.1      2020-08-26 [1] CRAN (R 4.1.0)
#>  R.oo          1.24.0     2020-08-26 [1] CRAN (R 4.1.0)
#>  R.utils       2.11.0     2021-09-26 [1] CRAN (R 4.1.1)
#>  R6            2.5.1      2021-08-19 [1] CRAN (R 4.1.0)
#>  reprex        2.0.1      2021-08-05 [1] CRAN (R 4.1.0)
#>  rlang         1.0.2      2022-03-04 [1] CRAN (R 4.1.2)
#>  rmarkdown     2.12       2022-03-02 [1] CRAN (R 4.1.2)
#>  rstudioapi    0.13       2020-11-12 [1] CRAN (R 4.1.0)
#>  scales        1.1.1.9000 2022-03-11 [1] Github (r-lib/scales@13b01f0)
#>  sessioninfo   1.2.2      2021-12-06 [1] CRAN (R 4.1.1)
#>  stringi       1.7.6      2021-11-29 [1] CRAN (R 4.1.1)
#>  stringr       1.4.0      2019-02-10 [1] CRAN (R 4.1.0)
#>  styler        1.6.2      2021-09-23 [1] CRAN (R 4.1.1)
#>  tibble        3.1.6      2021-11-07 [1] CRAN (R 4.1.1)
#>  tidyr         1.2.0      2022-02-01 [1] CRAN (R 4.1.2)
#>  tidyselect    1.1.2      2022-02-21 [1] CRAN (R 4.1.2)
#>  utf8          1.2.2      2021-07-24 [1] CRAN (R 4.1.0)
#>  vctrs         0.3.8      2021-04-29 [1] CRAN (R 4.1.0)
#>  withr         2.5.0      2022-03-03 [1] CRAN (R 4.1.2)
#>  xfun          0.30       2022-03-02 [1] CRAN (R 4.1.2)
#>  xml2          1.3.3      2021-11-30 [1] CRAN (R 4.1.1)
#>  yaml          2.3.5      2022-02-21 [1] CRAN (R 4.1.2)
#> 
#>  [1] C:/Users/.../Documents/R/win-library/4.1
#>  [2] C:/Users/.../Documents/R/R-4.1.2/library
#> 
#> ------------------------------------------------------------------------------
```

</details>
