### PR TITLE
Shorten the titles of visual tests to suppress warnings

### DIFF
--- a/tests/testthat/_snaps/guides/guide-bins-understands-coinciding-limits-and-bins-3.svg
+++ b/tests/testthat/_snaps/guides/guide-bins-understands-coinciding-limits-and-bins-3.svg
@@ -309,6 +309,6 @@
 <text x='694.94' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>2004</text>
 <text x='694.94' y='320.56' style='font-size: 8.80px; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>2006</text>
 <text x='694.94' y='337.84' style='font-size: 8.80px; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>2008</text>
-<text x='32.79' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='375.72px' lengthAdjust='spacingAndGlyphs'>guide_bins understands coinciding limits and bins showing limits</text>
+<text x='32.79' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='300.89px' lengthAdjust='spacingAndGlyphs'>guide_bins understands coinciding limits and bins 3</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/guides/guide-colorsteps-understands-coinciding-limits-and-bins-3.svg
+++ b/tests/testthat/_snaps/guides/guide-colorsteps-understands-coinciding-limits-and-bins-3.svg
@@ -297,6 +297,6 @@
 <text x='694.94' y='268.72' style='font-size: 8.80px; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>2006</text>
 <text x='694.94' y='251.44' style='font-size: 8.80px; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>2008</text>
 <text x='672.18' y='241.79' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>year</text>
-<text x='32.79' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='411.67px' lengthAdjust='spacingAndGlyphs'>guide_colorsteps understands coinciding limits and bins showing limits</text>
+<text x='32.79' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='336.85px' lengthAdjust='spacingAndGlyphs'>guide_colorsteps understands coinciding limits and bins 3</text>
 </g>
 </svg>

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -611,7 +611,7 @@ test_that("binning scales understand the different combinations of limits, break
                            breaks = c(2000, 2002, 2004, 2006, 2008),
                            guide = 'bins')
   )
-  expect_doppelganger("guide_bins understands coinciding limits and bins showing limits",
+  expect_doppelganger("guide_bins understands coinciding limits and bins 3",
     p + scale_color_binned(limits = c(1999, 2008),
                            breaks = c(1999, 2000, 2002, 2004, 2006),
                            guide = 'bins', show.limits = TRUE)
@@ -631,7 +631,7 @@ test_that("binning scales understand the different combinations of limits, break
     p + scale_color_binned(limits = c(1999, 2008),
                            breaks = c(2000, 2002, 2004, 2006, 2008))
   )
-  expect_doppelganger("guide_colorsteps understands coinciding limits and bins showing limits",
+  expect_doppelganger("guide_colorsteps understands coinciding limits and bins 3",
     p + scale_color_binned(limits = c(1999, 2008),
                            breaks = c(1999, 2000, 2002, 2004, 2006),
                            show.limits = TRUE)


### PR DESCRIPTION
Fix #4878