### PR TITLE
Documentation clarifying stat_density/after_stat n

### DIFF
--- a/R/aes-evaluation.r
+++ b/R/aes-evaluation.r
@@ -23,10 +23,11 @@
 #' `after_stat()` replaces the old approaches of using either `stat()` or
 #' surrounding the variable names with `..`.
 #'
-#' @note Evaluation after stat transformation will only have access to the
-#' variables calculated by the stat. Evaluation after scaling will only have
-#' access to the final aesthetics of the layer (including non-mapped, default
-#' aesthetics). The original layer data can only be accessed at the first stage.
+#' @note Evaluation after stat transformation will have access to the
+#' variables calculated by the stat, not the original mapped values. Evaluation
+#' after scaling will only have access to the final aesthetics of the layer
+#' (including non-mapped, default aesthetics). The original layer data can only
+#' be accessed at the first stage.
 #'
 #' @param x An aesthetic expression using variables calculated by the stat
 #'   (`after_stat()`) or layer aesthetics (`after_scale()`).

--- a/R/stat-density.r
+++ b/R/stat-density.r
@@ -21,6 +21,7 @@
 #'   \item{count}{density * number of points - useful for stacked density
 #'      plots}
 #'   \item{scaled}{density estimate, scaled to maximum of 1}
+#'   \item{n}{number of points}
 #'   \item{ndensity}{alias for `scaled`, to mirror the syntax of
 #'    [`stat_bin()`]}
 #' }

--- a/man/aes_eval.Rd
+++ b/man/aes_eval.Rd
@@ -51,10 +51,11 @@ you can use the \code{stage()} function to collect multiple mappings.
 surrounding the variable names with \code{..}.
 }
 \note{
-Evaluation after stat transformation will only have access to the
-variables calculated by the stat. Evaluation after scaling will only have
-access to the final aesthetics of the layer (including non-mapped, default
-aesthetics). The original layer data can only be accessed at the first stage.
+Evaluation after stat transformation will have access to the
+variables calculated by the stat, not the original mapped values. Evaluation
+after scaling will only have access to the final aesthetics of the layer
+(including non-mapped, default aesthetics). The original layer data can only
+be accessed at the first stage.
 }
 \examples{
 # Default histogram display

--- a/man/geom_density.Rd
+++ b/man/geom_density.Rd
@@ -146,6 +146,7 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 \item{count}{density * number of points - useful for stacked density
 plots}
 \item{scaled}{density estimate, scaled to maximum of 1}
+\item{n}{number of points}
 \item{ndensity}{alias for \code{scaled}, to mirror the syntax of
 \code{\link[=stat_bin]{stat_bin()}}}
 }


### PR DESCRIPTION
Fixes #4476 by clarifying that n is a computed value of stat_density() that can is not available as original mapping in after_stat. Also wording better specifies that after_stat masks original mapping, but not variables in parent scope(s).