### PR TITLE
increase dig.lab until breeaks are unique

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # ggplot2 (development version)
 
+* Fix a bug in `stat_contour_filled()` where break value differences below a 
+  certain number of digits would cause the computations to fail (@thomasp85, 
+  #4874)
+
 * `stage()` now properly refers to the values without scale transformations for
   the stage of `after_stat`. If your code requires the scaled version of the
   values for some reason, you have to apply the same transformation by yourself,

--- a/R/stat-contour.r
+++ b/R/stat-contour.r
@@ -328,11 +328,17 @@ iso_to_polygon <- function(iso, group = 1) {
 #' @noRd
 #'
 pretty_isoband_levels <- function(isoband_levels, dig.lab = 3) {
-  interval_low <- gsub(":.*$", "", isoband_levels)
-  interval_high <- gsub("^[^:]*:", "", isoband_levels)
+  interval_low <- as.numeric(gsub(":.*$", "", isoband_levels))
+  interval_high <- as.numeric(gsub("^[^:]*:", "", isoband_levels))
 
-  label_low <- format(as.numeric(interval_low), digits = dig.lab, trim = TRUE)
-  label_high <- format(as.numeric(interval_high), digits = dig.lab, trim = TRUE)
+  breaks <- unique(c(interval_low, interval_high))
+
+  while(anyDuplicated(format(breaks, digits = dig.lab, trim = TRUE))) {
+    dig.lab <- dig.lab + 1
+  }
+
+  label_low <- format(interval_low, digits = dig.lab, trim = TRUE)
+  label_high <- format(interval_high, digits = dig.lab, trim = TRUE)
 
   # from the isoband::isobands() docs:
   # the intervals specifying isobands are closed at their lower boundary


### PR DESCRIPTION
Fix #4874 

This PR introduces a gradual increasing of the number of digits until all breaks are uniquely identifiable