### PR TITLE
fix misplacing points in position_dodge2

### DIFF
--- a/R/position-dodge2.r
+++ b/R/position-dodge2.r
@@ -138,7 +138,7 @@ find_x_overlaps <- function(df) {
   overlaps[1] <- counter <- 1
 
   for (i in seq_asc(2, nrow(df))) {
-    if (is.na(df$xmin[i]) || is.na(df$xmax[i - 1]) || df$xmin[i] >= df$xmax[i - 1]) {
+    if (is.na(df$xmin[i]) || is.na(df$xmax[i - 1]) || df$xmin[i] > df$xmax[i - 1]) {
       counter <- counter + 1
     }
     overlaps[i] <- counter


### PR DESCRIPTION
Fix #4327 

This PR fixes the bug that misplaced geom objects when they had zero width. 