### PR TITLE
Use linewidth more

### DIFF
--- a/R/annotation-map.r
+++ b/R/annotation-map.r
@@ -41,8 +41,8 @@ NULL
 #' # use with coord_sf() for appropriate projection
 #' p +
 #'   coord_sf(
-#'     crs = st_crs(3347),
-#'     default_crs = st_crs(4326),  # data is provided as long-lat
+#'     crs = sf::st_crs(3347),
+#'     default_crs = sf::st_crs(4326),  # data is provided as long-lat
 #'     xlim = c(-84, -76),
 #'     ylim = c(34, 37.2)
 #'   )
@@ -52,9 +52,9 @@ NULL
 #' p +
 #'   geom_sf(
 #'     data = nc, inherit.aes = FALSE,
-#'     fill = NA, color = "black", size = 0.1
+#'     fill = NA, color = "black", linewidth = 0.1
 #'   ) +
-#'   coord_sf(crs = st_crs(3347), default_crs = st_crs(4326))
+#'   coord_sf(crs = sf::st_crs(3347), default_crs = sf::st_crs(4326))
 #' }}}
 annotation_map <- function(map, ...) {
   # Get map input into correct form
@@ -99,7 +99,7 @@ GeomAnnotationMap <- ggproto("GeomAnnotationMap", GeomMap,
       id = grob_id,
       gp = gpar(
         col = data$colour, fill = alpha(data$fill, data$alpha),
-        lwd = data$size * .pt)
+        lwd = data$linewidth * .pt)
       )
   },
 

--- a/R/annotation.r
+++ b/R/annotation.r
@@ -30,7 +30,7 @@
 #' p + annotate("segment", x = 2.5, xend = 4, y = 15, yend = 25,
 #'   colour = "blue")
 #' p + annotate("pointrange", x = 3.5, y = 20, ymin = 12, ymax = 28,
-#'   colour = "red", size = 1.5)
+#'   colour = "red", size = 2.5, linewidth = 1.5)
 #'
 #' p + annotate("text", x = 2:3, y = 20:21, label = c("my label", "label 2"))
 #'

--- a/R/fortify-lm.r
+++ b/R/fortify-lm.r
@@ -55,13 +55,13 @@
 #'
 #' plot(mod, which = 5)
 #' ggplot(mod, aes(.hat, .stdresid)) +
-#'   geom_vline(size = 2, colour = "white", xintercept = 0) +
-#'   geom_hline(size = 2, colour = "white", yintercept = 0) +
+#'   geom_vline(linewidth = 2, colour = "white", xintercept = 0) +
+#'   geom_hline(linewidth = 2, colour = "white", yintercept = 0) +
 #'   geom_point() + geom_smooth(se = FALSE)
 #'
 #' ggplot(mod, aes(.hat, .stdresid)) +
 #'   geom_point(aes(size = .cooksd)) +
-#'   geom_smooth(se = FALSE, size = 0.5)
+#'   geom_smooth(se = FALSE, linewidth = 0.5)
 #'
 #' plot(mod, which = 6)
 #' ggplot(mod, aes(.hat, .cooksd)) +

--- a/R/geom-density2d.r
+++ b/R/geom-density2d.r
@@ -35,7 +35,7 @@
 #'
 #' # contour bands and contour lines
 #' m + geom_density_2d_filled(alpha = 0.5) +
-#'   geom_density_2d(size = 0.25, colour = "black")
+#'   geom_density_2d(linewidth = 0.25, colour = "black")
 #'
 #' set.seed(4393)
 #' dsmall <- diamonds[sample(nrow(diamonds), 1000), ]

--- a/R/geom-linerange.r
+++ b/R/geom-linerange.r
@@ -5,7 +5,7 @@
 #'
 #' @eval rd_orientation()
 #'
