### PR TITLE
Performance: Avoid split.data.frame if there's only one panel

### DIFF
--- a/R/geom-.r
+++ b/R/geom-.r
@@ -78,7 +78,7 @@ Geom <- ggproto("Geom",
     # Trim off extra parameters
     params <- params[intersect(names(params), self$parameters())]
 
-    if (length(levels(data$PANEL)) > 1L) {
+    if (nlevels(as.factor(data$PANEL)) > 1L) {
       data_panels <- split(data, data$PANEL)
     } else {
       data_panels <- list(data)

--- a/R/geom-.r
+++ b/R/geom-.r
@@ -78,7 +78,12 @@ Geom <- ggproto("Geom",
     # Trim off extra parameters
     params <- params[intersect(names(params), self$parameters())]
 
-    lapply(split(data, data$PANEL), function(data) {
+    if (length(levels(data$PANEL)) > 1L) {
+      data_panels <- split(data, data$PANEL)
+    } else {
+      data_panels <- list(data)
+    }
+    lapply(data_panels, function(data) {
       if (empty(data)) return(zeroGrob())
 
       panel_params <- layout$panel_params[[data$PANEL[1]]]


### PR DESCRIPTION
Splitting a data frame according to a factor with one level will give a list with the data frame.

On layers with 1E7 data points, this `split` call costs 1.7 seconds out of the 18 seconds it currently takes me to build the plot. I intend to drive those 18 seconds to 6 seconds or less.

I have (maybe too extensively) documented my progress at:

- https://github.com/tidyverse/ggplot2/issues/4989

This is the second low hanging fruit after #4990.

Happy to further discuss this :smiley: 

Proposed NEWS entry (not added to avoid trivial conflicts)

```
* Performance improvement on plots without facets and lots of data
  points (@zeehio, #4991)
``