### PR TITLE
Remove duplicated CoordPolar$render_fg()

### DIFF
--- a/R/coord-polar.r
+++ b/R/coord-polar.r
@@ -245,41 +245,6 @@ CoordPolar <- ggproto("CoordPolar", Coord,
 
     # Combine the two ends of the scale if they are close
     theta <- theta[!is.na(theta)]
-    ends_apart <- (theta[length(theta)] - theta[1]) %% (2 * pi)
-    if (length(theta) > 0 && ends_apart < 0.05) {
-      n <- length(labels)
-      if (is.expression(labels)) {
-        combined <- substitute(paste(a, "/", b),
-          list(a = labels[[1]], b = labels[[n]]))
-      } else {
-        combined <- paste(labels[1], labels[n], sep = "/")
-      }
-      labels[[n]] <- combined
-      labels <- labels[-1]
-      theta <- theta[-1]
-    }
-
-    grobTree(
-      if (length(labels) > 0) element_render(
-        theme, "axis.text.x",
-        labels, 0.45 * sin(theta) + 0.5, 0.45 * cos(theta) + 0.5,
-        hjust = 0.5, vjust = 0.5,
-        default.units = "native"
-      ),
-      element_render(theme, "panel.border")
-    )
-  },
-
-  render_fg = function(self, panel_params, theme) {
-    if (is.null(panel_params$theta.major)) {
-      return(element_render(theme, "panel.border"))
-    }
-
-    theta <- theta_rescale(self, panel_params$theta.major, panel_params)
-    labels <- panel_params$theta.labels
-
-    # Combine the two ends of the scale if they are close
-    theta <- theta[!is.na(theta)]
     ends_apart <- (theta[length(theta)] - theta[1]) %% (2*pi)
     if (length(theta) > 0 && ends_apart < 0.05 && !is.null(labels)) {
       n <- length(labels)


### PR DESCRIPTION
For unknown reason, `CoordPolar` has two `render_fg()`s. I just happened to find this, and found no clue on the context why this happened (it has had the two versions since 2015: https://github.com/tidyverse/ggplot2/commit/1487e0100515312b4ff2777163d09fdaf4f86655).

I think this is almost harmless, but this should be removed to avoid confusion. The code is already diverged a bit, but I believe the second is the one actually used (e.g. https://github.com/tidyverse/ggplot2/pull/4115 goes only to the second one), so I remove the first one.