### PR TITLE
Don't use I() to format the layer call

### DIFF
--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -421,7 +421,7 @@ by_layer <- function(f, layers, data, step = NULL) {
       out[[i]] <- f(l = layers[[i]], d = data[[i]])
     },
     error = function(cnd) {
-      cli::cli_abort(c("Problem while {step}.", "i" = "Error occurred in the {ordinal(i)} layer."), call = I(layers[[i]]$constructor), parent = cnd)
+      cli::cli_abort(c("Problem while {step}.", "i" = "Error occurred in the {ordinal(i)} layer."), call = layers[[i]]$constructor, parent = cnd)
     }
   )
   out

--- a/tests/testthat/_snaps/layer.md
+++ b/tests/testthat/_snaps/layer.md
@@ -69,6 +69,21 @@
     x `fill = NULL`
     i Did you map your stat in the wrong layer?
 
+# layer reports the error with correct index etc
+
+    Problem while setting up geom.
+    i Error occurred in the 1st layer.
+    Caused by error in `compute_geom_1()`:
+    ! `geom_linerange()` requires the following missing aesthetics: ymax or xmin and xmax
+
+---
+
+    Problem while converting geom to grob.
+    i Error occurred in the 2nd layer.
+    Caused by error in `draw_group()`:
+    ! Can only draw one boxplot per group
+    i Did you forget `aes(group = ...)`?
+
 # layer_data returns a data.frame
 
     `layer_data()` must return a <data.frame>

--- a/tests/testthat/test-layer.r
+++ b/tests/testthat/test-layer.r
@@ -108,6 +108,21 @@ test_that("retransform works on computed aesthetics in `map_statistic`", {
   expect_equal(layer_data(p)$y, c(9, 25))
 })
 
+test_that("layer reports the error with correct index etc", {
+  p <- ggplot(mtcars) + geom_linerange(aes(disp, mpg), ymin = 2)
+
+  expect_snapshot_error(ggplotGrob(p))
+
+  p <- ggplot(
+    data_frame(x = "one value", y = 3, value = 4:6),
+    aes(x, ymin = 0, lower = 1, middle = y, upper = value, ymax = 10)
+  ) +
+    geom_point(aes(x = x, y = y), inherit.aes = FALSE) +
+    geom_boxplot(stat = "identity")
+
+  expect_snapshot_error(ggplotGrob(p))
+})
+
 # Data extraction ---------------------------------------------------------
 
 test_that("layer_data returns a data.frame", {


### PR DESCRIPTION
@Hadley am I right in remembering that you ultimately didn't want the full call in the error message out of fear that it would be too long?