### PR TITLE
Apply the same fix as #4667 to draw_key_point()

### DIFF
--- a/R/legend-draw.r
+++ b/R/legend-draw.r
@@ -30,13 +30,17 @@ draw_key_point <- function(data, params, size) {
     data$shape <- translate_shape_string(data$shape)
   }
 
+  # NULL means the default stroke size, and NA means no stroke.
+  stroke_size <- data$stroke %||% 0.5
+  stroke_size[is.na(stroke_size)] <- 0
+
   pointsGrob(0.5, 0.5,
     pch = data$shape,
     gp = gpar(
       col = alpha(data$colour %||% "black", data$alpha),
       fill = alpha(data$fill %||% "black", data$alpha),
-      fontsize = (data$size %||% 1.5) * .pt + (data$stroke %||% 0.5) * .stroke / 2,
-      lwd = (data$stroke %||% 0.5) * .stroke / 2
+      fontsize = (data$size %||% 1.5) * .pt + stroke_size * .stroke / 2,
+      lwd = stroke_size * .stroke / 2
     )
   )
 }


### PR DESCRIPTION
Address https://github.com/tidyverse/ggplot2/pull/4667#issuecomment-1210419214

``` r
devtools::load_all("~/GitHub/ggplot2/")
#> ℹ Loading ggplot2
ggplot(mtcars, aes(wt, mpg)) + geom_point(aes(size = qsec), alpha = .5, stroke = NA)
```

![](https://i.imgur.com/9BF70Ji.png)

<sup>Created on 2022-08-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
