### PR TITLE
Let geoms pass parameters to scales. ScaleContinuous methods to map values to colours

### DIFF
--- a/R/geom-.r
+++ b/R/geom-.r
@@ -202,8 +202,20 @@ Geom <- ggproto("Geom",
   },
 
   # Should the geom rename size to linewidth?
-  rename_size = FALSE
-
+  rename_size = FALSE,
+  # Parameters to pass to scale$map() for each aesthetic:
+  # This can be either a named list (names are aesthetics, values are lists of parameters)
+  # or a function that takes a list of geom parameters as input and returns the list.
+  # The scale_params can be used to tell the scale map function a mapping method.
+  #   e.g. scale_params = list(fill = list(mapping_method = "raw"))
+  # See the map method for ScaleContinuous in R/scale-.r for further details.
+  #
+  # The scale_params will be used to tell the scale map function the expected colour
+  # format, in case the geom prefers native colours (because it uses nativeRaster objects)
+  # instead of the default character vector:
+  #   e.g. scale_params = list(fill = list("color_fmt" = "character")) # "#00FF00"
+  #   e.g. scale_params = list(fill = list("color_fmt" = "native"))    # from nativeRaster
+  scale_params = list()
 )
 
 

--- a/R/layer.r
+++ b/R/layer.r
@@ -391,6 +391,14 @@ Layer <- ggproto("Layer", NULL,
     self$geom$setup_data(data, self$computed_geom_params)
   },
 
