### PR TITLE
fix dropping of inf values from jitter plot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Fix a bug in `position_jitter()` where infinity values were dropped (@javlon,
+  #4790).
+
 * `geom_linerange()` now respects the `na.rm` argument (#4927, @thomasp85)
 
 * Improve the support for `guide_axis()` on `coord_trans()` (@yutannihilation, #3959)

--- a/R/position-jitter.r
+++ b/R/position-jitter.r
@@ -87,6 +87,9 @@ PositionJitter <- ggproto("PositionJitter", Position,
     fixed_jitter <- with_seed_null(params$seed, transform_position(dummy_data, trans_x, trans_y))
     x_jit <- fixed_jitter$x - x
     y_jit <- fixed_jitter$y - y
+    # Avoid nan values, if x or y has Inf values
+    x_jit[is.infinite(x)] <- 0
+    y_jit[is.infinite(y)] <- 0
 
     # Apply jitter
     transform_position(data, function(x) x + x_jit, function(x) x + y_jit)


### PR DESCRIPTION
Fix #4790 

This PR fixes a bug where infinity values were dropped in a jitter plot.