### PR TITLE
Fixes #4399 fullrange documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -85,7 +85,7 @@ precedence between `bins` and `binwidth`. (@eliocamp, #4651)
   `geom_linerange()` are now orientation-aware (@mjskay, #4732)
   
 * Updated documentation for `geom_smooth()` to more clearly describe effects of the 
-  `fullrange` paramter (@thoolihan, #4399).
+  `fullrange` parameter (@thoolihan, #4399).
 
 # ggplot2 3.3.5
 This is a very small release focusing on fixing a couple of untenable issues 

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -124,8 +124,7 @@ lines. Only used with loess, i.e. when \code{method = "loess"},
 or when \code{method = NULL} (the default) and there are fewer than 1,000
 observations.}
 
-\item{fullrange}{Should the fit span the full range of the plot, or just
-the data?}
+\item{fullrange}{If TRUE, fullrange expands the smoothing line to the range of the plot, potentially beyond the data. This does not extend the line into any additional padding created by \code{\link[=expansion]{expansion()}}.
 
 \item{level}{Level of confidence interval to use (0.95 by default).}
 


### PR DESCRIPTION
Fixes #4399: Provides clearer documentation for fullrange parameter of geom_smooth(), explaining that when TRUE, the smoothing line spans the plot area potentially beyond data, but not including padding created by expansion. NEWS.md updated included.

This is my first commit/pull request for ggplot2. I reviewed contributing, wiki, and ggplot2 website guidelines. Please let me know if I have missed anything.