+  get_scale_params = function(self) {
+    if (is.function(self$geom$scale_params)) {
+      self$geom$scale_params(params = self$computed_geom_params)
+    } else {
+      self$geom$scale_params
+    }
+  },
+
   compute_position = function(self, data, layout) {
     if (empty(data)) return(data_frame0())
 

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -88,7 +88,8 @@ ggplot_build.ggplot <- function(plot) {
   npscales <- scales$non_position_scales()
   if (npscales$n() > 0) {
     lapply(data, scales_train_df, scales = npscales)
-    data <- lapply(data, scales_map_df, scales = npscales)
+    scale_params <- by_layer(function(l, d) l$get_scale_params(), layers, data, "getting scale_params")
+    data <- mapply(scales_map_df, df = data, scale_params = scale_params, MoreArgs = list(scales = npscales), SIMPLIFY = FALSE)
   }
 
   # Fill in defaults etc.

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -458,9 +458,12 @@ Scale <- ggproto("Scale", NULL,
     cli::cli_abort("Not implemented")
   },
 
-  map_df = function(self, df, i = NULL) {
+  map_df = function(self, df, i = NULL, scale_params = NULL) {
     if (empty(df)) {
       return()
+    }
+    if (is.null(scale_params)) {
+      scale_params <- list()
     }
 
     aesthetics <- intersect(self$aesthetics, names(df))
@@ -469,14 +472,24 @@ Scale <- ggproto("Scale", NULL,
       return()
     }
 
-    if (is.null(i)) {
-      lapply(aesthetics, function(j) self$map(df[[j]]))
+    if ("scale_params" %in% names(ggproto_formals(self$map))) {
+      if (is.null(i)) {
+        lapply(aesthetics, function(j) self$map(df[[j]], scale_params = scale_params[[j]]))
+      } else {
+        lapply(aesthetics, function(j) self$map(df[[j]][i], scale_params = scale_params[[j]]))
+      }
     } else {
-      lapply(aesthetics, function(j) self$map(df[[j]][i]))
+      # Eventually warn if self$map() does not accept scale_params
+      if (is.null(i)) {
+        lapply(aesthetics, function(j) self$map(df[[j]]))
+      } else {
+        lapply(aesthetics, function(j) self$map(df[[j]][i]))
+      }
+
     }
   },
 
-  map = function(self, x, limits = self$get_limits()) {
+  map = function(self, x, limits = self$get_limits(), scale_params = NULL) {
     cli::cli_abort("Not implemented")
   },
 

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -615,12 +615,49 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
 
   transform = default_transform,
 
-  map = function(self, x, limits = self$get_limits()) {
+  map = function(self, x, limits = self$get_limits(), scale_params = NULL) {
     x <- self$rescale(self$oob(x, range = limits), limits)
-
-    uniq <- unique0(x)
-    pal <- self$palette(uniq)
-    scaled <- pal[match(x, uniq)]
+    if (is.null(scale_params)) {
+      scale_params <- list()
+    }
+    # A mapping method maps the x values in [0-1] range to a continuous aesthetic.
+    # "unique": The default. Find unique values in x, map the unique values to colours,
+    #           match the mapped colours to original x values.
+    # "raw": just map all x values to colours. More efficient if we know there are not
+    #        many repeated values. Usually less efficient if there are some repeated
+    #        values.
+    # "binned": Bin `x` into `mapping_method_bins` levels. Map those levels to colours.
+    #           Assign the colour to each value corresponding to their bin.
+    #           This approach is faster with large vectors, but is lossy.
+    mapping_method <- scale_params[["mapping_method"]]
+    if (is.null(mapping_method)) {
+      mapping_method <- "unique"
+    }
+    if (is.character(mapping_method) && !mapping_method %in% c("unique", "raw", "binned")) {
+      cli::cli_warn(c(
+        "ScaleContinous does not support the mapping method {mapping_method}",
+        "i" = "Using 'unique' instead."
+      ))
+      mapping_method <- "unique"
+    }
+    if (mapping_method == "unique") {
+      uniq <- unique0(x)
+      pal <- self$palette(uniq)
+      scaled <- pal[match(x, uniq)]
+    } else if (mapping_method == "raw") {
+      scaled <- self$palette(x)
+    } else if (mapping_method == "binned") {
+      mapping_method_bins <- scale_params[["mapping_method_bins"]]
+      if (is.null(mapping_method_bins)) {
+        mapping_method_bins <- 1024L
+      }
+      mapping_method_bins <- as.integer(mapping_method_bins[1L])
+      breaks <- seq(from = 0, to = 1, length.out = mapping_method_bins + 1L)
+      colormap <- c(self$na.value, self$palette(breaks), self$na.value)
+      # values below 0 belong to the first bucket, but zero belongs to the second bucket:
+      breaks[1] <- -.Machine$double.eps
+      scaled <- colormap[findInterval(x, breaks, rightmost.closed = TRUE) + 1L]
+    }
 
     ifelse(!is.na(scaled), scaled, self$na.value)
   },

--- a/R/scales-.r
+++ b/R/scales-.r
@@ -70,10 +70,23 @@ scales_train_df <- function(scales, df, drop = FALSE) {
 }
 
 # Map values from a data.frame. Returns data.frame
-scales_map_df <- function(scales, df) {
+scales_map_df <- function(scales, df, scale_params = NULL) {
   if (empty(df) || length(scales$scales) == 0) return(df)
 
-  mapped <- unlist(lapply(scales$scales, function(scale) scale$map_df(df = df)), recursive = FALSE)
+  mapped <- unlist(
+    lapply(
+      scales$scales,
+      function(scale) {
+        if ("scale_params" %in% names(ggproto_formals(self$map_df))) {
+          scale$map_df(df = df, scale_params = scale_params)
+        } else {
+          # Eventually warn if scale$map_df() does not accept scale_params
+          scale$map_df(df = df)
+        }
+      }
+    ),
+    recursive = FALSE
+  )
 
   data_frame0(!!!mapped, df[setdiff(names(df), names(mapped))])
 }

--- a/tests/testthat/test-scale-colour-continuous.R
+++ b/tests/testthat/test-scale-colour-continuous.R
@@ -18,3 +18,12 @@ test_that("type argument is checked for proper input", {
     scale_colour_continuous(type = "abc")
   )
 })
+
+test_that("scale_params mapping_method supports binned", {
+  sc <- scale_fill_continuous()
+  x <- seq(0, 1, length.out = 10)
+  only_two <- sc$map(x, limits = c(0, 1), scale_params = list(mapping_method = "binned", mapping_method_bins = 2))
+  expect_equal(length(unique(only_two)), 2L)
+})
+
+


### PR DESCRIPTION
This is the base of one of the pillars of:

- #4989

Currently:
- geoms map data frame columns to aesthetics.
- scales transform those column values into aesthetics values.
- geoms use the transformed values into renderable objects (grobs)

The user can freely combine geoms with scales, and use multiple geoms with the same scale. The independence between geoms and scales lets most geoms work with most scales and that is a great core part of ggplot2.

While this independence is great, there are some implementation details left to ggplot2 that leave room for improvement in terms of performance. In particular, as shown on #4989, a plot that can be built and rendered in <6 seconds may take ~45 seconds in ggplot2.

One of the major bottlenecks is the mapping of column values into aesthetic values, done by the `scale$map()` method. What can we do to make it faster?

1. Make the underlying implementation of mapping values to colours faster
2. Letting the scales know how does the geom expect the aesthetic values to be.
3. Changing how values are mapped to colours

### Make the underlying implementation of mapping values to colours faster

The first point is mostly taken care in other pull requests in the `scales` and `farver` packages and it covers things like:
* Improving the missing value replacement
* Reducing intermediate memory copies and sweeps on the data

### Letting the scales know how does the geom expect the aesthetic values to be.

The second point needs some communication between geoms and scales. To give an example: when a geom maps a data to a fill or colour aesthetic, the scale will transform column values into a character vector ("#ff0000",...). Some geoms do not use character colours, but rather use native colours (for nativeRaster objects, in integer format) and they must do the format conversion when rendering (e.g. https://github.com/zeehio/ggmatrix/blob/98445bf28caaca1022c03a542b8b4541034566a2/R/geom_matrix_raster.R#L123). If the geom can tell the scale that it would rather have colours in native format, and if the scale can tell the same to the palette, the intermediate character representation of colours can be avoided with significant performance benefits. This pull request defines a way for geoms to communicate with scales, but the example described in this paragraph is tackled in a future pull request.

### Changing how values are mapped to colours

The third point is how values are mapped to colours and it is what this pull request is concerned about. The pull request focuses on `ScaleContinuous` because it is one of the most common scales, but similar adjustments could be applied to other scales if desired.

`ScaleContinous` maps values to palette colours as follows:

1. unique values are found
2. unique values are mapped to colors
3. colors are matched to the original vector

- https://github.com/tidyverse/ggplot2/blob/63125db184b6e7d5516007574b5d15acbfd8f470/R/scale-.r#L608-L610

When most values are unique, this mapping could be faster by simply maping all values to colors,
without finding and matching unique values first. In some cases the geom can guess or know if that is going to be the case.

This pull request establishes a way for geoms to communicate parameters to scales, and specifically use those parameters to define three different `mapping_method`s. By default the current "unique" approach is used. The geom may specify `"raw"` or `"binned"` instead.

The geom defines a new method `scale_params=` that typically will be a list (or a function that takes the computed params and returns that list). The list is named with the aesthetics, and for each aesthetic it provides a list with options.

For instance, the geom may now specify `scale_params = list(fill=list(mapping_method = "raw"))` to tell the scale corresponding to the `fill` aesthetic to use a "raw" mapping method, this is without finding unique values first. The "raw" method is usually faster than the current "unique" method for instance when the data consists of doubles without duplicate values.

Besides the default "unique" and the new "raw" mapping methods, we also allow the geom to ask to use the "binned" mapping method where the geom specifies a number of intervals to use `scale_params = list(fill=list(mapping_method = "binned", mapping_method_bins = 256))` and the mapping process is as follows:

- values are binned in N intervals
- intervals are mapped to colors

This approach is "lossy" (we have a maximum of N different colours), but this can be *much* faster and have almost no difference with respect to the other mapping methods.

### Questions/Discussion

- Shouldn't this `"mapping_method"` be just a scale argument?
        Yes... with a "but maybe". Yes, that makes sense. If the `"mapping_method"` is a relevant argument for the scale it could be one of the `scale_*_gradient(...)` arguments. However it seems a rather "internal" argument and it won't be easy for a regular user to see its effect. An alternative could be to sample the vector we want to map and, based on the density of unique values in the sample, we could choose either "unique" or "raw". However, by letting the geom hint the scale we can let the scale use a more efficient default mapping method in some scenarios.
