### PR TITLE
fix dropping minor breaks

### DIFF
--- a/R/scale-view.r
+++ b/R/scale-view.r
@@ -18,8 +18,9 @@ view_scale_primary <- function(scale, limits = scale$get_limits(),
   if(!scale$is_discrete()) {
     # continuous_range can be specified in arbitrary order, but
     # continuous scales expect the one in ascending order.
-    breaks <- scale$get_breaks(sort(continuous_range))
-    minor_breaks <- scale$get_breaks_minor(b = breaks, limits = sort(continuous_range))
+    continuous_scale_sorted <- sort(continuous_range)
+    breaks <- scale$get_breaks(continuous_scale_sorted)
+    minor_breaks <- scale$get_breaks_minor(b = breaks, limits = continuous_scale_sorted)
   } else {
     breaks <- scale$get_breaks(limits)
     minor_breaks <- scale$get_breaks_minor(b = breaks, limits = limits)

--- a/R/scale-view.r
+++ b/R/scale-view.r
@@ -19,7 +19,7 @@ view_scale_primary <- function(scale, limits = scale$get_limits(),
     # continuous_range can be specified in arbitrary order, but
     # continuous scales expect the one in ascending order.
     breaks <- scale$get_breaks(sort(continuous_range))
-    minor_breaks <- scale$get_breaks_minor(b = breaks, limits = continuous_range)
+    minor_breaks <- scale$get_breaks_minor(b = breaks, limits = sort(continuous_range))
   } else {
     breaks <- scale$get_breaks(limits)
     minor_breaks <- scale$get_breaks_minor(b = breaks, limits = limits)


### PR DESCRIPTION
Fix #4516.

This PR fixes the bug when `coord_cartesian()` has limits in descending order.

The issue and its solution are similar to issue #3952.