### PR TITLE
Restore names of guides after setup_panel_guides()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
-
+* Fixed a regression in `Coord::train_panel_guides()` where names of guides were 
+  dropped (@maxsutton, #5063)
+  
 # ggplot2 3.4.0
 This is a minor release focusing on tightening up the internals and ironing out
 some inconsistencies in the API. The biggest change is the addition of the 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
   (@teunbrand based on @clauswilke's suggestion, #5053).
 * The `lwd` alias now correctly replaced by `linewidth` instead of `size` 
   (@teunbrand based on @clauswilke's suggestion #5051).
-* Fixed a regression in `Coord::train_panel_guides()` where names of guides were 
+* Fixed a regression in `Coord$train_panel_guides()` where names of guides were 
   dropped (@maxsutton, #5063)
   
 # ggplot2 3.4.0

--- a/R/coord-.r
+++ b/R/coord-.r
@@ -158,9 +158,11 @@ Coord <- ggproto("Coord",
 
   train_panel_guides = function(self, panel_params, layers, default_mapping, params = list()) {
     aesthetics <- c("x", "y", "x.sec", "y.sec")
-    names(aesthetics) <- aesthetics
+
     # If the panel_params doesn't contain the scale, there's no guide for the aesthetic
     aesthetics <- intersect(aesthetics, names(panel_params$guides))
+    
+    names(aesthetics) <- aesthetics
 
     panel_params$guides <- lapply(aesthetics, function(aesthetic) {
       axis <- substr(aesthetic, 1, 1)

--- a/tests/testthat/test-coord-.r
+++ b/tests/testthat/test-coord-.r
@@ -24,3 +24,19 @@ test_that("message when replacing non-default coordinate system", {
   )
 
 })
+
+test_that("guide names are not removed by `train_panel_guides()`", {
+  gg <- ggplot()
+  data <- ggplot_build(gg)
+
+  # Excerpt from ggplot_gtable.ggplot_built
+  plot <- data$plot
+  layout <- data$layout
+  data <- data$data
+
+  layout$setup_panel_guides(plot$guides, plot$layers, plot$mapping)
+
+  # Line showing change in outcome
+  expect_equal(names(layout$panel_params[[1]]$guides),
+               c("x", "y", "x.sec", "y.sec"))
+})


### PR DESCRIPTION
Fix #5063 

This fixes the names of aesthetics being dropped by `intersect()` by moving the assigning of names until after the `intersect()` call. 