### PR TITLE
Add rename_size=TRUE to GeomSf, GeomCrossbar, GeomPointrange, and GeomSmooth

### DIFF
--- a/R/geom-crossbar.r
+++ b/R/geom-crossbar.r
@@ -107,5 +107,7 @@ GeomCrossbar <- ggproto("GeomCrossbar", Geom,
       GeomPolygon$draw_panel(box, panel_params, coord, lineend = lineend, linejoin = linejoin),
       GeomSegment$draw_panel(middle, panel_params, coord, lineend = lineend, linejoin = linejoin)
     )))
-  }
+  },
+
+  rename_size = TRUE
 )

--- a/R/geom-pointrange.r
+++ b/R/geom-pointrange.r
@@ -57,5 +57,7 @@ GeomPointrange <- ggproto("GeomPointrange", Geom,
         GeomPoint$draw_panel(transform(data, size = size * fatten), panel_params, coord)
       ))
     )
-  }
+  },
+
+  rename_size = TRUE
 )

--- a/R/geom-sf.R
+++ b/R/geom-sf.R
@@ -149,7 +149,9 @@ GeomSf <- ggproto("GeomSf", Geom,
     } else {
       draw_key_polygon(data, params, size)
     }
-  }
+  },
+
+  rename_size = TRUE
 )
 
 default_aesthetics <- function(type) {

--- a/R/geom-smooth.r
+++ b/R/geom-smooth.r
@@ -160,5 +160,7 @@ GeomSmooth <- ggproto("GeomSmooth", Geom,
   optional_aes = c("ymin", "ymax"),
 
   default_aes = aes(colour = "#3366FF", fill = "grey60", linewidth = 1,
-    linetype = 1, weight = 1, alpha = 0.4)
+    linetype = 1, weight = 1, alpha = 0.4),
+
+  rename_size = TRUE
 )


### PR DESCRIPTION
Fix #4883 

``` r
library(ggplot2)

ns <- asNamespace("ggplot2")
geoms_names <- ls(ns, pattern = "Geom.*")
geoms <- lapply(geoms_names, \(x) get(x, ns))

# geoms that use linewidth but don't have rename_size = TRUE
idx <- vapply(geoms, \(x) {
  use_linewidth <- "linewidth" %in% x$aesthetics()
  dont_rename_size <- !isTRUE(x$rename_size)
  use_linewidth && dont_rename_size
}, logical(1L))

geoms_names[idx]
#> [1] "GeomCrossbar"   "GeomPointrange" "GeomSf"         "GeomSmooth"
```

<sup>Created on 2022-06-20 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
