### PR TITLE
stat_bin deals with `width` per usual

### DIFF
--- a/R/stat-bin.r
+++ b/R/stat-bin.r
@@ -124,9 +124,6 @@ StatBin <- ggproto("StatBin", Stat,
       params$closed <- if (params$right) "right" else "left"
       params$right <- NULL
     }
-    if (!is.null(params$width)) {
-      deprecate_warn0("2.1.0", "stat_bin(width)", "geom_bar()")
-    }
     if (!is.null(params$boundary) && !is.null(params$center)) {
       cli::cli_abort("Only one of {.arg boundary} and {.arg center} may be specified in {.fn {snake_class(self)}}.")
     }
@@ -147,8 +144,7 @@ StatBin <- ggproto("StatBin", Stat,
                            breaks = NULL, flipped_aes = FALSE,
                            # The following arguments are not used, but must
                            # be listed so parameters are computed correctly
-                           origin = NULL, right = NULL, drop = NULL,
-                           width = NULL) {
+                           origin = NULL, right = NULL, drop = NULL) {
     x <- flipped_names(flipped_aes)$x
     if (!is.null(breaks)) {
       if (!scales[[x]]$is_discrete()) {


### PR DESCRIPTION
This PR aims to fix #2756.

In brief, it removes a deprecation warning in `stat_bin()` for the `width` argument that has been deprecated 7 years ago. The deprecation warning that suggested `geom_bar()` was particularly confusing when using `geom_bar()` + `stat = "bin"`. It now just gives the usual 'Ignoring unknown parameters: `width`' message when used in combination with a geom that has no `width` parameter.