### PR TITLE
Remove rename_size = TRUE for sf and pointrange geoms

### DIFF
--- a/R/geom-pointrange.r
+++ b/R/geom-pointrange.r
@@ -57,7 +57,5 @@ GeomPointrange <- ggproto("GeomPointrange", Geom,
         GeomPoint$draw_panel(transform(data, size = size * fatten), panel_params, coord)
       ))
     )
-  },
-
-  rename_size = TRUE
+  }
 )

--- a/R/geom-sf.R
+++ b/R/geom-sf.R
@@ -149,9 +149,7 @@ GeomSf <- ggproto("GeomSf", Geom,
     } else {
       draw_key_polygon(data, params, size)
     }
-  },
-
-  rename_size = TRUE
+  }
 )
 
 default_aesthetics <- function(type) {


### PR DESCRIPTION
This PR partly reverses #4884 as the omission of `rename_size = TRUE` in geom_pointrange()` and `geom_sf()` was intentional since `size` remains a valid aesthetic.