### PR TITLE
Chained errors with contextual info in layers

### DIFF
--- a/R/ggproto.r
+++ b/R/ggproto.r
@@ -153,7 +153,7 @@ fetch_ggproto <- function(x, name) {
     return(res)
   }
 
-  make_proto_method(x, res)
+  make_proto_method(x, res, name)
 }
 
 #' @export
@@ -163,19 +163,22 @@ fetch_ggproto <- function(x, name) {
     return(res)
   }
 
-  make_proto_method(.subset2(x, "self"), res)
+  make_proto_method(.subset2(x, "self"), res, name)
 }
 
-make_proto_method <- function(self, f) {
+make_proto_method <- function(self, f, name) {
   args <- formals(f)
   # is.null is a fast path for a common case; the %in% check is slower but also
   # catches the case where there's a `self = NULL` argument.
   has_self  <- !is.null(args[["self"]]) || "self"  %in% names(args)
 
+  # We assign the method with its correct name and construct a call to it to
+  # make errors reported as coming from the method name rather than `f()`
+  assign(name, f, envir = environment())
   if (has_self) {
-    fun <- function(...) f(..., self = self)
+    fun <- inject(function(...) !!call2(name, quote(...), self = quote(self)))
   } else {
-    fun <- function(...) f(...)
+    fun <- inject(function(...) !!call2(name, quote(...)))
   }
 
   class(fun) <- "ggproto_method"

--- a/R/ggproto.r
+++ b/R/ggproto.r
@@ -175,11 +175,11 @@ make_proto_method <- function(self, f, name) {
   # We assign the method with its correct name and construct a call to it to
   # make errors reported as coming from the method name rather than `f()`
   assign(name, f, envir = environment())
+  args <- list(quote(...))
   if (has_self) {
-    fun <- inject(function(...) !!call2(name, quote(...), self = quote(self)))
-  } else {
-    fun <- inject(function(...) !!call2(name, quote(...)))
+    args$self <- quote(self)
   }
+  fun <- inject(function(...) !!call2(name, !!!args))
 
   class(fun) <- "ggproto_method"
   fun

--- a/R/layer-sf.R
+++ b/R/layer-sf.R
@@ -13,6 +13,7 @@ layer_sf <- function(geom = NULL, stat = NULL,
                      position = NULL, params = list(),
                      inherit.aes = TRUE, check.aes = TRUE, check.param = TRUE,
                      show.legend = NA) {
+  call_env <- caller_env()
   if (is.character(show.legend)) {
     legend_key_type <- show.legend
     show.legend <- TRUE
@@ -21,7 +22,10 @@ layer_sf <- function(geom = NULL, stat = NULL,
   }
 
   # inherit from LayerSf class to add `legend_key_type` slot
-  layer_class <- ggproto(NULL, LayerSf, legend_key_type = legend_key_type)
+  layer_class <- ggproto(NULL, LayerSf,
+    constructor = frame_call(call_env),
+    legend_key_type = legend_key_type
+  )
 
   layer(
     geom = geom, stat = stat, data = data, mapping = mapping,

--- a/R/layer.r
+++ b/R/layer.r
@@ -328,7 +328,7 @@ Layer <- ggproto("Layer", NULL,
       issues <- paste0("{.code ", nondata_stat_cols, " = ", as_label(aesthetics[[nondata_stat_cols]]), "}")
       names(issues) <- rep("x", length(issues))
       cli::cli_abort(c(
-        "Aesthetics are not valid computed stats.",
+        "Aesthetics must be valid computed stats.",
         "x" = "The following aesthetics are invalid:",
         issues,
         "i" = "Did you map your stat in the wrong layer?"

--- a/R/layer.r
+++ b/R/layer.r
@@ -140,7 +140,10 @@ layer <- function(geom = NULL, stat = NULL,
   # adjust the legend draw key if requested
   geom <- set_draw_key(geom, key_glyph)
 
+  fr_call <- layer_class$constructor %||% frame_call(call_env)
+
   ggproto("LayerInstance", layer_class,
+    constructor = fr_call,
     geom = geom,
     geom_params = geom_params,
     stat = stat,
@@ -169,6 +172,7 @@ validate_mapping <- function(mapping, call = caller_env()) {
 }
 
 Layer <- ggproto("Layer", NULL,
+  constructor = NULL,
   geom = NULL,
   geom_params = NULL,
   stat = NULL,

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -35,19 +35,11 @@ ggplot_build.ggplot <- function(plot) {
   data <- rep(list(NULL), length(layers))
 
   scales <- plot$scales
-  # Apply function to layer and matching data
-  by_layer <- function(f) {
-    out <- vector("list", length(data))
-    for (i in seq_along(data)) {
-      out[[i]] <- f(l = layers[[i]], d = data[[i]])
-    }
-    out
-  }
 
   # Allow all layers to make any final adjustments based
   # on raw input data and plot info
-  data <- by_layer(function(l, d) l$layer_data(plot$data))
-  data <- by_layer(function(l, d) l$setup_layer(d, plot))
+  data <- by_layer(function(l, d) l$layer_data(plot$data), layers, data, "computing layer data")
+  data <- by_layer(function(l, d) l$setup_layer(d, plot), layers, data, "setting up layer")
 
   # Initialise panels, add extra data for margins & missing faceting
   # variables, and add on a PANEL variable to data
@@ -55,7 +47,7 @@ ggplot_build.ggplot <- function(plot) {
   data <- layout$setup(data, plot$data, plot$plot_env)
 
   # Compute aesthetics to produce data with generalised variable names
-  data <- by_layer(function(l, d) l$compute_aesthetics(d, plot))
+  data <- by_layer(function(l, d) l$compute_aesthetics(d, plot), layers, data, "computing aesthetics")
 
   # Transform all scales
   data <- lapply(data, scales_transform_df, scales = scales)
@@ -69,17 +61,17 @@ ggplot_build.ggplot <- function(plot) {
   data <- layout$map_position(data)
 
   # Apply and map statistics
-  data <- by_layer(function(l, d) l$compute_statistic(d, layout))
-  data <- by_layer(function(l, d) l$map_statistic(d, plot))
+  data <- by_layer(function(l, d) l$compute_statistic(d, layout), layers, data, "computing statistics")
+  data <- by_layer(function(l, d) l$map_statistic(d, plot), layers, data, "mapping statistics to aesthetics")
 
   # Make sure missing (but required) aesthetics are added
   scales_add_missing(plot, c("x", "y"), plot$plot_env)
 
   # Reparameterise geoms from (e.g.) y and width to ymin and ymax
-  data <- by_layer(function(l, d) l$compute_geom_1(d))
+  data <- by_layer(function(l, d) l$compute_geom_1(d), layers, data, "setting up geom")
 
   # Apply position adjustments
-  data <- by_layer(function(l, d) l$compute_position(d, layout))
+  data <- by_layer(function(l, d) l$compute_position(d, layout), layers, data, "computing positions")
 
   # Reset position scales, then re-train and map.  This ensures that facets
   # have control over the range of a plot: is it generated from what is
@@ -97,10 +89,10 @@ ggplot_build.ggplot <- function(plot) {
   }
 
   # Fill in defaults etc.
-  data <- by_layer(function(l, d) l$compute_geom_2(d))
+  data <- by_layer(function(l, d) l$compute_geom_2(d), layers, data, "setting up geom aesthetics")
 
   # Let layer stat have a final say before rendering
-  data <- by_layer(function(l, d) l$finish_statistics(d))
+  data <- by_layer(function(l, d) l$finish_statistics(d), layers, data, "finishing layer stat")
 
   # Let Layout modify data before rendering
   data <- layout$finish_data(data)
@@ -168,7 +160,7 @@ ggplot_gtable.ggplot_built <- function(data) {
   data <- data$data
   theme <- plot_theme(plot)
 
-  geom_grobs <- Map(function(l, d) l$draw_geom(d, layout), plot$layers, data)
+  geom_grobs <- by_layer(function(l, d) l$draw_geom(d, layout), plot$layers, data, "converting geom to grob")
   layout$setup_panel_guides(plot$guides, plot$layers, plot$mapping)
   plot_table <- layout$render(geom_grobs, data, theme, plot$labels)
 
@@ -418,4 +410,19 @@ ggplot_gtable.ggplot_built <- function(data) {
 #' @export
 ggplotGrob <- function(x) {
   ggplot_gtable(ggplot_build(x))
+}
+
+# Apply function to layer and matching data
+by_layer <- function(f, layers, data, step = NULL) {
+  ordinal <- label_ordinal()
+  out <- vector("list", length(data))
+  try_fetch(
+    for (i in seq_along(data)) {
+      out[[i]] <- f(l = layers[[i]], d = data[[i]])
+    },
+    error = function(cnd) {
+      cli::cli_abort(c("Problem {step}", "i" = "Error occurred in the {ordinal(i)} layer"), call = I(layers[[i]]$constructor), parent = cnd)
+    }
+  )
+  out
 }

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -61,8 +61,8 @@ ggplot_build.ggplot <- function(plot) {
   data <- layout$map_position(data)
 
   # Apply and map statistics
-  data <- by_layer(function(l, d) l$compute_statistic(d, layout), layers, data, "computing statistics")
-  data <- by_layer(function(l, d) l$map_statistic(d, plot), layers, data, "mapping statistics to aesthetics")
+  data <- by_layer(function(l, d) l$compute_statistic(d, layout), layers, data, "computing stat")
+  data <- by_layer(function(l, d) l$map_statistic(d, plot), layers, data, "mapping stat to aesthetics")
 
   # Make sure missing (but required) aesthetics are added
   scales_add_missing(plot, c("x", "y"), plot$plot_env)
@@ -71,7 +71,7 @@ ggplot_build.ggplot <- function(plot) {
   data <- by_layer(function(l, d) l$compute_geom_1(d), layers, data, "setting up geom")
 
   # Apply position adjustments
-  data <- by_layer(function(l, d) l$compute_position(d, layout), layers, data, "computing positions")
+  data <- by_layer(function(l, d) l$compute_position(d, layout), layers, data, "computing position")
 
   # Reset position scales, then re-train and map.  This ensures that facets
   # have control over the range of a plot: is it generated from what is
@@ -421,7 +421,7 @@ by_layer <- function(f, layers, data, step = NULL) {
       out[[i]] <- f(l = layers[[i]], d = data[[i]])
     },
     error = function(cnd) {
-      cli::cli_abort(c("Problem {step}", "i" = "Error occurred in the {ordinal(i)} layer"), call = I(layers[[i]]$constructor), parent = cnd)
+      cli::cli_abort(c("Problem while {step}.", "i" = "Error occurred in the {ordinal(i)} layer."), call = I(layers[[i]]$constructor), parent = cnd)
     }
   )
   out

--- a/tests/testthat/_snaps/annotate.md
+++ b/tests/testthat/_snaps/annotate.md
@@ -1,10 +1,16 @@
 # annotation_raster() and annotation_custom() requires cartesian coordinates
 
-    `annotation_raster()` only works with `coord_cartesian()`
+    Problem converting geom to grob
+    i Error occurred in the 1st layer
+    Caused by error in `draw_panel()`:
+    ! `annotation_raster()` only works with `coord_cartesian()`
 
 ---
 
-    `annotation_custom()` only works with `coord_cartesian()`
+    Problem converting geom to grob
+    i Error occurred in the 1st layer
+    Caused by error in `draw_panel()`:
+    ! `annotation_custom()` only works with `coord_cartesian()`
 
 # annotation_map() checks the input data
 

--- a/tests/testthat/_snaps/annotate.md
+++ b/tests/testthat/_snaps/annotate.md
@@ -1,14 +1,14 @@
 # annotation_raster() and annotation_custom() requires cartesian coordinates
 
-    Problem converting geom to grob
-    i Error occurred in the 1st layer
+    Problem while converting geom to grob.
+    i Error occurred in the 1st layer.
     Caused by error in `draw_panel()`:
     ! `annotation_raster()` only works with `coord_cartesian()`
 
 ---
 
-    Problem converting geom to grob
-    i Error occurred in the 1st layer
+    Problem while converting geom to grob.
+    i Error occurred in the 1st layer.
     Caused by error in `draw_panel()`:
     ! `annotation_custom()` only works with `coord_cartesian()`
 

--- a/tests/testthat/_snaps/geom-.md
+++ b/tests/testthat/_snaps/geom-.md
@@ -1,6 +1,9 @@
 # aesthetic checking in geom throws correct errors
 
-    Aesthetic modifiers returned invalid values
+    Problem setting up geom aesthetics
+    i Error occurred in the 1st layer
+    Caused by error in `use_defaults()`:
+    ! Aesthetic modifiers returned invalid values
     x The following mappings are invalid
     x `colour = after_scale(data)`
     i Did you map the modifier in the wrong layer?

--- a/tests/testthat/_snaps/geom-.md
+++ b/tests/testthat/_snaps/geom-.md
@@ -1,7 +1,7 @@
 # aesthetic checking in geom throws correct errors
 
-    Problem setting up geom aesthetics
-    i Error occurred in the 1st layer
+    Problem while setting up geom aesthetics.
+    i Error occurred in the 1st layer.
     Caused by error in `use_defaults()`:
     ! Aesthetic modifiers returned invalid values
     x The following mappings are invalid

--- a/tests/testthat/_snaps/geom-dotplot.md
+++ b/tests/testthat/_snaps/geom-dotplot.md
@@ -5,12 +5,12 @@
 # weight aesthetic is checked
 
     Computation failed in `stat_bindot()`
-    Caused by error in `f()`:
+    Caused by error in `compute_group()`:
     ! Weights must be nonnegative integers.
 
 ---
 
     Computation failed in `stat_bindot()`
-    Caused by error in `f()`:
+    Caused by error in `compute_group()`:
     ! Weights must be nonnegative integers.
 

--- a/tests/testthat/_snaps/geom-linerange.md
+++ b/tests/testthat/_snaps/geom-linerange.md
@@ -1,4 +1,7 @@
 # geom_linerange request the right aesthetics
 
-    `geom_linerange()` requires the following missing aesthetics: ymax or xmin and xmax
+    Problem setting up geom
+    i Error occurred in the 1st layer
+    Caused by error in `compute_geom_1()`:
+    ! `geom_linerange()` requires the following missing aesthetics: ymax or xmin and xmax
 

--- a/tests/testthat/_snaps/geom-linerange.md
+++ b/tests/testthat/_snaps/geom-linerange.md
@@ -1,7 +1,7 @@
 # geom_linerange request the right aesthetics
 
-    Problem setting up geom
-    i Error occurred in the 1st layer
+    Problem while setting up geom.
+    i Error occurred in the 1st layer.
     Caused by error in `compute_geom_1()`:
     ! `geom_linerange()` requires the following missing aesthetics: ymax or xmin and xmax
 

--- a/tests/testthat/_snaps/geom-path.md
+++ b/tests/testthat/_snaps/geom-path.md
@@ -1,7 +1,7 @@
 # geom_path() throws meaningful error on bad combination of varying aesthetics
 
-    Problem converting geom to grob
-    i Error occurred in the 1st layer
+    Problem while converting geom to grob.
+    i Error occurred in the 1st layer.
     Caused by error in `draw_panel()`:
     ! `geom_path()` can't have varying colour, size, and/or alpha along the line when linetype isn't solid
 

--- a/tests/testthat/_snaps/geom-path.md
+++ b/tests/testthat/_snaps/geom-path.md
@@ -1,4 +1,7 @@
 # geom_path() throws meaningful error on bad combination of varying aesthetics
 
-    `geom_path()` can't have varying colour, size, and/or alpha along the line when linetype isn't solid
+    Problem converting geom to grob
+    i Error occurred in the 1st layer
+    Caused by error in `draw_panel()`:
+    ! `geom_path()` can't have varying colour, size, and/or alpha along the line when linetype isn't solid
 

--- a/tests/testthat/_snaps/geom-raster.md
+++ b/tests/testthat/_snaps/geom-raster.md
@@ -16,5 +16,8 @@
 
 ---
 
-    `geom_raster()` only works with `coord_cartesian()`
+    Problem converting geom to grob
+    i Error occurred in the 1st layer
+    Caused by error in `draw_panel()`:
+    ! `geom_raster()` only works with `coord_cartesian()`
 

--- a/tests/testthat/_snaps/geom-raster.md
+++ b/tests/testthat/_snaps/geom-raster.md
@@ -16,8 +16,8 @@
 
 ---
 
-    Problem converting geom to grob
-    i Error occurred in the 1st layer
+    Problem while converting geom to grob.
+    i Error occurred in the 1st layer.
     Caused by error in `draw_panel()`:
     ! `geom_raster()` only works with `coord_cartesian()`
 

--- a/tests/testthat/_snaps/geom-ribbon.md
+++ b/tests/testthat/_snaps/geom-ribbon.md
@@ -1,14 +1,23 @@
 # geom_ribbon() checks the aesthetics
 
-    Either xmin or xmax must be given as an aesthetic.
+    Problem setting up geom
+    i Error occurred in the 1st layer
+    Caused by error in `setup_data()`:
+    ! Either xmin or xmax must be given as an aesthetic.
 
 ---
 
-    Either ymin or ymax must be given as an aesthetic.
+    Problem setting up geom
+    i Error occurred in the 1st layer
+    Caused by error in `setup_data()`:
+    ! Either ymin or ymax must be given as an aesthetic.
 
 ---
 
-    Aesthetics can not vary along a ribbon
+    Problem converting geom to grob
+    i Error occurred in the 1st layer
+    Caused by error in `draw_group()`:
+    ! Aesthetics can not vary along a ribbon
 
 ---
 

--- a/tests/testthat/_snaps/geom-ribbon.md
+++ b/tests/testthat/_snaps/geom-ribbon.md
@@ -1,21 +1,21 @@
 # geom_ribbon() checks the aesthetics
 
-    Problem setting up geom
-    i Error occurred in the 1st layer
+    Problem while setting up geom.
+    i Error occurred in the 1st layer.
     Caused by error in `setup_data()`:
     ! Either xmin or xmax must be given as an aesthetic.
 
 ---
 
-    Problem setting up geom
-    i Error occurred in the 1st layer
+    Problem while setting up geom.
+    i Error occurred in the 1st layer.
     Caused by error in `setup_data()`:
     ! Either ymin or ymax must be given as an aesthetic.
 
 ---
 
-    Problem converting geom to grob
-    i Error occurred in the 1st layer
+    Problem while converting geom to grob.
+    i Error occurred in the 1st layer.
     Caused by error in `draw_group()`:
     ! Aesthetics can not vary along a ribbon
 

--- a/tests/testthat/_snaps/geom-sf.md
+++ b/tests/testthat/_snaps/geom-sf.md
@@ -1,6 +1,9 @@
 # errors are correctly triggered
 
-    `geom_sf()` can only be used with `coord_sf()`
+    Problem converting geom to grob
+    i Error occurred in the 1st layer
+    Caused by error in `draw_panel()`:
+    ! `geom_sf()` can only be used with `coord_sf()`
 
 ---
 

--- a/tests/testthat/_snaps/geom-sf.md
+++ b/tests/testthat/_snaps/geom-sf.md
@@ -1,7 +1,7 @@
 # errors are correctly triggered
 
-    Problem converting geom to grob
-    i Error occurred in the 1st layer
+    Problem while converting geom to grob.
+    i Error occurred in the 1st layer.
     Caused by error in `draw_panel()`:
     ! `geom_sf()` can only be used with `coord_sf()`
 

--- a/tests/testthat/_snaps/geom-violin.md
+++ b/tests/testthat/_snaps/geom-violin.md
@@ -1,14 +1,14 @@
 # quantiles fails outside 0-1 bound
 
-    Problem converting geom to grob
-    i Error occurred in the 1st layer
+    Problem while converting geom to grob.
+    i Error occurred in the 1st layer.
     Caused by error in `draw_group()`:
     ! `draw_quantiles` must be between 0 and 1
 
 ---
 
-    Problem converting geom to grob
-    i Error occurred in the 1st layer
+    Problem while converting geom to grob.
+    i Error occurred in the 1st layer.
     Caused by error in `draw_group()`:
     ! `draw_quantiles` must be between 0 and 1
 

--- a/tests/testthat/_snaps/geom-violin.md
+++ b/tests/testthat/_snaps/geom-violin.md
@@ -1,8 +1,14 @@
 # quantiles fails outside 0-1 bound
 
-    `draw_quantiles` must be between 0 and 1
+    Problem converting geom to grob
+    i Error occurred in the 1st layer
+    Caused by error in `draw_group()`:
+    ! `draw_quantiles` must be between 0 and 1
 
 ---
 
-    `draw_quantiles` must be between 0 and 1
+    Problem converting geom to grob
+    i Error occurred in the 1st layer
+    Caused by error in `draw_group()`:
+    ! `draw_quantiles` must be between 0 and 1
 

--- a/tests/testthat/_snaps/guides.md
+++ b/tests/testthat/_snaps/guides.md
@@ -1,13 +1,3 @@
-# binning scales understand the different combinations of limits, breaks, labels, and show.limits
-
-    `show.limits` is ignored when `labels` are given as a character vector
-    i Either add the limits to `breaks` or provide a function for `labels`
-
----
-
-    `show.limits` is ignored when `labels` are given as a character vector
-    i Either add the limits to `breaks` or provide a function for `labels`
-
 # axis_label_element_overrides errors when angles are outside the range [0, 90]
 
     Unrecognized `axis_position`: "test"
@@ -67,6 +57,16 @@
 
     Breaks not formatted correctly for a bin legend.
     i Use `(<lower>, <upper>]` format to indicate bins
+
+# binning scales understand the different combinations of limits, breaks, labels, and show.limits
+
+    `show.limits` is ignored when `labels` are given as a character vector
+    i Either add the limits to `breaks` or provide a function for `labels`
+
+---
+
+    `show.limits` is ignored when `labels` are given as a character vector
+    i Either add the limits to `breaks` or provide a function for `labels`
 
 # a warning is generated when guides(<scale> = FALSE) is specified
 

--- a/tests/testthat/_snaps/layer.md
+++ b/tests/testthat/_snaps/layer.md
@@ -29,21 +29,30 @@
 
 # invalid aesthetics throws errors
 
-    Aesthetics are not valid data columns.
+    Problem computing aesthetics
+    i Error occurred in the 1st layer
+    Caused by error in `compute_aesthetics()`:
+    ! Aesthetics are not valid data columns.
     x The following aesthetics are invalid:
     x `fill = data`
     i Did you mistype the name of a data column or forget to add `after_stat()`?
 
 ---
 
-    Aesthetics are not valid computed stats.
+    Problem mapping statistics to aesthetics
+    i Error occurred in the 1st layer
+    Caused by error in `map_statistic()`:
+    ! Aesthetics must be valid computed stats.
     x The following aesthetics are invalid:
     x `fill = after_stat(data)`
     i Did you map your stat in the wrong layer?
 
 # function aesthetics are wrapped with stat()
 
-    Aesthetics are not valid data columns.
+    Problem computing aesthetics
+    i Error occurred in the 1st layer
+    Caused by error in `compute_aesthetics()`:
+    ! Aesthetics are not valid data columns.
     x The following aesthetics are invalid:
     x `colour = NULL`
     x `fill = NULL`
@@ -51,7 +60,10 @@
 
 # computed stats are in appropriate layer
 
-    Aesthetics are not valid computed stats.
+    Problem mapping statistics to aesthetics
+    i Error occurred in the 1st layer
+    Caused by error in `map_statistic()`:
+    ! Aesthetics must be valid computed stats.
     x The following aesthetics are invalid:
     x `colour = NULL`
     x `fill = NULL`

--- a/tests/testthat/_snaps/layer.md
+++ b/tests/testthat/_snaps/layer.md
@@ -29,8 +29,8 @@
 
 # invalid aesthetics throws errors
 
-    Problem computing aesthetics
-    i Error occurred in the 1st layer
+    Problem while computing aesthetics.
+    i Error occurred in the 1st layer.
     Caused by error in `compute_aesthetics()`:
     ! Aesthetics are not valid data columns.
     x The following aesthetics are invalid:
@@ -39,8 +39,8 @@
 
 ---
 
-    Problem mapping statistics to aesthetics
-    i Error occurred in the 1st layer
+    Problem while mapping stat to aesthetics.
+    i Error occurred in the 1st layer.
     Caused by error in `map_statistic()`:
     ! Aesthetics must be valid computed stats.
     x The following aesthetics are invalid:
@@ -49,8 +49,8 @@
 
 # function aesthetics are wrapped with stat()
 
-    Problem computing aesthetics
-    i Error occurred in the 1st layer
+    Problem while computing aesthetics.
+    i Error occurred in the 1st layer.
     Caused by error in `compute_aesthetics()`:
     ! Aesthetics are not valid data columns.
     x The following aesthetics are invalid:
@@ -60,8 +60,8 @@
 
 # computed stats are in appropriate layer
 
-    Problem mapping statistics to aesthetics
-    i Error occurred in the 1st layer
+    Problem while mapping stat to aesthetics.
+    i Error occurred in the 1st layer.
     Caused by error in `map_statistic()`:
     ! Aesthetics must be valid computed stats.
     x The following aesthetics are invalid:

--- a/tests/testthat/_snaps/position-jitterdodge.md
+++ b/tests/testthat/_snaps/position-jitterdodge.md
@@ -1,4 +1,7 @@
 # position_jitterdodge() fails with meaningful error
 
-    `position_jitterdodge()` requires at least one aesthetic to dodge by
+    Problem computing positions
+    i Error occurred in the 1st layer
+    Caused by error in `setup_params()`:
+    ! `position_jitterdodge()` requires at least one aesthetic to dodge by
 

--- a/tests/testthat/_snaps/position-jitterdodge.md
+++ b/tests/testthat/_snaps/position-jitterdodge.md
@@ -1,7 +1,7 @@
 # position_jitterdodge() fails with meaningful error
 
-    Problem computing positions
-    i Error occurred in the 1st layer
+    Problem while computing position.
+    i Error occurred in the 1st layer.
     Caused by error in `setup_params()`:
     ! `position_jitterdodge()` requires at least one aesthetic to dodge by
 

--- a/tests/testthat/_snaps/stat-bin.md
+++ b/tests/testthat/_snaps/stat-bin.md
@@ -1,14 +1,23 @@
 # stat_bin throws error when wrong combination of aesthetic is present
 
-    `stat_bin()` requires an x or y aesthetic.
+    Problem computing statistics
+    i Error occurred in the 1st layer
+    Caused by error in `setup_params()`:
+    ! `stat_bin()` requires an x or y aesthetic.
 
 ---
 
-    `stat_bin()` must only have an x or y aesthetic.
+    Problem computing statistics
+    i Error occurred in the 1st layer
+    Caused by error in `setup_params()`:
+    ! `stat_bin()` must only have an x or y aesthetic.
 
 ---
 
-    `stat_bin()` requires a continuous x aesthetic
+    Problem computing statistics
+    i Error occurred in the 1st layer
+    Caused by error in `setup_params()`:
+    ! `stat_bin()` requires a continuous x aesthetic
     x the x aesthetic is discrete.
     i Perhaps you want `stat="count"`?
 
@@ -46,5 +55,8 @@
 
 # stat_count throws error when both x and y aesthetic present
 
-    `stat_count()` must only have an x or y aesthetic.
+    Problem computing statistics
+    i Error occurred in the 1st layer
+    Caused by error in `setup_params()`:
+    ! `stat_count()` must only have an x or y aesthetic.
 

--- a/tests/testthat/_snaps/stat-bin.md
+++ b/tests/testthat/_snaps/stat-bin.md
@@ -1,21 +1,21 @@
 # stat_bin throws error when wrong combination of aesthetic is present
 
-    Problem computing statistics
-    i Error occurred in the 1st layer
+    Problem while computing stat.
+    i Error occurred in the 1st layer.
     Caused by error in `setup_params()`:
     ! `stat_bin()` requires an x or y aesthetic.
 
 ---
 
-    Problem computing statistics
-    i Error occurred in the 1st layer
+    Problem while computing stat.
+    i Error occurred in the 1st layer.
     Caused by error in `setup_params()`:
     ! `stat_bin()` must only have an x or y aesthetic.
 
 ---
 
-    Problem computing statistics
-    i Error occurred in the 1st layer
+    Problem while computing stat.
+    i Error occurred in the 1st layer.
     Caused by error in `setup_params()`:
     ! `stat_bin()` requires a continuous x aesthetic
     x the x aesthetic is discrete.
@@ -55,8 +55,8 @@
 
 # stat_count throws error when both x and y aesthetic present
 
-    Problem computing statistics
-    i Error occurred in the 1st layer
+    Problem while computing stat.
+    i Error occurred in the 1st layer.
     Caused by error in `setup_params()`:
     ! `stat_count()` must only have an x or y aesthetic.
 

--- a/tests/testthat/_snaps/stat-boxplot.md
+++ b/tests/testthat/_snaps/stat-boxplot.md
@@ -8,5 +8,8 @@
 
 # stat_boxplot errors with missing x/y aesthetics
 
-    `stat_boxplot()` requires an x or y aesthetic.
+    Problem computing statistics
+    i Error occurred in the 1st layer
+    Caused by error in `setup_params()`:
+    ! `stat_boxplot()` requires an x or y aesthetic.
 

--- a/tests/testthat/_snaps/stat-boxplot.md
+++ b/tests/testthat/_snaps/stat-boxplot.md
@@ -8,8 +8,8 @@
 
 # stat_boxplot errors with missing x/y aesthetics
 
-    Problem computing statistics
-    i Error occurred in the 1st layer
+    Problem while computing stat.
+    i Error occurred in the 1st layer.
     Caused by error in `setup_params()`:
     ! `stat_boxplot()` requires an x or y aesthetic.
 

--- a/tests/testthat/_snaps/stat-count.md
+++ b/tests/testthat/_snaps/stat-count.md
@@ -1,14 +1,14 @@
 # stat_count() checks the aesthetics
 
-    Problem computing statistics
-    i Error occurred in the 1st layer
+    Problem while computing stat.
+    i Error occurred in the 1st layer.
     Caused by error in `setup_params()`:
     ! `stat_count()` requires an x or y aesthetic.
 
 ---
 
-    Problem computing statistics
-    i Error occurred in the 1st layer
+    Problem while computing stat.
+    i Error occurred in the 1st layer.
     Caused by error in `setup_params()`:
     ! `stat_count()` must only have an x or y aesthetic.
 

--- a/tests/testthat/_snaps/stat-count.md
+++ b/tests/testthat/_snaps/stat-count.md
@@ -1,8 +1,14 @@
 # stat_count() checks the aesthetics
 
-    `stat_count()` requires an x or y aesthetic.
+    Problem computing statistics
+    i Error occurred in the 1st layer
+    Caused by error in `setup_params()`:
+    ! `stat_count()` requires an x or y aesthetic.
 
 ---
 
-    `stat_count()` must only have an x or y aesthetic.
+    Problem computing statistics
+    i Error occurred in the 1st layer
+    Caused by error in `setup_params()`:
+    ! `stat_count()` must only have an x or y aesthetic.
 

--- a/tests/testthat/_snaps/stat-density.md
+++ b/tests/testthat/_snaps/stat-density.md
@@ -1,4 +1,7 @@
 # stat_density works in both directions
 
-    `stat_density()` requires an x or y aesthetic.
+    Problem computing statistics
+    i Error occurred in the 1st layer
+    Caused by error in `setup_params()`:
+    ! `stat_density()` requires an x or y aesthetic.
 

--- a/tests/testthat/_snaps/stat-density.md
+++ b/tests/testthat/_snaps/stat-density.md
@@ -1,7 +1,7 @@
 # stat_density works in both directions
 
-    Problem computing statistics
-    i Error occurred in the 1st layer
+    Problem while computing stat.
+    i Error occurred in the 1st layer.
     Caused by error in `setup_params()`:
     ! `stat_density()` requires an x or y aesthetic.
 

--- a/tests/testthat/_snaps/stat-density2d.md
+++ b/tests/testthat/_snaps/stat-density2d.md
@@ -1,5 +1,8 @@
 # stat_density2d can produce contour and raster data
 
-    Invalid value of `contour_var` ("abcd")
+    Problem computing statistics
+    i Error occurred in the 1st layer
+    Caused by error in `compute_layer()`:
+    ! Invalid value of `contour_var` ("abcd")
     i Supported values are "density", "ndensity", and "count".
 

--- a/tests/testthat/_snaps/stat-density2d.md
+++ b/tests/testthat/_snaps/stat-density2d.md
@@ -1,7 +1,7 @@
 # stat_density2d can produce contour and raster data
 
-    Problem computing statistics
-    i Error occurred in the 1st layer
+    Problem while computing stat.
+    i Error occurred in the 1st layer.
     Caused by error in `compute_layer()`:
     ! Invalid value of `contour_var` ("abcd")
     i Supported values are "density", "ndensity", and "count".

--- a/tests/testthat/_snaps/stat-ecdf.md
+++ b/tests/testthat/_snaps/stat-ecdf.md
@@ -1,7 +1,7 @@
 # stat_ecdf works in both directions
 
-    Problem computing statistics
-    i Error occurred in the 1st layer
+    Problem while computing stat.
+    i Error occurred in the 1st layer.
     Caused by error in `setup_params()`:
     ! `stat_ecdf()` requires an x or y aesthetic.
 

--- a/tests/testthat/_snaps/stat-ecdf.md
+++ b/tests/testthat/_snaps/stat-ecdf.md
@@ -1,4 +1,7 @@
 # stat_ecdf works in both directions
 
-    `stat_ecdf()` requires an x or y aesthetic.
+    Problem computing statistics
+    i Error occurred in the 1st layer
+    Caused by error in `setup_params()`:
+    ! `stat_ecdf()` requires an x or y aesthetic.
 

--- a/tests/testthat/_snaps/stat-qq.md
+++ b/tests/testthat/_snaps/stat-qq.md
@@ -1,18 +1,18 @@
 # error is thrown with wrong quantile input
 
     Computation failed in `stat_qq()`
-    Caused by error in `f()`:
+    Caused by error in `compute_group()`:
     ! The length of `quantiles` must match the length of the data
 
 ---
 
     Computation failed in `stat_qq_line()`
-    Caused by error in `f()`:
+    Caused by error in `compute_group()`:
     ! `quantiles` must have the same length as the data
 
 ---
 
     Computation failed in `stat_qq_line()`
-    Caused by error in `f()`:
+    Caused by error in `compute_group()`:
     ! Cannot fit line quantiles 0.15. `line.p` must have length 2.
 


### PR DESCRIPTION
This PR improves the error reporting when errors occur during evaluations of a layer. It also adds an improvement to all errors in ggproto methods since the methods are now called by name so we avoid the useless `Error in f()` we get now.

The new look of layer errors is:

``` r
ggplot(economics_long, aes(date, value01, colour = date)) +
  geom_point() + 
  geom_line(linetype = 2)
#> Error in `geom_line(linetype = 2)`:
#> ! Problem converting geom to grob
#> ℹ Error occurred in the 2nd layer
#> Caused by error in `draw_panel()` at ggplot2/R/ggproto.r:179:18:
#> ! `geom_line()` can't have varying colour, size, and/or alpha along the line when
#>   linetype isn't solid
```

which is a mouthful but a huge improvement in terms of letting the user understand how their code is wrong

The remaining question is if this error chaining should be expanded to other ggproto objects in play during plot rendering. I feel it is less imperative than the layer errors because facets and coords are singular in the plot and they are thus less likely to cause confusion as to where the error occurred. I'm however open to expanding the `try_fetch` implementations in `ggplot_build()` to cover it all