### PR TITLE
document default values for label justifications in guides

### DIFF
--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -32,7 +32,8 @@
 #'   object of [element_text()] is expected. By default, the theme is
 #'   specified by `legend.text` in [theme()].
 #' @param label.hjust A numeric specifying horizontal justification of the
-#'   label text.
+#'   label text. The default for standard text is 0 (left-aligned) and 1
+#'   (right-aligned) for expressions.
 #' @param label.vjust A numeric specifying vertical justification of the label
 #'   text.
 #' @param keywidth A numeric or a [grid::unit()] object specifying

--- a/man/guide_bins.Rd
+++ b/man/guide_bins.Rd
@@ -62,7 +62,8 @@ object of \code{\link[=element_text]{element_text()}} is expected. By default, t
 specified by \code{legend.text} in \code{\link[=theme]{theme()}}.}
 
 \item{label.hjust}{A numeric specifying horizontal justification of the
-label text.}
+label text. The default for standard text is 0 (left-aligned) and 1
+(right-aligned) for expressions.}
 
 \item{label.vjust}{A numeric specifying vertical justification of the label
 text.}

--- a/man/guide_colourbar.Rd
+++ b/man/guide_colourbar.Rd
@@ -99,7 +99,8 @@ object of \code{\link[=element_text]{element_text()}} is expected. By default, t
 specified by \code{legend.text} in \code{\link[=theme]{theme()}}.}
 
 \item{label.hjust}{A numeric specifying horizontal justification of the
-label text.}
+label text. The default for standard text is 0 (left-aligned) and 1
+(right-aligned) for expressions.}
 
 \item{label.vjust}{A numeric specifying vertical justification of the label
 text.}

--- a/man/guide_coloursteps.Rd
+++ b/man/guide_coloursteps.Rd
@@ -69,7 +69,8 @@ label. One of "top", "bottom" (default for horizontal guide), "left", or
 object of \code{\link[=element_text]{element_text()}} is expected. By default, the theme is
 specified by \code{legend.text} in \code{\link[=theme]{theme()}}.}
     \item{\code{label.hjust}}{A numeric specifying horizontal justification of the
-label text.}
+label text. The default for standard text is 0 (left-aligned) and 1
+(right-aligned) for expressions.}
     \item{\code{label.vjust}}{A numeric specifying vertical justification of the label
 text.}
     \item{\code{order}}{positive integer less than 99 that specifies the order of

--- a/man/guide_legend.Rd
+++ b/man/guide_legend.Rd
@@ -60,7 +60,8 @@ object of \code{\link[=element_text]{element_text()}} is expected. By default, t
 specified by \code{legend.text} in \code{\link[=theme]{theme()}}.}
 
 \item{label.hjust}{A numeric specifying horizontal justification of the
-label text.}
+label text. The default for standard text is 0 (left-aligned) and 1
+(right-aligned) for expressions.}
 
 \item{label.vjust}{A numeric specifying vertical justification of the label
 text.}


### PR DESCRIPTION
Fix #4814 