### PR TITLE
Update faithfuld.R

### DIFF
--- a/data-raw/faithfuld.R
+++ b/data-raw/faithfuld.R
@@ -3,7 +3,7 @@ library(dplyr)
 f2d <- MASS::kde2d(faithful$eruptions, faithful$waiting, h = c(1, 10), n = 75)
 
 faithfuld <- expand.grid(eruptions = f2d$x, waiting = f2d$y) %>%
-  tbl_df() %>%
+  as_tibble() %>%
   mutate(density = as.vector(f2d$z))
 
 devtools::use_data(faithfuld, overwrite = TRUE)


### PR DESCRIPTION
`tbl_df()` was deprecated in dplyr 1.0.0.
Please use `tibble::as_tibble()` instead.