### PR TITLE
Add an example for stat_align()

### DIFF
--- a/R/geom-ribbon.r
+++ b/R/geom-ribbon.r
@@ -41,6 +41,22 @@
 #' h +
 #'   geom_ribbon(aes(ymin = level - 1, ymax = level + 1), fill = "grey70") +
 #'   geom_line(aes(y = level))
+#'
+#' # The underlying stat_align() takes care of unaligned data points
+#' df <- data.frame(
+#'   g = c("a", "a", "a", "b", "b", "b"),
+#'   x = c(1, 3, 5, 2, 4, 6),
+#'   y = c(2, 5, 1, 3, 6, 7)
+#' )
+#' a <- ggplot(df, aes(x, y, fill = g)) +
+#'   geom_area()
+#'
+#' # Two groups have points on different X values.
+#' a + geom_point(size = 8) + facet_grid(g ~ .)
+#'
+#' # stat_align() interpolates and aligns the value so that the areas can stack
+#' # properly.
+#' a + geom_point(stat = "align", position = "stack", size = 8)
 geom_ribbon <- function(mapping = NULL, data = NULL,
                         stat = "identity", position = "identity",
                         ...,

--- a/man/geom_ribbon.Rd
+++ b/man/geom_ribbon.Rd
@@ -158,6 +158,22 @@ h + geom_area(aes(x = level, y = year), orientation = "y")
 h +
   geom_ribbon(aes(ymin = level - 1, ymax = level + 1), fill = "grey70") +
   geom_line(aes(y = level))
+
+# The underlying stat_align() takes care of unaligned data points
+df <- data.frame(
+  g = c("a", "a", "a", "b", "b", "b"),
+  x = c(1, 3, 5, 2, 4, 6),
+  y = c(2, 5, 1, 3, 6, 7)
+)
+a <- ggplot(df, aes(x, y, fill = g)) +
+  geom_area()
+
+# Two groups have points on different X values.
+a + geom_point(size = 8) + facet_grid(g ~ .)
+
+# stat_align() interpolates and aligns the value so that the areas can stack
+# properly.
+a + geom_point(stat = "align", position = "stack", size = 8)
 }
 \seealso{
 \code{\link[=geom_bar]{geom_bar()}} for discrete intervals (bars),


### PR DESCRIPTION
A followup of #4889. I think the document should have one or two examples to show how `stat_align()` works.

``` r
devtools::load_all("~/GitHub/ggplot2/")
#> ℹ Loading ggplot2
df <- data.frame(
  g = c("a", "a", "a", "b", "b", "b"),
  x = c(1, 3, 5, 2, 4, 6),
  y = c(2, 5, 1, 3, 6, 7)
)
a <- ggplot(df, aes(x, y, fill = g)) +
  geom_area()

# Two groups have points on different X values.
a + geom_point(size = 8) + facet_grid(g ~ .)
```

![](https://i.imgur.com/0W6zHSe.png)

``` r

# stat_align() interpolates and aligns the value so that the areas can stack
# properly.
a + geom_point(stat = "align", position = "stack", size = 8)
```

![](https://i.imgur.com/PqFnrQN.png)

<sup>Created on 2022-08-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
