### PR TITLE
Use rlang::hash instead of digest

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,6 @@ Depends:
     R (>= 3.3)
 Imports: 
     cli,
-    digest,
     glue,
     grDevices,
     grid,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Use `rlang::hash()` instead of `digest::digest()`. This update may lead to 
+  changes in the automatic sorting of legends (@thomasp85, #4458)
+
 * Fix various issues with how `labels`, `breaks`, `limits`, and `show.limits`
   interact in the different binning guides (@thomasp85, #4831)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # ggplot2 (development version)
 
 * Use `rlang::hash()` instead of `digest::digest()`. This update may lead to 
-  changes in the automatic sorting of legends (@thomasp85, #4458)
+  changes in the automatic sorting of legends. In order to enforce a specific
+  legend order use the `order` argument in the guide. (@thomasp85, #4458)
 
 * Fix various issues with how `labels`, `breaks`, `limits`, and `show.limits`
   interact in the different binning guides (@thomasp85, #4831)

--- a/R/guide-bins.R
+++ b/R/guide-bins.R
@@ -209,7 +209,7 @@ guide_train.bins <- function(guide, scale, aesthetic = NULL) {
   guide$key <- key
   guide$hash <- with(
     guide,
-    digest::digest(list(title, key$.label, direction, name))
+    hash(list(title, key$.label, direction, name))
   )
   guide
 }

--- a/R/guide-colorbar.r
+++ b/R/guide-colorbar.r
@@ -230,7 +230,7 @@ guide_train.colorbar <- function(guide, scale, aesthetic = NULL) {
     guide$key <- guide$key[nrow(guide$key):1, ]
     guide$bar <- guide$bar[nrow(guide$bar):1, ]
   }
-  guide$hash <- with(guide, digest::digest(list(title, key$.label, bar, name)))
+  guide$hash <- with(guide, hash(list(title, key$.label, bar, name)))
   guide
 }
 

--- a/R/guide-colorsteps.R
+++ b/R/guide-colorsteps.R
@@ -121,7 +121,7 @@ guide_train.colorsteps <- function(guide, scale, aesthetic = NULL) {
       guide$key <- guide$key[nrow(guide$key):1, ]
       guide$bar <- guide$bar[nrow(guide$bar):1, ]
     }
-    guide$hash <- with(guide, digest::digest(list(title, key$.label, bar, name)))
+    guide$hash <- with(guide, hash(list(title, key$.label, bar, name)))
   } else {
     guide <- NextMethod()
     limits <- scale$get_limits()

--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -227,7 +227,7 @@ guide_train.legend <- function(guide, scale, aesthetic = NULL) {
   guide$key <- key
   guide$hash <- with(
     guide,
-    digest::digest(list(title, key$.label, direction, name))
+    hash(list(title, key$.label, direction, name))
   )
   guide
 }

--- a/R/guides-axis.r
+++ b/R/guides-axis.r
@@ -89,7 +89,7 @@ guide_train.axis <- function(guide, scale, aesthetic = NULL) {
   }
 
   guide$name <- paste0(guide$name, "_", aesthetic)
-  guide$hash <- digest::digest(list(guide$title, guide$key$.value, guide$key$.label, guide$name))
+  guide$hash <- hash(list(guide$title, guide$key$.value, guide$key$.label, guide$name))
   guide
 }
 

--- a/tests/testthat/_snaps/draw-key/horizontal-boxplot-and-crossbar.svg
+++ b/tests/testthat/_snaps/draw-key/horizontal-boxplot-and-crossbar.svg
@@ -65,33 +65,33 @@
 <text x='348.60' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='32.41px' lengthAdjust='spacingAndGlyphs'>middle</text>
 <text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='34.25px' lengthAdjust='spacingAndGlyphs'>group1</text>
 <rect x='680.27' y='228.58' width='34.25' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='680.27' y='237.29' style='font-size: 11.00px; font-family: sans;' textLength='34.25px' lengthAdjust='spacingAndGlyphs'>group2</text>
+<text x='680.27' y='237.29' style='font-size: 11.00px; font-family: sans;' textLength='34.25px' lengthAdjust='spacingAndGlyphs'>group1</text>
 <rect x='680.27' y='243.91' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polygon points='684.59,246.07 693.23,246.07 693.23,259.03 684.59,259.03 684.59,246.07 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<polygon points='684.59,246.07 693.23,246.07 693.23,259.03 684.59,259.03 684.59,246.07 ' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: none;' />
-<polyline points='688.91,246.07 688.91,259.03 ' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter;' />
+<polyline points='681.99,252.55 684.59,252.55 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter;' />
+<polyline points='693.23,252.55 695.82,252.55 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter;' />
+<polygon points='684.59,246.07 693.23,246.07 693.23,259.03 684.59,259.03 684.59,246.07 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<polygon points='684.59,246.07 693.23,246.07 693.23,259.03 684.59,259.03 684.59,246.07 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: none;' />
+<polyline points='688.91,246.07 688.91,259.03 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='680.27' y='261.19' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polygon points='684.59,263.35 693.23,263.35 693.23,276.31 684.59,276.31 684.59,263.35 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
-<polygon points='684.59,263.35 693.23,263.35 693.23,276.31 684.59,276.31 684.59,263.35 ' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: none;' />
-<polyline points='688.91,263.35 688.91,276.31 ' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter;' />
-<text x='703.03' y='255.58' style='font-size: 8.80px; font-family: sans;' textLength='4.40px' lengthAdjust='spacingAndGlyphs'>c</text>
-<text x='703.03' y='272.86' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>d</text>
+<polyline points='681.99,269.83 684.59,269.83 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter;' />
+<polyline points='693.23,269.83 695.82,269.83 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter;' />
+<polygon points='684.59,263.35 693.23,263.35 693.23,276.31 684.59,276.31 684.59,263.35 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
+<polygon points='684.59,263.35 693.23,263.35 693.23,276.31 684.59,276.31 684.59,263.35 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: none;' />
+<polyline points='688.91,263.35 688.91,276.31 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter;' />
+<text x='703.03' y='255.58' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>a</text>
+<text x='703.03' y='272.86' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text>
 <rect x='680.27' y='289.43' width='34.25' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='680.27' y='298.14' style='font-size: 11.00px; font-family: sans;' textLength='34.25px' lengthAdjust='spacingAndGlyphs'>group1</text>
+<text x='680.27' y='298.14' style='font-size: 11.00px; font-family: sans;' textLength='34.25px' lengthAdjust='spacingAndGlyphs'>group2</text>
 <rect x='680.27' y='304.76' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='681.99,313.40 684.59,313.40 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter;' />
-<polyline points='693.23,313.40 695.82,313.40 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter;' />
-<polygon points='684.59,306.92 693.23,306.92 693.23,319.88 684.59,319.88 684.59,306.92 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
-<polygon points='684.59,306.92 693.23,306.92 693.23,319.88 684.59,319.88 684.59,306.92 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: none;' />
-<polyline points='688.91,306.92 688.91,319.88 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter;' />
+<polygon points='684.59,306.92 693.23,306.92 693.23,319.88 684.59,319.88 684.59,306.92 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<polygon points='684.59,306.92 693.23,306.92 693.23,319.88 684.59,319.88 684.59,306.92 ' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: none;' />
+<polyline points='688.91,306.92 688.91,319.88 ' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter;' />
 <rect x='680.27' y='322.04' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='681.99,330.68 684.59,330.68 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter;' />
-<polyline points='693.23,330.68 695.82,330.68 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter;' />
-<polygon points='684.59,324.20 693.23,324.20 693.23,337.16 684.59,337.16 684.59,324.20 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF;' />
-<polygon points='684.59,324.20 693.23,324.20 693.23,337.16 684.59,337.16 684.59,324.20 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: none;' />
-<polyline points='688.91,324.20 688.91,337.16 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter;' />
-<text x='703.03' y='316.43' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>a</text>
-<text x='703.03' y='333.71' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text>
+<polygon points='684.59,324.20 693.23,324.20 693.23,337.16 684.59,337.16 684.59,324.20 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<polygon points='684.59,324.20 693.23,324.20 693.23,337.16 684.59,337.16 684.59,324.20 ' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: none;' />
+<polyline points='688.91,324.20 688.91,337.16 ' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter;' />
+<text x='703.03' y='316.43' style='font-size: 8.80px; font-family: sans;' textLength='4.40px' lengthAdjust='spacingAndGlyphs'>c</text>
+<text x='703.03' y='333.71' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>d</text>
 <text x='27.90' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='183.47px' lengthAdjust='spacingAndGlyphs'>horizontal boxplot and crossbar</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/draw-key/horizontal-linerange-and-pointrange.svg
+++ b/tests/testthat/_snaps/draw-key/horizontal-linerange-and-pointrange.svg
@@ -59,23 +59,23 @@
 <text x='348.60' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='32.41px' lengthAdjust='spacingAndGlyphs'>middle</text>
 <text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='34.25px' lengthAdjust='spacingAndGlyphs'>group1</text>
 <rect x='680.27' y='228.58' width='34.25' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='680.27' y='237.29' style='font-size: 11.00px; font-family: sans;' textLength='34.25px' lengthAdjust='spacingAndGlyphs'>group2</text>
+<text x='680.27' y='237.29' style='font-size: 11.00px; font-family: sans;' textLength='34.25px' lengthAdjust='spacingAndGlyphs'>group1</text>
 <rect x='680.27' y='243.91' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='681.99' y1='252.55' x2='695.82' y2='252.55' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<circle cx='688.91' cy='252.55' r='2.84' style='stroke-width: 1.42; stroke: none; fill: #000000;' />
+<line x1='681.99' y1='252.55' x2='695.82' y2='252.55' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
 <rect x='680.27' y='261.19' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='681.99' y1='269.83' x2='695.82' y2='269.83' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<polygon points='688.91,265.41 692.73,272.04 685.08,272.04 ' style='stroke-width: 1.42; stroke: none; fill: #000000;' />
-<text x='703.03' y='255.58' style='font-size: 8.80px; font-family: sans;' textLength='4.40px' lengthAdjust='spacingAndGlyphs'>c</text>
-<text x='703.03' y='272.86' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>d</text>
+<line x1='681.99' y1='269.83' x2='695.82' y2='269.83' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<text x='703.03' y='255.58' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>a</text>
+<text x='703.03' y='272.86' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text>
 <rect x='680.27' y='289.43' width='34.25' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='680.27' y='298.14' style='font-size: 11.00px; font-family: sans;' textLength='34.25px' lengthAdjust='spacingAndGlyphs'>group1</text>
+<text x='680.27' y='298.14' style='font-size: 11.00px; font-family: sans;' textLength='34.25px' lengthAdjust='spacingAndGlyphs'>group2</text>
 <rect x='680.27' y='304.76' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='681.99' y1='313.40' x2='695.82' y2='313.40' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<line x1='681.99' y1='313.40' x2='695.82' y2='313.40' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<circle cx='688.91' cy='313.40' r='2.84' style='stroke-width: 1.42; stroke: none; fill: #000000;' />
 <rect x='680.27' y='322.04' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='681.99' y1='330.68' x2='695.82' y2='330.68' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
-<text x='703.03' y='316.43' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>a</text>
-<text x='703.03' y='333.71' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text>
+<line x1='681.99' y1='330.68' x2='695.82' y2='330.68' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polygon points='688.91,326.26 692.73,332.89 685.08,332.89 ' style='stroke-width: 1.42; stroke: none; fill: #000000;' />
+<text x='703.03' y='316.43' style='font-size: 8.80px; font-family: sans;' textLength='4.40px' lengthAdjust='spacingAndGlyphs'>c</text>
+<text x='703.03' y='333.71' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>d</text>
 <text x='27.90' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='206.96px' lengthAdjust='spacingAndGlyphs'>horizontal linerange and pointrange</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/draw-key/rectangle-and-dotplot-key-glyphs.svg
+++ b/tests/testthat/_snaps/draw-key/rectangle-and-dotplot-key-glyphs.svg
@@ -56,22 +56,22 @@
 <text x='638.38' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
 <text x='351.17' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
 <text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
-<rect x='678.06' y='228.58' width='36.46' height='32.61' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='678.06' y='237.29' style='font-size: 11.00px; font-family: sans;' textLength='29.96px' lengthAdjust='spacingAndGlyphs'>colour</text>
+<rect x='678.06' y='228.58' width='27.65' height='67.17' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='678.06' y='237.29' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>z</text>
 <rect x='678.06' y='243.91' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='678.06' y='243.91' width='17.28' height='17.28' style='stroke-width: 0.75; stroke: none; fill: #F8766D;' />
-<text x='700.82' y='255.58' style='font-size: 8.80px; font-family: sans;' textLength='13.70px' lengthAdjust='spacingAndGlyphs'>line</text>
-<rect x='678.06' y='272.15' width='27.65' height='67.17' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='678.06' y='280.86' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>z</text>
-<rect x='678.06' y='287.48' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<circle cx='686.70' cy='296.12' r='3.24' style='stroke-width: 0.75; stroke-linecap: butt; fill: #F8766D;' />
-<rect x='678.06' y='304.76' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<circle cx='686.70' cy='313.40' r='3.24' style='stroke-width: 0.75; stroke-linecap: butt; fill: #00BA38;' />
+<circle cx='686.70' cy='252.55' r='3.24' style='stroke-width: 0.75; stroke-linecap: butt; fill: #F8766D;' />
+<rect x='678.06' y='261.19' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='686.70' cy='269.83' r='3.24' style='stroke-width: 0.75; stroke-linecap: butt; fill: #00BA38;' />
+<rect x='678.06' y='278.47' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='686.70' cy='287.11' r='3.24' style='stroke-width: 0.75; stroke-linecap: butt; fill: #619CFF;' />
+<text x='700.82' y='255.58' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>a</text>
+<text x='700.82' y='272.86' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text>
+<text x='700.82' y='290.14' style='font-size: 8.80px; font-family: sans;' textLength='4.40px' lengthAdjust='spacingAndGlyphs'>c</text>
+<rect x='678.06' y='306.71' width='36.46' height='32.61' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='678.06' y='315.42' style='font-size: 11.00px; font-family: sans;' textLength='29.96px' lengthAdjust='spacingAndGlyphs'>colour</text>
 <rect x='678.06' y='322.04' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<circle cx='686.70' cy='330.68' r='3.24' style='stroke-width: 0.75; stroke-linecap: butt; fill: #619CFF;' />
-<text x='700.82' y='299.15' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>a</text>
-<text x='700.82' y='316.43' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text>
-<text x='700.82' y='333.71' style='font-size: 8.80px; font-family: sans;' textLength='4.40px' lengthAdjust='spacingAndGlyphs'>c</text>
+<rect x='678.06' y='322.04' width='17.28' height='17.28' style='stroke-width: 0.75; stroke: none; fill: #F8766D;' />
+<text x='700.82' y='333.71' style='font-size: 8.80px; font-family: sans;' textLength='13.70px' lengthAdjust='spacingAndGlyphs'>line</text>
 <text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='189.35px' lengthAdjust='spacingAndGlyphs'>rectangle and dotplot key glyphs</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/draw-key/time-series-and-polygon-key-glyphs.svg
+++ b/tests/testthat/_snaps/draw-key/time-series-and-polygon-key-glyphs.svg
@@ -56,22 +56,22 @@
 <text x='638.38' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
 <text x='351.17' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
 <text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
-<rect x='678.06' y='228.58' width='36.46' height='32.61' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='678.06' y='237.29' style='font-size: 11.00px; font-family: sans;' textLength='29.96px' lengthAdjust='spacingAndGlyphs'>colour</text>
+<rect x='678.06' y='228.58' width='27.65' height='67.17' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='678.06' y='237.29' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>z</text>
 <rect x='678.06' y='243.91' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='678.06,259.46 684.98,250.82 688.43,254.28 695.34,245.64 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
-<text x='700.82' y='255.58' style='font-size: 8.80px; font-family: sans;' textLength='13.70px' lengthAdjust='spacingAndGlyphs'>line</text>
-<rect x='678.06' y='272.15' width='27.65' height='67.17' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='678.06' y='280.86' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>z</text>
-<rect x='678.06' y='287.48' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='680.22' y='289.64' width='12.96' height='12.96' style='stroke-width: 3.25; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='678.06' y='304.76' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='680.22' y='306.92' width='12.96' height='12.96' style='stroke-width: 3.25; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='680.22' y='246.07' width='12.96' height='12.96' style='stroke-width: 3.25; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='678.06' y='261.19' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='680.22' y='263.35' width='12.96' height='12.96' style='stroke-width: 3.25; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='678.06' y='278.47' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='680.22' y='280.63' width='12.96' height='12.96' style='stroke-width: 3.25; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<text x='700.82' y='255.58' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>a</text>
+<text x='700.82' y='272.86' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text>
+<text x='700.82' y='290.14' style='font-size: 8.80px; font-family: sans;' textLength='4.40px' lengthAdjust='spacingAndGlyphs'>c</text>
+<rect x='678.06' y='306.71' width='36.46' height='32.61' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='678.06' y='315.42' style='font-size: 11.00px; font-family: sans;' textLength='29.96px' lengthAdjust='spacingAndGlyphs'>colour</text>
 <rect x='678.06' y='322.04' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='680.22' y='324.20' width='12.96' height='12.96' style='stroke-width: 3.25; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<text x='700.82' y='299.15' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>a</text>
-<text x='700.82' y='316.43' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text>
-<text x='700.82' y='333.71' style='font-size: 8.80px; font-family: sans;' textLength='4.40px' lengthAdjust='spacingAndGlyphs'>c</text>
+<polyline points='678.06,337.59 684.98,328.95 688.43,332.41 695.34,323.77 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<text x='700.82' y='333.71' style='font-size: 8.80px; font-family: sans;' textLength='13.70px' lengthAdjust='spacingAndGlyphs'>line</text>
 <text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='205.48px' lengthAdjust='spacingAndGlyphs'>time series and polygon key glyphs</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/guides.md
+++ b/tests/testthat/_snaps/guides.md
@@ -1,13 +1,3 @@
-# binning scales understand the different combinations of limits, breaks, labels, and show.limits
-
-    `show.limits` is ignored when `labels` are given as a character vector
-    i Either add the limits to `breaks` or provide a function for `labels`
-
----
-
-    `show.limits` is ignored when `labels` are given as a character vector
-    i Either add the limits to `breaks` or provide a function for `labels`
-
 # axis_label_element_overrides errors when angles are outside the range [0, 90]
 
     Unrecognized `axis_position`: "test"
@@ -67,6 +57,16 @@
 
     Breaks not formatted correctly for a bin legend.
     i Use `(<lower>, <upper>]` format to indicate bins
+
+# binning scales understand the different combinations of limits, breaks, labels, and show.limits
+
+    `show.limits` is ignored when `labels` are given as a character vector
+    i Either add the limits to `breaks` or provide a function for `labels`
+
+---
+
+    `show.limits` is ignored when `labels` are given as a character vector
+    i Either add the limits to `breaks` or provide a function for `labels`
 
 # a warning is generated when guides(<scale> = FALSE) is specified
 

--- a/tests/testthat/_snaps/guides/legend-inside-plot-bottom-left-of-legend-at-center.svg
+++ b/tests/testthat/_snaps/guides/legend-inside-plot-bottom-left-of-legend-at-center.svg
@@ -51,35 +51,35 @@
 <text x='588.07' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text>
 <text x='377.33' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
 <text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
-<rect x='377.33' y='104.08' width='29.12' height='67.17' style='stroke-width: 1.07; fill: #FFFFFF;' />
-<text x='377.33' y='112.79' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
-<rect x='377.33' y='119.42' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='378.04' y='120.12' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='377.33' y='136.70' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='378.04' y='137.40' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='377.33' y='153.98' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='378.04' y='154.68' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<text x='400.09' y='131.08' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>A</text>
-<text x='400.09' y='148.36' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>B</text>
-<text x='400.09' y='165.64' style='font-size: 8.80px; font-family: sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text>
-<rect x='377.33' y='182.21' width='34.99' height='101.73' style='stroke-width: 1.07; fill: #FFFFFF;' />
-<image width='17.28' height='86.40' x='377.33' y='197.55' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAmElEQVQ4ja2UQRLDMAgDd3hk/tnX5agcknFaCoa0vnkMCEnGsL12GQhDYDpPwoDrpBFlRDWi/9Wu6AHC9FkLYLrzlhD3oJ3mDvRHRYy7IC8A7bCK8gpWKYDzeQVArDcDyD2YAnSofZvzaOA6Q7Oahp/dmRuVTQ0xU5TGP2o8Waool1obVuv1q8qP9xPvg633XlGLDtfIhNUBcBeA5ss0BXMAAAAASUVORK5CYII='/>
-<text x='400.09' y='286.83' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='400.09' y='265.30' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
-<text x='400.09' y='243.78' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
-<text x='400.09' y='222.25' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='400.09' y='200.72' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
-<text x='377.33' y='190.93' style='font-size: 11.00px; font-family: sans;' textLength='15.29px' lengthAdjust='spacingAndGlyphs'>1:3</text>
-<line x1='377.33' y1='283.80' x2='380.78' y2='283.80' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='377.33' y1='262.28' x2='380.78' y2='262.28' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='377.33' y1='240.75' x2='380.78' y2='240.75' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='377.33' y1='219.22' x2='380.78' y2='219.22' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='377.33' y1='197.69' x2='380.78' y2='197.69' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='391.15' y1='283.80' x2='394.61' y2='283.80' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='391.15' y1='262.28' x2='394.61' y2='262.28' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='391.15' y1='240.75' x2='394.61' y2='240.75' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='391.15' y1='219.22' x2='394.61' y2='219.22' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='391.15' y1='197.69' x2='394.61' y2='197.69' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='377.33' y='104.08' width='34.99' height='101.73' style='stroke-width: 1.07; fill: #FFFFFF;' />
+<image width='17.28' height='86.40' x='377.33' y='119.42' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAmElEQVQ4ja2UQRLDMAgDd3hk/tnX5agcknFaCoa0vnkMCEnGsL12GQhDYDpPwoDrpBFlRDWi/9Wu6AHC9FkLYLrzlhD3oJ3mDvRHRYy7IC8A7bCK8gpWKYDzeQVArDcDyD2YAnSofZvzaOA6Q7Oahp/dmRuVTQ0xU5TGP2o8Waool1obVuv1q8qP9xPvg633XlGLDtfIhNUBcBeA5ss0BXMAAAAASUVORK5CYII='/>
+<text x='400.09' y='208.70' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='400.09' y='187.17' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='400.09' y='165.64' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text x='400.09' y='144.12' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='400.09' y='122.59' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='377.33' y='112.79' style='font-size: 11.00px; font-family: sans;' textLength='15.29px' lengthAdjust='spacingAndGlyphs'>1:3</text>
+<line x1='377.33' y1='205.67' x2='380.78' y2='205.67' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='377.33' y1='184.14' x2='380.78' y2='184.14' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='377.33' y1='162.62' x2='380.78' y2='162.62' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='377.33' y1='141.09' x2='380.78' y2='141.09' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='377.33' y1='119.56' x2='380.78' y2='119.56' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='391.15' y1='205.67' x2='394.61' y2='205.67' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='391.15' y1='184.14' x2='394.61' y2='184.14' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='391.15' y1='162.62' x2='394.61' y2='162.62' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='391.15' y1='141.09' x2='394.61' y2='141.09' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='391.15' y1='119.56' x2='394.61' y2='119.56' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='377.33' y='216.77' width='29.12' height='67.17' style='stroke-width: 1.07; fill: #FFFFFF;' />
+<text x='377.33' y='225.49' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<rect x='377.33' y='232.11' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='378.04' y='232.82' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='377.33' y='249.39' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='378.04' y='250.10' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='377.33' y='266.67' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='378.04' y='267.38' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<text x='400.09' y='243.78' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>A</text>
+<text x='400.09' y='261.06' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>B</text>
+<text x='400.09' y='278.34' style='font-size: 8.80px; font-family: sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text>
 <text x='40.13' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='284.73px' lengthAdjust='spacingAndGlyphs'>legend inside plot, bottom left of legend at center</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/guides/legend-inside-plot-bottom-left.svg
+++ b/tests/testthat/_snaps/guides/legend-inside-plot-bottom-left.svg
@@ -51,35 +51,35 @@
 <text x='588.07' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text>
 <text x='377.33' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
 <text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
-<rect x='40.13' y='365.25' width='29.12' height='67.17' style='stroke-width: 1.07; fill: #FFFFFF;' />
-<text x='40.13' y='373.96' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
-<rect x='40.13' y='380.58' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='40.84' y='381.29' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='40.13' y='397.86' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='40.84' y='398.57' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='40.13' y='415.14' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='40.84' y='415.85' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<text x='62.89' y='392.25' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>A</text>
-<text x='62.89' y='409.53' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>B</text>
-<text x='62.89' y='426.81' style='font-size: 8.80px; font-family: sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text>
-<rect x='40.13' y='443.38' width='34.99' height='101.73' style='stroke-width: 1.07; fill: #FFFFFF;' />
-<image width='17.28' height='86.40' x='40.13' y='458.71' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAmElEQVQ4ja2UQRLDMAgDd3hk/tnX5agcknFaCoa0vnkMCEnGsL12GQhDYDpPwoDrpBFlRDWi/9Wu6AHC9FkLYLrzlhD3oJ3mDvRHRYy7IC8A7bCK8gpWKYDzeQVArDcDyD2YAnSofZvzaOA6Q7Oahp/dmRuVTQ0xU5TGP2o8Waool1obVuv1q8qP9xPvg633XlGLDtfIhNUBcBeA5ss0BXMAAAAASUVORK5CYII='/>
-<text x='62.89' y='548.00' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='62.89' y='526.47' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
-<text x='62.89' y='504.94' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
-<text x='62.89' y='483.41' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='62.89' y='461.88' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
-<text x='40.13' y='452.09' style='font-size: 11.00px; font-family: sans;' textLength='15.29px' lengthAdjust='spacingAndGlyphs'>1:3</text>
-<line x1='40.13' y1='544.97' x2='43.59' y2='544.97' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='40.13' y1='523.44' x2='43.59' y2='523.44' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='40.13' y1='501.91' x2='43.59' y2='501.91' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='40.13' y1='480.38' x2='43.59' y2='480.38' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='40.13' y1='458.86' x2='43.59' y2='458.86' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='53.96' y1='544.97' x2='57.41' y2='544.97' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='53.96' y1='523.44' x2='57.41' y2='523.44' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='53.96' y1='501.91' x2='57.41' y2='501.91' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='53.96' y1='480.38' x2='57.41' y2='480.38' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='53.96' y1='458.86' x2='57.41' y2='458.86' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='40.13' y='365.25' width='34.99' height='101.73' style='stroke-width: 1.07; fill: #FFFFFF;' />
+<image width='17.28' height='86.40' x='40.13' y='380.58' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAmElEQVQ4ja2UQRLDMAgDd3hk/tnX5agcknFaCoa0vnkMCEnGsL12GQhDYDpPwoDrpBFlRDWi/9Wu6AHC9FkLYLrzlhD3oJ3mDvRHRYy7IC8A7bCK8gpWKYDzeQVArDcDyD2YAnSofZvzaOA6Q7Oahp/dmRuVTQ0xU5TGP2o8Waool1obVuv1q8qP9xPvg633XlGLDtfIhNUBcBeA5ss0BXMAAAAASUVORK5CYII='/>
+<text x='62.89' y='469.86' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='62.89' y='448.34' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='62.89' y='426.81' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text x='62.89' y='405.28' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='62.89' y='383.75' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='40.13' y='373.96' style='font-size: 11.00px; font-family: sans;' textLength='15.29px' lengthAdjust='spacingAndGlyphs'>1:3</text>
+<line x1='40.13' y1='466.84' x2='43.59' y2='466.84' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='40.13' y1='445.31' x2='43.59' y2='445.31' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='40.13' y1='423.78' x2='43.59' y2='423.78' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='40.13' y1='402.25' x2='43.59' y2='402.25' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='40.13' y1='380.72' x2='43.59' y2='380.72' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='53.96' y1='466.84' x2='57.41' y2='466.84' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='53.96' y1='445.31' x2='57.41' y2='445.31' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='53.96' y1='423.78' x2='57.41' y2='423.78' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='53.96' y1='402.25' x2='57.41' y2='402.25' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='53.96' y1='380.72' x2='57.41' y2='380.72' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='40.13' y='477.94' width='29.12' height='67.17' style='stroke-width: 1.07; fill: #FFFFFF;' />
+<text x='40.13' y='486.65' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<rect x='40.13' y='493.27' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='40.84' y='493.98' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='40.13' y='510.55' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='40.84' y='511.26' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='40.13' y='527.83' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='40.84' y='528.54' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<text x='62.89' y='504.94' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>A</text>
+<text x='62.89' y='522.22' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>B</text>
+<text x='62.89' y='539.50' style='font-size: 8.80px; font-family: sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text>
 <text x='40.13' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='171.71px' lengthAdjust='spacingAndGlyphs'>legend inside plot, bottom left</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/guides/legend-inside-plot-centered.svg
+++ b/tests/testthat/_snaps/guides/legend-inside-plot-centered.svg
@@ -51,35 +51,35 @@
 <text x='588.07' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text>
 <text x='377.33' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
 <text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
-<rect x='359.83' y='194.02' width='29.12' height='67.17' style='stroke-width: 1.07; fill: #FFFFFF;' />
-<text x='359.83' y='202.73' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
-<rect x='359.83' y='209.35' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='360.54' y='210.06' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='359.83' y='226.63' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='360.54' y='227.34' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='359.83' y='243.91' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='360.54' y='244.62' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<text x='382.59' y='221.02' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>A</text>
-<text x='382.59' y='238.30' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>B</text>
-<text x='382.59' y='255.58' style='font-size: 8.80px; font-family: sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text>
-<rect x='359.83' y='272.15' width='34.99' height='101.73' style='stroke-width: 1.07; fill: #FFFFFF;' />
-<image width='17.28' height='86.40' x='359.83' y='287.48' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAmElEQVQ4ja2UQRLDMAgDd3hk/tnX5agcknFaCoa0vnkMCEnGsL12GQhDYDpPwoDrpBFlRDWi/9Wu6AHC9FkLYLrzlhD3oJ3mDvRHRYy7IC8A7bCK8gpWKYDzeQVArDcDyD2YAnSofZvzaOA6Q7Oahp/dmRuVTQ0xU5TGP2o8Waool1obVuv1q8qP9xPvg633XlGLDtfIhNUBcBeA5ss0BXMAAAAASUVORK5CYII='/>
-<text x='382.59' y='376.76' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='382.59' y='355.24' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
-<text x='382.59' y='333.71' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
-<text x='382.59' y='312.18' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='382.59' y='290.65' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
-<text x='359.83' y='280.86' style='font-size: 11.00px; font-family: sans;' textLength='15.29px' lengthAdjust='spacingAndGlyphs'>1:3</text>
-<line x1='359.83' y1='373.74' x2='363.29' y2='373.74' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='359.83' y1='352.21' x2='363.29' y2='352.21' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='359.83' y1='330.68' x2='363.29' y2='330.68' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='359.83' y1='309.15' x2='363.29' y2='309.15' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='359.83' y1='287.62' x2='363.29' y2='287.62' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='373.65' y1='373.74' x2='377.11' y2='373.74' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='373.65' y1='352.21' x2='377.11' y2='352.21' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='373.65' y1='330.68' x2='377.11' y2='330.68' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='373.65' y1='309.15' x2='377.11' y2='309.15' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='373.65' y1='287.62' x2='377.11' y2='287.62' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='359.83' y='194.02' width='34.99' height='101.73' style='stroke-width: 1.07; fill: #FFFFFF;' />
+<image width='17.28' height='86.40' x='359.83' y='209.35' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAmElEQVQ4ja2UQRLDMAgDd3hk/tnX5agcknFaCoa0vnkMCEnGsL12GQhDYDpPwoDrpBFlRDWi/9Wu6AHC9FkLYLrzlhD3oJ3mDvRHRYy7IC8A7bCK8gpWKYDzeQVArDcDyD2YAnSofZvzaOA6Q7Oahp/dmRuVTQ0xU5TGP2o8Waool1obVuv1q8qP9xPvg633XlGLDtfIhNUBcBeA5ss0BXMAAAAASUVORK5CYII='/>
+<text x='382.59' y='298.63' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='382.59' y='277.10' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='382.59' y='255.58' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text x='382.59' y='234.05' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='382.59' y='212.52' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='359.83' y='202.73' style='font-size: 11.00px; font-family: sans;' textLength='15.29px' lengthAdjust='spacingAndGlyphs'>1:3</text>
+<line x1='359.83' y1='295.60' x2='363.29' y2='295.60' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='359.83' y1='274.08' x2='363.29' y2='274.08' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='359.83' y1='252.55' x2='363.29' y2='252.55' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='359.83' y1='231.02' x2='363.29' y2='231.02' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='359.83' y1='209.49' x2='363.29' y2='209.49' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='373.65' y1='295.60' x2='377.11' y2='295.60' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='373.65' y1='274.08' x2='377.11' y2='274.08' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='373.65' y1='252.55' x2='377.11' y2='252.55' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='373.65' y1='231.02' x2='377.11' y2='231.02' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='373.65' y1='209.49' x2='377.11' y2='209.49' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='359.83' y='306.71' width='29.12' height='67.17' style='stroke-width: 1.07; fill: #FFFFFF;' />
+<text x='359.83' y='315.42' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<rect x='359.83' y='322.04' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='360.54' y='322.75' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='359.83' y='339.32' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='360.54' y='340.03' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='359.83' y='356.60' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='360.54' y='357.31' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<text x='382.59' y='333.71' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>A</text>
+<text x='382.59' y='350.99' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>B</text>
+<text x='382.59' y='368.27' style='font-size: 8.80px; font-family: sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text>
 <text x='40.13' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='161.46px' lengthAdjust='spacingAndGlyphs'>legend inside plot, centered</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/guides/legend-inside-plot-top-right.svg
+++ b/tests/testthat/_snaps/guides/legend-inside-plot-top-right.svg
@@ -51,35 +51,35 @@
 <text x='588.07' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text>
 <text x='377.33' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
 <text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
-<rect x='679.53' y='22.78' width='29.12' height='67.17' style='stroke-width: 1.07; fill: #FFFFFF;' />
-<text x='679.53' y='31.50' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
-<rect x='679.53' y='38.12' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='680.24' y='38.83' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='679.53' y='55.40' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='680.24' y='56.11' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='679.53' y='72.68' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='680.24' y='73.39' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<text x='702.29' y='49.78' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>A</text>
-<text x='702.29' y='67.06' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>B</text>
-<text x='702.29' y='84.34' style='font-size: 8.80px; font-family: sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text>
-<rect x='679.53' y='100.92' width='34.99' height='101.73' style='stroke-width: 1.07; fill: #FFFFFF;' />
-<image width='17.28' height='86.40' x='679.53' y='116.25' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAmElEQVQ4ja2UQRLDMAgDd3hk/tnX5agcknFaCoa0vnkMCEnGsL12GQhDYDpPwoDrpBFlRDWi/9Wu6AHC9FkLYLrzlhD3oJ3mDvRHRYy7IC8A7bCK8gpWKYDzeQVArDcDyD2YAnSofZvzaOA6Q7Oahp/dmRuVTQ0xU5TGP2o8Waool1obVuv1q8qP9xPvg633XlGLDtfIhNUBcBeA5ss0BXMAAAAASUVORK5CYII='/>
-<text x='702.29' y='205.53' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='702.29' y='184.00' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
-<text x='702.29' y='162.48' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
-<text x='702.29' y='140.95' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='702.29' y='119.42' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
-<text x='679.53' y='109.63' style='font-size: 11.00px; font-family: sans;' textLength='15.29px' lengthAdjust='spacingAndGlyphs'>1:3</text>
-<line x1='679.53' y1='202.50' x2='682.98' y2='202.50' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='679.53' y1='180.98' x2='682.98' y2='180.98' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='679.53' y1='159.45' x2='682.98' y2='159.45' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='679.53' y1='137.92' x2='682.98' y2='137.92' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='679.53' y1='116.39' x2='682.98' y2='116.39' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='693.35' y1='202.50' x2='696.81' y2='202.50' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='693.35' y1='180.98' x2='696.81' y2='180.98' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='693.35' y1='159.45' x2='696.81' y2='159.45' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='693.35' y1='137.92' x2='696.81' y2='137.92' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='693.35' y1='116.39' x2='696.81' y2='116.39' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='679.53' y='22.78' width='34.99' height='101.73' style='stroke-width: 1.07; fill: #FFFFFF;' />
+<image width='17.28' height='86.40' x='679.53' y='38.12' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAmElEQVQ4ja2UQRLDMAgDd3hk/tnX5agcknFaCoa0vnkMCEnGsL12GQhDYDpPwoDrpBFlRDWi/9Wu6AHC9FkLYLrzlhD3oJ3mDvRHRYy7IC8A7bCK8gpWKYDzeQVArDcDyD2YAnSofZvzaOA6Q7Oahp/dmRuVTQ0xU5TGP2o8Waool1obVuv1q8qP9xPvg633XlGLDtfIhNUBcBeA5ss0BXMAAAAASUVORK5CYII='/>
+<text x='702.29' y='127.40' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='702.29' y='105.87' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='702.29' y='84.34' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text x='702.29' y='62.82' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='702.29' y='41.29' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='679.53' y='31.50' style='font-size: 11.00px; font-family: sans;' textLength='15.29px' lengthAdjust='spacingAndGlyphs'>1:3</text>
+<line x1='679.53' y1='124.37' x2='682.98' y2='124.37' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='679.53' y1='102.84' x2='682.98' y2='102.84' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='679.53' y1='81.32' x2='682.98' y2='81.32' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='679.53' y1='59.79' x2='682.98' y2='59.79' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='679.53' y1='38.26' x2='682.98' y2='38.26' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='693.35' y1='124.37' x2='696.81' y2='124.37' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='693.35' y1='102.84' x2='696.81' y2='102.84' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='693.35' y1='81.32' x2='696.81' y2='81.32' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='693.35' y1='59.79' x2='696.81' y2='59.79' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='693.35' y1='38.26' x2='696.81' y2='38.26' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='679.53' y='135.48' width='29.12' height='67.17' style='stroke-width: 1.07; fill: #FFFFFF;' />
+<text x='679.53' y='144.19' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<rect x='679.53' y='150.81' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='680.24' y='151.52' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='679.53' y='168.09' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='680.24' y='168.80' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='679.53' y='185.37' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='680.24' y='186.08' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<text x='702.29' y='162.48' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>A</text>
+<text x='702.29' y='179.76' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>B</text>
+<text x='702.29' y='197.04' style='font-size: 8.80px; font-family: sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text>
 <text x='40.13' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='157.77px' lengthAdjust='spacingAndGlyphs'>legend inside plot, top right</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/guides/padding-in-legend-box.svg
+++ b/tests/testthat/_snaps/guides/padding-in-legend-box.svg
@@ -51,35 +51,35 @@
 <text x='550.74' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text>
 <text x='354.35' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
 <text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
-<rect x='679.53' y='194.02' width='29.12' height='67.17' style='stroke-width: 1.07; fill: #FFFFFF;' />
-<text x='679.53' y='202.73' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
-<rect x='679.53' y='209.35' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='680.24' y='210.06' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='679.53' y='226.63' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='680.24' y='227.34' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='679.53' y='243.91' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='680.24' y='244.62' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<text x='702.29' y='221.02' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>A</text>
-<text x='702.29' y='238.30' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>B</text>
-<text x='702.29' y='255.58' style='font-size: 8.80px; font-family: sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text>
-<rect x='679.53' y='272.15' width='34.99' height='101.73' style='stroke-width: 1.07; fill: #FFFFFF;' />
-<image width='17.28' height='86.40' x='679.53' y='287.48' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAmElEQVQ4ja2UQRLDMAgDd3hk/tnX5agcknFaCoa0vnkMCEnGsL12GQhDYDpPwoDrpBFlRDWi/9Wu6AHC9FkLYLrzlhD3oJ3mDvRHRYy7IC8A7bCK8gpWKYDzeQVArDcDyD2YAnSofZvzaOA6Q7Oahp/dmRuVTQ0xU5TGP2o8Waool1obVuv1q8qP9xPvg633XlGLDtfIhNUBcBeA5ss0BXMAAAAASUVORK5CYII='/>
-<text x='702.29' y='376.76' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='702.29' y='355.24' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
-<text x='702.29' y='333.71' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
-<text x='702.29' y='312.18' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='702.29' y='290.65' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
-<text x='679.53' y='280.86' style='font-size: 11.00px; font-family: sans;' textLength='15.29px' lengthAdjust='spacingAndGlyphs'>1:3</text>
-<line x1='679.53' y1='373.74' x2='682.98' y2='373.74' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='679.53' y1='352.21' x2='682.98' y2='352.21' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='679.53' y1='330.68' x2='682.98' y2='330.68' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='679.53' y1='309.15' x2='682.98' y2='309.15' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='679.53' y1='287.62' x2='682.98' y2='287.62' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='693.35' y1='373.74' x2='696.81' y2='373.74' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='693.35' y1='352.21' x2='696.81' y2='352.21' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='693.35' y1='330.68' x2='696.81' y2='330.68' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='693.35' y1='309.15' x2='696.81' y2='309.15' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='693.35' y1='287.62' x2='696.81' y2='287.62' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='679.53' y='194.02' width='34.99' height='101.73' style='stroke-width: 1.07; fill: #FFFFFF;' />
+<image width='17.28' height='86.40' x='679.53' y='209.35' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAmElEQVQ4ja2UQRLDMAgDd3hk/tnX5agcknFaCoa0vnkMCEnGsL12GQhDYDpPwoDrpBFlRDWi/9Wu6AHC9FkLYLrzlhD3oJ3mDvRHRYy7IC8A7bCK8gpWKYDzeQVArDcDyD2YAnSofZvzaOA6Q7Oahp/dmRuVTQ0xU5TGP2o8Waool1obVuv1q8qP9xPvg633XlGLDtfIhNUBcBeA5ss0BXMAAAAASUVORK5CYII='/>
+<text x='702.29' y='298.63' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='702.29' y='277.10' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='702.29' y='255.58' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text x='702.29' y='234.05' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='702.29' y='212.52' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='679.53' y='202.73' style='font-size: 11.00px; font-family: sans;' textLength='15.29px' lengthAdjust='spacingAndGlyphs'>1:3</text>
+<line x1='679.53' y1='295.60' x2='682.98' y2='295.60' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='679.53' y1='274.08' x2='682.98' y2='274.08' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='679.53' y1='252.55' x2='682.98' y2='252.55' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='679.53' y1='231.02' x2='682.98' y2='231.02' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='679.53' y1='209.49' x2='682.98' y2='209.49' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='693.35' y1='295.60' x2='696.81' y2='295.60' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='693.35' y1='274.08' x2='696.81' y2='274.08' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='693.35' y1='252.55' x2='696.81' y2='252.55' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='693.35' y1='231.02' x2='696.81' y2='231.02' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<line x1='693.35' y1='209.49' x2='696.81' y2='209.49' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<rect x='679.53' y='306.71' width='29.12' height='67.17' style='stroke-width: 1.07; fill: #FFFFFF;' />
+<text x='679.53' y='315.42' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<rect x='679.53' y='322.04' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='680.24' y='322.75' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='679.53' y='339.32' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='680.24' y='340.03' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='679.53' y='356.60' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='680.24' y='357.31' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<text x='702.29' y='333.71' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>A</text>
+<text x='702.29' y='350.99' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>B</text>
+<text x='702.29' y='368.27' style='font-size: 8.80px; font-family: sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text>
 <text x='40.13' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='129.18px' lengthAdjust='spacingAndGlyphs'>padding in legend box</text>
 </g>
 </svg>


### PR DESCRIPTION
Fix #4458 

This PR removes the digest dependencies in favour of `rlang::hash()`.

Since guides are sorted by their hash value and the hash value changes it can lead to changes in the automatic ordering of legends, as reflected in the change in visual tests. Since we make no promises on how they are sorted I think this is fine but should of course be communicated