### PR TITLE
Correct spelling of 'aesthetic' in `check_linewidth()`

### DIFF
--- a/R/geom-.r
+++ b/R/geom-.r
@@ -240,7 +240,7 @@ check_aesthetics <- function(x, n) {
 
 check_linewidth <- function(data, name) {
   if (is.null(data$linewidth) && !is.null(data$size)) {
-    deprecate_soft0("3.4.0", I(paste0("Using the `size` aesthietic with ", name)), I("the `linewidth` aesthetic"))
+    deprecate_soft0("3.4.0", I(paste0("Using the `size` aesthetic with ", name)), I("the `linewidth` aesthetic"))
     data$linewidth <- data$size
   }
   data


### PR DESCRIPTION
The word 'aesthetic' is misspelled in the deprecation message issued by `check_linewidth()`. This PR fixes the typo.