### PR TITLE
`stat_ecdf()` responds to scale transform

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* Renamed computed aesthetic in `stat_ecdf()` to `ecdf`, to prevent incorrect
+  scale transformations (@teunbrand, #5113 and #5112).
 * Fixed a regression in `geom_hex()` where aesthetics were replicated across 
   bins (@thomasp85, #5037 and #5044)
 * Fixed spurious warning when `weight` aesthetic was used in `stat_smooth()` 

--- a/R/stat-ecdf.r
+++ b/R/stat-ecdf.r
@@ -22,7 +22,7 @@
 #'   and (Inf, 1)
 #' @section Computed variables:
 #' \describe{
-#'   \item{y}{cumulative density corresponding x}
+#'   \item{ecdf}{cumulative density corresponding x}
 #' }
 #' @export
 #' @examples
@@ -74,7 +74,7 @@ stat_ecdf <- function(mapping = NULL, data = NULL,
 StatEcdf <- ggproto("StatEcdf", Stat,
   required_aes = c("x|y"),
 
-  default_aes = aes(y = after_stat(y)),
+  default_aes = aes(x = after_stat(ecdf), y = after_stat(ecdf)),
 
   setup_params = function(self, data, params) {
     params$flipped_aes <- has_flipped_aes(data, params, main_is_orthogonal = FALSE, main_is_continuous = TRUE)
@@ -104,7 +104,7 @@ StatEcdf <- ggproto("StatEcdf", Stat,
 
     df_ecdf <- data_frame0(
       x = x,
-      y = data_ecdf,
+      ecdf = data_ecdf,
       .size = length(x)
     )
     df_ecdf$flipped_aes <- flipped_aes

--- a/man/stat_ecdf.Rd
+++ b/man/stat_ecdf.Rd
@@ -89,7 +89,7 @@ and will be output on the unused one.
 \section{Computed variables}{
 
 \describe{
-\item{y}{cumulative density corresponding x}
+\item{ecdf}{cumulative density corresponding x}
 }
 }
 

--- a/tests/testthat/test-stat-ecdf.R
+++ b/tests/testthat/test-stat-ecdf.R
@@ -15,3 +15,15 @@ test_that("stat_ecdf works in both directions", {
   expect_snapshot_error(ggplot_build(p))
 })
 
+# See #5113 and #5112
+test_that("stat_ecdf responds to axis transformations", {
+  n <- 4
+  answer <- c(seq(0, 1, length.out = n + 1), 1)
+  p <- ggplot(data_frame0(x = seq_len(n)), aes(x)) + stat_ecdf()
+
+  ld <- layer_data(p)
+  expect_equal(ld$y, answer)
+
+  ld <- layer_data(p + scale_y_sqrt())
+  expect_equal(ld$y, sqrt(answer))
+})


### PR DESCRIPTION
This PR aims to fix #5112 and #5113.

Because this stat used to have `y = after_stat(y)`, it computed a column named `y`. This, of course, is recognised as a position aesthetic, but that also meant that it was back-transformed in `scales_backtransform_df()` (whereas it shouldn't be). The fix proposed herein is to simply rename the computed aesthetic to `ecdf` such that it is no longer automatically backtransformed. 