### PR TITLE
Use conditionMessage(e) instead of e$message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* Errors converted to warnings now always report the original error message (@zeehio, #4765)
+
 * `annotate()` now documents unsupported geoms (`geom_abline()`, `geom_hline()`
   and `geom_vline()`), and warns when they are requested (@mikmart, #4719)
 

--- a/R/stat-.r
+++ b/R/stat-.r
@@ -98,7 +98,7 @@ Stat <- ggproto("Stat",
     dapply(data, "PANEL", function(data) {
       scales <- layout$get_scales(data$PANEL[1])
       tryCatch(do.call(self$compute_panel, args), error = function(e) {
-        warn(glue("Computation failed in `{snake_class(self)}()`:\n{e$message}"))
+        warn(glue("Computation failed in `{snake_class(self)}()`:\n{conditionMessage(e)}"))
         new_data_frame()
       })
     })

--- a/R/stat-density-2d.r
+++ b/R/stat-density-2d.r
@@ -154,7 +154,7 @@ StatDensity2d <- ggproto("StatDensity2d", Stat,
     dapply(data, "PANEL", function(data) {
       scales <- layout$get_scales(data$PANEL[1])
       tryCatch(do.call(contour_stat$compute_panel, args), error = function(e) {
-        warn(glue("Computation failed in `{snake_class(self)}()`:\n{e$message}"))
+        warn(glue("Computation failed in `{snake_class(self)}()`:\n{conditionMessage(e)}"))
         new_data_frame()
       })
     })


### PR DESCRIPTION
This pull request improves ggplot2 error handling by using `conditionMessage(e)` instead of `e$message`.

Some error messages were not printed. See the following reprex, which assumes `hexbin` is NOT installed:

# Before:

We have no clue why the computation failed

``` r
#remove.packages("hexbin")
library(ggplot2)
plt1 <- ggplot(iris) + 
  geom_hex(aes(x = Sepal.Length, y = Sepal.Width))
#> Warning: Computation failed in `stat_binhex()`:
```

<sup>Created on 2022-03-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>


# After:

We know what to do, just install hexbin!

``` r
#remove.packages("hexbin")
library(ggplot2)
plt1<- ggplot(iris) + 
  geom_hex(aes(x = Sepal.Length, y = Sepal.Width))
#> Warning: Computation failed in `stat_binhex()`:
#> The package `hexbin` is required for `stat_binhex()`
```


<sup>Created on 2022-03-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>