-#' @eval rd_aesthetics("geom", "linerange")
+#' @eval rd_aesthetics("geom", "linerange", "Note that `geom_pointrange()` also understands `size` for the size of the points.")
 #' @param fatten A multiplicative factor used to increase the size of the
 #'   middle bar in `geom_crossbar()` and the middle point in
 #'   `geom_pointrange()`.

--- a/R/geom-path.r
+++ b/R/geom-path.r
@@ -67,9 +67,9 @@
 #' # Control line join parameters
 #' df <- data.frame(x = 1:3, y = c(4, 1, 9))
 #' base <- ggplot(df, aes(x, y))
-#' base + geom_path(size = 10)
-#' base + geom_path(size = 10, lineend = "round")
-#' base + geom_path(size = 10, linejoin = "mitre", lineend = "butt")
+#' base + geom_path(linewidth = 10)
+#' base + geom_path(linewidth = 10, lineend = "round")
+#' base + geom_path(linewidth = 10, linejoin = "mitre", lineend = "butt")
 #'
 #' # You can use NAs to break the line.
 #' df <- data.frame(x = 1:5, y = c(1, 2, NA, 4, 5))

--- a/R/geom-polygon.r
+++ b/R/geom-polygon.r
@@ -56,7 +56,7 @@
 #'   y = cumsum(runif(50,max = 0.1))
 #' )
 #'
-#' p + geom_line(data = stream, colour = "grey30", size = 5)
+#' p + geom_line(data = stream, colour = "grey30", linewidth = 5)
 #'
 #' # And if the positions are in longitude and latitude, you can use
 #' # coord_map to produce different map projections.

--- a/R/geom-quantile.r
+++ b/R/geom-quantile.r
@@ -28,7 +28,7 @@
 #' m + geom_quantile(method = "rqss", lambda = 0.1)
 #'
 #' # Set aesthetics to fixed value
-#' m + geom_quantile(colour = "red", size = 2, alpha = 0.5)
+#' m + geom_quantile(colour = "red", linewidth = 2, alpha = 0.5)
 geom_quantile <- function(mapping = NULL, data = NULL,
                           stat = "quantile", position = "identity",
                           ...,

--- a/R/geom-segment.r
+++ b/R/geom-segment.r
@@ -67,7 +67,7 @@
 #' with(counts, plot(x, Freq, type = "h", lwd = 10))
 #'
 #' ggplot(counts, aes(x, Freq)) +
-#'   geom_segment(aes(xend = x, yend = 0), size = 10, lineend = "butt")
+#'   geom_segment(aes(xend = x, yend = 0), linewidth = 10, lineend = "butt")
 geom_segment <- function(mapping = NULL, data = NULL,
                          stat = "identity", position = "identity",
                          ...,

--- a/R/scale-linetype.r
+++ b/R/scale-linetype.r
@@ -25,7 +25,7 @@
 #'   )
 #' )
 #' ggplot(df_lines) +
-#'   geom_hline(aes(linetype = linetype, yintercept = 0), size = 2) +
+#'   geom_hline(aes(linetype = linetype, yintercept = 0), linewidth = 2) +
 #'   scale_linetype_identity() +
 #'   facet_grid(linetype ~ .) +
 #'   theme_void(20)

--- a/R/stat-summary.r
+++ b/R/stat-summary.r
@@ -50,12 +50,12 @@
 #' @export
 #' @examples
 #' d <- ggplot(mtcars, aes(cyl, mpg)) + geom_point()
-#' d + stat_summary(fun.data = "mean_cl_boot", colour = "red", size = 2)
+#' d + stat_summary(fun.data = "mean_cl_boot", colour = "red", linewidth = 2, size = 3)
 #'
 #' # Orientation follows the discrete axis
 #' ggplot(mtcars, aes(mpg, factor(cyl))) +
 #'   geom_point() +
-#'   stat_summary(fun.data = "mean_cl_boot", colour = "red", size = 2)
+#'   stat_summary(fun.data = "mean_cl_boot", colour = "red", linewidth = 2, size = 3)
 #'
 #' # You can supply individual functions to summarise the value at
 #' # each x:

--- a/man/annotate.Rd
+++ b/man/annotate.Rd
@@ -61,7 +61,7 @@ p + annotate("rect", xmin = 3, xmax = 4.2, ymin = 12, ymax = 21,
 p + annotate("segment", x = 2.5, xend = 4, y = 15, yend = 25,
   colour = "blue")
 p + annotate("pointrange", x = 3.5, y = 20, ymin = 12, ymax = 28,
-  colour = "red", size = 1.5)
+  colour = "red", size = 2.5, linewidth = 1.5)
 
 p + annotate("text", x = 2:3, y = 20:21, label = c("my label", "label 2"))
 

--- a/man/annotation_map.Rd
+++ b/man/annotation_map.Rd
@@ -47,8 +47,8 @@ if (requireNamespace("sf", quietly = TRUE)) {
 # use with coord_sf() for appropriate projection
 p +
   coord_sf(
-    crs = st_crs(3347),
-    default_crs = st_crs(4326),  # data is provided as long-lat
+    crs = sf::st_crs(3347),
+    default_crs = sf::st_crs(4326),  # data is provided as long-lat
     xlim = c(-84, -76),
     ylim = c(34, 37.2)
   )
@@ -58,8 +58,8 @@ nc <- sf::st_read(system.file("shape/nc.shp", package = "sf"), quiet = TRUE)
 p +
   geom_sf(
     data = nc, inherit.aes = FALSE,
-    fill = NA, color = "black", size = 0.1
+    fill = NA, color = "black", linewidth = 0.1
   ) +
-  coord_sf(crs = st_crs(3347), default_crs = st_crs(4326))
+  coord_sf(crs = sf::st_crs(3347), default_crs = sf::st_crs(4326))
 }}}
 }

