### PR TITLE
Improve error messages when base pipe operator is used wrongly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* improved error messages when `|>` is used instead of `+` (@92amartins, #4792)
+
 * `...` supports `rlang::list2` dynamic dots in all public functions. (@mone27, #4764) 
 
 * `theme()` now has a `strip.clip` argument, that can be set to `"off"` to 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # ggplot2 (development version)
 
-* improved error messages when `|>` is used instead of `+` (@92amartins, #4792)
+* Improved error messages when `|>` is used instead of `+` (@92amartins, #4792)
 
 * `...` supports `rlang::list2` dynamic dots in all public functions. (@mone27, #4764) 
 

--- a/R/facet-grid-.r
+++ b/R/facet-grid-.r
@@ -161,7 +161,7 @@ grid_as_facets_list <- function(rows, cols) {
       if(inherits(rows, "ggplot")) {
         msg <- paste0(
           msg, "\n",
-          "Did you use %>% instead of +?"
+          "Did you use %>% or |> instead of +?"
         )
       }
       abort(msg)

--- a/R/layer.r
+++ b/R/layer.r
@@ -153,7 +153,7 @@ validate_mapping <- function(mapping) {
     if (inherits(mapping, "ggplot")) {
       msg <- paste0(
         msg, "\n",
-        "Did you use %>% instead of +?"
+        "Did you use %>% or |> instead of +?"
       )
     }
 


### PR DESCRIPTION
This PR is an attempt to fix #4792.

I tried to follow the @yutannihilation guidelines on the original issue.

Couldn't figure it out how to include proper snaps.

Further guidance is greatly appreciated