### PR TITLE
Fixes #4399

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,9 @@ precedence between `bins` and `binwidth`. (@eliocamp, #4651)
 
 * Key glyphs for `geom_boxplot()`, `geom_crossbar()`, `geom_pointrange()`, and
   `geom_linerange()` are now orientation-aware (@mjskay, #4732)
+  
+* Updated documentation for `geom_smooth()` to more clearly describe effects of the 
+  `fullrange` parameter (@thoolihan, #4399).  
 
 # ggplot2 3.3.5
 This is a very small release focusing on fixing a couple of untenable issues 

--- a/R/stat-smooth.r
+++ b/R/stat-smooth.r
@@ -20,8 +20,9 @@
 #'   observations and `formula = y ~ s(x, bs = "cs")` otherwise.
 #' @param se Display confidence interval around smooth? (`TRUE` by default, see
 #'   `level` to control.)
-#' @param fullrange Should the fit span the full range of the plot, or just
-#'   the data?
+#' @param fullrange If TRUE, `fullrange` expands the smoothing line to the range of the plot,
+#'   potentially beyond the data. This does not extend the line into any additional padding
+#'   created by `expansion`.
 #' @param level Level of confidence interval to use (0.95 by default).
 #' @param span Controls the amount of smoothing for the default loess smoother.
 #'   Smaller numbers produce wigglier lines, larger numbers produce smoother

--- a/R/stat-smooth.r
+++ b/R/stat-smooth.r
@@ -20,7 +20,7 @@
 #'   observations and `formula = y ~ s(x, bs = "cs")` otherwise.
 #' @param se Display confidence interval around smooth? (`TRUE` by default, see
 #'   `level` to control.)
-#' @param fullrange If TRUE, `fullrange` expands the smoothing line to the range of the plot,
+#' @param fullrange If `TRUE`, the smoothing line gets expanded to the range of the plot,
 #'   potentially beyond the data. This does not extend the line into any additional padding
 #'   created by `expansion`.
 #' @param level Level of confidence interval to use (0.95 by default).

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -124,8 +124,9 @@ lines. Only used with loess, i.e. when \code{method = "loess"},
 or when \code{method = NULL} (the default) and there are fewer than 1,000
 observations.}
 
-\item{fullrange}{Should the fit span the full range of the plot, or just
-the data?}
+\item{fullrange}{If TRUE, \code{fullrange} expands the smoothing line to the range of the plot,
+potentially beyond the data. This does not extend the line into any additional padding
+created by \code{expansion}.}
 
 \item{level}{Level of confidence interval to use (0.95 by default).}
 

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -124,7 +124,7 @@ lines. Only used with loess, i.e. when \code{method = "loess"},
 or when \code{method = NULL} (the default) and there are fewer than 1,000
 observations.}
 
-\item{fullrange}{If TRUE, \code{fullrange} expands the smoothing line to the range of the plot,
+\item{fullrange}{If \code{TRUE}, the smoothing line gets expanded to the range of the plot,
 potentially beyond the data. This does not extend the line into any additional padding
 created by \code{expansion}.}
 


### PR DESCRIPTION
Clearer documentation indicating that fullrange may extend beyond the data but does not fill the area created by expansion.

Docs regenerated by devtools::document() did create some warnings that are unrelated to these changes. Presumably known issues?