--- a/man/fortify.lm.Rd
+++ b/man/fortify.lm.Rd
@@ -66,13 +66,13 @@ ggplot(mod, aes(seq_along(.cooksd), .cooksd)) +
 
 plot(mod, which = 5)
 ggplot(mod, aes(.hat, .stdresid)) +
-  geom_vline(size = 2, colour = "white", xintercept = 0) +
-  geom_hline(size = 2, colour = "white", yintercept = 0) +
+  geom_vline(linewidth = 2, colour = "white", xintercept = 0) +
+  geom_hline(linewidth = 2, colour = "white", yintercept = 0) +
   geom_point() + geom_smooth(se = FALSE)
 
 ggplot(mod, aes(.hat, .stdresid)) +
   geom_point(aes(size = .cooksd)) +
-  geom_smooth(se = FALSE, size = 0.5)
+  geom_smooth(se = FALSE, linewidth = 0.5)
 
 plot(mod, which = 6)
 ggplot(mod, aes(.hat, .cooksd)) +

--- a/man/geom_density_2d.Rd
+++ b/man/geom_density_2d.Rd
@@ -237,7 +237,7 @@ m + geom_density_2d_filled(alpha = 0.5)
 
 # contour bands and contour lines
 m + geom_density_2d_filled(alpha = 0.5) +
-  geom_density_2d(size = 0.25, colour = "black")
+  geom_density_2d(linewidth = 0.25, colour = "black")
 
 set.seed(4393)
 dsmall <- diamonds[sample(nrow(diamonds), 1000), ]

--- a/man/geom_linerange.Rd
+++ b/man/geom_linerange.Rd
@@ -139,6 +139,8 @@ This geom treats each axis differently and, thus, can thus have two orientations
 \item \code{linetype}
 \item \code{linewidth}
 }
+Note that \code{geom_pointrange()} also understands \code{size} for the size of the points.
+
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 }
 

