### PR TITLE
Example of changing legend glyph for geom_text

### DIFF
--- a/R/geom-path.r
+++ b/R/geom-path.r
@@ -34,8 +34,9 @@
 #' @examples
 #' # geom_line() is suitable for time series
 #' ggplot(economics, aes(date, unemploy)) + geom_line()
+#' # separate by colour and use "timeseries" legend key glyph
 #' ggplot(economics_long, aes(date, value01, colour = variable)) +
-#'   geom_line()
+#'   geom_line(key_glyph = "timeseries")
 #'
 #' # You can get a timeseries that run vertically by setting the orientation
 #' ggplot(economics, aes(unemploy, date)) + geom_line(orientation = "y")

--- a/R/geom-text.r
+++ b/R/geom-text.r
@@ -86,6 +86,11 @@
 #'   scale_colour_discrete(l = 40)
 #' p + geom_label(aes(fill = factor(cyl)), colour = "white", fontface = "bold")
 #'
+#' # Customise legend, change legend label from a to a dot
+#' p + geom_text(aes(colour = factor(cyl))) +
+#'   scale_colour_hue("Cylinders",
+#'                    guide = guide_legend(override.aes = aes(label = "●")))
+#'
 #' p + geom_text(aes(size = wt))
 #' # Scale height of text, rather than sqrt(height)
 #' p +

--- a/R/geom-text.r
+++ b/R/geom-text.r
@@ -85,16 +85,11 @@
 #' p + geom_text(aes(colour = factor(cyl))) +
 #'   scale_colour_discrete(l = 40)
 #' p + geom_label(aes(fill = factor(cyl)), colour = "white", fontface = "bold")
-#'
-#' # Customise legend, change legend label from a to a dot
-#' p + geom_text(aes(colour = factor(cyl))) +
-#'   scale_colour_hue("Cylinders",
-#'                    guide = guide_legend(override.aes = aes(label = "●")))
-#'
-#' p + geom_text(aes(size = wt))
+#' # Scale size with height, and change legend key glyph from a to point
+#' p + geom_text(aes(size = wt), key_glyph = "point")
 #' # Scale height of text, rather than sqrt(height)
 #' p +
-#'   geom_text(aes(size = wt)) +
+#'   geom_text(aes(size = wt), key_glyph = "point") +
 #'   scale_radius(range = c(3,6))
 #'
 #' # You can display expressions by setting parse = TRUE.  The


### PR DESCRIPTION
A common use-case is to want to change the legend glyph for geom_text from 

E.G. This stack overflow question has 48k views:
https://stackoverflow.com/questions/18337653/remove-a-from-legend-when-using-aesthetics-and-geom-text

This pull request adds to `geom_text` help a simple example of replacing the a with a dot / [unicode black circle](https://util.unicode.org/UnicodeJsps/character.jsp?a=25CF), using `guide_legend`.

```r 
p <- ggplot(mtcars, aes(wt, mpg, label = rownames(mtcars)))
# ... etc

# Customise legend, change legend label from a to a dot
p + geom_text(aes(colour = factor(cyl))) +
  scale_colour_hue("Cylinders",
                   guide = guide_legend(override.aes = aes(label = "●")))
```