### PR TITLE
Try no RSPM to fix temporary errors on the Windows runner

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
-          use-public-rspm: false
+          use-public-rspm: ${{ runner.os != 'Windows' || matrix.config.r != 'release' }}
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
-          use-public-rspm: true
+          use-public-rspm: false
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
(This pull request is not intended to be merged, just to test if the CI runs well even after the release of R 4.2. But we can merge this if we want the CI to be fixed immediately.)

It seems RSPM is not ready for R 4.2 for Windows.