--- a/man/geom_path.Rd
+++ b/man/geom_path.Rd
@@ -192,9 +192,9 @@ c + geom_line(
 # Control line join parameters
 df <- data.frame(x = 1:3, y = c(4, 1, 9))
 base <- ggplot(df, aes(x, y))
-base + geom_path(size = 10)
-base + geom_path(size = 10, lineend = "round")
-base + geom_path(size = 10, linejoin = "mitre", lineend = "butt")
+base + geom_path(linewidth = 10)
+base + geom_path(linewidth = 10, lineend = "round")
+base + geom_path(linewidth = 10, linejoin = "mitre", lineend = "butt")
 
 # You can use NAs to break the line.
 df <- data.frame(x = 1:5, y = c(1, 2, NA, 4, 5))

--- a/man/geom_polygon.Rd
+++ b/man/geom_polygon.Rd
@@ -134,7 +134,7 @@ stream <- data.frame(
   y = cumsum(runif(50,max = 0.1))
 )
 
-p + geom_line(data = stream, colour = "grey30", size = 5)
+p + geom_line(data = stream, colour = "grey30", linewidth = 5)
 
 # And if the positions are in longitude and latitude, you can use
 # coord_map to produce different map projections.

--- a/man/geom_quantile.Rd
+++ b/man/geom_quantile.Rd
@@ -141,5 +141,5 @@ m + geom_quantile(method = "rqss")
 m + geom_quantile(method = "rqss", lambda = 0.1)
 
 # Set aesthetics to fixed value
-m + geom_quantile(colour = "red", size = 2, alpha = 0.5)
+m + geom_quantile(colour = "red", linewidth = 2, alpha = 0.5)
 }

--- a/man/geom_segment.Rd
+++ b/man/geom_segment.Rd
@@ -182,7 +182,7 @@ counts$x <- as.numeric(as.character(counts$x))
 with(counts, plot(x, Freq, type = "h", lwd = 10))
 
 ggplot(counts, aes(x, Freq)) +
-  geom_segment(aes(xend = x, yend = 0), size = 10, lineend = "butt")
+  geom_segment(aes(xend = x, yend = 0), linewidth = 10, lineend = "butt")
 }
 \seealso{
 \code{\link[=geom_path]{geom_path()}} and \code{\link[=geom_line]{geom_line()}} for multi-

--- a/man/scale_linetype.Rd
+++ b/man/scale_linetype.Rd
@@ -92,7 +92,7 @@ df_lines <- data.frame(
   )
 )
 ggplot(df_lines) +
-  geom_hline(aes(linetype = linetype, yintercept = 0), size = 2) +
+  geom_hline(aes(linetype = linetype, yintercept = 0), linewidth = 2) +
   scale_linetype_identity() +
   facet_grid(linetype ~ .) +
   theme_void(20)

--- a/man/stat_summary.Rd
+++ b/man/stat_summary.Rd
@@ -186,12 +186,12 @@ If no aggregation functions are supplied, will default to
 
 \examples{
 d <- ggplot(mtcars, aes(cyl, mpg)) + geom_point()
-d + stat_summary(fun.data = "mean_cl_boot", colour = "red", size = 2)
+d + stat_summary(fun.data = "mean_cl_boot", colour = "red", linewidth = 2, size = 3)
 
 # Orientation follows the discrete axis
 ggplot(mtcars, aes(mpg, factor(cyl))) +
   geom_point() +
-  stat_summary(fun.data = "mean_cl_boot", colour = "red", size = 2)
+  stat_summary(fun.data = "mean_cl_boot", colour = "red", linewidth = 2, size = 3)
 
 # You can supply individual functions to summarise the value at
 # each x:


### PR DESCRIPTION
During reviewing #4956, I found several examples still use `size` where it should be `linewidth`. This pull request mainly fixes it as well as

* Added `sf::` prefix to the examples in `annotation_map()`. These don't fail just because they are in dontrun.
* Fixed `annotation_map()`. It seems it was broken.
* Add a note that `pointrange()` also understands `size` aesthetics in actual.