### PR TITLE
Write out units in full in `ggsave` error

### DIFF
--- a/R/save.r
+++ b/R/save.r
@@ -147,6 +147,13 @@ plot_dim <- function(dim = c(NA, NA), scale = 1, units = "in",
   }
 
   if (limitsize && any(dim >= 50)) {
+    units <- switch(
+      units,
+      "in" = "inches",
+      "cm" = "centimeters",
+      "mm" = "millimeters",
+      "px" = "pixels"
+    )
     cli::cli_abort(c(
       "Dimensions exceed 50 inches ({.arg height} and {.arg width} are specified in {.emph {units}} not pixels).",
       "i" = "If you're sure you want a plot that big, use {.code limitsize = FALSE}.

--- a/R/save.r
+++ b/R/save.r
@@ -154,8 +154,17 @@ plot_dim <- function(dim = c(NA, NA), scale = 1, units = "in",
       "mm" = "millimeters",
       "px" = "pixels"
     )
+    msg <- paste0(
+      "Dimensions exceed 50 inches ({.arg height} and {.arg width} are ",
+      "specified in {.emph {units}}"
+    )
+    if (units == "pixels") {
+      msg <- paste0(msg, ").")
+    } else {
+      msg <- paste0(msg, " not pixels).")
+    }
     cli::cli_abort(c(
-      "Dimensions exceed 50 inches ({.arg height} and {.arg width} are specified in {.emph {units}} not pixels).",
+      msg,
       "i" = "If you're sure you want a plot that big, use {.code limitsize = FALSE}.
     "), call = call)
   }

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -74,6 +74,7 @@ test_that("uses 7x7 if no graphics device open", {
 test_that("warned about large plot unless limitsize = FALSE", {
   expect_error(plot_dim(c(50, 50)), "exceed 50 inches")
   expect_equal(plot_dim(c(50, 50), limitsize = FALSE), c(50, 50))
+  expect_error(plot_dim(c(15000, 15000), units = "px"), "in pixels).")
 })
 
 test_that("scale multiplies height & width", {


### PR DESCRIPTION
This PR aims to fix #5048.

In brief, all units are written out in full in the error message (not just inches). Also, there was a possibility that the user could see a confusing error like this:

> "Dimensions exceed 50 inches (height and width are specified in pixels not pixels)."

Which is now being avoided by omitting the 'not pixels' ending of the error message.