### PR TITLE
Fix a failing test on geom_sf()

### DIFF
--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -237,7 +237,7 @@ test_that("geom_sf draws arrows correctly", {
             as.numeric(sf::st_coordinates(nc)[x + 1, 1:2])
             )
         )
-      ), sf::st_crs(nc)
+      )
     ), "LINESTRING"
   )
 


### PR DESCRIPTION
It seems this currently errors because `sf::st_crs(nc)` returns `NA` (as `nc` is a sf**g** object, it doesn't have any CRS). This pull request just removes the line.

``` r
nc_tiny_coords <- data.frame(
  x = c(-81.473, -81.741, -81.67, -81.345, -81.266, -81.24, -81.473),
  y = c(36.234, 36.392, 36.59, 36.573, 36.437, 36.365, 36.234)
)

nc <- sf::st_linestring(
    sf::st_coordinates(sf::st_as_sf(nc_tiny_coords, coords = c("x", "y"), crs = 4326))
  )

nc2 <- sf::st_cast(
  sf::st_sfc(
    sf::st_multilinestring(lapply(
      1:(length(sf::st_coordinates(nc)[, 1]) - 1),
        function(x) rbind(
          as.numeric(sf::st_coordinates(nc)[x, 1:2]),
          as.numeric(sf::st_coordinates(nc)[x + 1, 1:2])
          )
      )
    ), sf::st_crs(nc)
  ), "LINESTRING"
)
#> Error in CPL_get_bbox(obj, 2): Not compatible with requested type: [type=character; target=double].
```

<sup>Created on 2022-07-23 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
