### PR TITLE
Rescale geom_density for non-linear scales

### DIFF
--- a/R/stat-density.r
+++ b/R/stat-density.r
@@ -133,10 +133,12 @@ compute_density <- function(x, w, from, to, trans, bw = "nrd0", adjust = 1,
     sum(y * x_diff, na.rm = TRUE)
   }
 
-  total_pre <- integrate_density(dens$x, dens$y)
-  total_post <- integrate_density(trans$inverse(dens$x), dens$y)
+  if (trans$name != "identity") {
+    area_pre <- integrate_density(dens$x, dens$y)
+    area_post <- integrate_density(trans$inverse(dens$x), dens$y)
 
-  dens$y <- dens$y * total_pre / total_post
+    dens$y <- dens$y * area_pre / area_post
+  }
 
   new_data_frame(list(
     x = dens$x,


### PR DESCRIPTION
This is a proof-of-concept to address #4783. There might be some context I'm missing here, so I'm interested to hear feedback before proceeding any further.

``` r
library(tidyverse)

p <- tibble(x = rnorm(1000, mean = 10)) %>%
  ggplot(aes(x)) +
  geom_density() +
  geom_function(fun = dnorm, args = list(mean = 10), color = "red")

p + scale_x_continuous(limits = c(1, NA))
```

![](https://i.imgur.com/zWKiIa1.png)

``` r
p + scale_x_log10(limits = c(1, NA))
```

![](https://i.imgur.com/lavm6ac.png)

``` r
p + scale_x_sqrt(limits = c(1, NA))
```

![](https://i.imgur.com/XO3Qogj.png)

<sup>Created on 2022-03-30 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>