### PR TITLE
Fix a warning "... may be used in an incorrect context"

### DIFF
--- a/R/save.r
+++ b/R/save.r
@@ -173,8 +173,10 @@ plot_dev <- function(device, filename = NULL, dpi = 300, call = caller_env()) {
     if ("units" %in% names(args)) {
       call_args$units <- 'in'
     }
-    args <- modify_list(list(...), call_args)
-    dev <- function(...) inject(device(!!!args))
+    dev <- function(...) {
+      args <- modify_list(list(...), call_args)
+      inject(device(!!!args))
+    }
     return(dev)
   }
 


### PR DESCRIPTION
A small followup of #4868.

I found this warning on our CI.

```
* checking R code for possible problems ... NOTE
Warning: Warning: <anonymous>: ... may be used in an incorrect context: ‘list(...)’ (/home/runner/work/ggplot2/ggplot2/check/ggplot2.Rcheck/00_pkg_src/ggplot2/R/save.r:176)
plot_dev: ... may be used in an incorrect context: ‘list(...)’
  (/home/runner/work/ggplot2/ggplot2/check/ggplot2.Rcheck/00_pkg_src/ggplot2/R/save.r:176)
Warning: Warning: <anonymous>: ... may be used in an incorrect context: ‘list(...)’ (/home/runner/work/ggplot2/ggplot2/check/ggplot2.Rcheck/00_pkg_src/ggplot2/R/save.r:176)
```

Looking at the corresponding line before vctrs, I guess this was the intention.

https://github.com/tidyverse/ggplot2/blob/7571122f6a9455ccce9f8ceb9a2196c0a70be646/R/save.r#L176