### PR TITLE
Fix CI failures on oldrel-4 (i.e. R 3.5)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -62,11 +62,8 @@ jobs:
           cache-version: 2
           extra-packages: >
             any::rcmdcheck,
-            maps=?ignore-before-r=3.5.0,
             Hmisc=?ignore-before-r=3.6.0,
-            mapproj=?ignore-before-r=3.5.0,
-            multcomp=?ignore-before-r=3.5.0,
-            quantreg=?ignore-before-r=3.5.0,
+            quantreg=?ignore-before-r=3.6.0,
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/tests/testthat/test-geom-quantile.R
+++ b/tests/testthat/test-geom-quantile.R
@@ -1,4 +1,5 @@
 test_that("geom_quantile matches quantile regression", {
+  skip_if(packageVersion("base") < "3.6.0") # warnPartialMatchArgs didn't accept FALSE
   withr::local_options(
     warnPartialMatchArgs = FALSE,
     warnPartialMatchDollar = FALSE

--- a/tests/testthat/test-geom-smooth.R
+++ b/tests/testthat/test-geom-smooth.R
@@ -22,6 +22,7 @@ test_that("geom_smooth works in both directions", {
 })
 
 test_that("default smoothing methods for small and large data sets work", {
+  skip_if(packageVersion("base") < "3.6.0") # warnPartialMatchArgs didn't accept FALSE
   withr::local_options(warnPartialMatchArgs = FALSE)
   # Numeric differences on the MLK machine on CRAN makes these test fail
   # on that particular machine


### PR DESCRIPTION
Currently the CI fails with this error:

```
   Error: 
  ! error in pak subprocess
  Caused by error: 
  ! Cannot install packages:
  * deps::.: Can't install dependency quantreg
  * quantreg: Can't install dependency MatrixModels
  * MatrixModels: Needs R >= 3.6.0
```

This pull request bumps the version of `ignore-before-r` for quantreg, and remove unnecessary `ignore-before-r` as the oldest one is now R 3.5.

Also, it seems `warnPartialMatchArgs` did not accept `FALSE` at the time of R 3.5. So this pull request skips the tests on R < 3.6.

```
══ Failed tests ════════════════════════════════════════════════════════════════
── Error (???): geom_quantile matches quantile regression ──────────────────────
Error in `options(old_options)`: invalid value for 'warnPartialMatchArgs'
Backtrace:
    ▆
 1. └─withr (local) `<fn>`(`<env>`)

[ FAIL 1 | WARN 0 | SKIP 77 | PASS 1846 ]
```