### PR TITLE
Use theta-specific theme elements

### DIFF
--- a/R/coord-polar.r
+++ b/R/coord-polar.r
@@ -261,7 +261,7 @@ CoordPolar <- ggproto("CoordPolar", Coord,
 
     grobTree(
       if (length(labels) > 0) element_render(
-        theme, "axis.text.x",
+        theme, paste0("axis.text.", self$theta),
         labels,
         unit(0.45 * sin(theta) + 0.5, "native"),
         unit(0.45 * cos(theta) + 0.5, "native"),


### PR DESCRIPTION
The tick text around the polar plot previously always used the `axis.text.x` theme element, but if you change `theta` to `y`, you'll actually want to use the `axis.text.y` theme element.