### PR TITLE
Handle `filename` better in `ggsave()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* `ggsave()` warns when multiple `filename`s are given, and only writes to the
+  first file (@teunbrand, #5114).
 * Fixed a regression in `geom_hex()` where aesthetics were replicated across 
   bins (@thomasp85, #5037 and #5044)
 * Fixed spurious warning when `weight` aesthetic was used in `stat_smooth()` 

--- a/R/save.r
+++ b/R/save.r
@@ -77,6 +77,17 @@ ggsave <- function(filename, plot = last_plot(),
                    device = NULL, path = NULL, scale = 1,
                    width = NA, height = NA, units = c("in", "cm", "mm", "px"),
                    dpi = 300, limitsize = TRUE, bg = NULL, ...) {
+  if (length(filename) != 1) {
+    if (length(filename) == 0) {
+      cli::cli_abort("{.arg filename} cannot be empty.")
+    }
+    len <- length(filename)
+    filename <- filename[1]
+    cli::cli_warn(c(
+      "{.arg filename} must have length 1, not length {len}.",
+      "!" = "Only the first, {.file {filename}}, will be used."
+    ))
+  }
 
   dpi <- parse_dpi(dpi)
   dev <- plot_dev(device, filename, dpi = dpi)

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -56,6 +56,21 @@ test_that("ggsave can handle blank background", {
   expect_true(grepl("fill: none", bg))
 })
 
+test_that("ggsave warns about empty or multiple filenames", {
+  filenames <- c("plot1.png", "plot2.png")
+  plot <- ggplot(mtcars, aes(disp, mpg)) + geom_point()
+
+  withr::with_file(filenames, {
+    expect_warning(
+      suppressMessages(ggsave(filenames, plot)),
+      "`filename` must have length 1"
+    )
+    expect_error(
+      ggsave(character(), plot),
+      "`filename` cannot be empty."
+    )
+  })
+})
 
 # plot_dim ---------------------------------------------------------------
 


### PR DESCRIPTION
This PR comes out of the discussion in #5114.

`ggsave()` gives some unhelpful error messages when the `filename` argument was inappropriate:

``` r
library(ggplot2)

p <- ggplot(mtcars, aes(mpg, disp)) + geom_point()
filenames <- c("plot1.png", "plot2.png")

# Casually plotting
ggsave(filenames, p)
#> Error in `ggsave()`:
#> ! `device` must be "NULL", a string or a function.

# Alright, let's try to fix the above error...
ggsave(filenames, p, "png")
#> Saving 7 x 5 in image
#> Error in if (!dir.exists(dir)) {: the condition has length > 1

# Might programmatically provide 0-length vector for some reason
ggsave(character(), p, "png")
#> Saving 7 x 5 in image
#> Error in if (!dir.exists(dir)) {: argument is of length zero
```

With this PR:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

ggsave(filenames, p)
#> Warning: `filename` must have length 1, not length 2.
#> ! Only the first, 'plot1.png', will be used.
#> Saving 7 x 5 in image

ggsave(character(), p, "png")
#> Error in `ggsave()`:
#> ! `filename` cannot be empty.
```

<sup>Created on 2022-12-22 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
