### PR TITLE
Extend palette contract: Palette capabilities

### DIFF
--- a/R/ggproto.r
+++ b/R/ggproto.r
@@ -351,3 +351,7 @@ format.ggproto_method <- function(x, ...) {
 
 # proto2 TODO: better way of getting formals for self$draw
 ggproto_formals <- function(x) formals(environment(x)$f)
+
+ggproto_attr <- function(x, which, default = NULL) {
+  attr(environment(x)$f, which = which, exact = TRUE) %||% default
+}

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -609,7 +609,14 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
     pal <- self$palette(uniq)
     scaled <- pal[match(x, uniq)]
 
-    ifelse(!is.na(scaled), scaled, self$na.value)
+    # A specific palette can have as attribute "may_return_NA = FALSE"
+    # If it has such attribute, we will skip the ifelse(!is.na(scaled), ...)
+    pal_may_return_na <- ggproto_attr(self$palette, "may_return_NA", default = TRUE)
+    if (pal_may_return_na) {
+      scaled <- ifelse(!is.na(scaled), scaled, self$na.value)
+    }
+
+    scaled
   },
 
   rescale = function(self, x, limits = self$get_limits(), range = limits) {

--- a/tests/testthat/test-scale-colour-continuous.R
+++ b/tests/testthat/test-scale-colour-continuous.R
@@ -18,3 +18,32 @@ test_that("type argument is checked for proper input", {
     scale_colour_continuous(type = "abc")
   )
 })
+
+test_that("palette with may_return_NA=FALSE works as expected", {
+  sc <- scale_fill_continuous()
+  # A palette that may return NAs, will have NAs replaced by the scale's na.value
+  # by the scale:
+  sc$palette <- structure(
+    function(x) {
+      rep(NA_character_, length(x))
+    },
+    may_return_NA = TRUE
+  )
+  sc$na.value <- "red"
+  nat <- sc$map(0.5, limits = c(0, 1))
+  expect_equal(nat, "red")
+
+  # This palette is lying, because it returns NA even though it says it can't.
+  # The scale will not replace the NA values, leading to further errors.
+  # You should not do this in production, but it helps to test:
+  sc <- scale_fill_continuous()
+  sc$palette <- structure(
+    function(x) {
+      rep(NA_character_, length(x))
+    },
+    may_return_NA = FALSE
+  )
+  sc$na.value <- "red"
+  nat <- sc$map(0.5, limits = c(0, 1))
+  expect_equal(nat, NA_character_)
+})


### PR DESCRIPTION
The goal of this pull request is to improve the performance of checking for missing values when mapping values to colours using a palette.

Some palettes may be able to guarantee that they never return missing values as colours. For those palettes it does not make sense that we check if there are missing values in their output.

In this pull request, I use (although I don't depend on it):
- https://github.com/r-lib/scales/pull/372

Basically, that pull request extends the palette contract by adding attributes to it. One of those attributes is `may_return_NA` which, if set to `FALSE`, then ggplot2 can assume the output of the palette has no missing values and skip the corresponding check.

The relevant part of this pull request is:

```r
# A specific palette can have as attribute "may_return_NA = FALSE"
# If it has such attribute, we will skip the ifelse(!is.na(scaled), ...)
pal_may_return_na <- ggproto_attr(self$palette, "may_return_NA", default = TRUE)
if (pal_may_return_na) {
  scaled <- ifelse(!is.na(scaled), scaled, self$na.value)
}
```

Related to:
- #4989 