### PR TITLE
Add a note that geom_raster() ignores `colour`

### DIFF
--- a/R/geom-tile.r
+++ b/R/geom-tile.r
@@ -7,7 +7,7 @@
 #' `y`, `width`, `height`). `geom_raster()` is a high
 #' performance special case for when all the tiles are the same size.
 #'
-#' @eval rd_aesthetics("geom", "tile")
+#' @eval rd_aesthetics("geom", "tile", "Note: `geom_raster()` ignores `colour`.")
 #' @inheritParams layer
 #' @inheritParams geom_point
 #' @inheritParams geom_segment

--- a/R/geom-tile.r
+++ b/R/geom-tile.r
@@ -7,7 +7,7 @@
 #' `y`, `width`, `height`). `geom_raster()` is a high
 #' performance special case for when all the tiles are the same size.
 #'
-#' @eval rd_aesthetics("geom", "tile", "Note: `geom_raster()` ignores `colour`.")
+#' @eval rd_aesthetics("geom", "tile", "Note that `geom_raster()` ignores `colour`.")
 #' @inheritParams layer
 #' @inheritParams geom_point
 #' @inheritParams geom_segment

--- a/R/utilities-help.r
+++ b/R/utilities-help.r
@@ -1,4 +1,6 @@
-rd_aesthetics <- function(type, name) {
+# Use extra_note arg to add some notes (e.g. the document is shared with multiple
+# Geoms and there's some difference among their aesthetics).
+rd_aesthetics <- function(type, name, extra_note = NULL) {
   obj <- switch(type,
     geom = check_subclass(name, "Geom", env = globalenv()),
     stat = check_subclass(name, "Stat", env = globalenv())
@@ -7,6 +9,7 @@ rd_aesthetics <- function(type, name) {
 
   c(
     "@section Aesthetics:",
+    extra_note,
     paste0(
       "\\code{", type, "_", name, "()} ",
       "understands the following aesthetics (required aesthetics are in bold):"

--- a/R/utilities-help.r
+++ b/R/utilities-help.r
@@ -9,7 +9,6 @@ rd_aesthetics <- function(type, name, extra_note = NULL) {
 
   c(
     "@section Aesthetics:",
-    extra_note,
     paste0(
       "\\code{", type, "_", name, "()} ",
       "understands the following aesthetics (required aesthetics are in bold):"
@@ -17,7 +16,8 @@ rd_aesthetics <- function(type, name, extra_note = NULL) {
     "\\itemize{",
     paste0("  \\item ", aes),
     "}",
-    "Learn more about setting these aesthetics in \\code{vignette(\"ggplot2-specs\")}."
+    "Learn more about setting these aesthetics in \\code{vignette(\"ggplot2-specs\")}.",
+    extra_note
   )
 }
 

--- a/R/utilities-help.r
+++ b/R/utilities-help.r
@@ -16,8 +16,8 @@ rd_aesthetics <- function(type, name, extra_note = NULL) {
     "\\itemize{",
     paste0("  \\item ", aes),
     "}",
-    "Learn more about setting these aesthetics in \\code{vignette(\"ggplot2-specs\")}.",
-    extra_note
+    if (!is.null(extra_note)) paste0(extra_note, "\n"),
+    "Learn more about setting these aesthetics in \\code{vignette(\"ggplot2-specs\")}."
   )
 }
 

--- a/man/geom_tile.Rd
+++ b/man/geom_tile.Rd
@@ -113,6 +113,7 @@ performance special case for when all the tiles are the same size.
 }
 \section{Aesthetics}{
 
+Note: \code{geom_raster()} ignores \code{colour}.
 \code{geom_tile()} understands the following aesthetics (required aesthetics are in bold):
 \itemize{
 \item \strong{\code{x}}

--- a/man/geom_tile.Rd
+++ b/man/geom_tile.Rd
@@ -126,8 +126,9 @@ performance special case for when all the tiles are the same size.
 \item \code{linewidth}
 \item \code{width}
 }
+Note that \code{geom_raster()} ignores \code{colour}.
+
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
-Note: \code{geom_raster()} ignores \code{colour}.
 }
 
 \examples{

--- a/man/geom_tile.Rd
+++ b/man/geom_tile.Rd
@@ -113,7 +113,6 @@ performance special case for when all the tiles are the same size.
 }
 \section{Aesthetics}{
 
-Note: \code{geom_raster()} ignores \code{colour}.
 \code{geom_tile()} understands the following aesthetics (required aesthetics are in bold):
 \itemize{
 \item \strong{\code{x}}
@@ -128,6 +127,7 @@ Note: \code{geom_raster()} ignores \code{colour}.
 \item \code{width}
 }
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
+Note: \code{geom_raster()} ignores \code{colour}.
 }
 
 \examples{


### PR DESCRIPTION
Fix #3935

This pull request also adds `extra_note` argument to the internal function `rd_aesthetics`. I don't come up with particular issue other than #3935, but I expect some extra note will be useful in several places so I believe this is worth adding.