### PR TITLE
Reset geom/stat defaults

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* `update_geom_defaults()` and `update_stat_defaults()` can now use `new = NULL`
+  to reset the original defaults (@teunbrand, #4993).
 * Fixed a regression in `geom_hex()` where aesthetics were replicated across 
   bins (@thomasp85, #5037 and #5044)
 * Fixed spurious warning when `weight` aesthetic was used in `stat_smooth()` 

--- a/R/geom-defaults.r
+++ b/R/geom-defaults.r
@@ -1,28 +1,69 @@
+geom_defaults_cache <- new.env(parent = emptyenv())
+stat_defaults_cache <- new.env(parent = emptyenv())
+
 #' Modify geom/stat aesthetic defaults for future plots
 #'
 #' @param stat,geom Name of geom/stat to modify (like `"point"` or
 #'   `"bin"`), or a Geom/Stat object (like `GeomPoint` or
 #'   `StatBin`).
-#' @param new Named list of aesthetics.
+#' @param new Named list of aesthetics. Alternatively, `NULL` to reset the
+#'   defaults.
 #' @keywords internal
 #' @export
 #' @examples
 #' update_geom_defaults("point", list(colour = "darkblue"))
 #' ggplot(mtcars, aes(mpg, wt)) + geom_point()
-#' update_geom_defaults("point", list(colour = "black"))
+#' # Reset defaults by using `new = NULL`
+#' update_geom_defaults("point", NULL)
 #' @rdname update_defaults
 update_geom_defaults <- function(geom, new) {
-  g <- check_subclass(geom, "Geom", env = parent.frame())
-  old <- g$default_aes
-  g$default_aes <- defaults(rename_aes(new), old)
-  invisible()
+  if (is.null(new)) {
+
+    vec_assert(geom, character(), 1)
+    old <- geom_defaults_cache[[geom]]
+    if (!is.null(old)) {
+      new <- update_geom_defaults(geom, old)
+      env_unbind(geom_defaults_cache, geom)
+    }
+    invisible(new)
+
+  } else {
+
+    g <- check_subclass(geom, "Geom", env = parent.frame())
+    old <- g$default_aes
+    # Only update cache the first time
+    if (!geom %in% ls(geom_defaults_cache)) {
+      geom_defaults_cache[[geom]] <- old
+    }
+    g$default_aes <- defaults(rename_aes(new), old)
+    invisible(old)
+
+  }
 }
 
 #' @rdname update_defaults
 #' @export
 update_stat_defaults <- function(stat, new) {
-  g <- check_subclass(stat, "Stat", env = parent.frame())
-  old <- g$default_aes
-  g$default_aes <- defaults(rename_aes(new), old)
-  invisible()
+  if (is.null(new)) {
+
+    vec_assert(stat, character(), 1)
+    old <- stat_defaults_cache[[stat]]
+    if (!is.null(old)) {
+      new <- update_geom_defaults(stat, old)
+      env_unbind(geom_defaults_cache, stat)
+    }
+    invisible(new)
+
+  } else {
+
+    g <- check_subclass(stat, "Stat", env = parent.frame())
+    old <- g$default_aes
+    # Only update cache the first time
+    if (!stat %in% ls(stat_defaults_cache)) {
+      stat_defaults_cache[[stat]] <- old
+    }
+    g$default_aes <- defaults(rename_aes(new), old)
+    invisible(old)
+
+  }
 }

--- a/man/update_defaults.Rd
+++ b/man/update_defaults.Rd
@@ -10,7 +10,8 @@ update_geom_defaults(geom, new)
 update_stat_defaults(stat, new)
 }
 \arguments{
-\item{new}{Named list of aesthetics.}
+\item{new}{Named list of aesthetics. Alternatively, \code{NULL} to reset the
+defaults.}
 
 \item{stat, geom}{Name of geom/stat to modify (like \code{"point"} or
 \code{"bin"}), or a Geom/Stat object (like \code{GeomPoint} or
@@ -22,6 +23,7 @@ Modify geom/stat aesthetic defaults for future plots
 \examples{
 update_geom_defaults("point", list(colour = "darkblue"))
 ggplot(mtcars, aes(mpg, wt)) + geom_point()
-update_geom_defaults("point", list(colour = "black"))
+# Reset defaults by using `new = NULL`
+update_geom_defaults("point", NULL)
 }
 \keyword{internal}

--- a/tests/testthat/test-geom-.R
+++ b/tests/testthat/test-geom-.R
@@ -5,3 +5,19 @@ test_that("aesthetic checking in geom throws correct errors", {
   aes <- list(a = 1:4, b = letters[1:4], c = TRUE, d = 1:2, e = 1:5)
   expect_snapshot_error(check_aesthetics(aes, 4))
 })
+
+test_that("geom defaults can be set and reset", {
+  l <- geom_point()
+  test <- l$geom$use_defaults(data_frame0())
+  expect_equal(test$colour, "black")
+
+  inv <- update_geom_defaults("point", list(colour = "red"))
+  test <- l$geom$use_defaults(data_frame0())
+  expect_equal(test$colour, "red")
+  expect_equal(inv$colour, "black")
+
+  inv <- update_geom_defaults("point", NULL)
+  test <- l$geom$use_defaults(data_frame0())
+  expect_equal(test$colour, "black")
+  expect_equal(inv$colour, "red")
+})


### PR DESCRIPTION
This PR aims to fix #4993.

In brief, it creates caches for geom/stat defaults that are populated the first time a default is changed with `update_{geom/stat}_defaults()`. Then it uses that cache to reset the original defaults when `new = NULL`. In addition, the functions invisibly return the previous defaults.

I could not find an appropriate unit test for `update_stat_defaults()`. The examples also don't include `update_stat_defaults()` and I'm having a hard time imagining a use case for that function.