### PR TITLE
rename size -> linewidth in element_rect and element_line

### DIFF
--- a/R/theme-defaults.r
+++ b/R/theme-defaults.r
@@ -117,12 +117,12 @@ theme_grey <- function(base_size = 11, base_family = "",
     # Elements in this first block aren't used directly, but are inherited
     # by others
     line =               element_line(
-                           colour = "black", size = base_line_size,
+                           colour = "black", linewidth = base_line_size,
                            linetype = 1, lineend = "butt"
                          ),
     rect =               element_rect(
                            fill = "white", colour = "black",
-                           size = base_rect_size, linetype = 1
+                           linewidth = base_rect_size, linetype = 1
                          ),
     text =               element_text(
                             family = base_family, face = "plain",
@@ -190,7 +190,7 @@ theme_grey <- function(base_size = 11, base_family = "",
     panel.background =   element_rect(fill = "grey92", colour = NA),
     panel.border =       element_blank(),
     panel.grid =         element_line(colour = "white"),
-    panel.grid.minor =   element_line(size = rel(0.5)),
+    panel.grid.minor =   element_line(linewidth = rel(0.5)),
     panel.spacing =      unit(half_line, "pt"),
     panel.spacing.x =    NULL,
     panel.spacing.y =    NULL,
@@ -264,7 +264,7 @@ theme_bw <- function(base_size = 11, base_family = "",
       panel.border     = element_rect(fill = NA, colour = "grey20"),
       # make gridlines dark, same contrast with white as in theme_grey
       panel.grid = element_line(colour = "grey92"),
-      panel.grid.minor = element_line(size = rel(0.5)),
+      panel.grid.minor = element_line(linewidth = rel(0.5)),
       # contour strips to match panel contour
       strip.background = element_rect(fill = "grey85", colour = "grey20"),
       # match legend key to background
@@ -292,15 +292,15 @@ theme_linedraw <- function(base_size = 11, base_family = "",
     theme(
       # black text and ticks on the axes
       axis.text        = element_text(colour = "black", size = rel(0.8)),
-      axis.ticks       = element_line(colour = "black", size = rel(0.5)),
+      axis.ticks       = element_line(colour = "black", linewidth = rel(0.5)),
       # NB: match the *visual* thickness of axis ticks to the panel border
       #     0.5 clipped looks like 0.25
 
       # pure black panel border and grid lines, but thinner
-      panel.border     = element_rect(fill = NA, colour = "black", size = rel(1)),
+      panel.border     = element_rect(fill = NA, colour = "black", linewidth = rel(1)),
       panel.grid       = element_line(colour = "black"),
-      panel.grid.major = element_line(size = rel(0.1)),
-      panel.grid.minor = element_line(size = rel(0.05)),
+      panel.grid.major = element_line(linewidth = rel(0.1)),
+      panel.grid.minor = element_line(linewidth = rel(0.05)),
 
       # strips with black background and white text
       strip.background = element_rect(fill = "black"),
@@ -331,15 +331,15 @@ theme_light <- function(base_size = 11, base_family = "",
     theme(
       # white panel with light grey border
       panel.background = element_rect(fill = "white", colour = NA),
-      panel.border     = element_rect(fill = NA, colour = "grey70", size = rel(1)),
+      panel.border     = element_rect(fill = NA, colour = "grey70", linewidth = rel(1)),
       # light grey, thinner gridlines
       # => make them slightly darker to keep acceptable contrast
       panel.grid       = element_line(colour = "grey87"),
-      panel.grid.major = element_line(size = rel(0.5)),
-      panel.grid.minor = element_line(size = rel(0.25)),
+      panel.grid.major = element_line(linewidth = rel(0.5)),
+      panel.grid.minor = element_line(linewidth = rel(0.25)),
 
       # match axes ticks thickness to gridlines and colour to panel border
-      axis.ticks       = element_line(colour = "grey70", size = rel(0.5)),
+      axis.ticks       = element_line(colour = "grey70", linewidth = rel(0.5)),
 
       # match legend key to panel.background
       legend.key       = element_rect(fill = "white", colour = NA),
@@ -377,11 +377,11 @@ theme_dark <- function(base_size = 11, base_family = "",
       # inverse grid lines contrast compared to theme_grey
       # make them thinner and try to keep the same visual contrast as in theme_light
       panel.grid       = element_line(colour = "grey42"),
-      panel.grid.major = element_line(size = rel(0.5)),
-      panel.grid.minor = element_line(size = rel(0.25)),
+      panel.grid.major = element_line(linewidth = rel(0.5)),
+      panel.grid.minor = element_line(linewidth = rel(0.25)),
 
       # match axes ticks thickness to gridlines
-      axis.ticks       = element_line(colour = "grey20", size = rel(0.5)),
+      axis.ticks       = element_line(colour = "grey20", linewidth = rel(0.5)),
 
       # match legend key to panel.background
       legend.key       = element_rect(fill = "grey50", colour = NA),
@@ -441,13 +441,13 @@ theme_classic <- function(base_size = 11, base_family = "",
       panel.grid.minor = element_blank(),
 
       # show axes
-      axis.line      = element_line(colour = "black", size = rel(1)),
+      axis.line      = element_line(colour = "black", linewidth = rel(1)),
 
       # match legend key to panel.background
       legend.key       = element_blank(),
 
       # simple, black and white strips
-      strip.background = element_rect(fill = "white", colour = "black", size = rel(2)),
+      strip.background = element_rect(fill = "white", colour = "black", linewidth = rel(2)),
       # NB: size is 1 but clipped, it looks like the 0.5 of the axes
 
       complete = TRUE
@@ -531,12 +531,12 @@ theme_test <- function(base_size = 11, base_family = "",
 
   t <- theme(
     line =               element_line(
-                           colour = "black", size = base_line_size,
+                           colour = "black", linewidth = base_line_size,
                            linetype = 1, lineend = "butt"
                          ),
     rect =               element_rect(
                            fill = "white", colour = "black",
-                           size = base_rect_size, linetype = 1
+                           linewidth = base_rect_size, linetype = 1
                          ),
     text =               element_text(
                             family = base_family, face = "plain",

--- a/R/theme-elements.r
+++ b/R/theme-elements.r
@@ -44,7 +44,7 @@
 #'   plot.background = element_rect(
 #'     fill = "grey90",
 #'     colour = "black",
-#'     size = 1
+#'     linewidth = 1
 #'   )
 #' )
 #' @name element
@@ -66,7 +66,7 @@ element_rect <- function(fill = NULL, colour = NULL, linewidth = NULL,
   linetype = NULL, color = NULL, inherit.blank = FALSE, size = deprecated()) {
 
   if (lifecycle::is_present(size)) {
-    lifecycle::deprecate_soft("3.4.0", "element_rect(size)", "element_rect(linewidth)")
+    lifecycle::deprecate_warn("3.4.0", "element_rect(size)", "element_rect(linewidth)")
     linewidth <- size
   }
 
@@ -90,7 +90,7 @@ element_line <- function(colour = NULL, linewidth = NULL, linetype = NULL,
   lineend = NULL, color = NULL, arrow = NULL, inherit.blank = FALSE, size = deprecated()) {
 
   if (lifecycle::is_present(size)) {
-    lifecycle::deprecate_soft("3.4.0", "element_line(size)", "element_line(linewidth)")
+    lifecycle::deprecate_warn("3.4.0", "element_line(size)", "element_line(linewidth)")
     linewidth <- size
   }
 
@@ -215,7 +215,7 @@ element_grob.element_rect <- function(element, x = 0.5, y = 0.5,
   fill = NULL, colour = NULL, linewidth = NULL, linetype = NULL, ..., size = deprecated()) {
 
   if (lifecycle::is_present(size)) {
-    lifecycle::deprecate_soft("3.4.0", "element_grob.element_rect(size)", "element_grob.element_rect(linewidth)")
+    lifecycle::deprecate_warn("3.4.0", "element_grob.element_rect(size)", "element_grob.element_rect(linewidth)")
     linewidth <- size
   }
 
@@ -264,7 +264,7 @@ element_grob.element_line <- function(element, x = 0:1, y = 0:1,
   default.units = "npc", id.lengths = NULL, ..., size = deprecated()) {
 
   if (lifecycle::is_present(size)) {
-    lifecycle::deprecate_soft("3.4.0", "element_grob.element_line(size)", "element_grob.element_line(linewidth)")
+    lifecycle::deprecate_warn("3.4.0", "element_grob.element_line(size)", "element_grob.element_line(linewidth)")
     linewidth <- size
   }
 

--- a/R/theme-elements.r
+++ b/R/theme-elements.r
@@ -14,7 +14,8 @@
 #'
 #' @param fill Fill colour.
 #' @param colour,color Line/border colour. Color is an alias for colour.
-#' @param size Line/border size in mm; text size in pts.
+#' @param linewidth Line/border size in mm.
+#' @param size text size in pts.
 #' @param inherit.blank Should this element inherit the existence of an
 #'   `element_blank` among its parents? If `TRUE` the existence of
 #'   a blank element among its parents will cause this element to be blank as
@@ -61,12 +62,17 @@ element_blank <- function() {
 
 #' @export
 #' @rdname element
-element_rect <- function(fill = NULL, colour = NULL, size = NULL,
-  linetype = NULL, color = NULL, inherit.blank = FALSE) {
+element_rect <- function(fill = NULL, colour = NULL, linewidth = NULL,
+  linetype = NULL, color = NULL, inherit.blank = FALSE, size = deprecated()) {
+
+  if (lifecycle::is_present(size)) {
+    lifecycle::deprecate_soft("3.4.0", "element_rect(size)", "element_rect(linewidth)")
+    linewidth <- size
+  }
 
   if (!is.null(color))  colour <- color
   structure(
-    list(fill = fill, colour = colour, size = size, linetype = linetype,
+    list(fill = fill, colour = colour, linewidth = linewidth, linetype = linetype,
          inherit.blank = inherit.blank),
     class = c("element_rect", "element")
   )
@@ -80,13 +86,18 @@ element_rect <- function(fill = NULL, colour = NULL, size = NULL,
 #'    lengths in consecutive positions in the string.
 #' @param lineend Line end Line end style (round, butt, square)
 #' @param arrow Arrow specification, as created by [grid::arrow()]
-element_line <- function(colour = NULL, size = NULL, linetype = NULL,
-  lineend = NULL, color = NULL, arrow = NULL, inherit.blank = FALSE) {
+element_line <- function(colour = NULL, linewidth = NULL, linetype = NULL,
+  lineend = NULL, color = NULL, arrow = NULL, inherit.blank = FALSE, size = deprecated()) {
+
+  if (lifecycle::is_present(size)) {
+    lifecycle::deprecate_soft("3.4.0", "element_line(size)", "element_line(linewidth)")
+    linewidth <- size
+  }
 
   if (!is.null(color))  colour <- color
   if (is.null(arrow)) arrow <- FALSE
   structure(
-    list(colour = colour, size = size, linetype = linetype, lineend = lineend,
+    list(colour = colour, linewidth = linewidth, linetype = linetype, lineend = lineend,
       arrow = arrow, inherit.blank = inherit.blank),
     class = c("element_line", "element")
   )
@@ -201,11 +212,16 @@ element_grob.element_blank <- function(element, ...)  zeroGrob()
 #' @export
 element_grob.element_rect <- function(element, x = 0.5, y = 0.5,
   width = 1, height = 1,
-  fill = NULL, colour = NULL, size = NULL, linetype = NULL, ...) {
+  fill = NULL, colour = NULL, linewidth = NULL, linetype = NULL, ..., size = deprecated()) {
+
+  if (lifecycle::is_present(size)) {
+    lifecycle::deprecate_soft("3.4.0", "element_grob.element_rect(size)", "element_grob.element_rect(linewidth)")
+    linewidth <- size
+  }
 
   # The gp settings can override element_gp
-  gp <- gpar(lwd = len0_null(size * .pt), col = colour, fill = fill, lty = linetype)
-  element_gp <- gpar(lwd = len0_null(element$size * .pt), col = element$colour,
+  gp <- gpar(lwd = len0_null(linewidth * .pt), col = colour, fill = fill, lty = linetype)
+  element_gp <- gpar(lwd = len0_null(element$linewidth * .pt), col = element$colour,
     fill = element$fill, lty = element$linetype)
 
   rectGrob(x, y, width, height, gp = modify_list(element_gp, gp), ...)
@@ -244,17 +260,22 @@ element_grob.element_text <- function(element, label = "", x = NULL, y = NULL,
 
 #' @export
 element_grob.element_line <- function(element, x = 0:1, y = 0:1,
-  colour = NULL, size = NULL, linetype = NULL, lineend = NULL,
-  default.units = "npc", id.lengths = NULL, ...) {
+  colour = NULL, linewidth = NULL, linetype = NULL, lineend = NULL,
+  default.units = "npc", id.lengths = NULL, ..., size = deprecated()) {
+
+  if (lifecycle::is_present(size)) {
+    lifecycle::deprecate_soft("3.4.0", "element_grob.element_line(size)", "element_grob.element_line(linewidth)")
+    linewidth <- size
+  }
 
   # The gp settings can override element_gp
   gp <- gpar(
     col = colour, fill = colour,
-    lwd = len0_null(size * .pt), lty = linetype, lineend = lineend
+    lwd = len0_null(linewidth * .pt), lty = linetype, lineend = lineend
   )
   element_gp <- gpar(
     col = element$colour, fill = element$colour,
-    lwd = len0_null(element$size * .pt), lty = element$linetype,
+    lwd = len0_null(element$linewidth * .pt), lty = element$linetype,
     lineend = element$lineend
   )
   arrow <- if (is.logical(element$arrow) && !element$arrow) {

--- a/R/theme.r
+++ b/R/theme.r
@@ -204,9 +204,9 @@
 #'
 #' # Axes ----------------------------------------------------------------------
 #' # Change styles of axes texts and lines
-#' p1 + theme(axis.line = element_line(size = 3, colour = "grey80"))
+#' p1 + theme(axis.line = element_line(linewidth = 3, colour = "grey80"))
 #' p1 + theme(axis.text = element_text(colour = "blue"))
-#' p1 + theme(axis.ticks = element_line(size = 2))
+#' p1 + theme(axis.ticks = element_line(linewidth = 2))
 #'
 #' # Change the appearance of the y-axis title
 #' p1 + theme(axis.title.y = element_text(size = rel(1.5), angle = 90))

--- a/R/theme.r
+++ b/R/theme.r
@@ -712,6 +712,11 @@ combine_elements <- function(e1, e2) {
     e1$size <- e2$size * unclass(e1$size)
   }
 
+  # Calculate relative linewidth
+  if (is.rel(e1$linewidth)) {
+    e1$linewidth <- e2$linewidth * unclass(e1$linewidth)
+  }
+
   e1
 }
 

--- a/man/element.Rd
+++ b/man/element.Rd
@@ -140,7 +140,7 @@ plot + theme(
   plot.background = element_rect(
     fill = "grey90",
     colour = "black",
-    size = 1
+    linewidth = 1
   )
 )
 }

--- a/man/element.Rd
+++ b/man/element.Rd
@@ -16,20 +16,22 @@ element_blank()
 element_rect(
   fill = NULL,
   colour = NULL,
-  size = NULL,
+  linewidth = NULL,
   linetype = NULL,
   color = NULL,
-  inherit.blank = FALSE
+  inherit.blank = FALSE,
+  size = deprecated()
 )
 
 element_line(
   colour = NULL,
-  size = NULL,
+  linewidth = NULL,
   linetype = NULL,
   lineend = NULL,
   color = NULL,
   arrow = NULL,
-  inherit.blank = FALSE
+  inherit.blank = FALSE,
+  size = deprecated()
 )
 
 element_text(
@@ -59,7 +61,7 @@ can be most easily scaled with the text.}
 
 \item{colour, color}{Line/border colour. Color is an alias for colour.}
 
-\item{size}{Line/border size in mm; text size in pts.}
+\item{linewidth}{Line/border size in mm.}
 
 \item{linetype}{Line type. An integer (0:8), a name (blank, solid,
 dashed, dotted, dotdash, longdash, twodash), or a string with
@@ -71,6 +73,8 @@ lengths in consecutive positions in the string.}
 a blank element among its parents will cause this element to be blank as
 well. If \code{FALSE} any blank parent element will be ignored when
 calculating final element state.}
+
+\item{size}{text size in pts.}
 
 \item{lineend}{Line end Line end style (round, butt, square)}
 

--- a/man/theme.Rd
+++ b/man/theme.Rd
@@ -338,9 +338,9 @@ p1 + theme(
 
 # Axes ----------------------------------------------------------------------
 # Change styles of axes texts and lines
-p1 + theme(axis.line = element_line(size = 3, colour = "grey80"))
+p1 + theme(axis.line = element_line(linewidth = 3, colour = "grey80"))
 p1 + theme(axis.text = element_text(colour = "blue"))
-p1 + theme(axis.ticks = element_line(size = 2))
+p1 + theme(axis.ticks = element_line(linewidth = 2))
 
 # Change the appearance of the y-axis title
 p1 + theme(axis.title.y = element_text(size = rel(1.5), angle = 90))

--- a/tests/testthat/_snaps/theme.md
+++ b/tests/testthat/_snaps/theme.md
@@ -18,7 +18,7 @@
 
 ---
 
-    Theme element `test` has "NULL" property without default: fill, colour, size, and linetype
+    Theme element `test` has "NULL" property without default: fill, colour, linewidth, and linetype
 
 # element tree can be modified
 

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -243,7 +243,7 @@ test_that("colorsteps and bins checks the breaks format", {
 # Visual tests ------------------------------------------------------------
 
 test_that("axis guides are drawn correctly", {
-  theme_test_axis <- theme_test() + theme(axis.line = element_line(size = 0.5))
+  theme_test_axis <- theme_test() + theme(axis.line = element_line(linewidth = 0.5))
   test_draw_axis <- function(n_breaks = 3,
                              break_positions = seq_len(n_breaks) / (n_breaks + 1),
                              labels = as.character,
@@ -330,7 +330,7 @@ test_that("axis guides are drawn correctly in plots", {
     ggplot(mtcars, aes(wt, mpg)) +
       geom_point() +
       theme_test() +
-      theme(axis.line = element_line(size = 5, lineend = "square"))
+      theme(axis.line = element_line(linewidth = 5, lineend = "square"))
   )
 })
 

--- a/tests/testthat/test-scales-breaks-labels.r
+++ b/tests/testthat/test-scales-breaks-labels.r
@@ -282,7 +282,7 @@ test_that("minor breaks draw correctly", {
   )
   theme <- theme_test() +
     theme(
-      panel.grid.major = element_line(colour = "grey30", size = 0.5),
+      panel.grid.major = element_line(colour = "grey30", linewidth = 0.5),
       panel.grid.minor = element_line(colour = "grey70")
     )
 

--- a/tests/testthat/test-theme.r
+++ b/tests/testthat/test-theme.r
@@ -131,7 +131,7 @@ test_that("calculating theme element inheritance works", {
   # Check that inheritance from derived class works
   element_dummyrect <- function(dummy) { # like element_rect but w/ dummy argument
     structure(list(
-      fill = NULL, colour = NULL, dummy = dummy, size = NULL,
+      fill = NULL, colour = NULL, dummy = dummy, linewidth = NULL,
       linetype = NULL, inherit.blank = FALSE
     ), class = c("element_dummyrect", "element_rect", "element"))
   }
@@ -139,7 +139,7 @@ test_that("calculating theme element inheritance works", {
   e <- calc_element(
     "panel.background",
     theme(
-      rect = element_rect(fill = "white", colour = "black", size = 0.5, linetype = 1),
+      rect = element_rect(fill = "white", colour = "black", linewidth = 0.5, linetype = 1),
       panel.background = element_dummyrect(dummy = 5),
       complete = TRUE # need to prevent pulling in default theme
     )
@@ -148,7 +148,7 @@ test_that("calculating theme element inheritance works", {
   expect_identical(
     e,
     structure(list(
-      fill = "white", colour = "black", dummy = 5, size = 0.5, linetype = 1,
+      fill = "white", colour = "black", dummy = 5, linewidth = 0.5, linetype = 1,
       inherit.blank = TRUE # this is true because we're requesting a complete theme
     ), class = c("element_dummyrect", "element_rect", "element"))
   )
@@ -336,15 +336,15 @@ test_that("elements can be merged", {
     merge_element(element_text(colour = "blue"), text_base),
     element_text(colour = "blue", size = 10)
   )
-  rect_base <- element_rect(colour = "red", size = 10)
+  rect_base <- element_rect(colour = "red", linewidth = 10)
   expect_equal(
     merge_element(element_rect(colour = "blue"), rect_base),
-    element_rect(colour = "blue", size = 10)
+    element_rect(colour = "blue", linewidth = 10)
   )
-  line_base <- element_line(colour = "red", size = 10)
+  line_base <- element_line(colour = "red", linewidth = 10)
   expect_equal(
     merge_element(element_line(colour = "blue"), line_base),
-    element_line(colour = "blue", size = 10)
+    element_line(colour = "blue", linewidth = 10)
   )
   expect_error(
     merge_element(text_base, rect_base),

--- a/vignettes/articles/faq-customising.Rmd
+++ b/vignettes/articles/faq-customising.Rmd
@@ -185,13 +185,13 @@ Set the color in `panel.background` element of `theme()` with `element_rect()`, 
 
 <summary>See example</summary>
 
-You can set the background colour of the plot with `panel.backgroun` in `theme()`.
-In the following example the border is made thicker with `size = 3` to
+You can set the background colour of the plot with `panel.background` in `theme()`.
+In the following example the border is made thicker with `linewidth = 3` to
 
 ```{r}
 ggplot(mpg, aes(x = hwy, y = cty)) +
   geom_point() +
-  theme(panel.background = element_rect(fill = "lightblue", colour = "red", size = 3))
+  theme(panel.background = element_rect(fill = "lightblue", colour = "red", linewidth = 3))
 ```
 
 If you want to change the colour of the plotting area but not the panel where the panel, you can so the same thing with `plot.background`.
@@ -199,7 +199,7 @@ If you want to change the colour of the plotting area but not the panel where th
 ```{r}
 ggplot(mpg, aes(x = hwy, y = cty)) +
   geom_point() +
-  theme(plot.background = element_rect(fill = "lightblue", colour = "red", size = 3))
+  theme(plot.background = element_rect(fill = "lightblue", colour = "red", linewidth = 3))
 ```
 
 Note that ggplot2 has a variety of [complete themes](https://ggplot2.tidyverse.org/reference/ggtheme.html) that might already do what you're hoping to accomplish.
@@ -217,7 +217,7 @@ And you can continue customization based on one of these themes.
 ggplot(mpg, aes(x = hwy, y = cty)) +
   geom_point() +
   theme_minimal() +
-  theme(plot.background = element_rect(colour = "red", size = 3))
+  theme(plot.background = element_rect(colour = "red", linewidth = 3))
 ```
 
 You might also find the [**thematic**](https://rstudio.github.io/thematic/) package useful for simplified theming of your plots.

--- a/vignettes/ggplot2-in-packages.Rmd
+++ b/vignettes/ggplot2-in-packages.Rmd
@@ -181,7 +181,7 @@ When creating a new theme, it's always good practice to start with an existing t
 theme_custom <- function(...) {
   theme_grey(...) %+replace% 
     theme(
-      panel.border = element_rect(size = 1, fill = NA),
+      panel.border = element_rect(linewidth = 1, fill = NA),
       panel.background = element_blank(),
       panel.grid = element_line(colour = "grey80")
     )


### PR DESCRIPTION
Fix #4953 

This fixes the oversight in the size to linewidth change in the element functions.

I believe I've fixed all instances of calls to the `element_*()` functions but please review carefully