### PR TITLE
Date break doc improvement

### DIFF
--- a/R/scale-date.r
+++ b/R/scale-date.r
@@ -15,10 +15,13 @@
 #'   - A function that takes the limits as input and returns breaks as output
 #' @param date_breaks A string giving the distance between breaks like "2
 #'   weeks", or "10 years". If both `breaks` and `date_breaks` are
-#'   specified, `date_breaks` wins.
+#'   specified, `date_breaks` wins. Valid specifications are 'sec', 'min',
+#'   'hour', 'day', 'week', 'month' or 'year', optionally followed by 's'.
 #' @param date_minor_breaks A string giving the distance between minor breaks
 #'   like "2 weeks", or "10 years". If both `minor_breaks` and
-#'   `date_minor_breaks` are specified, `date_minor_breaks` wins.
+#'   `date_minor_breaks` are specified, `date_minor_breaks` wins. Valid
+#'   specifications are 'sec', 'min', 'hour', 'day', 'week', 'month' or 'year',
+#'   optionally followed by 's'.
 #' @param minor_breaks One of:
 #'   - `NULL` for no breaks
 #'   - `waiver()` for the breaks specified by `date_minor_breaks`

--- a/R/scale-date.r
+++ b/R/scale-date.r
@@ -285,14 +285,14 @@ datetime_scale <- function(aesthetics, trans, palette,
 
 
   # Backward compatibility
-  if (is.character(breaks)) breaks <- date_breaks(breaks)
-  if (is.character(minor_breaks)) minor_breaks <- date_breaks(minor_breaks)
+  if (is.character(breaks)) breaks <- breaks_width(breaks)
+  if (is.character(minor_breaks)) minor_breaks <- breaks_width(minor_breaks)
 
   if (!is.waive(date_breaks)) {
-    breaks <- date_breaks(date_breaks)
+    breaks <- breaks_width(date_breaks)
   }
   if (!is.waive(date_minor_breaks)) {
-    minor_breaks <- date_breaks(date_minor_breaks)
+    minor_breaks <- breaks_width(date_minor_breaks)
   }
   if (!is.waive(date_labels)) {
     labels <- function(self, x) {

--- a/man/scale_date.Rd
+++ b/man/scale_date.Rd
@@ -119,7 +119,8 @@ omitted.}
 
 \item{date_breaks}{A string giving the distance between breaks like "2
 weeks", or "10 years". If both \code{breaks} and \code{date_breaks} are
-specified, \code{date_breaks} wins.}
+specified, \code{date_breaks} wins. Valid specifications are 'sec', 'min',
+'hour', 'day', 'week', 'month' or 'year', optionally followed by 's'.}
 
 \item{labels}{One of:
 \itemize{
@@ -148,7 +149,9 @@ output
 
 \item{date_minor_breaks}{A string giving the distance between minor breaks
 like "2 weeks", or "10 years". If both \code{minor_breaks} and
-\code{date_minor_breaks} are specified, \code{date_minor_breaks} wins.}
+\code{date_minor_breaks} are specified, \code{date_minor_breaks} wins. Valid
+specifications are 'sec', 'min', 'hour', 'day', 'week', 'month' or 'year',
+optionally followed by 's'.}
 
 \item{limits}{One of:
 \itemize{

--- a/tests/testthat/_snaps/scale_date/scale-x-date-breaks-breaks-width-2-weeks.svg
+++ b/tests/testthat/_snaps/scale_date/scale-x-date-breaks-breaks-width-2-weeks.svg
@@ -59,6 +59,6 @@
 <text x='708.64' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='45.02px' lengthAdjust='spacingAndGlyphs'>2012-06-11</text>
 <text x='377.33' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='11.62px' lengthAdjust='spacingAndGlyphs'>dx</text>
 <text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='23.85px' lengthAdjust='spacingAndGlyphs'>price</text>
-<text x='40.13' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='280.55px' lengthAdjust='spacingAndGlyphs'>scale_x_date(breaks = date_breaks("2 weeks"))</text>
+<text x='40.13' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='285.67px' lengthAdjust='spacingAndGlyphs'>scale_x_date(breaks = breaks_width("2 weeks"))</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/scale_date/scale-y-date-breaks-breaks-width-2-weeks.svg
+++ b/tests/testthat/_snaps/scale_date/scale-y-date-breaks-breaks-width-2-weeks.svg
@@ -59,6 +59,6 @@
 <text x='687.11' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>1.00</text>
 <text x='391.27' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='23.85px' lengthAdjust='spacingAndGlyphs'>price</text>
 <text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='11.62px' lengthAdjust='spacingAndGlyphs'>dx</text>
-<text x='68.02' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='280.55px' lengthAdjust='spacingAndGlyphs'>scale_y_date(breaks = date_breaks("2 weeks"))</text>
+<text x='68.02' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='285.67px' lengthAdjust='spacingAndGlyphs'>scale_y_date(breaks = breaks_width("2 weeks"))</text>
 </g>
 </svg>

--- a/tests/testthat/test-scale_date.R
+++ b/tests/testthat/test-scale_date.R
@@ -16,8 +16,8 @@ test_that("date scale draws correctly", {
   expect_doppelganger("dates along x, default breaks",
     dt
   )
-  expect_doppelganger("scale_x_date(breaks = date_breaks(\"2 weeks\"))",
-    dt + scale_x_date(breaks = date_breaks("2 weeks"))
+  expect_doppelganger("scale_x_date(breaks = breaks_width(\"2 weeks\"))",
+    dt + scale_x_date(breaks = breaks_width("2 weeks"))
   )
   expect_doppelganger("scale_x_date(breaks = \"3 weeks\")",
     dt + scale_x_date(date_breaks = "3 weeks")
@@ -31,8 +31,8 @@ test_that("date scale draws correctly", {
 
   dt <- ggplot(df, aes(price, dx)) + geom_line()
   expect_doppelganger("dates along y, default breaks", dt)
-  expect_doppelganger("scale_y_date(breaks = date_breaks(\"2 weeks\"))",
-    dt + scale_y_date(breaks = date_breaks("2 weeks"))
+  expect_doppelganger("scale_y_date(breaks = breaks_width(\"2 weeks\"))",
+    dt + scale_y_date(breaks = breaks_width("2 weeks"))
   )
   expect_doppelganger("scale_y_date(breaks = \"3 weeks\")",
     dt + scale_y_date(date_breaks = "3 weeks")


### PR DESCRIPTION
This PR attempts to partially fix #4970. Moreover, it replaces using the `date_breaks()` function, which was retired >3 years ago in https://github.com/r-lib/scales/commit/1eb66ea1311ef5f7413e7aa2ae6928f92328f313 and superceded by `breaks_width()`. If the error message in #4970 needs to be improved, the {scales} package is the appropriate place for that.