### PR TITLE
Computed variable and delayed evaluation docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* `ggsave()` warns when multiple `filename`s are given, and only writes to the
+  first file (@teunbrand, #5114).
 * Fixed a regression in `geom_hex()` where aesthetics were replicated across 
   bins (@thomasp85, #5037 and #5044)
 * Fixed spurious warning when `weight` aesthetic was used in `stat_smooth()` 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,5 @@
 # ggplot2 (development version)
 
-* `ggsave()` warns when multiple `filename`s are given, and only writes to the
-  first file (@teunbrand, #5114).
 * Fixed a regression in `geom_hex()` where aesthetics were replicated across 
   bins (@thomasp85, #5037 and #5044)
 * Fixed spurious warning when `weight` aesthetic was used in `stat_smooth()` 

--- a/R/aes-evaluation.r
+++ b/R/aes-evaluation.r
@@ -1,12 +1,19 @@
 #' Control aesthetic evaluation
 #'
+#' @description
 #' Most [aesthetics][aes()] are mapped from variables found in the data.
 #' Sometimes, however, you want to delay the mapping until later in the
 #' rendering process. ggplot2 has three stages of the data that you can map
 #' aesthetics from, and three functions to control at which stage aesthetics
 #' should be evaluated.
 #'
-#' @usage # These functions can be used inside the `aes()` function
+#' @description
+#' `after_stat()` replaces the old approaches of using either `stat()`, e.g.
+#' `stat(density)`, or surrounding the variable names with `..`, e.g.
+#' `..density..`.
+#'
+#' @usage
+#' # These functions can be used inside the `aes()` function
 #' # used as the `mapping` argument in layers, for example:
 #' # geom_density(mapping = aes(y = after_stat(scaled)))
 #'
@@ -80,9 +87,9 @@
 #' ```
 #'
 #' ## Complex staging
-#'   If you want to map the same aesthetic multiple times, e.g. map `x` to a
-#'   data column for the stat, but remap it for the geom, you can use the
-#'   `stage()` function to collect multiple mappings.
+#' If you want to map the same aesthetic multiple times, e.g. map `x` to a
+#' data column for the stat, but remap it for the geom, you can use the
+#' `stage()` function to collect multiple mappings.
 #'
 #' ```r
 #' # Use stage to modify the scaled fill
@@ -102,10 +109,6 @@
 #'     fun.data = ~ round(data.frame(mean = mean(.x), sd = sd(.x)), 2)
 #'   )
 #' ```
-#' @note
-#' `after_stat()` replaces the old approaches of using either `stat()`, e.g.
-#' `stat(density)`, or surrounding the variable names with `..`, e.g.
-#' `..density..`.
 #' @rdname aes_eval
 #' @name aes_eval
 #'

--- a/R/aes-evaluation.r
+++ b/R/aes-evaluation.r
@@ -90,16 +90,15 @@
 #' ggplot(mpg, aes(class, hwy)) +
 #'   geom_boxplot(aes(fill = stage(class, after_scale = alpha(fill, 0.4))))
 #'
-#' # Using data for computing summary, but placing label elsewhere, as well as
-#' # using the computed 'y' as part of the label.
+#' # Using data for computing summary, but placing label elsewhere.
+#' # Also, we're making our own computed variable to use for the label.
 #' ggplot(mpg, aes(class, displ)) +
 #'   geom_violin() +
 #'   stat_summary(
 #'     aes(y = stage(displ, after_stat = 8),
-#'         label = after_stat(paste(y, ymax, sep = " ± "))),
+#'         label = after_stat(paste(mean, "±", sd))),
 #'     geom = "text",
-#'     fun = ~ round(mean(.x), 2),
-#'     fun.max = ~ round(sd(.x), 2)
+#'     fun.data = ~ round(data.frame(mean = mean(.x), sd = sd(.x)), 2)
 #'   )
 #' ```
 #'

--- a/R/aes-evaluation.r
+++ b/R/aes-evaluation.r
@@ -2,39 +2,106 @@
 #'
 #' Most aesthetics are mapped from variables found in the data. Sometimes,
 #' however, you want to delay the mapping until later in the rendering process.
-#' ggplot2 has three stages of the data that you can map aesthetics from. The
-#' default is to map at the beginning, using the layer data provided by the
-#' user. The second stage is after the data has been transformed by the layer
-#' stat. The third and last stage is after the data has been transformed and
-#' mapped by the plot scales. The most common example of mapping from stat
-#' transformed data is the height of bars in [geom_histogram()]:
-#' the height does not come from a variable in the underlying data, but
-#' is instead mapped to the `count` computed by [stat_bin()]. An example of
-#' mapping from scaled data could be to use a desaturated version of the stroke
-#' colour for fill. If you want to map directly from the layer data you should
-#' not do anything special. In order to map from stat transformed data you
-#' should use the `after_stat()` function to flag that evaluation of the
-#' aesthetic mapping should be postponed until after stat transformation.
-#' Similarly, you should use `after_scale()` to flag evaluation of mapping for
-#' after data has been scaled. If you want to map the same aesthetic multiple
-#' times, e.g. map `x` to a data column for the stat, but remap it for the geom,
-#' you can use the `stage()` function to collect multiple mappings.
+#' ggplot2 has three stages of the data that you can map aesthetics from, and
+#' three functions to control at which stage aesthetics should be evaluated.
 #'
+#' @usage # These functions can be used inside the `aes()` function
+#' # used as the `mapping` argument in layers.
+#'
+#' @param x <[`data-masking`][rlang::topic-data-mask]> An aesthetic expression
+#'   using variables calculated by the stat (`after_stat()`) or layer aesthetics
+#'   (`after_scale()`).
+#' @param start <[`data-masking`][rlang::topic-data-mask]> An aesthetic
+#'   expression using variables from the layer data.
+#' @param after_stat <[`data-masking`][rlang::topic-data-mask]> An aesthetic
+#'   expression using variables calculated by the stat.
+#' @param after_scale <[`data-masking`][rlang::topic-data-mask]> An aesthetic
+#'   expression using layer aesthetics.
+#'
+#' @note
 #' `after_stat()` replaces the old approaches of using either `stat()` or
 #' surrounding the variable names with `..`.
 #'
-#' @note Evaluation after stat transformation will have access to the
-#' variables calculated by the stat, not the original mapped values. Evaluation
-#' after scaling will only have access to the final aesthetics of the layer
-#' (including non-mapped, default aesthetics). The original layer data can only
-#' be accessed at the first stage.
+#' @section Staging:
+#' Below follows an overview of the three stages of evaluation and how aesthetic
+#' evaluation can be controlled.
 #'
-#' @param x An aesthetic expression using variables calculated by the stat
-#'   (`after_stat()`) or layer aesthetics (`after_scale()`).
-#' @param start An aesthetic expression using variables from the layer data.
-#' @param after_stat An aesthetic expression using variables calculated by the
-#'   stat.
-#' @param after_scale An aesthetic expression using layer aesthetics.
+#' ## Stage 1: direct input
+#'   The default is to map at the beginning, using the layer data provided by
+#'   the user. If you want to map directly from the layer data you should not do
+#'   anything special. This is the only stage where the original layer data can
+#'   be accessed.
+#'
+#' ```{r direct_input, eval = FALSE}
+#' # 'x' and 'y' are mapped directly
+#' ggplot(mtcars) + geom_point(aes(x = mpg, y = disp))
+#' ```
+#'
+#' ## Stage 2: after stat transformation
+#'   The second stage is after the data has been transformed by the layer
+#'   stat. The most common example of mapping from stat transformed data is the
+#'   height of bars in [geom_histogram()]: the height does not come from a
+#'   variable in the underlying data, but is instead mapped to the `count`
+#'   computed by [stat_bin()]. In order to map from stat transformed data you
+#'   should use the `after_stat()` function to flag that evaluation of the
+#'   aesthetic mapping should be postponed until after stat transformation.
+#'   Evaluation after stat transformation will have access to the variables
+#'   calculated by the stat, not the original mapped values. The 'computed
+#'   variables' section in each stat lists which variables are available to
+#'   access.
+#'
+#' ```{r after_stat_transformation, eval = FALSE}
+#' # The 'y' values for the histogram are computed by the stat
+#' ggplot(faithful, aes(x = waiting)) +
+#'   geom_histogram()
+#'
+#' # Choosing a different computed variable to display, matching up the
+#' # histogram with the density plot
+#' ggplot(faithful, aes(x = waiting)) +
+#'   geom_histogram(aes(y = after_stat(density))) +
+#'   geom_density()
+#' ```
+#'
+#' ## Stage 3: after scale transformation
+#'   The third and last stage is after the data has been transformed and
+#'   mapped by the plot scales. An example of mapping from scaled data could
+#'   be to use a desaturated version of the stroke colour for fill. You should
+#'   use `after_scale()` to flag evaluation of mapping for after data has been
+#'   scaled. Evaluation after scaling will only have access to the final
+#'   aesthetics of the layer (including non-mapped, default aesthetics).
+#'
+#' ```{r after_scale_transformation, eval = FALSE}
+#' # The exact colour is known after scale transformation
+#' ggplot(mpg, aes(cty, colour = factor(cyl))) +
+#'   geom_density()
+#'
+#' # We re-use colour properties for the fill without a separate fill scale
+#' ggplot(mpg, aes(cty, colour = factor(cyl))) +
+#'   geom_density(aes(fill = after_scale(alpha(colour, 0.3))))
+#' ```
+#'
+#' ## Complex staging
+#'   If you want to map the same aesthetic multiple times, e.g. map `x` to a
+#'   data column for the stat, but remap it for the geom, you can use the
+#'   `stage()` function to collect multiple mappings.
+#'
+#' ```{r complex_staging, eval = FALSE}
+#' # Use stage to modify the scaled fill
+#' ggplot(mpg, aes(class, hwy)) +
+#'   geom_boxplot(aes(fill = stage(class, after_scale = alpha(fill, 0.4))))
+#'
+#' # Using data for computing summary, but placing label elsewhere, as well as
+#' # using the computed 'y' as part of the label.
+#' ggplot(mpg, aes(class, displ)) +
+#'   geom_violin() +
+#'   stat_summary(
+#'     aes(y = stage(displ, after_stat = 8),
+#'         label = after_stat(paste(y, ymax, sep = " ± "))),
+#'     geom = "text",
+#'     fun = ~ round(mean(.x), 2),
+#'     fun.max = ~ round(sd(.x), 2)
+#'   )
+#' ```
 #'
 #' @rdname aes_eval
 #' @name aes_eval
@@ -55,6 +122,44 @@
 #' # Use stage to modify the scaled fill
 #' ggplot(mpg, aes(class, hwy)) +
 #'   geom_boxplot(aes(fill = stage(class, after_scale = alpha(fill, 0.4))))
+#'
+#' # Making a proportional stacked density plot
+#' ggplot(mpg, aes(cty)) +
+#'   geom_density(
+#'     aes(colour = factor(cyl),
+#'         fill = after_scale(alpha(colour, 0.3)),
+#'         y = after_stat(count / sum(n[!duplicated(group)]))),
+#'     position = "stack", bw = 1
+#'   ) +
+#'   geom_density(bw = 1)
+#'
+#' # Imitating a ridgeline plot
+#' ggplot(mpg, aes(cty, colour = factor(cyl))) +
+#'   geom_ribbon(
+#'     stat = "density", outline.type = "upper",
+#'     aes(fill = after_scale(alpha(colour, 0.3)),
+#'         ymin = after_stat(group),
+#'         ymax = after_stat(group + ndensity))
+#'   )
+#'
+#' # Labelling a bar plot
+#' ggplot(mpg, aes(class)) +
+#'   geom_bar() +
+#'   geom_text(
+#'     aes(y = after_stat(count + 2),
+#'         label = after_stat(count)),
+#'     stat = "count"
+#'   )
+#'
+#' # Labelling the upper hinge of a boxplot,
+#' # inspired by June Choe
+#' ggplot(mpg, aes(displ, class)) +
+#'   geom_boxplot(outlier.shape = NA) +
+#'   geom_text(
+#'     aes(label = after_stat(xmax),
+#'         x = stage(displ, after_stat = xmax)),
+#'     stat = "boxplot", hjust = -0.5
+#'   )
 NULL
 
 #' @rdname aes_eval

--- a/R/aes-evaluation.r
+++ b/R/aes-evaluation.r
@@ -1,9 +1,10 @@
 #' Control aesthetic evaluation
 #'
-#' Most aesthetics are mapped from variables found in the data. Sometimes,
-#' however, you want to delay the mapping until later in the rendering process.
-#' ggplot2 has three stages of the data that you can map aesthetics from, and
-#' three functions to control at which stage aesthetics should be evaluated.
+#' Most [aesthetics][aes()] are mapped from variables found in the data.
+#' Sometimes, however, you want to delay the mapping until later in the
+#' rendering process. ggplot2 has three stages of the data that you can map
+#' aesthetics from, and three functions to control at which stage aesthetics
+#' should be evaluated.
 #'
 #' @usage # These functions can be used inside the `aes()` function
 #' # used as the `mapping` argument in layers, for example:

--- a/R/aes.r
+++ b/R/aes.r
@@ -31,6 +31,8 @@ NULL
 #'   are typically omitted because they are so common; all other aesthetics must be named.
 #' @seealso [vars()] for another quoting function designed for
 #'   faceting specifications.
+#'
+#'   [Delayed evaluation][aes_eval] for working with computed variables.
 #' @return A list with class `uneval`. Components of the list are either
 #'   quosures or constants.
 #' @export

--- a/R/geom-dotplot.r
+++ b/R/geom-dotplot.r
@@ -18,16 +18,19 @@
 #'
 #' @eval rd_aesthetics("geom", "dotplot")
 #' @section Computed variables:
+#' These are calculated by the 'stat' part of layers and can be accessed with
+#' [delayed evaluation][aes_eval].
 #' \describe{
-#'   \item{x}{center of each bin, if binaxis is "x"}
-#'   \item{y}{center of each bin, if binaxis is "x"}
-#'   \item{binwidth}{max width of each bin if method is "dotdensity";
-#'     width of each bin if method is "histodot"}
-#'   \item{count}{number of points in bin}
-#'   \item{ncount}{count, scaled to maximum of 1}
-#'   \item{density}{density of points in bin, scaled to integrate to 1,
-#'     if method is "histodot"}
-#'   \item{ndensity}{density, scaled to maximum of 1, if method is "histodot"}
+#'   \item{`after_stat(x)`}{center of each bin, if binaxis is "x"}
+#'   \item{`after_stat(y)`}{center of each bin, if binaxis is "x"}
+#'   \item{`after_stat(binwidth)`}{max width of each bin if method is
+#'     "dotdensity"; width of each bin if method is "histodot"}
+#'   \item{`after_stat(count)`}{number of points in bin}
+#'   \item{`after_stat(ncount)`}{count, scaled to maximum of 1}
+#'   \item{`after_stat(density)`}{density of points in bin, scaled to integrate
+#'     to 1, if method is "histodot"}
+#'   \item{`after_stat(ndensity)`}{density, scaled to maximum of 1, if method is
+#'     "histodot"}
 #' }
 #'
 #' @inheritParams layer

--- a/R/geom-dotplot.r
+++ b/R/geom-dotplot.r
@@ -17,21 +17,17 @@
 #' to match the number of dots.
 #'
 #' @eval rd_aesthetics("geom", "dotplot")
-#' @section Computed variables:
-#' These are calculated by the 'stat' part of layers and can be accessed with
-#' [delayed evaluation][aes_eval].
-#' \describe{
-#'   \item{`after_stat(x)`}{center of each bin, if binaxis is "x"}
-#'   \item{`after_stat(y)`}{center of each bin, if binaxis is "x"}
-#'   \item{`after_stat(binwidth)`}{max width of each bin if method is
-#'     "dotdensity"; width of each bin if method is "histodot"}
-#'   \item{`after_stat(count)`}{number of points in bin}
-#'   \item{`after_stat(ncount)`}{count, scaled to maximum of 1}
-#'   \item{`after_stat(density)`}{density of points in bin, scaled to integrate
-#'     to 1, if method is "histodot"}
-#'   \item{`after_stat(ndensity)`}{density, scaled to maximum of 1, if method is
-#'     "histodot"}
-#' }
+#' @eval rd_computed_vars(
+#'   x = 'center of each bin, if `binaxis` is `"x"`.',
+#'   y = 'center of each bin, if `binaxis` is `"x"`.',
+#'   binwidth = 'maximum width of each bin if method is `"dotdensity"`;
+#'   width of each bin if method is `"histodot"`.',
+#'   count   = "number of points in bin.",
+#'   ncount  = "count, scaled to a maximum of 1.",
+#'   density = 'density of points in bin, scaled to integrate to 1, if method
+#'   is `"histodot"`.',
+#'   ndensity = 'density, scaled to maximum of 1, if method is `"histodot"`.'
+#' )
 #'
 #' @inheritParams layer
 #' @inheritParams geom_point

--- a/R/save.r
+++ b/R/save.r
@@ -77,6 +77,17 @@ ggsave <- function(filename, plot = last_plot(),
                    device = NULL, path = NULL, scale = 1,
                    width = NA, height = NA, units = c("in", "cm", "mm", "px"),
                    dpi = 300, limitsize = TRUE, bg = NULL, ...) {
+  if (length(filename) != 1) {
+    if (length(filename) == 0) {
+      cli::cli_abort("{.arg filename} cannot be empty.")
+    }
+    len <- length(filename)
+    filename <- filename[1]
+    cli::cli_warn(c(
+      "{.arg filename} must have length 1, not length {len}.",
+      "!" = "Only the first, {.file {filename}}, will be used."
+    ))
+  }
 
   dpi <- parse_dpi(dpi)
   dev <- plot_dev(device, filename, dpi = dpi)

--- a/R/save.r
+++ b/R/save.r
@@ -147,8 +147,24 @@ plot_dim <- function(dim = c(NA, NA), scale = 1, units = "in",
   }
 
   if (limitsize && any(dim >= 50)) {
+    units <- switch(
+      units,
+      "in" = "inches",
+      "cm" = "centimeters",
+      "mm" = "millimeters",
+      "px" = "pixels"
+    )
+    msg <- paste0(
+      "Dimensions exceed 50 inches ({.arg height} and {.arg width} are ",
+      "specified in {.emph {units}}"
+    )
+    if (units == "pixels") {
+      msg <- paste0(msg, ").")
+    } else {
+      msg <- paste0(msg, " not pixels).")
+    }
     cli::cli_abort(c(
-      "Dimensions exceed 50 inches ({.arg height} and {.arg width} are specified in {.emph {units}} not pixels).",
+      msg,
       "i" = "If you're sure you want a plot that big, use {.code limitsize = FALSE}.
     "), call = call)
   }

--- a/R/save.r
+++ b/R/save.r
@@ -77,17 +77,6 @@ ggsave <- function(filename, plot = last_plot(),
                    device = NULL, path = NULL, scale = 1,
                    width = NA, height = NA, units = c("in", "cm", "mm", "px"),
                    dpi = 300, limitsize = TRUE, bg = NULL, ...) {
-  if (length(filename) != 1) {
-    if (length(filename) == 0) {
-      cli::cli_abort("{.arg filename} cannot be empty.")
-    }
-    len <- length(filename)
-    filename <- filename[1]
-    cli::cli_warn(c(
-      "{.arg filename} must have length 1, not length {len}.",
-      "!" = "Only the first, {.file {filename}}, will be used."
-    ))
-  }
 
   dpi <- parse_dpi(dpi)
   dev <- plot_dev(device, filename, dpi = dpi)

--- a/R/stat-bin.r
+++ b/R/stat-bin.r
@@ -27,17 +27,13 @@
 #'   or left edges of bins are included in the bin.
 #' @param pad If `TRUE`, adds empty bins at either end of x. This ensures
 #'   frequency polygons touch 0. Defaults to `FALSE`.
-#' @section Computed variables:
-#' These are calculated by the 'stat' part of layers and can be accessed with
-#' [delayed evaluation][aes_eval].
-#' \describe{
-#'   \item{`after_stat(count)`}{number of points in bin}
-#'   \item{`after_stat(density)`}{density of points in bin, scaled to integrate
-#'     to 1}
-#'   \item{`after_stat(ncount)`}{count, scaled to maximum of 1}
-#'   \item{`after_stat(ndensity)`}{density, scaled to maximum of 1}
-#'   \item{`after_stat(width)`}{widths of bins}
-#' }
+#' @eval rd_computed_vars(
+#'   count    = "number of points in bin.",
+#'   density  = "density of points in bin, scaled to integrate to 1.",
+#'   ncount   = "count, scaled to a maximum of 1.",
+#'   ndensity = "density, scaled to a maximum of 1.",
+#'   width    = "widths of bins."
+#' )
 #'
 #' @section Dropped variables:
 #' \describe{

--- a/R/stat-bin.r
+++ b/R/stat-bin.r
@@ -28,12 +28,15 @@
 #' @param pad If `TRUE`, adds empty bins at either end of x. This ensures
 #'   frequency polygons touch 0. Defaults to `FALSE`.
 #' @section Computed variables:
+#' These are calculated by the 'stat' part of layers and can be accessed with
+#' [delayed evaluation][aes_eval].
 #' \describe{
-#'   \item{`count`}{number of points in bin}
-#'   \item{`density`}{density of points in bin, scaled to integrate to 1}
-#'   \item{`ncount`}{count, scaled to maximum of 1}
-#'   \item{`ndensity`}{density, scaled to maximum of 1}
-#'   \item{`width`}{widths of bins}
+#'   \item{`after_stat(count)`}{number of points in bin}
+#'   \item{`after_stat(density)`}{density of points in bin, scaled to integrate
+#'     to 1}
+#'   \item{`after_stat(ncount)`}{count, scaled to maximum of 1}
+#'   \item{`after_stat(ndensity)`}{density, scaled to maximum of 1}
+#'   \item{`after_stat(width)`}{widths of bins}
 #' }
 #'
 #' @section Dropped variables:

--- a/R/stat-bin2d.r
+++ b/R/stat-bin2d.r
@@ -5,16 +5,12 @@
 #' @param drop if `TRUE` removes all cells with 0 counts.
 #' @export
 #' @rdname geom_bin_2d
-#' @section Computed variables:
-#' These are calculated by the 'stat' part of layers and can be accessed with
-#' [delayed evaluation][aes_eval].
-#' \describe{
-#'   \item{`after_stat(count)`}{number of points in bin}
-#'   \item{`after_stat(density)`}{density of points in bin, scaled to integrate
-#'     to 1}
-#'   \item{`after_stat(ncount)`}{count, scaled to maximum of 1}
-#'   \item{`after_stat(ndensity)`}{density, scaled to maximum of 1}
-#' }
+#' @eval rd_computed_vars(
+#'   count    = "number of points in bin.",
+#'   density  = "density of points in bin, scaled to integrate to 1.",
+#'   ncount   = "count, scaled to maximum of 1.",
+#'   ndensity = "density, scaled to a maximum of 1."
+#' )
 stat_bin_2d <- function(mapping = NULL, data = NULL,
                         geom = "tile", position = "identity",
                         ...,

--- a/R/stat-bin2d.r
+++ b/R/stat-bin2d.r
@@ -6,11 +6,14 @@
 #' @export
 #' @rdname geom_bin_2d
 #' @section Computed variables:
+#' These are calculated by the 'stat' part of layers and can be accessed with
+#' [delayed evaluation][aes_eval].
 #' \describe{
-#'   \item{count}{number of points in bin}
-#'   \item{density}{density of points in bin, scaled to integrate to 1}
-#'   \item{ncount}{count, scaled to maximum of 1}
-#'   \item{ndensity}{density, scaled to maximum of 1}
+#'   \item{`after_stat(count)`}{number of points in bin}
+#'   \item{`after_stat(density)`}{density of points in bin, scaled to integrate
+#'     to 1}
+#'   \item{`after_stat(ncount)`}{count, scaled to maximum of 1}
+#'   \item{`after_stat(ndensity)`}{density, scaled to maximum of 1}
 #' }
 stat_bin_2d <- function(mapping = NULL, data = NULL,
                         geom = "tile", position = "identity",

--- a/R/stat-binhex.r
+++ b/R/stat-binhex.r
@@ -1,16 +1,12 @@
 #' @export
 #' @rdname geom_hex
 #' @inheritParams stat_bin_2d
-#' @section Computed variables:
-#' These are calculated by the 'stat' part of layers and can be accessed with
-#' [delayed evaluation][aes_eval].
-#' \describe{
-#'   \item{`after_stat(count)`}{number of points in bin}
-#'   \item{`after_stat(density)`}{density of points in bin, scaled to integrate
-#'     to 1}
-#'   \item{`after_stat(ncount)`}{count, scaled to maximum of 1}
-#'   \item{`after_stat(ndensity)`}{density, scaled to maximum of 1}
-#' }
+#' @eval rd_computed_vars(
+#'   count    = "number of points in bin.",
+#'   density  = "density of points in bin, scaled to integrate to 1.",
+#'   ncount   = "count, scaled to maximum of 1.",
+#'   ndensity = "density, scaled to maximum of 1."
+#' )
 stat_bin_hex <- function(mapping = NULL, data = NULL,
                          geom = "hex", position = "identity",
                          ...,

--- a/R/stat-binhex.r
+++ b/R/stat-binhex.r
@@ -2,11 +2,14 @@
 #' @rdname geom_hex
 #' @inheritParams stat_bin_2d
 #' @section Computed variables:
+#' These are calculated by the 'stat' part of layers and can be accessed with
+#' [delayed evaluation][aes_eval].
 #' \describe{
-#'   \item{count}{number of points in bin}
-#'   \item{density}{density of points in bin, scaled to integrate to 1}
-#'   \item{ncount}{count, scaled to maximum of 1}
-#'   \item{ndensity}{density, scaled to maximum of 1}
+#'   \item{`after_stat(count)`}{number of points in bin}
+#'   \item{`after_stat(density)`}{density of points in bin, scaled to integrate
+#'     to 1}
+#'   \item{`after_stat(ncount)`}{count, scaled to maximum of 1}
+#'   \item{`after_stat(ndensity)`}{density, scaled to maximum of 1}
 #' }
 stat_bin_hex <- function(mapping = NULL, data = NULL,
                          geom = "hex", position = "identity",

--- a/R/stat-boxplot.r
+++ b/R/stat-boxplot.r
@@ -2,16 +2,25 @@
 #' @param coef Length of the whiskers as multiple of IQR. Defaults to 1.5.
 #' @inheritParams stat_identity
 #' @section Computed variables:
-#' `stat_boxplot()` provides the following variables, some of which depend on the orientation:
+#' These are calculated by the 'stat' part of layers and can be accessed with
+#' [delayed evaluation][aes_eval]. `stat_boxplot()` provides the following
+#' variables, some of which depend on the orientation:
 #' \describe{
-#'   \item{width}{width of boxplot}
-#'   \item{ymin *or* xmin}{lower whisker = smallest observation greater than or equal to lower hinge - 1.5 * IQR}
-#'   \item{lower *or* xlower}{lower hinge, 25% quantile}
-#'   \item{notchlower}{lower edge of notch = median - 1.58 * IQR / sqrt(n)}
-#'   \item{middle *or* xmiddle}{median, 50% quantile}
-#'   \item{notchupper}{upper edge of notch = median + 1.58 * IQR / sqrt(n)}
-#'   \item{upper *or* xupper}{upper hinge, 75% quantile}
-#'   \item{ymax *or* xmax}{upper whisker = largest observation less than or equal to upper hinge + 1.5 * IQR}
+#'   \item{`after_stat(width)`}{width of boxplot}
+#'   \item{`after_stat(ymin)` *or* `after_stat(xmin)`}{lower whisker = smallest
+#'     observation greater than or equal to lower hinge - 1.5 * IQR}
+#'   \item{`after_stat(lower)` *or* `after_stat(xlower)`}{lower hinge, 25%
+#'     quantile}
+#'   \item{`after_stat(notchlower)`}{lower edge of notch =
+#'     median - 1.58 * IQR / sqrt(n)}
+#'   \item{`after_stat(middle)` *or* `after_stat(xmiddle)`}{median,
+#'     50% quantile}
+#'   \item{`after_stat(notchupper)`}{upper edge of notch =
+#'     median + 1.58 * IQR / sqrt(n)}
+#'   \item{`after_stat(upper)` *or* `after_stat(xupper)`}{upper hinge, 75%
+#'     quantile}
+#'   \item{`after_stat(ymax)` *or* `after_stat(xmax)`}{upper whisker = largest
+#'     observation less than or equal to upper hinge + 1.5 * IQR}
 #' }
 #' @export
 stat_boxplot <- function(mapping = NULL, data = NULL,

--- a/R/stat-boxplot.r
+++ b/R/stat-boxplot.r
@@ -1,28 +1,21 @@
 #' @rdname geom_boxplot
 #' @param coef Length of the whiskers as multiple of IQR. Defaults to 1.5.
 #' @inheritParams stat_identity
-#' @section Computed variables:
-#' These are calculated by the 'stat' part of layers and can be accessed with
-#' [delayed evaluation][aes_eval]. `stat_boxplot()` provides the following
-#' variables, some of which depend on the orientation:
-#' \describe{
-#'   \item{`after_stat(width)`}{width of boxplot}
-#'   \item{`after_stat(ymin)` *or* `after_stat(xmin)`}{lower whisker = smallest
-#'     observation greater than or equal to lower hinge - 1.5 * IQR}
-#'   \item{`after_stat(lower)` *or* `after_stat(xlower)`}{lower hinge, 25%
-#'     quantile}
-#'   \item{`after_stat(notchlower)`}{lower edge of notch =
-#'     median - 1.58 * IQR / sqrt(n)}
-#'   \item{`after_stat(middle)` *or* `after_stat(xmiddle)`}{median,
-#'     50% quantile}
-#'   \item{`after_stat(notchupper)`}{upper edge of notch =
-#'     median + 1.58 * IQR / sqrt(n)}
-#'   \item{`after_stat(upper)` *or* `after_stat(xupper)`}{upper hinge, 75%
-#'     quantile}
-#'   \item{`after_stat(ymax)` *or* `after_stat(xmax)`}{upper whisker = largest
-#'     observation less than or equal to upper hinge + 1.5 * IQR}
-#' }
 #' @export
+#' @eval rd_computed_vars(
+#'   .details = "`stat_boxplot()` provides the following variables, some of
+#'   which depend on the orientation:",
+#'   width = "width of boxplot.",
+#'   "ymin|xmin" = "lower whisker = smallest observation greater than or equal
+#'   to lower hinger - 1.5 * IQR.",
+#'   "lower|xlower" = "lower hinge, 25% quantile.",
+#'   notchlower = "lower edge of notch = median - 1.58 * IQR / sqrt(n).",
+#'   "middle|xmiddle" = "median, 50% quantile.",
+#'   notchupper = "upper edge of notch = median + 1.58 * IQR / sqrt(n).",
+#'   "upper|xupper" = "upper hinge, 75% quantile.",
+#'   "ymax|xmax" = "upper whisker = largest observation less than or equal to
+#'   upper hinger + 1.5 * IQR."
+#' )
 stat_boxplot <- function(mapping = NULL, data = NULL,
                          geom = "boxplot", position = "dodge2",
                          ...,

--- a/R/stat-contour.r
+++ b/R/stat-contour.r
@@ -3,24 +3,21 @@
 #' @export
 #' @eval rd_aesthetics("stat", "contour")
 #' @eval rd_aesthetics("stat", "contour_filled")
-#' @section Computed variables:
-#' These are calculated by the 'stat' part of layers and can be accessed with
-#' [delayed evaluation][aes_eval]. The computed variables differ somewhat for
-#' contour lines (computed by `stat_contour()`) and contour bands (filled
-#' contours, computed by `stat_contour_filled()`). The variables `nlevel` and
-#' `piece` are available for both, whereas `level_low`, `level_high`, and
-#' `level_mid` are only available for bands. The variable `level` is a numeric
-#' or a factor depending on whether lines or bands are calculated.
-#' \describe{
-#'  \item{`after_stat(level)`}{Height of contour. For contour lines, this is
-#'    numeric vector that represents bin boundaries. For contour bands, this is
-#'    an ordered factor that represents bin ranges.}
-#'  \item{`after_stat(level_low)`, `after_stat(level_high)`,
-#'    `after_stat(level_mid)`}{(contour bands only) Lower and upper bin
-#'    boundaries for each band, as well the mid point between the boundaries.}
-#'  \item{`after_stat(nlevel)`}{Height of contour, scaled to maximum of 1.}
-#'  \item{`after_stat(piece)`}{Contour piece (an integer).}
-#' }
+#' @eval rd_computed_vars(
+#'   .details = "The computed variables differ somewhat for contour lines
+#'   (compbuted by `stat_contour()`) and contour bands (filled contours,
+#'   computed by `stat_contour_filled()`). The variables `nlevel` and `piece`
+#'   are available for both, whereas `level_low`, `level_high`, and `level_mid`
+#'   are only available for bands. The variable `level` is a numeric or a factor
+#'   depending on whether lines or bands are calculated.",
+#'   level = "Height of contour. For contour lines, this is a numeric vector
+#'   that represents bin boundaries. For contour bands, this is an ordered
+#'   factor that represents bin ranges.",
+#'   "level_low,level_high,level_mid" = "(contour bands only) Lower and upper
+#'   bin boundaries for each band, as well as the mid point between boundaries.",
+#'   nlevel = "Height of contour, scaled to a maximum of 1.",
+#'   piece = "Contour piece (an integer)."
+#' )
 #'
 #' @section Dropped variables:
 #' \describe{

--- a/R/stat-contour.r
+++ b/R/stat-contour.r
@@ -4,19 +4,22 @@
 #' @eval rd_aesthetics("stat", "contour")
 #' @eval rd_aesthetics("stat", "contour_filled")
 #' @section Computed variables:
-#' The computed variables differ somewhat for contour lines (computed by
-#' `stat_contour()`) and contour bands (filled contours, computed by `stat_contour_filled()`).
-#' The variables `nlevel` and `piece` are available for both, whereas `level_low`, `level_high`,
-#' and `level_mid` are only available for bands. The variable `level` is a numeric or a factor
-#' depending on whether lines or bands are calculated.
+#' These are calculated by the 'stat' part of layers and can be accessed with
+#' [delayed evaluation][aes_eval]. The computed variables differ somewhat for
+#' contour lines (computed by `stat_contour()`) and contour bands (filled
+#' contours, computed by `stat_contour_filled()`). The variables `nlevel` and
+#' `piece` are available for both, whereas `level_low`, `level_high`, and
+#' `level_mid` are only available for bands. The variable `level` is a numeric
+#' or a factor depending on whether lines or bands are calculated.
 #' \describe{
-#'  \item{`level`}{Height of contour. For contour lines, this is numeric vector that
-#'    represents bin boundaries. For contour bands, this is an ordered factor that
-#'    represents bin ranges.}
-#'  \item{`level_low`, `level_high`, `level_mid`}{(contour bands only) Lower and upper
-#'    bin boundaries for each band, as well the mid point between the boundaries.}
-#'  \item{`nlevel`}{Height of contour, scaled to maximum of 1.}
-#'  \item{`piece`}{Contour piece (an integer).}
+#'  \item{`after_stat(level)`}{Height of contour. For contour lines, this is
+#'    numeric vector that represents bin boundaries. For contour bands, this is
+#'    an ordered factor that represents bin ranges.}
+#'  \item{`after_stat(level_low)`, `after_stat(level_high)`,
+#'    `after_stat(level_mid)`}{(contour bands only) Lower and upper bin
+#'    boundaries for each band, as well the mid point between the boundaries.}
+#'  \item{`after_stat(nlevel)`}{Height of contour, scaled to maximum of 1.}
+#'  \item{`after_stat(piece)`}{Contour piece (an integer).}
 #' }
 #'
 #' @section Dropped variables:

--- a/R/stat-count.r
+++ b/R/stat-count.r
@@ -1,7 +1,9 @@
 #' @section Computed variables:
+#' These are calculated by the 'stat' part of layers and can be accessed with
+#' [delayed evaluation][aes_eval].
 #' \describe{
-#'   \item{count}{number of points in bin}
-#'   \item{prop}{groupwise proportion}
+#'   \item{`after_stat(count)`}{number of points in bin}
+#'   \item{`after_stat(prop)`}{groupwise proportion}
 #' }
 #' @seealso [stat_bin()], which bins data in ranges and counts the
 #'   cases in each range. It differs from `stat_count()`, which counts the

--- a/R/stat-count.r
+++ b/R/stat-count.r
@@ -1,10 +1,7 @@
-#' @section Computed variables:
-#' These are calculated by the 'stat' part of layers and can be accessed with
-#' [delayed evaluation][aes_eval].
-#' \describe{
-#'   \item{`after_stat(count)`}{number of points in bin}
-#'   \item{`after_stat(prop)`}{groupwise proportion}
-#' }
+#' @eval rd_computed_vars(
+#'   count = "number of points in bin.",
+#'   prop  = "groupwise proportion"
+#' )
 #' @seealso [stat_bin()], which bins data in ranges and counts the
 #'   cases in each range. It differs from `stat_count()`, which counts the
 #'   number of cases at each `x` position (without binning into ranges).

--- a/R/stat-density-2d.r
+++ b/R/stat-density-2d.r
@@ -14,15 +14,17 @@
 #'    using the a bandwidth estimator. For example, `adjust = 1/2` means
 #'    use half of the default bandwidth.
 #' @section Computed variables:
-#' `stat_density_2d()` and `stat_density_2d_filled()` compute different
-#' variables depending on whether contouring is turned on or off. With
-#' contouring off (`contour = FALSE`), both stats behave the same, and the
-#' following variables are provided:
+#' These are calculated by the 'stat' part of layers and can be accessed with
+#' [delayed evaluation][aes_eval]. `stat_density_2d()` and
+#' `stat_density_2d_filled()` compute different variables depending on whether
+#' contouring is turned on or off. With contouring off (`contour = FALSE`), both
+#' stats behave the same, and the following variables are provided:
 #' \describe{
-#'   \item{`density`}{The density estimate.}
-#'   \item{`ndensity`}{Density estimate, scaled to a maximum of 1.}
-#'   \item{`count`}{Density estimate * number of observations in group.}
-#'   \item{`n`}{Number of observations in each group.}
+#'   \item{`after_stat(density)`}{The density estimate.}
+#'   \item{`after_stat(ndensity)`}{Density estimate, scaled to a maximum of 1.}
+#'   \item{`after_stat(count)`}{Density estimate * number of observations in
+#'     group.}
+#'   \item{`after_stat(n)`}{Number of observations in each group.}
 #' }
 #'
 #' With contouring on (`contour = TRUE`), either [stat_contour()] or

--- a/R/stat-density-2d.r
+++ b/R/stat-density-2d.r
@@ -13,20 +13,18 @@
 #'    'NULL'. This makes it possible to adjust the bandwidth while still
 #'    using the a bandwidth estimator. For example, `adjust = 1/2` means
 #'    use half of the default bandwidth.
-#' @section Computed variables:
-#' These are calculated by the 'stat' part of layers and can be accessed with
-#' [delayed evaluation][aes_eval]. `stat_density_2d()` and
-#' `stat_density_2d_filled()` compute different variables depending on whether
-#' contouring is turned on or off. With contouring off (`contour = FALSE`), both
-#' stats behave the same, and the following variables are provided:
-#' \describe{
-#'   \item{`after_stat(density)`}{The density estimate.}
-#'   \item{`after_stat(ndensity)`}{Density estimate, scaled to a maximum of 1.}
-#'   \item{`after_stat(count)`}{Density estimate * number of observations in
-#'     group.}
-#'   \item{`after_stat(n)`}{Number of observations in each group.}
-#' }
+#' @eval rd_computed_vars(
+#'   .details = "`stat_density_2d()` and `stat_density_2d_filled()` compute
+#'   different variables depending on whether contouring is turned on or off.
+#'   With contouring off (`contour = FALSE`), both stats behave the same, and
+#'   the following variables are provided:",
+#'   density  = "The density estimate.",
+#'   ndensity = "Density estimate, scaled to a maximum of 1.",
+#'   count    = "Density estimate * number of observations in group.",
+#'   n        = "Number of observations in each group."
+#' )
 #'
+#' @section Computed variables:
 #' With contouring on (`contour = TRUE`), either [stat_contour()] or
 #' [stat_contour_filled()] (for contour lines or contour bands,
 #' respectively) is run after the density estimate has been obtained,

--- a/R/stat-density.r
+++ b/R/stat-density.r
@@ -21,13 +21,15 @@
 #'   reflecting tails outside `bounds` around their closest edge. Data points
 #'   outside of bounds are removed with a warning.
 #' @section Computed variables:
+#' These are calculated by the 'stat' part of layers and can be accessed with
+#' [delayed evaluation][aes_eval].
 #' \describe{
-#'   \item{density}{density estimate}
-#'   \item{count}{density * number of points - useful for stacked density
-#'      plots}
-#'   \item{scaled}{density estimate, scaled to maximum of 1}
-#'   \item{n}{number of points}
-#'   \item{ndensity}{alias for `scaled`, to mirror the syntax of
+#'   \item{`after_stat(density)`}{density estimate}
+#'   \item{`after_stat(count)`}{density * number of points - useful for stacked
+#'     density plots}
+#'   \item{`after_stat(scaled)`}{density estimate, scaled to maximum of 1}
+#'   \item{`after_stat(n)`}{number of points}
+#'   \item{`after_stat(ndensity)`}{alias for `scaled`, to mirror the syntax of
 #'    [`stat_bin()`]}
 #' }
 #' @export

--- a/R/stat-density.r
+++ b/R/stat-density.r
@@ -20,18 +20,13 @@
 #'   finite, boundary effect of default density estimation will be corrected by
 #'   reflecting tails outside `bounds` around their closest edge. Data points
 #'   outside of bounds are removed with a warning.
-#' @section Computed variables:
-#' These are calculated by the 'stat' part of layers and can be accessed with
-#' [delayed evaluation][aes_eval].
-#' \describe{
-#'   \item{`after_stat(density)`}{density estimate}
-#'   \item{`after_stat(count)`}{density * number of points - useful for stacked
-#'     density plots}
-#'   \item{`after_stat(scaled)`}{density estimate, scaled to maximum of 1}
-#'   \item{`after_stat(n)`}{number of points}
-#'   \item{`after_stat(ndensity)`}{alias for `scaled`, to mirror the syntax of
-#'    [`stat_bin()`]}
-#' }
+#' @eval rd_computed_vars(
+#'  density  = "density estimate.",
+#'  count    = "density * number of points - useful for stacked density plots.",
+#'  scaled   = "density estimate, scaled to maximum of 1.",
+#'  n        = "number of points.",
+#'  ndensity = "alias for `scaled`, to mirror the syntax of [`stat_bin()`]."
+#' )
 #' @export
 #' @rdname geom_density
 stat_density <- function(mapping = NULL, data = NULL,

--- a/R/stat-ecdf.r
+++ b/R/stat-ecdf.r
@@ -20,12 +20,9 @@
 #'   of points to interpolate with.
 #' @param pad If `TRUE`, pad the ecdf with additional points (-Inf, 0)
 #'   and (Inf, 1)
-#' @section Computed variables:
-#' These are calculated by the 'stat' part of layers and can be accessed with
-#' [delayed evaluation][aes_eval].
-#' \describe{
-#'   \item{`after_stat(y)`}{cumulative density corresponding x}
-#' }
+#' @eval rd_computed_vars(
+#'   y = "Cumulative density corresponding to `x`."
+#' )
 #' @export
 #' @examples
 #' set.seed(1)

--- a/R/stat-ecdf.r
+++ b/R/stat-ecdf.r
@@ -21,8 +21,10 @@
 #' @param pad If `TRUE`, pad the ecdf with additional points (-Inf, 0)
 #'   and (Inf, 1)
 #' @section Computed variables:
+#' These are calculated by the 'stat' part of layers and can be accessed with
+#' [delayed evaluation][aes_eval].
 #' \describe{
-#'   \item{y}{cumulative density corresponding x}
+#'   \item{`after_stat(y)`}{cumulative density corresponding x}
 #' }
 #' @export
 #' @examples

--- a/R/stat-function.r
+++ b/R/stat-function.r
@@ -5,14 +5,10 @@
 #' @param n Number of points to interpolate along the x axis.
 #' @param args List of additional arguments passed on to the function defined by `fun`.
 #' @param xlim Optionally, specify the range of the function.
-#' @section Computed variables:
-#' These are calculated by the 'stat' part of layers and can be accessed with
-#' [delayed evaluation][aes_eval]. `stat_function()` computes the following
-#' variables:
-#' \describe{
-#'   \item{`after_stat(x)`}{x values along a grid}
-#'   \item{`after_stat(y)`}{value of the function evaluated at corresponding x}
-#' }
+#' @eval rd_computed_vars(
+#'   x = "`x` values along a grid.",
+#'   y = "values of the function evaluated at corresponding `x`."
+#' )
 #' @seealso [rlang::as_function()]
 #' @export
 #' @rdname geom_function

--- a/R/stat-function.r
+++ b/R/stat-function.r
@@ -6,10 +6,12 @@
 #' @param args List of additional arguments passed on to the function defined by `fun`.
 #' @param xlim Optionally, specify the range of the function.
 #' @section Computed variables:
-#' `stat_function()` computes the following variables:
+#' These are calculated by the 'stat' part of layers and can be accessed with
+#' [delayed evaluation][aes_eval]. `stat_function()` computes the following
+#' variables:
 #' \describe{
-#'   \item{x}{x values along a grid}
-#'   \item{y}{value of the function evaluated at corresponding x}
+#'   \item{`after_stat(x)`}{x values along a grid}
+#'   \item{`after_stat(y)`}{value of the function evaluated at corresponding x}
 #' }
 #' @seealso [rlang::as_function()]
 #' @export

--- a/R/stat-qq.r
+++ b/R/stat-qq.r
@@ -12,17 +12,19 @@
 #' @inheritParams layer
 #' @inheritParams geom_point
 #' @section Computed variables:
+#' These are calculated by the 'stat' part of layers and can be accessed with
+#' [delayed evaluation][aes_eval].
 #' Variables computed by `stat_qq()`:
 #' \describe{
-#'   \item{sample}{sample quantiles}
-#'   \item{theoretical}{theoretical quantiles}
+#'   \item{`after_stat(sample)`}{sample quantiles}
+#'   \item{`after_stat(theoretical)`}{theoretical quantiles}
 #' }
 #' Variables computed by `stat_qq_line()`:
 #' \describe{
-#'   \item{x}{x-coordinates of the endpoints of the line segment connecting the
-#'            points at the chosen quantiles of the theoretical and the sample
-#'            distributions}
-#'   \item{y}{y-coordinates of the endpoints}
+#'   \item{`after_stat(x)`}{x-coordinates of the endpoints of the line segment
+#'     connecting the points at the chosen quantiles of the theoretical and the
+#'     sample distributions}
+#'   \item{`after_stat(y)`}{y-coordinates of the endpoints}
 #' }
 #' @export
 #' @examples

--- a/R/stat-qq.r
+++ b/R/stat-qq.r
@@ -11,21 +11,20 @@
 #'   function.
 #' @inheritParams layer
 #' @inheritParams geom_point
-#' @section Computed variables:
-#' These are calculated by the 'stat' part of layers and can be accessed with
-#' [delayed evaluation][aes_eval].
-#' Variables computed by `stat_qq()`:
-#' \describe{
-#'   \item{`after_stat(sample)`}{sample quantiles}
-#'   \item{`after_stat(theoretical)`}{theoretical quantiles}
-#' }
-#' Variables computed by `stat_qq_line()`:
-#' \describe{
-#'   \item{`after_stat(x)`}{x-coordinates of the endpoints of the line segment
-#'     connecting the points at the chosen quantiles of the theoretical and the
-#'     sample distributions}
-#'   \item{`after_stat(y)`}{y-coordinates of the endpoints}
-#' }
+#' @eval rd_computed_vars(
+#'  .details = "\\cr Variables computed by `stat_qq()`:",
+#'  sample      = "Sample quantiles.",
+#'  theoretical = "Theoretical quantiles."
+#' )
+#' @eval rd_computed_vars(
+#'   .skip_intro = TRUE,
+#'   .details = "Variables computed by `stat_qq_line()`:",
+#'   x = "x-coordinates of the endpoints of the line segment connecting the
+#'   points at the chosen quantiles of the theoretical and the sample
+#'   distributions.",
+#'   y = "y-coordinates of the endpoints."
+#' )
+#'
 #' @export
 #' @examples
 #' \donttest{

--- a/R/stat-quantile.r
+++ b/R/stat-quantile.r
@@ -4,12 +4,9 @@
 #'    [`quantreg::rq()`]) and `"rqss"` (for [`quantreg::rqss()`]).
 #' @inheritParams layer
 #' @inheritParams geom_point
-#' @section Computed variables:
-#' These are calculated by the 'stat' part of layers and can be accessed with
-#' [delayed evaluation][aes_eval].
-#' \describe{
-#'   \item{`after_stat(quantile)`}{quantile of distribution}
-#' }
+#' @eval rd_computed_vars(
+#'   quantile = "Quantile of distribution."
+#' )
 #' @export
 #' @rdname geom_quantile
 stat_quantile <- function(mapping = NULL, data = NULL,

--- a/R/stat-quantile.r
+++ b/R/stat-quantile.r
@@ -5,8 +5,10 @@
 #' @inheritParams layer
 #' @inheritParams geom_point
 #' @section Computed variables:
+#' These are calculated by the 'stat' part of layers and can be accessed with
+#' [delayed evaluation][aes_eval].
 #' \describe{
-#'   \item{quantile}{quantile of distribution}
+#'   \item{`after_stat(quantile)`}{quantile of distribution}
 #' }
 #' @export
 #' @rdname geom_quantile

--- a/R/stat-sf-coordinates.R
+++ b/R/stat-sf-coordinates.R
@@ -24,13 +24,10 @@
 #' otherwise `sf::st_point_on_surface()` may fail when the geometries have M
 #' dimension.
 #'
-#' @section Computed variables:
-#' These are calculated by the 'stat' part of layers and can be accessed with
-#' [delayed evaluation][aes_eval].
-#' \describe{
-#'   \item{`after_stat(x)`}{X dimension of the simple feature}
-#'   \item{`after_stat(y)`}{Y dimension of the simple feature}
-#' }
+#' @eval rd_computed_vars(
+#'  x = "X dimension of the simple feature.",
+#'  y = "Y dimension of the simple feature."
+#' )
 #'
 #' @examples
 #' if (requireNamespace("sf", quietly = TRUE)) {

--- a/R/stat-sf-coordinates.R
+++ b/R/stat-sf-coordinates.R
@@ -25,9 +25,11 @@
 #' dimension.
 #'
 #' @section Computed variables:
+#' These are calculated by the 'stat' part of layers and can be accessed with
+#' [delayed evaluation][aes_eval].
 #' \describe{
-#'   \item{x}{X dimension of the simple feature}
-#'   \item{y}{Y dimension of the simple feature}
+#'   \item{`after_stat(x)`}{X dimension of the simple feature}
+#'   \item{`after_stat(y)`}{Y dimension of the simple feature}
 #' }
 #'
 #' @examples

--- a/R/stat-smooth.r
+++ b/R/stat-smooth.r
@@ -32,18 +32,15 @@
 #' @param n Number of points at which to evaluate smoother.
 #' @param method.args List of additional arguments passed on to the modelling
 #'   function defined by `method`.
-#' @section Computed variables:
-#' These are calculated by the 'stat' part of layers and can be accessed with
-#' [delayed evaluation][aes_eval]. `stat_smooth()` provides the following
-#' variables, some of which depend on the orientation:
-#' \describe{
-#'   \item{`after_stat(y)` *or* `after_stat(x)`}{predicted value}
-#'   \item{`after_stat(ymin)` *or* `after_stat(xmin)`}{lower pointwise
-#'     confidence interval around the mean}
-#'   \item{`after_stat(ymax)` *or* `after_stat(xmax)`}{upper pointwise
-#'     confidence interval around the mean}
-#'   \item{`after_stat(se)`}{standard error}
-#' }
+#'
+#' @eval rd_computed_vars(
+#'   .details = "`stat_smooth()` provides the following variables, some of
+#'   which depend on the orientation:",
+#'   "y|x" = "Predicted value.",
+#'   "ymin|xmin" = "Lower pointwise confidence interval around the mean.",
+#'   "ymax|xmax" = "Upper pointwise confidence interval around the mean.",
+#'   "se" = "Standard error."
+#' )
 #' @export
 #' @rdname geom_smooth
 stat_smooth <- function(mapping = NULL, data = NULL,

--- a/R/stat-smooth.r
+++ b/R/stat-smooth.r
@@ -33,12 +33,16 @@
 #' @param method.args List of additional arguments passed on to the modelling
 #'   function defined by `method`.
 #' @section Computed variables:
-#' `stat_smooth()` provides the following variables, some of which depend on the orientation:
+#' These are calculated by the 'stat' part of layers and can be accessed with
+#' [delayed evaluation][aes_eval]. `stat_smooth()` provides the following
+#' variables, some of which depend on the orientation:
 #' \describe{
-#'   \item{y *or* x}{predicted value}
-#'   \item{ymin *or* xmin}{lower pointwise confidence interval around the mean}
-#'   \item{ymax *or* xmax}{upper pointwise confidence interval around the mean}
-#'   \item{se}{standard error}
+#'   \item{`after_stat(y)` *or* `after_stat(x)`}{predicted value}
+#'   \item{`after_stat(ymin)` *or* `after_stat(xmin)`}{lower pointwise
+#'     confidence interval around the mean}
+#'   \item{`after_stat(ymax)` *or* `after_stat(xmax)`}{upper pointwise
+#'     confidence interval around the mean}
+#'   \item{`after_stat(se)`}{standard error}
 #' }
 #' @export
 #' @rdname geom_smooth

--- a/R/stat-sum.r
+++ b/R/stat-sum.r
@@ -1,9 +1,11 @@
 #' @inheritParams layer
 #' @inheritParams geom_point
 #' @section Computed variables:
+#' These are calculated by the 'stat' part of layers and can be accessed with
+#' [delayed evaluation][aes_eval].
 #' \describe{
-#'  \item{n}{number of observations at position}
-#'  \item{prop}{percent of points in that panel at that position}
+#'  \item{`after_stat(n)`}{number of observations at position}
+#'  \item{`after_stat(prop)`}{percent of points in that panel at that position}
 #' }
 #' @export
 #' @rdname geom_count

--- a/R/stat-sum.r
+++ b/R/stat-sum.r
@@ -1,12 +1,9 @@
 #' @inheritParams layer
 #' @inheritParams geom_point
-#' @section Computed variables:
-#' These are calculated by the 'stat' part of layers and can be accessed with
-#' [delayed evaluation][aes_eval].
-#' \describe{
-#'  \item{`after_stat(n)`}{number of observations at position}
-#'  \item{`after_stat(prop)`}{percent of points in that panel at that position}
-#' }
+#' @eval rd_computed_vars(
+#'   n = "Number of observations at position.",
+#'   prop = "Percent of points in that panel at that position."
+#' )
 #' @export
 #' @rdname geom_count
 stat_sum <- function(mapping = NULL, data = NULL,

--- a/R/stat-summary-2d.r
+++ b/R/stat-summary-2d.r
@@ -10,13 +10,11 @@
 #'  - `x`: horizontal position
 #'  - `y`: vertical position
 #'  - `z`: value passed to the summary function
-#' @section Computed variables:
-#' These are calculated by the 'stat' part of layers and can be accessed with
-#' [delayed evaluation][aes_eval].
-#' \describe{
-#'   \item{`after_stat(x)`,`after_stat(y)`}{Location}
-#'   \item{`after_stat(value)`}{Value of summary statistic.}
-#' }
+#'
+#' @eval rd_computed_vars(
+#'   "x,y" = "Location.",
+#'   value = "Value of summary statistic."
+#' )
 #'
 #' @section Dropped variables:
 #' \describe{

--- a/R/stat-summary-2d.r
+++ b/R/stat-summary-2d.r
@@ -11,9 +11,11 @@
 #'  - `y`: vertical position
 #'  - `z`: value passed to the summary function
 #' @section Computed variables:
+#' These are calculated by the 'stat' part of layers and can be accessed with
+#' [delayed evaluation][aes_eval].
 #' \describe{
-#'   \item{x,y}{Location}
-#'   \item{value}{Value of summary statistic.}
+#'   \item{`after_stat(x)`,`after_stat(y)`}{Location}
+#'   \item{`after_stat(value)`}{Value of summary statistic.}
 #' }
 #'
 #' @section Dropped variables:

--- a/R/stat-ydensity.r
+++ b/R/stat-ydensity.r
@@ -4,19 +4,18 @@
 #' @param scale if "area" (default), all violins have the same area (before trimming
 #'   the tails). If "count", areas are scaled proportionally to the number of
 #'   observations. If "width", all violins have the same maximum width.
-#' @section Computed variables:
-#' These are calculated by the 'stat' part of layers and can be accessed with
-#' [delayed evaluation][aes_eval].
-#' \describe{
-#'   \item{`after_stat(density)`}{density estimate}
-#'   \item{`after_stat(scaled)`}{density estimate, scaled to maximum of 1}
-#'   \item{`after_stat(count)`}{density * number of points - probably useless
-#'     for violin plots}
-#'   \item{`after_stat(violinwidth)`}{density scaled for the violin plot,
-#'     according to area, counts or to a constant maximum width}
-#'   \item{`after_stat(n)`}{number of points}
-#'   \item{`after_stat(width)`}{width of violin bounding box}
-#' }
+#'
+#' @eval rd_computed_vars(
+#'   density = "Density estimate.",
+#'   scaled  = "Density estimate, scaled to a maximum of 1.",
+#'   count   = "Density * number of points - probably useless for violin
+#'   plots.",
+#'   violinwidth = "Density scaled for the violin plot, according to area,
+#'   counts or to a constant maximum width.",
+#'   n = "Number of points.",
+#'   width = "Width of violin bounding box."
+#' )
+#'
 #' @seealso [geom_violin()] for examples, and [stat_density()]
 #'   for examples with data along the x axis.
 #' @export

--- a/R/stat-ydensity.r
+++ b/R/stat-ydensity.r
@@ -5,14 +5,17 @@
 #'   the tails). If "count", areas are scaled proportionally to the number of
 #'   observations. If "width", all violins have the same maximum width.
 #' @section Computed variables:
+#' These are calculated by the 'stat' part of layers and can be accessed with
+#' [delayed evaluation][aes_eval].
 #' \describe{
-#'   \item{density}{density estimate}
-#'   \item{scaled}{density estimate, scaled to maximum of 1}
-#'   \item{count}{density * number of points - probably useless for violin plots}
-#'   \item{violinwidth}{density scaled for the violin plot, according to area, counts
-#'                      or to a constant maximum width}
-#'   \item{n}{number of points}
-#'   \item{width}{width of violin bounding box}
+#'   \item{`after_stat(density)`}{density estimate}
+#'   \item{`after_stat(scaled)`}{density estimate, scaled to maximum of 1}
+#'   \item{`after_stat(count)`}{density * number of points - probably useless
+#'     for violin plots}
+#'   \item{`after_stat(violinwidth)`}{density scaled for the violin plot,
+#'     according to area, counts or to a constant maximum width}
+#'   \item{`after_stat(n)`}{number of points}
+#'   \item{`after_stat(width)`}{width of violin bounding box}
 #' }
 #' @seealso [geom_violin()] for examples, and [stat_density()]
 #'   for examples with data along the x axis.

--- a/R/utilities-help.r
+++ b/R/utilities-help.r
@@ -86,20 +86,20 @@ rd_computed_vars <- function(..., .details = "", .skip_intro = FALSE) {
   header <- "@section Computed variables: "
   intro  <- paste0(
     "These are calculated by the 'stat' part of layers and can be accessed ",
-    "with \\link[=aes_eval]{delayed evaluation}. "
+    "with [delayed evaluation][aes_eval]. "
   )
   if (.skip_intro) intro <- ""
   preamble <- c(header, paste0(intro, gsub("\n", "", .details)))
 
   # Format items
-  fmt_items <- gsub(",", ")}, \\code{after_stat(", items, fixed = TRUE)
-  fmt_items <- gsub("|", ")} \\emph{or} \\code{after_stat(",
+  fmt_items <- gsub(",", ")`, `after_stat(", items, fixed = TRUE)
+  fmt_items <- gsub("|", ")` *or* `after_stat(",
                     fmt_items, fixed = TRUE)
-  fmt_items <- paste0("\\item{\\code{after_stat(", fmt_items, ")}")
+  fmt_items <- paste0("*  `after_stat(", fmt_items, ")`")
 
   # Compose item-list
-  fmt_descr <- paste0(gsub("\n", "", descr), "}")
-  fmt_list  <- paste(fmt_items, fmt_descr, sep = "\\cr ")
+  fmt_descr <- gsub("\n", "", descr)
+  fmt_list  <- paste(fmt_items, fmt_descr, sep = ": ")
 
-  c(preamble, "\\itemize{", fmt_list, "}")
+  c(preamble, fmt_list)
 }

--- a/R/utilities-help.r
+++ b/R/utilities-help.r
@@ -99,7 +99,7 @@ rd_computed_vars <- function(..., .details = "", .skip_intro = FALSE) {
 
   # Compose item-list
   fmt_descr <- gsub("\n", "", descr)
-  fmt_list  <- paste(fmt_items, fmt_descr, sep = ": ")
+  fmt_list  <- paste(fmt_items, fmt_descr, sep = "\\cr ")
 
   c(preamble, fmt_list)
 }

--- a/R/utilities-help.r
+++ b/R/utilities-help.r
@@ -49,3 +49,57 @@ rd_orientation <- function() {
     )
   )
 }
+
+#' Format 'Computed variables' section
+#'
+#' This is a helper function that helps format the 'Computed variables' section
+#' of stat documentation pages. Briefly, it points to the delayed evaluation
+#' documentation and it wraps the variable names in
+#' 'after_stat()'.
+#'
+#' @param ... Named variable - description pairs. Variable names get wrapped in
+#'   `after_stat()`. Variable names may be of the form "x|y" or "x,y" to format
+#'   as "`after_stat(x)` or `after_stat(y)`" and
+#'   "`after_stat(x)`, `after_stat(y)`" respectively.
+#' @param .details Additional details to include in the preamble.
+#' @param .skip_intro A logical, which if `TRUE` omits the link to the delayed
+#'   evaluation docs. Can be useful when documenting two stat functions on the
+#'   same page with different arguments, but no need to repeat the introduction
+#'   in the second stat function (see e.g. `?stat_qq`).
+#'
+#' @return Formatted code that can be inserted into a .rd file.
+#' @keywords internal
+#' @noRd
+#' @examples
+#' rd_computed_vars(
+#'   .details = "`stat_foobar()` computes the following variables:",
+#'   "foo|bar" = "foobar",
+#'   "bar,qux" = "quux",
+#'   corge = "grault"
+#' )
+rd_computed_vars <- function(..., .details = "", .skip_intro = FALSE) {
+  args  <- list(...)
+  items <- names(args)
+  descr <- unname(args)
+
+  # Format preamble
+  header <- "@section Computed variables: "
+  intro  <- paste0(
+    "These are calculated by the 'stat' part of layers and can be accessed ",
+    "with \\link[=aes_eval]{delayed evaluation}. "
+  )
+  if (.skip_intro) intro <- ""
+  preamble <- c(header, paste0(intro, gsub("\n", "", .details)))
+
+  # Format items
+  fmt_items <- gsub(",", ")}, \\code{after_stat(", items, fixed = TRUE)
+  fmt_items <- gsub("|", ")} \\emph{or} \\code{after_stat(",
+                    fmt_items, fixed = TRUE)
+  fmt_items <- paste0("\\item{\\code{after_stat(", fmt_items, ")}")
+
+  # Compose item-list
+  fmt_descr <- paste0(gsub("\n", "", descr), "}")
+  fmt_list  <- paste(fmt_items, fmt_descr, sep = "\\cr ")
+
+  c(preamble, "\\itemize{", fmt_list, "}")
+}

--- a/man/aes.Rd
+++ b/man/aes.Rd
@@ -86,4 +86,6 @@ scatter_by(mtcars, cut3(disp), drat)
 \seealso{
 \code{\link[=vars]{vars()}} for another quoting function designed for
 faceting specifications.
+
+\link[=aes_eval]{Delayed evaluation} for working with computed variables.
 }

--- a/man/aes_eval.Rd
+++ b/man/aes_eval.Rd
@@ -9,7 +9,8 @@
 \title{Control aesthetic evaluation}
 \usage{
 # These functions can be used inside the `aes()` function
-# used as the `mapping` argument in layers.
+# used as the `mapping` argument in layers, for example:
+# geom_density(mapping = aes(y = after_stat(scaled)))
 
 after_stat(x)
 
@@ -38,11 +39,11 @@ ggplot2 has three stages of the data that you can map aesthetics from, and
 three functions to control at which stage aesthetics should be evaluated.
 }
 \note{
-\code{after_stat()} replaces the old approaches of using either \code{stat()} or
-surrounding the variable names with \code{..}.
+\code{after_stat()} replaces the old approaches of using either \code{stat()}, e.g.
+\code{stat(density)}, or surrounding the variable names with \code{..}, e.g.
+\code{..density..}.
 }
 \section{Staging}{
-
 Below follows an overview of the three stages of evaluation and how aesthetic
 evaluation can be controlled.
 \subsection{Stage 1: direct input}{
@@ -117,8 +118,10 @@ ggplot(mpg, aes(class, hwy)) +
 ggplot(mpg, aes(class, displ)) +
   geom_violin() +
   stat_summary(
-    aes(y = stage(displ, after_stat = 8),
-        label = after_stat(paste(mean, "±", sd))),
+    aes(
+      y = stage(displ, after_stat = 8),
+      label = after_stat(paste(mean, "±", sd))
+    ),
     geom = "text",
     fun.data = ~ round(data.frame(mean = mean(.x), sd = sd(.x)), 2)
   )
@@ -146,9 +149,11 @@ ggplot(mpg, aes(class, hwy)) +
 # Making a proportional stacked density plot
 ggplot(mpg, aes(cty)) +
   geom_density(
-    aes(colour = factor(cyl),
-        fill = after_scale(alpha(colour, 0.3)),
-        y = after_stat(count / sum(n[!duplicated(group)]))),
+    aes(
+      colour = factor(cyl),
+      fill = after_scale(alpha(colour, 0.3)),
+      y = after_stat(count / sum(n[!duplicated(group)]))
+    ),
     position = "stack", bw = 1
   ) +
   geom_density(bw = 1)
@@ -157,17 +162,21 @@ ggplot(mpg, aes(cty)) +
 ggplot(mpg, aes(cty, colour = factor(cyl))) +
   geom_ribbon(
     stat = "density", outline.type = "upper",
-    aes(fill = after_scale(alpha(colour, 0.3)),
-        ymin = after_stat(group),
-        ymax = after_stat(group + ndensity))
+    aes(
+      fill = after_scale(alpha(colour, 0.3)),
+      ymin = after_stat(group),
+      ymax = after_stat(group + ndensity)
+    )
   )
 
 # Labelling a bar plot
 ggplot(mpg, aes(class)) +
   geom_bar() +
   geom_text(
-    aes(y = after_stat(count + 2),
-        label = after_stat(count)),
+    aes(
+      y = after_stat(count + 2),
+      label = after_stat(count)
+    ),
     stat = "count"
   )
 
@@ -176,8 +185,10 @@ ggplot(mpg, aes(class)) +
 ggplot(mpg, aes(displ, class)) +
   geom_boxplot(outlier.shape = NA) +
   geom_text(
-    aes(label = after_stat(xmax),
-        x = stage(displ, after_stat = xmax)),
+    aes(
+      label = after_stat(xmax),
+      x = stage(displ, after_stat = xmax)
+    ),
     stat = "boxplot", hjust = -0.5
   )
 }

--- a/man/aes_eval.Rd
+++ b/man/aes_eval.Rd
@@ -33,10 +33,11 @@ expression using variables calculated by the stat.}
 expression using layer aesthetics.}
 }
 \description{
-Most aesthetics are mapped from variables found in the data. Sometimes,
-however, you want to delay the mapping until later in the rendering process.
-ggplot2 has three stages of the data that you can map aesthetics from, and
-three functions to control at which stage aesthetics should be evaluated.
+Most \link[=aes]{aesthetics} are mapped from variables found in the data.
+Sometimes, however, you want to delay the mapping until later in the
+rendering process. ggplot2 has three stages of the data that you can map
+aesthetics from, and three functions to control at which stage aesthetics
+should be evaluated.
 }
 \note{
 \code{after_stat()} replaces the old approaches of using either \code{stat()}, e.g.

--- a/man/aes_eval.Rd
+++ b/man/aes_eval.Rd
@@ -112,16 +112,15 @@ data column for the stat, but remap it for the geom, you can use the
 ggplot(mpg, aes(class, hwy)) +
   geom_boxplot(aes(fill = stage(class, after_scale = alpha(fill, 0.4))))
 
-# Using data for computing summary, but placing label elsewhere, as well as
-# using the computed 'y' as part of the label.
+# Using data for computing summary, but placing label elsewhere.
+# Also, we're making our own computed variable to use for the label.
 ggplot(mpg, aes(class, displ)) +
   geom_violin() +
   stat_summary(
     aes(y = stage(displ, after_stat = 8),
-        label = after_stat(paste(y, ymax, sep = " ± "))),
+        label = after_stat(paste(mean, "±", sd))),
     geom = "text",
-    fun = ~ round(mean(.x), 2),
-    fun.max = ~ round(sd(.x), 2)
+    fun.data = ~ round(data.frame(mean = mean(.x), sd = sd(.x)), 2)
   )
 }\if{html}{\out{</div>}}
 }

--- a/man/aes_eval.Rd
+++ b/man/aes_eval.Rd
@@ -38,8 +38,7 @@ Sometimes, however, you want to delay the mapping until later in the
 rendering process. ggplot2 has three stages of the data that you can map
 aesthetics from, and three functions to control at which stage aesthetics
 should be evaluated.
-}
-\note{
+
 \code{after_stat()} replaces the old approaches of using either \code{stat()}, e.g.
 \code{stat(density)}, or surrounding the variable names with \code{..}, e.g.
 \code{..density..}.

--- a/man/aes_eval.Rd
+++ b/man/aes_eval.Rd
@@ -8,6 +8,9 @@
 \alias{stage}
 \title{Control aesthetic evaluation}
 \usage{
+# These functions can be used inside the `aes()` function
+# used as the `mapping` argument in layers.
+
 after_stat(x)
 
 after_scale(x)
@@ -15,48 +18,115 @@ after_scale(x)
 stage(start = NULL, after_stat = NULL, after_scale = NULL)
 }
 \arguments{
-\item{x}{An aesthetic expression using variables calculated by the stat
-(\code{after_stat()}) or layer aesthetics (\code{after_scale()}).}
+\item{x}{<\code{\link[rlang:topic-data-mask]{data-masking}}> An aesthetic expression
+using variables calculated by the stat (\code{after_stat()}) or layer aesthetics
+(\code{after_scale()}).}
 
-\item{start}{An aesthetic expression using variables from the layer data.}
+\item{start}{<\code{\link[rlang:topic-data-mask]{data-masking}}> An aesthetic
+expression using variables from the layer data.}
 
-\item{after_stat}{An aesthetic expression using variables calculated by the
-stat.}
+\item{after_stat}{<\code{\link[rlang:topic-data-mask]{data-masking}}> An aesthetic
+expression using variables calculated by the stat.}
 
-\item{after_scale}{An aesthetic expression using layer aesthetics.}
+\item{after_scale}{<\code{\link[rlang:topic-data-mask]{data-masking}}> An aesthetic
+expression using layer aesthetics.}
 }
 \description{
 Most aesthetics are mapped from variables found in the data. Sometimes,
 however, you want to delay the mapping until later in the rendering process.
-ggplot2 has three stages of the data that you can map aesthetics from. The
-default is to map at the beginning, using the layer data provided by the
-user. The second stage is after the data has been transformed by the layer
-stat. The third and last stage is after the data has been transformed and
-mapped by the plot scales. The most common example of mapping from stat
-transformed data is the height of bars in \code{\link[=geom_histogram]{geom_histogram()}}:
-the height does not come from a variable in the underlying data, but
-is instead mapped to the \code{count} computed by \code{\link[=stat_bin]{stat_bin()}}. An example of
-mapping from scaled data could be to use a desaturated version of the stroke
-colour for fill. If you want to map directly from the layer data you should
-not do anything special. In order to map from stat transformed data you
-should use the \code{after_stat()} function to flag that evaluation of the
-aesthetic mapping should be postponed until after stat transformation.
-Similarly, you should use \code{after_scale()} to flag evaluation of mapping for
-after data has been scaled. If you want to map the same aesthetic multiple
-times, e.g. map \code{x} to a data column for the stat, but remap it for the geom,
-you can use the \code{stage()} function to collect multiple mappings.
+ggplot2 has three stages of the data that you can map aesthetics from, and
+three functions to control at which stage aesthetics should be evaluated.
 }
-\details{
+\note{
 \code{after_stat()} replaces the old approaches of using either \code{stat()} or
 surrounding the variable names with \code{..}.
 }
-\note{
-Evaluation after stat transformation will have access to the
-variables calculated by the stat, not the original mapped values. Evaluation
-after scaling will only have access to the final aesthetics of the layer
-(including non-mapped, default aesthetics). The original layer data can only
-be accessed at the first stage.
+\section{Staging}{
+
+Below follows an overview of the three stages of evaluation and how aesthetic
+evaluation can be controlled.
+\subsection{Stage 1: direct input}{
+
+The default is to map at the beginning, using the layer data provided by
+the user. If you want to map directly from the layer data you should not do
+anything special. This is the only stage where the original layer data can
+be accessed.
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# 'x' and 'y' are mapped directly
+ggplot(mtcars) + geom_point(aes(x = mpg, y = disp))
+}\if{html}{\out{</div>}}
 }
+
+\subsection{Stage 2: after stat transformation}{
+
+The second stage is after the data has been transformed by the layer
+stat. The most common example of mapping from stat transformed data is the
+height of bars in \code{\link[=geom_histogram]{geom_histogram()}}: the height does not come from a
+variable in the underlying data, but is instead mapped to the \code{count}
+computed by \code{\link[=stat_bin]{stat_bin()}}. In order to map from stat transformed data you
+should use the \code{after_stat()} function to flag that evaluation of the
+aesthetic mapping should be postponed until after stat transformation.
+Evaluation after stat transformation will have access to the variables
+calculated by the stat, not the original mapped values. The 'computed
+variables' section in each stat lists which variables are available to
+access.
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# The 'y' values for the histogram are computed by the stat
+ggplot(faithful, aes(x = waiting)) +
+  geom_histogram()
+
+# Choosing a different computed variable to display, matching up the
+# histogram with the density plot
+ggplot(faithful, aes(x = waiting)) +
+  geom_histogram(aes(y = after_stat(density))) +
+  geom_density()
+}\if{html}{\out{</div>}}
+}
+
+\subsection{Stage 3: after scale transformation}{
+
+The third and last stage is after the data has been transformed and
+mapped by the plot scales. An example of mapping from scaled data could
+be to use a desaturated version of the stroke colour for fill. You should
+use \code{after_scale()} to flag evaluation of mapping for after data has been
+scaled. Evaluation after scaling will only have access to the final
+aesthetics of the layer (including non-mapped, default aesthetics).
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# The exact colour is known after scale transformation
+ggplot(mpg, aes(cty, colour = factor(cyl))) +
+  geom_density()
+
+# We re-use colour properties for the fill without a separate fill scale
+ggplot(mpg, aes(cty, colour = factor(cyl))) +
+  geom_density(aes(fill = after_scale(alpha(colour, 0.3))))
+}\if{html}{\out{</div>}}
+}
+
+\subsection{Complex staging}{
+
+If you want to map the same aesthetic multiple times, e.g. map \code{x} to a
+data column for the stat, but remap it for the geom, you can use the
+\code{stage()} function to collect multiple mappings.
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# Use stage to modify the scaled fill
+ggplot(mpg, aes(class, hwy)) +
+  geom_boxplot(aes(fill = stage(class, after_scale = alpha(fill, 0.4))))
+
+# Using data for computing summary, but placing label elsewhere, as well as
+# using the computed 'y' as part of the label.
+ggplot(mpg, aes(class, displ)) +
+  geom_violin() +
+  stat_summary(
+    aes(y = stage(displ, after_stat = 8),
+        label = after_stat(paste(y, ymax, sep = " ± "))),
+    geom = "text",
+    fun = ~ round(mean(.x), 2),
+    fun.max = ~ round(sd(.x), 2)
+  )
+}\if{html}{\out{</div>}}
+}
+}
+
 \examples{
 # Default histogram display
 ggplot(mpg, aes(displ)) +
@@ -73,4 +143,42 @@ ggplot(mpg, aes(class, hwy)) +
 # Use stage to modify the scaled fill
 ggplot(mpg, aes(class, hwy)) +
   geom_boxplot(aes(fill = stage(class, after_scale = alpha(fill, 0.4))))
+
+# Making a proportional stacked density plot
+ggplot(mpg, aes(cty)) +
+  geom_density(
+    aes(colour = factor(cyl),
+        fill = after_scale(alpha(colour, 0.3)),
+        y = after_stat(count / sum(n[!duplicated(group)]))),
+    position = "stack", bw = 1
+  ) +
+  geom_density(bw = 1)
+
+# Imitating a ridgeline plot
+ggplot(mpg, aes(cty, colour = factor(cyl))) +
+  geom_ribbon(
+    stat = "density", outline.type = "upper",
+    aes(fill = after_scale(alpha(colour, 0.3)),
+        ymin = after_stat(group),
+        ymax = after_stat(group + ndensity))
+  )
+
+# Labelling a bar plot
+ggplot(mpg, aes(class)) +
+  geom_bar() +
+  geom_text(
+    aes(y = after_stat(count + 2),
+        label = after_stat(count)),
+    stat = "count"
+  )
+
+# Labelling the upper hinge of a boxplot,
+# inspired by June Choe
+ggplot(mpg, aes(displ, class)) +
+  geom_boxplot(outlier.shape = NA) +
+  geom_text(
+    aes(label = after_stat(xmax),
+        x = stage(displ, after_stat = xmax)),
+    stat = "boxplot", hjust = -0.5
+  )
 }

--- a/man/geom_bar.Rd
+++ b/man/geom_bar.Rd
@@ -179,11 +179,10 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with
-\link[=aes_eval]{delayed evaluation}.
-\describe{
-\item{\code{after_stat(count)}}{number of points in bin}
-\item{\code{after_stat(prop)}}{groupwise proportion}
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
+\itemize{
+\item{\code{after_stat(count)}\cr number of points in bin.}
+\item{\code{after_stat(prop)}\cr groupwise proportion}
 }
 }
 

--- a/man/geom_bar.Rd
+++ b/man/geom_bar.Rd
@@ -181,8 +181,8 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item{\code{after_stat(count)}\cr number of points in bin.}
-\item{\code{after_stat(prop)}\cr groupwise proportion}
+\item \code{after_stat(count)}: number of points in bin.
+\item \code{after_stat(prop)}: groupwise proportion
 }
 }
 

--- a/man/geom_bar.Rd
+++ b/man/geom_bar.Rd
@@ -179,9 +179,11 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
+These are calculated by the 'stat' part of layers and can be accessed with
+\link[=aes_eval]{delayed evaluation}.
 \describe{
-\item{count}{number of points in bin}
-\item{prop}{groupwise proportion}
+\item{\code{after_stat(count)}}{number of points in bin}
+\item{\code{after_stat(prop)}}{groupwise proportion}
 }
 }
 

--- a/man/geom_bar.Rd
+++ b/man/geom_bar.Rd
@@ -181,8 +181,8 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item \code{after_stat(count)}: number of points in bin.
-\item \code{after_stat(prop)}: groupwise proportion
+\item \code{after_stat(count)}\cr number of points in bin.
+\item \code{after_stat(prop)}\cr groupwise proportion
 }
 }
 

--- a/man/geom_bin_2d.Rd
+++ b/man/geom_bin_2d.Rd
@@ -109,14 +109,12 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with
-\link[=aes_eval]{delayed evaluation}.
-\describe{
-\item{\code{after_stat(count)}}{number of points in bin}
-\item{\code{after_stat(density)}}{density of points in bin, scaled to integrate
-to 1}
-\item{\code{after_stat(ncount)}}{count, scaled to maximum of 1}
-\item{\code{after_stat(ndensity)}}{density, scaled to maximum of 1}
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
+\itemize{
+\item{\code{after_stat(count)}\cr number of points in bin.}
+\item{\code{after_stat(density)}\cr density of points in bin, scaled to integrate to 1.}
+\item{\code{after_stat(ncount)}\cr count, scaled to maximum of 1.}
+\item{\code{after_stat(ndensity)}\cr density, scaled to a maximum of 1.}
 }
 }
 

--- a/man/geom_bin_2d.Rd
+++ b/man/geom_bin_2d.Rd
@@ -109,11 +109,14 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
+These are calculated by the 'stat' part of layers and can be accessed with
+\link[=aes_eval]{delayed evaluation}.
 \describe{
-\item{count}{number of points in bin}
-\item{density}{density of points in bin, scaled to integrate to 1}
-\item{ncount}{count, scaled to maximum of 1}
-\item{ndensity}{density, scaled to maximum of 1}
+\item{\code{after_stat(count)}}{number of points in bin}
+\item{\code{after_stat(density)}}{density of points in bin, scaled to integrate
+to 1}
+\item{\code{after_stat(ncount)}}{count, scaled to maximum of 1}
+\item{\code{after_stat(ndensity)}}{density, scaled to maximum of 1}
 }
 }
 

--- a/man/geom_bin_2d.Rd
+++ b/man/geom_bin_2d.Rd
@@ -111,10 +111,10 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item{\code{after_stat(count)}\cr number of points in bin.}
-\item{\code{after_stat(density)}\cr density of points in bin, scaled to integrate to 1.}
-\item{\code{after_stat(ncount)}\cr count, scaled to maximum of 1.}
-\item{\code{after_stat(ndensity)}\cr density, scaled to a maximum of 1.}
+\item \code{after_stat(count)}: number of points in bin.
+\item \code{after_stat(density)}: density of points in bin, scaled to integrate to 1.
+\item \code{after_stat(ncount)}: count, scaled to maximum of 1.
+\item \code{after_stat(ndensity)}: density, scaled to a maximum of 1.
 }
 }
 

--- a/man/geom_bin_2d.Rd
+++ b/man/geom_bin_2d.Rd
@@ -111,10 +111,10 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item \code{after_stat(count)}: number of points in bin.
-\item \code{after_stat(density)}: density of points in bin, scaled to integrate to 1.
-\item \code{after_stat(ncount)}: count, scaled to maximum of 1.
-\item \code{after_stat(ndensity)}: density, scaled to a maximum of 1.
+\item \code{after_stat(count)}\cr number of points in bin.
+\item \code{after_stat(density)}\cr density of points in bin, scaled to integrate to 1.
+\item \code{after_stat(ncount)}\cr count, scaled to maximum of 1.
+\item \code{after_stat(ndensity)}\cr density, scaled to a maximum of 1.
 }
 }
 

--- a/man/geom_boxplot.Rd
+++ b/man/geom_boxplot.Rd
@@ -175,25 +175,16 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with
-\link[=aes_eval]{delayed evaluation}. \code{stat_boxplot()} provides the following
-variables, some of which depend on the orientation:
-\describe{
-\item{\code{after_stat(width)}}{width of boxplot}
-\item{\code{after_stat(ymin)} \emph{or} \code{after_stat(xmin)}}{lower whisker = smallest
-observation greater than or equal to lower hinge - 1.5 * IQR}
-\item{\code{after_stat(lower)} \emph{or} \code{after_stat(xlower)}}{lower hinge, 25\%
-quantile}
-\item{\code{after_stat(notchlower)}}{lower edge of notch =
-median - 1.58 * IQR / sqrt(n)}
-\item{\code{after_stat(middle)} \emph{or} \code{after_stat(xmiddle)}}{median,
-50\% quantile}
-\item{\code{after_stat(notchupper)}}{upper edge of notch =
-median + 1.58 * IQR / sqrt(n)}
-\item{\code{after_stat(upper)} \emph{or} \code{after_stat(xupper)}}{upper hinge, 75\%
-quantile}
-\item{\code{after_stat(ymax)} \emph{or} \code{after_stat(xmax)}}{upper whisker = largest
-observation less than or equal to upper hinge + 1.5 * IQR}
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}. \code{stat_boxplot()} provides the following variables, some of  which depend on the orientation:
+\itemize{
+\item{\code{after_stat(width)}\cr width of boxplot.}
+\item{\code{after_stat(ymin)} \emph{or} \code{after_stat(xmin)}\cr lower whisker = smallest observation greater than or equal  to lower hinger - 1.5 * IQR.}
+\item{\code{after_stat(lower)} \emph{or} \code{after_stat(xlower)}\cr lower hinge, 25\% quantile.}
+\item{\code{after_stat(notchlower)}\cr lower edge of notch = median - 1.58 * IQR / sqrt(n).}
+\item{\code{after_stat(middle)} \emph{or} \code{after_stat(xmiddle)}\cr median, 50\% quantile.}
+\item{\code{after_stat(notchupper)}\cr upper edge of notch = median + 1.58 * IQR / sqrt(n).}
+\item{\code{after_stat(upper)} \emph{or} \code{after_stat(xupper)}\cr upper hinge, 75\% quantile.}
+\item{\code{after_stat(ymax)} \emph{or} \code{after_stat(xmax)}\cr upper whisker = largest observation less than or equal to  upper hinger + 1.5 * IQR.}
 }
 }
 

--- a/man/geom_boxplot.Rd
+++ b/man/geom_boxplot.Rd
@@ -177,14 +177,14 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}. \code{stat_boxplot()} provides the following variables, some of  which depend on the orientation:
 \itemize{
-\item \code{after_stat(width)}: width of boxplot.
-\item \code{after_stat(ymin)} \emph{or} \code{after_stat(xmin)}: lower whisker = smallest observation greater than or equal  to lower hinger - 1.5 * IQR.
-\item \code{after_stat(lower)} \emph{or} \code{after_stat(xlower)}: lower hinge, 25\% quantile.
-\item \code{after_stat(notchlower)}: lower edge of notch = median - 1.58 * IQR / sqrt(n).
-\item \code{after_stat(middle)} \emph{or} \code{after_stat(xmiddle)}: median, 50\% quantile.
-\item \code{after_stat(notchupper)}: upper edge of notch = median + 1.58 * IQR / sqrt(n).
-\item \code{after_stat(upper)} \emph{or} \code{after_stat(xupper)}: upper hinge, 75\% quantile.
-\item \code{after_stat(ymax)} \emph{or} \code{after_stat(xmax)}: upper whisker = largest observation less than or equal to  upper hinger + 1.5 * IQR.
+\item \code{after_stat(width)}\cr width of boxplot.
+\item \code{after_stat(ymin)} \emph{or} \code{after_stat(xmin)}\cr lower whisker = smallest observation greater than or equal  to lower hinger - 1.5 * IQR.
+\item \code{after_stat(lower)} \emph{or} \code{after_stat(xlower)}\cr lower hinge, 25\% quantile.
+\item \code{after_stat(notchlower)}\cr lower edge of notch = median - 1.58 * IQR / sqrt(n).
+\item \code{after_stat(middle)} \emph{or} \code{after_stat(xmiddle)}\cr median, 50\% quantile.
+\item \code{after_stat(notchupper)}\cr upper edge of notch = median + 1.58 * IQR / sqrt(n).
+\item \code{after_stat(upper)} \emph{or} \code{after_stat(xupper)}\cr upper hinge, 75\% quantile.
+\item \code{after_stat(ymax)} \emph{or} \code{after_stat(xmax)}\cr upper whisker = largest observation less than or equal to  upper hinger + 1.5 * IQR.
 }
 }
 

--- a/man/geom_boxplot.Rd
+++ b/man/geom_boxplot.Rd
@@ -177,14 +177,14 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}. \code{stat_boxplot()} provides the following variables, some of  which depend on the orientation:
 \itemize{
-\item{\code{after_stat(width)}\cr width of boxplot.}
-\item{\code{after_stat(ymin)} \emph{or} \code{after_stat(xmin)}\cr lower whisker = smallest observation greater than or equal  to lower hinger - 1.5 * IQR.}
-\item{\code{after_stat(lower)} \emph{or} \code{after_stat(xlower)}\cr lower hinge, 25\% quantile.}
-\item{\code{after_stat(notchlower)}\cr lower edge of notch = median - 1.58 * IQR / sqrt(n).}
-\item{\code{after_stat(middle)} \emph{or} \code{after_stat(xmiddle)}\cr median, 50\% quantile.}
-\item{\code{after_stat(notchupper)}\cr upper edge of notch = median + 1.58 * IQR / sqrt(n).}
-\item{\code{after_stat(upper)} \emph{or} \code{after_stat(xupper)}\cr upper hinge, 75\% quantile.}
-\item{\code{after_stat(ymax)} \emph{or} \code{after_stat(xmax)}\cr upper whisker = largest observation less than or equal to  upper hinger + 1.5 * IQR.}
+\item \code{after_stat(width)}: width of boxplot.
+\item \code{after_stat(ymin)} \emph{or} \code{after_stat(xmin)}: lower whisker = smallest observation greater than or equal  to lower hinger - 1.5 * IQR.
+\item \code{after_stat(lower)} \emph{or} \code{after_stat(xlower)}: lower hinge, 25\% quantile.
+\item \code{after_stat(notchlower)}: lower edge of notch = median - 1.58 * IQR / sqrt(n).
+\item \code{after_stat(middle)} \emph{or} \code{after_stat(xmiddle)}: median, 50\% quantile.
+\item \code{after_stat(notchupper)}: upper edge of notch = median + 1.58 * IQR / sqrt(n).
+\item \code{after_stat(upper)} \emph{or} \code{after_stat(xupper)}: upper hinge, 75\% quantile.
+\item \code{after_stat(ymax)} \emph{or} \code{after_stat(xmax)}: upper whisker = largest observation less than or equal to  upper hinger + 1.5 * IQR.
 }
 }
 

--- a/man/geom_boxplot.Rd
+++ b/man/geom_boxplot.Rd
@@ -175,16 +175,25 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-\code{stat_boxplot()} provides the following variables, some of which depend on the orientation:
+These are calculated by the 'stat' part of layers and can be accessed with
+\link[=aes_eval]{delayed evaluation}. \code{stat_boxplot()} provides the following
+variables, some of which depend on the orientation:
 \describe{
-\item{width}{width of boxplot}
-\item{ymin \emph{or} xmin}{lower whisker = smallest observation greater than or equal to lower hinge - 1.5 * IQR}
-\item{lower \emph{or} xlower}{lower hinge, 25\% quantile}
-\item{notchlower}{lower edge of notch = median - 1.58 * IQR / sqrt(n)}
-\item{middle \emph{or} xmiddle}{median, 50\% quantile}
-\item{notchupper}{upper edge of notch = median + 1.58 * IQR / sqrt(n)}
-\item{upper \emph{or} xupper}{upper hinge, 75\% quantile}
-\item{ymax \emph{or} xmax}{upper whisker = largest observation less than or equal to upper hinge + 1.5 * IQR}
+\item{\code{after_stat(width)}}{width of boxplot}
+\item{\code{after_stat(ymin)} \emph{or} \code{after_stat(xmin)}}{lower whisker = smallest
+observation greater than or equal to lower hinge - 1.5 * IQR}
+\item{\code{after_stat(lower)} \emph{or} \code{after_stat(xlower)}}{lower hinge, 25\%
+quantile}
+\item{\code{after_stat(notchlower)}}{lower edge of notch =
+median - 1.58 * IQR / sqrt(n)}
+\item{\code{after_stat(middle)} \emph{or} \code{after_stat(xmiddle)}}{median,
+50\% quantile}
+\item{\code{after_stat(notchupper)}}{upper edge of notch =
+median + 1.58 * IQR / sqrt(n)}
+\item{\code{after_stat(upper)} \emph{or} \code{after_stat(xupper)}}{upper hinge, 75\%
+quantile}
+\item{\code{after_stat(ymax)} \emph{or} \code{after_stat(xmax)}}{upper whisker = largest
+observation less than or equal to upper hinge + 1.5 * IQR}
 }
 }
 

--- a/man/geom_contour.Rd
+++ b/man/geom_contour.Rd
@@ -208,19 +208,22 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-The computed variables differ somewhat for contour lines (computed by
-\code{stat_contour()}) and contour bands (filled contours, computed by \code{stat_contour_filled()}).
-The variables \code{nlevel} and \code{piece} are available for both, whereas \code{level_low}, \code{level_high},
-and \code{level_mid} are only available for bands. The variable \code{level} is a numeric or a factor
-depending on whether lines or bands are calculated.
+These are calculated by the 'stat' part of layers and can be accessed with
+\link[=aes_eval]{delayed evaluation}. The computed variables differ somewhat for
+contour lines (computed by \code{stat_contour()}) and contour bands (filled
+contours, computed by \code{stat_contour_filled()}). The variables \code{nlevel} and
+\code{piece} are available for both, whereas \code{level_low}, \code{level_high}, and
+\code{level_mid} are only available for bands. The variable \code{level} is a numeric
+or a factor depending on whether lines or bands are calculated.
 \describe{
-\item{\code{level}}{Height of contour. For contour lines, this is numeric vector that
-represents bin boundaries. For contour bands, this is an ordered factor that
-represents bin ranges.}
-\item{\code{level_low}, \code{level_high}, \code{level_mid}}{(contour bands only) Lower and upper
-bin boundaries for each band, as well the mid point between the boundaries.}
-\item{\code{nlevel}}{Height of contour, scaled to maximum of 1.}
-\item{\code{piece}}{Contour piece (an integer).}
+\item{\code{after_stat(level)}}{Height of contour. For contour lines, this is
+numeric vector that represents bin boundaries. For contour bands, this is
+an ordered factor that represents bin ranges.}
+\item{\code{after_stat(level_low)}, \code{after_stat(level_high)},
+\code{after_stat(level_mid)}}{(contour bands only) Lower and upper bin
+boundaries for each band, as well the mid point between the boundaries.}
+\item{\code{after_stat(nlevel)}}{Height of contour, scaled to maximum of 1.}
+\item{\code{after_stat(piece)}}{Contour piece (an integer).}
 }
 }
 

--- a/man/geom_contour.Rd
+++ b/man/geom_contour.Rd
@@ -208,22 +208,12 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with
-\link[=aes_eval]{delayed evaluation}. The computed variables differ somewhat for
-contour lines (computed by \code{stat_contour()}) and contour bands (filled
-contours, computed by \code{stat_contour_filled()}). The variables \code{nlevel} and
-\code{piece} are available for both, whereas \code{level_low}, \code{level_high}, and
-\code{level_mid} are only available for bands. The variable \code{level} is a numeric
-or a factor depending on whether lines or bands are calculated.
-\describe{
-\item{\code{after_stat(level)}}{Height of contour. For contour lines, this is
-numeric vector that represents bin boundaries. For contour bands, this is
-an ordered factor that represents bin ranges.}
-\item{\code{after_stat(level_low)}, \code{after_stat(level_high)},
-\code{after_stat(level_mid)}}{(contour bands only) Lower and upper bin
-boundaries for each band, as well the mid point between the boundaries.}
-\item{\code{after_stat(nlevel)}}{Height of contour, scaled to maximum of 1.}
-\item{\code{after_stat(piece)}}{Contour piece (an integer).}
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}. The computed variables differ somewhat for contour lines  (compbuted by \code{stat_contour()}) and contour bands (filled contours,  computed by \code{stat_contour_filled()}). The variables \code{nlevel} and \code{piece}  are available for both, whereas \code{level_low}, \code{level_high}, and \code{level_mid}  are only available for bands. The variable \code{level} is a numeric or a factor  depending on whether lines or bands are calculated.
+\itemize{
+\item{\code{after_stat(level)}\cr Height of contour. For contour lines, this is a numeric vector  that represents bin boundaries. For contour bands, this is an ordered  factor that represents bin ranges.}
+\item{\code{after_stat(level_low)}, \code{after_stat(level_high)}, \code{after_stat(level_mid)}\cr (contour bands only) Lower and upper  bin boundaries for each band, as well as the mid point between boundaries.}
+\item{\code{after_stat(nlevel)}\cr Height of contour, scaled to a maximum of 1.}
+\item{\code{after_stat(piece)}\cr Contour piece (an integer).}
 }
 }
 

--- a/man/geom_contour.Rd
+++ b/man/geom_contour.Rd
@@ -210,10 +210,10 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}. The computed variables differ somewhat for contour lines  (compbuted by \code{stat_contour()}) and contour bands (filled contours,  computed by \code{stat_contour_filled()}). The variables \code{nlevel} and \code{piece}  are available for both, whereas \code{level_low}, \code{level_high}, and \code{level_mid}  are only available for bands. The variable \code{level} is a numeric or a factor  depending on whether lines or bands are calculated.
 \itemize{
-\item \code{after_stat(level)}: Height of contour. For contour lines, this is a numeric vector  that represents bin boundaries. For contour bands, this is an ordered  factor that represents bin ranges.
-\item \code{after_stat(level_low)}, \code{after_stat(level_high)}, \code{after_stat(level_mid)}: (contour bands only) Lower and upper  bin boundaries for each band, as well as the mid point between boundaries.
-\item \code{after_stat(nlevel)}: Height of contour, scaled to a maximum of 1.
-\item \code{after_stat(piece)}: Contour piece (an integer).
+\item \code{after_stat(level)}\cr Height of contour. For contour lines, this is a numeric vector  that represents bin boundaries. For contour bands, this is an ordered  factor that represents bin ranges.
+\item \code{after_stat(level_low)}, \code{after_stat(level_high)}, \code{after_stat(level_mid)}\cr (contour bands only) Lower and upper  bin boundaries for each band, as well as the mid point between boundaries.
+\item \code{after_stat(nlevel)}\cr Height of contour, scaled to a maximum of 1.
+\item \code{after_stat(piece)}\cr Contour piece (an integer).
 }
 }
 

--- a/man/geom_contour.Rd
+++ b/man/geom_contour.Rd
@@ -210,10 +210,10 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}. The computed variables differ somewhat for contour lines  (compbuted by \code{stat_contour()}) and contour bands (filled contours,  computed by \code{stat_contour_filled()}). The variables \code{nlevel} and \code{piece}  are available for both, whereas \code{level_low}, \code{level_high}, and \code{level_mid}  are only available for bands. The variable \code{level} is a numeric or a factor  depending on whether lines or bands are calculated.
 \itemize{
-\item{\code{after_stat(level)}\cr Height of contour. For contour lines, this is a numeric vector  that represents bin boundaries. For contour bands, this is an ordered  factor that represents bin ranges.}
-\item{\code{after_stat(level_low)}, \code{after_stat(level_high)}, \code{after_stat(level_mid)}\cr (contour bands only) Lower and upper  bin boundaries for each band, as well as the mid point between boundaries.}
-\item{\code{after_stat(nlevel)}\cr Height of contour, scaled to a maximum of 1.}
-\item{\code{after_stat(piece)}\cr Contour piece (an integer).}
+\item \code{after_stat(level)}: Height of contour. For contour lines, this is a numeric vector  that represents bin boundaries. For contour bands, this is an ordered  factor that represents bin ranges.
+\item \code{after_stat(level_low)}, \code{after_stat(level_high)}, \code{after_stat(level_mid)}: (contour bands only) Lower and upper  bin boundaries for each band, as well as the mid point between boundaries.
+\item \code{after_stat(nlevel)}: Height of contour, scaled to a maximum of 1.
+\item \code{after_stat(piece)}: Contour piece (an integer).
 }
 }
 

--- a/man/geom_count.Rd
+++ b/man/geom_count.Rd
@@ -99,9 +99,11 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
+These are calculated by the 'stat' part of layers and can be accessed with
+\link[=aes_eval]{delayed evaluation}.
 \describe{
-\item{n}{number of observations at position}
-\item{prop}{percent of points in that panel at that position}
+\item{\code{after_stat(n)}}{number of observations at position}
+\item{\code{after_stat(prop)}}{percent of points in that panel at that position}
 }
 }
 

--- a/man/geom_count.Rd
+++ b/man/geom_count.Rd
@@ -101,8 +101,8 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item{\code{after_stat(n)}\cr Number of observations at position.}
-\item{\code{after_stat(prop)}\cr Percent of points in that panel at that position.}
+\item \code{after_stat(n)}: Number of observations at position.
+\item \code{after_stat(prop)}: Percent of points in that panel at that position.
 }
 }
 

--- a/man/geom_count.Rd
+++ b/man/geom_count.Rd
@@ -101,8 +101,8 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item \code{after_stat(n)}: Number of observations at position.
-\item \code{after_stat(prop)}: Percent of points in that panel at that position.
+\item \code{after_stat(n)}\cr Number of observations at position.
+\item \code{after_stat(prop)}\cr Percent of points in that panel at that position.
 }
 }
 

--- a/man/geom_count.Rd
+++ b/man/geom_count.Rd
@@ -99,11 +99,10 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with
-\link[=aes_eval]{delayed evaluation}.
-\describe{
-\item{\code{after_stat(n)}}{number of observations at position}
-\item{\code{after_stat(prop)}}{percent of points in that panel at that position}
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
+\itemize{
+\item{\code{after_stat(n)}\cr Number of observations at position.}
+\item{\code{after_stat(prop)}\cr Percent of points in that panel at that position.}
 }
 }
 

--- a/man/geom_density.Rd
+++ b/man/geom_density.Rd
@@ -150,16 +150,13 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with
-\link[=aes_eval]{delayed evaluation}.
-\describe{
-\item{\code{after_stat(density)}}{density estimate}
-\item{\code{after_stat(count)}}{density * number of points - useful for stacked
-density plots}
-\item{\code{after_stat(scaled)}}{density estimate, scaled to maximum of 1}
-\item{\code{after_stat(n)}}{number of points}
-\item{\code{after_stat(ndensity)}}{alias for \code{scaled}, to mirror the syntax of
-\code{\link[=stat_bin]{stat_bin()}}}
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
+\itemize{
+\item{\code{after_stat(density)}\cr density estimate.}
+\item{\code{after_stat(count)}\cr density * number of points - useful for stacked density plots.}
+\item{\code{after_stat(scaled)}\cr density estimate, scaled to maximum of 1.}
+\item{\code{after_stat(n)}\cr number of points.}
+\item{\code{after_stat(ndensity)}\cr alias for \code{scaled}, to mirror the syntax of \code{\link[=stat_bin]{stat_bin()}}.}
 }
 }
 

--- a/man/geom_density.Rd
+++ b/man/geom_density.Rd
@@ -152,11 +152,11 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item \code{after_stat(density)}: density estimate.
-\item \code{after_stat(count)}: density * number of points - useful for stacked density plots.
-\item \code{after_stat(scaled)}: density estimate, scaled to maximum of 1.
-\item \code{after_stat(n)}: number of points.
-\item \code{after_stat(ndensity)}: alias for \code{scaled}, to mirror the syntax of \code{\link[=stat_bin]{stat_bin()}}.
+\item \code{after_stat(density)}\cr density estimate.
+\item \code{after_stat(count)}\cr density * number of points - useful for stacked density plots.
+\item \code{after_stat(scaled)}\cr density estimate, scaled to maximum of 1.
+\item \code{after_stat(n)}\cr number of points.
+\item \code{after_stat(ndensity)}\cr alias for \code{scaled}, to mirror the syntax of \code{\link[=stat_bin]{stat_bin()}}.
 }
 }
 

--- a/man/geom_density.Rd
+++ b/man/geom_density.Rd
@@ -152,11 +152,11 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item{\code{after_stat(density)}\cr density estimate.}
-\item{\code{after_stat(count)}\cr density * number of points - useful for stacked density plots.}
-\item{\code{after_stat(scaled)}\cr density estimate, scaled to maximum of 1.}
-\item{\code{after_stat(n)}\cr number of points.}
-\item{\code{after_stat(ndensity)}\cr alias for \code{scaled}, to mirror the syntax of \code{\link[=stat_bin]{stat_bin()}}.}
+\item \code{after_stat(density)}: density estimate.
+\item \code{after_stat(count)}: density * number of points - useful for stacked density plots.
+\item \code{after_stat(scaled)}: density estimate, scaled to maximum of 1.
+\item \code{after_stat(n)}: number of points.
+\item \code{after_stat(ndensity)}: alias for \code{scaled}, to mirror the syntax of \code{\link[=stat_bin]{stat_bin()}}.
 }
 }
 

--- a/man/geom_density.Rd
+++ b/man/geom_density.Rd
@@ -150,13 +150,15 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
+These are calculated by the 'stat' part of layers and can be accessed with
+\link[=aes_eval]{delayed evaluation}.
 \describe{
-\item{density}{density estimate}
-\item{count}{density * number of points - useful for stacked density
-plots}
-\item{scaled}{density estimate, scaled to maximum of 1}
-\item{n}{number of points}
-\item{ndensity}{alias for \code{scaled}, to mirror the syntax of
+\item{\code{after_stat(density)}}{density estimate}
+\item{\code{after_stat(count)}}{density * number of points - useful for stacked
+density plots}
+\item{\code{after_stat(scaled)}}{density estimate, scaled to maximum of 1}
+\item{\code{after_stat(n)}}{number of points}
+\item{\code{after_stat(ndensity)}}{alias for \code{scaled}, to mirror the syntax of
 \code{\link[=stat_bin]{stat_bin()}}}
 }
 }

--- a/man/geom_density_2d.Rd
+++ b/man/geom_density_2d.Rd
@@ -192,18 +192,14 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with
-\link[=aes_eval]{delayed evaluation}. \code{stat_density_2d()} and
-\code{stat_density_2d_filled()} compute different variables depending on whether
-contouring is turned on or off. With contouring off (\code{contour = FALSE}), both
-stats behave the same, and the following variables are provided:
-\describe{
-\item{\code{after_stat(density)}}{The density estimate.}
-\item{\code{after_stat(ndensity)}}{Density estimate, scaled to a maximum of 1.}
-\item{\code{after_stat(count)}}{Density estimate * number of observations in
-group.}
-\item{\code{after_stat(n)}}{Number of observations in each group.}
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}. \code{stat_density_2d()} and \code{stat_density_2d_filled()} compute  different variables depending on whether contouring is turned on or off.  With contouring off (\code{contour = FALSE}), both stats behave the same, and  the following variables are provided:
+\itemize{
+\item{\code{after_stat(density)}\cr The density estimate.}
+\item{\code{after_stat(ndensity)}\cr Density estimate, scaled to a maximum of 1.}
+\item{\code{after_stat(count)}\cr Density estimate * number of observations in group.}
+\item{\code{after_stat(n)}\cr Number of observations in each group.}
 }
+
 
 With contouring on (\code{contour = TRUE}), either \code{\link[=stat_contour]{stat_contour()}} or
 \code{\link[=stat_contour_filled]{stat_contour_filled()}} (for contour lines or contour bands,

--- a/man/geom_density_2d.Rd
+++ b/man/geom_density_2d.Rd
@@ -194,10 +194,10 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}. \code{stat_density_2d()} and \code{stat_density_2d_filled()} compute  different variables depending on whether contouring is turned on or off.  With contouring off (\code{contour = FALSE}), both stats behave the same, and  the following variables are provided:
 \itemize{
-\item \code{after_stat(density)}: The density estimate.
-\item \code{after_stat(ndensity)}: Density estimate, scaled to a maximum of 1.
-\item \code{after_stat(count)}: Density estimate * number of observations in group.
-\item \code{after_stat(n)}: Number of observations in each group.
+\item \code{after_stat(density)}\cr The density estimate.
+\item \code{after_stat(ndensity)}\cr Density estimate, scaled to a maximum of 1.
+\item \code{after_stat(count)}\cr Density estimate * number of observations in group.
+\item \code{after_stat(n)}\cr Number of observations in each group.
 }
 
 

--- a/man/geom_density_2d.Rd
+++ b/man/geom_density_2d.Rd
@@ -192,15 +192,17 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-\code{stat_density_2d()} and \code{stat_density_2d_filled()} compute different
-variables depending on whether contouring is turned on or off. With
-contouring off (\code{contour = FALSE}), both stats behave the same, and the
-following variables are provided:
+These are calculated by the 'stat' part of layers and can be accessed with
+\link[=aes_eval]{delayed evaluation}. \code{stat_density_2d()} and
+\code{stat_density_2d_filled()} compute different variables depending on whether
+contouring is turned on or off. With contouring off (\code{contour = FALSE}), both
+stats behave the same, and the following variables are provided:
 \describe{
-\item{\code{density}}{The density estimate.}
-\item{\code{ndensity}}{Density estimate, scaled to a maximum of 1.}
-\item{\code{count}}{Density estimate * number of observations in group.}
-\item{\code{n}}{Number of observations in each group.}
+\item{\code{after_stat(density)}}{The density estimate.}
+\item{\code{after_stat(ndensity)}}{Density estimate, scaled to a maximum of 1.}
+\item{\code{after_stat(count)}}{Density estimate * number of observations in
+group.}
+\item{\code{after_stat(n)}}{Number of observations in each group.}
 }
 
 With contouring on (\code{contour = TRUE}), either \code{\link[=stat_contour]{stat_contour()}} or

--- a/man/geom_density_2d.Rd
+++ b/man/geom_density_2d.Rd
@@ -194,10 +194,10 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}. \code{stat_density_2d()} and \code{stat_density_2d_filled()} compute  different variables depending on whether contouring is turned on or off.  With contouring off (\code{contour = FALSE}), both stats behave the same, and  the following variables are provided:
 \itemize{
-\item{\code{after_stat(density)}\cr The density estimate.}
-\item{\code{after_stat(ndensity)}\cr Density estimate, scaled to a maximum of 1.}
-\item{\code{after_stat(count)}\cr Density estimate * number of observations in group.}
-\item{\code{after_stat(n)}\cr Number of observations in each group.}
+\item \code{after_stat(density)}: The density estimate.
+\item \code{after_stat(ndensity)}: Density estimate, scaled to a maximum of 1.
+\item \code{after_stat(count)}: Density estimate * number of observations in group.
+\item \code{after_stat(n)}: Number of observations in each group.
 }
 
 

--- a/man/geom_dotplot.Rd
+++ b/man/geom_dotplot.Rd
@@ -143,16 +143,19 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
+These are calculated by the 'stat' part of layers and can be accessed with
+\link[=aes_eval]{delayed evaluation}.
 \describe{
-\item{x}{center of each bin, if binaxis is "x"}
-\item{y}{center of each bin, if binaxis is "x"}
-\item{binwidth}{max width of each bin if method is "dotdensity";
-width of each bin if method is "histodot"}
-\item{count}{number of points in bin}
-\item{ncount}{count, scaled to maximum of 1}
-\item{density}{density of points in bin, scaled to integrate to 1,
-if method is "histodot"}
-\item{ndensity}{density, scaled to maximum of 1, if method is "histodot"}
+\item{\code{after_stat(x)}}{center of each bin, if binaxis is "x"}
+\item{\code{after_stat(y)}}{center of each bin, if binaxis is "x"}
+\item{\code{after_stat(binwidth)}}{max width of each bin if method is
+"dotdensity"; width of each bin if method is "histodot"}
+\item{\code{after_stat(count)}}{number of points in bin}
+\item{\code{after_stat(ncount)}}{count, scaled to maximum of 1}
+\item{\code{after_stat(density)}}{density of points in bin, scaled to integrate
+to 1, if method is "histodot"}
+\item{\code{after_stat(ndensity)}}{density, scaled to maximum of 1, if method is
+"histodot"}
 }
 }
 

--- a/man/geom_dotplot.Rd
+++ b/man/geom_dotplot.Rd
@@ -145,13 +145,13 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item{\code{after_stat(x)}\cr center of each bin, if \code{binaxis} is \code{"x"}.}
-\item{\code{after_stat(y)}\cr center of each bin, if \code{binaxis} is \code{"x"}.}
-\item{\code{after_stat(binwidth)}\cr maximum width of each bin if method is \code{"dotdensity"};  width of each bin if method is \code{"histodot"}.}
-\item{\code{after_stat(count)}\cr number of points in bin.}
-\item{\code{after_stat(ncount)}\cr count, scaled to a maximum of 1.}
-\item{\code{after_stat(density)}\cr density of points in bin, scaled to integrate to 1, if method  is \code{"histodot"}.}
-\item{\code{after_stat(ndensity)}\cr density, scaled to maximum of 1, if method is \code{"histodot"}.}
+\item \code{after_stat(x)}: center of each bin, if \code{binaxis} is \code{"x"}.
+\item \code{after_stat(y)}: center of each bin, if \code{binaxis} is \code{"x"}.
+\item \code{after_stat(binwidth)}: maximum width of each bin if method is \code{"dotdensity"};  width of each bin if method is \code{"histodot"}.
+\item \code{after_stat(count)}: number of points in bin.
+\item \code{after_stat(ncount)}: count, scaled to a maximum of 1.
+\item \code{after_stat(density)}: density of points in bin, scaled to integrate to 1, if method  is \code{"histodot"}.
+\item \code{after_stat(ndensity)}: density, scaled to maximum of 1, if method is \code{"histodot"}.
 }
 }
 

--- a/man/geom_dotplot.Rd
+++ b/man/geom_dotplot.Rd
@@ -145,13 +145,13 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item \code{after_stat(x)}: center of each bin, if \code{binaxis} is \code{"x"}.
-\item \code{after_stat(y)}: center of each bin, if \code{binaxis} is \code{"x"}.
-\item \code{after_stat(binwidth)}: maximum width of each bin if method is \code{"dotdensity"};  width of each bin if method is \code{"histodot"}.
-\item \code{after_stat(count)}: number of points in bin.
-\item \code{after_stat(ncount)}: count, scaled to a maximum of 1.
-\item \code{after_stat(density)}: density of points in bin, scaled to integrate to 1, if method  is \code{"histodot"}.
-\item \code{after_stat(ndensity)}: density, scaled to maximum of 1, if method is \code{"histodot"}.
+\item \code{after_stat(x)}\cr center of each bin, if \code{binaxis} is \code{"x"}.
+\item \code{after_stat(y)}\cr center of each bin, if \code{binaxis} is \code{"x"}.
+\item \code{after_stat(binwidth)}\cr maximum width of each bin if method is \code{"dotdensity"};  width of each bin if method is \code{"histodot"}.
+\item \code{after_stat(count)}\cr number of points in bin.
+\item \code{after_stat(ncount)}\cr count, scaled to a maximum of 1.
+\item \code{after_stat(density)}\cr density of points in bin, scaled to integrate to 1, if method  is \code{"histodot"}.
+\item \code{after_stat(ndensity)}\cr density, scaled to maximum of 1, if method is \code{"histodot"}.
 }
 }
 

--- a/man/geom_dotplot.Rd
+++ b/man/geom_dotplot.Rd
@@ -143,19 +143,15 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with
-\link[=aes_eval]{delayed evaluation}.
-\describe{
-\item{\code{after_stat(x)}}{center of each bin, if binaxis is "x"}
-\item{\code{after_stat(y)}}{center of each bin, if binaxis is "x"}
-\item{\code{after_stat(binwidth)}}{max width of each bin if method is
-"dotdensity"; width of each bin if method is "histodot"}
-\item{\code{after_stat(count)}}{number of points in bin}
-\item{\code{after_stat(ncount)}}{count, scaled to maximum of 1}
-\item{\code{after_stat(density)}}{density of points in bin, scaled to integrate
-to 1, if method is "histodot"}
-\item{\code{after_stat(ndensity)}}{density, scaled to maximum of 1, if method is
-"histodot"}
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
+\itemize{
+\item{\code{after_stat(x)}\cr center of each bin, if \code{binaxis} is \code{"x"}.}
+\item{\code{after_stat(y)}\cr center of each bin, if \code{binaxis} is \code{"x"}.}
+\item{\code{after_stat(binwidth)}\cr maximum width of each bin if method is \code{"dotdensity"};  width of each bin if method is \code{"histodot"}.}
+\item{\code{after_stat(count)}\cr number of points in bin.}
+\item{\code{after_stat(ncount)}\cr count, scaled to a maximum of 1.}
+\item{\code{after_stat(density)}\cr density of points in bin, scaled to integrate to 1, if method  is \code{"histodot"}.}
+\item{\code{after_stat(ndensity)}\cr density, scaled to maximum of 1, if method is \code{"histodot"}.}
 }
 }
 

--- a/man/geom_function.Rd
+++ b/man/geom_function.Rd
@@ -106,12 +106,10 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with
-\link[=aes_eval]{delayed evaluation}. \code{stat_function()} computes the following
-variables:
-\describe{
-\item{\code{after_stat(x)}}{x values along a grid}
-\item{\code{after_stat(y)}}{value of the function evaluated at corresponding x}
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
+\itemize{
+\item{\code{after_stat(x)}\cr \code{x} values along a grid.}
+\item{\code{after_stat(y)}\cr values of the function evaluated at corresponding \code{x}.}
 }
 }
 

--- a/man/geom_function.Rd
+++ b/man/geom_function.Rd
@@ -108,8 +108,8 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item \code{after_stat(x)}: \code{x} values along a grid.
-\item \code{after_stat(y)}: values of the function evaluated at corresponding \code{x}.
+\item \code{after_stat(x)}\cr \code{x} values along a grid.
+\item \code{after_stat(y)}\cr values of the function evaluated at corresponding \code{x}.
 }
 }
 

--- a/man/geom_function.Rd
+++ b/man/geom_function.Rd
@@ -108,8 +108,8 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item{\code{after_stat(x)}\cr \code{x} values along a grid.}
-\item{\code{after_stat(y)}\cr values of the function evaluated at corresponding \code{x}.}
+\item \code{after_stat(x)}: \code{x} values along a grid.
+\item \code{after_stat(y)}: values of the function evaluated at corresponding \code{x}.
 }
 }
 

--- a/man/geom_function.Rd
+++ b/man/geom_function.Rd
@@ -106,10 +106,12 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-\code{stat_function()} computes the following variables:
+These are calculated by the 'stat' part of layers and can be accessed with
+\link[=aes_eval]{delayed evaluation}. \code{stat_function()} computes the following
+variables:
 \describe{
-\item{x}{x values along a grid}
-\item{y}{value of the function evaluated at corresponding x}
+\item{\code{after_stat(x)}}{x values along a grid}
+\item{\code{after_stat(y)}}{value of the function evaluated at corresponding x}
 }
 }
 

--- a/man/geom_hex.Rd
+++ b/man/geom_hex.Rd
@@ -110,10 +110,10 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item \code{after_stat(count)}: number of points in bin.
-\item \code{after_stat(density)}: density of points in bin, scaled to integrate to 1.
-\item \code{after_stat(ncount)}: count, scaled to maximum of 1.
-\item \code{after_stat(ndensity)}: density, scaled to maximum of 1.
+\item \code{after_stat(count)}\cr number of points in bin.
+\item \code{after_stat(density)}\cr density of points in bin, scaled to integrate to 1.
+\item \code{after_stat(ncount)}\cr count, scaled to maximum of 1.
+\item \code{after_stat(ndensity)}\cr density, scaled to maximum of 1.
 }
 }
 

--- a/man/geom_hex.Rd
+++ b/man/geom_hex.Rd
@@ -108,11 +108,14 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
+These are calculated by the 'stat' part of layers and can be accessed with
+\link[=aes_eval]{delayed evaluation}.
 \describe{
-\item{count}{number of points in bin}
-\item{density}{density of points in bin, scaled to integrate to 1}
-\item{ncount}{count, scaled to maximum of 1}
-\item{ndensity}{density, scaled to maximum of 1}
+\item{\code{after_stat(count)}}{number of points in bin}
+\item{\code{after_stat(density)}}{density of points in bin, scaled to integrate
+to 1}
+\item{\code{after_stat(ncount)}}{count, scaled to maximum of 1}
+\item{\code{after_stat(ndensity)}}{density, scaled to maximum of 1}
 }
 }
 

--- a/man/geom_hex.Rd
+++ b/man/geom_hex.Rd
@@ -110,10 +110,10 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item{\code{after_stat(count)}\cr number of points in bin.}
-\item{\code{after_stat(density)}\cr density of points in bin, scaled to integrate to 1.}
-\item{\code{after_stat(ncount)}\cr count, scaled to maximum of 1.}
-\item{\code{after_stat(ndensity)}\cr density, scaled to maximum of 1.}
+\item \code{after_stat(count)}: number of points in bin.
+\item \code{after_stat(density)}: density of points in bin, scaled to integrate to 1.
+\item \code{after_stat(ncount)}: count, scaled to maximum of 1.
+\item \code{after_stat(ndensity)}: density, scaled to maximum of 1.
 }
 }
 

--- a/man/geom_hex.Rd
+++ b/man/geom_hex.Rd
@@ -108,14 +108,12 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with
-\link[=aes_eval]{delayed evaluation}.
-\describe{
-\item{\code{after_stat(count)}}{number of points in bin}
-\item{\code{after_stat(density)}}{density of points in bin, scaled to integrate
-to 1}
-\item{\code{after_stat(ncount)}}{count, scaled to maximum of 1}
-\item{\code{after_stat(ndensity)}}{density, scaled to maximum of 1}
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
+\itemize{
+\item{\code{after_stat(count)}\cr number of points in bin.}
+\item{\code{after_stat(density)}\cr density of points in bin, scaled to integrate to 1.}
+\item{\code{after_stat(ncount)}\cr count, scaled to maximum of 1.}
+\item{\code{after_stat(ndensity)}\cr density, scaled to maximum of 1.}
 }
 }
 

--- a/man/geom_histogram.Rd
+++ b/man/geom_histogram.Rd
@@ -175,15 +175,13 @@ This geom treats each axis differently and, thus, can thus have two orientations
 
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with
-\link[=aes_eval]{delayed evaluation}.
-\describe{
-\item{\code{after_stat(count)}}{number of points in bin}
-\item{\code{after_stat(density)}}{density of points in bin, scaled to integrate
-to 1}
-\item{\code{after_stat(ncount)}}{count, scaled to maximum of 1}
-\item{\code{after_stat(ndensity)}}{density, scaled to maximum of 1}
-\item{\code{after_stat(width)}}{widths of bins}
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
+\itemize{
+\item{\code{after_stat(count)}\cr number of points in bin.}
+\item{\code{after_stat(density)}\cr density of points in bin, scaled to integrate to 1.}
+\item{\code{after_stat(ncount)}\cr count, scaled to a maximum of 1.}
+\item{\code{after_stat(ndensity)}\cr density, scaled to a maximum of 1.}
+\item{\code{after_stat(width)}\cr widths of bins.}
 }
 }
 

--- a/man/geom_histogram.Rd
+++ b/man/geom_histogram.Rd
@@ -177,11 +177,11 @@ This geom treats each axis differently and, thus, can thus have two orientations
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item \code{after_stat(count)}: number of points in bin.
-\item \code{after_stat(density)}: density of points in bin, scaled to integrate to 1.
-\item \code{after_stat(ncount)}: count, scaled to a maximum of 1.
-\item \code{after_stat(ndensity)}: density, scaled to a maximum of 1.
-\item \code{after_stat(width)}: widths of bins.
+\item \code{after_stat(count)}\cr number of points in bin.
+\item \code{after_stat(density)}\cr density of points in bin, scaled to integrate to 1.
+\item \code{after_stat(ncount)}\cr count, scaled to a maximum of 1.
+\item \code{after_stat(ndensity)}\cr density, scaled to a maximum of 1.
+\item \code{after_stat(width)}\cr widths of bins.
 }
 }
 

--- a/man/geom_histogram.Rd
+++ b/man/geom_histogram.Rd
@@ -177,11 +177,11 @@ This geom treats each axis differently and, thus, can thus have two orientations
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item{\code{after_stat(count)}\cr number of points in bin.}
-\item{\code{after_stat(density)}\cr density of points in bin, scaled to integrate to 1.}
-\item{\code{after_stat(ncount)}\cr count, scaled to a maximum of 1.}
-\item{\code{after_stat(ndensity)}\cr density, scaled to a maximum of 1.}
-\item{\code{after_stat(width)}\cr widths of bins.}
+\item \code{after_stat(count)}: number of points in bin.
+\item \code{after_stat(density)}: density of points in bin, scaled to integrate to 1.
+\item \code{after_stat(ncount)}: count, scaled to a maximum of 1.
+\item \code{after_stat(ndensity)}: density, scaled to a maximum of 1.
+\item \code{after_stat(width)}: widths of bins.
 }
 }
 

--- a/man/geom_histogram.Rd
+++ b/man/geom_histogram.Rd
@@ -175,12 +175,15 @@ This geom treats each axis differently and, thus, can thus have two orientations
 
 \section{Computed variables}{
 
+These are calculated by the 'stat' part of layers and can be accessed with
+\link[=aes_eval]{delayed evaluation}.
 \describe{
-\item{\code{count}}{number of points in bin}
-\item{\code{density}}{density of points in bin, scaled to integrate to 1}
-\item{\code{ncount}}{count, scaled to maximum of 1}
-\item{\code{ndensity}}{density, scaled to maximum of 1}
-\item{\code{width}}{widths of bins}
+\item{\code{after_stat(count)}}{number of points in bin}
+\item{\code{after_stat(density)}}{density of points in bin, scaled to integrate
+to 1}
+\item{\code{after_stat(ncount)}}{count, scaled to maximum of 1}
+\item{\code{after_stat(ndensity)}}{density, scaled to maximum of 1}
+\item{\code{after_stat(width)}}{widths of bins}
 }
 }
 

--- a/man/geom_qq.Rd
+++ b/man/geom_qq.Rd
@@ -154,15 +154,15 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}. \cr Variables computed by \code{stat_qq()}:
 \itemize{
-\item \code{after_stat(sample)}: Sample quantiles.
-\item \code{after_stat(theoretical)}: Theoretical quantiles.
+\item \code{after_stat(sample)}\cr Sample quantiles.
+\item \code{after_stat(theoretical)}\cr Theoretical quantiles.
 }
 
 
 Variables computed by \code{stat_qq_line()}:
 \itemize{
-\item \code{after_stat(x)}: x-coordinates of the endpoints of the line segment connecting the  points at the chosen quantiles of the theoretical and the sample  distributions.
-\item \code{after_stat(y)}: y-coordinates of the endpoints.
+\item \code{after_stat(x)}\cr x-coordinates of the endpoints of the line segment connecting the  points at the chosen quantiles of the theoretical and the sample  distributions.
+\item \code{after_stat(y)}\cr y-coordinates of the endpoints.
 }
 }
 

--- a/man/geom_qq.Rd
+++ b/man/geom_qq.Rd
@@ -152,17 +152,19 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
+These are calculated by the 'stat' part of layers and can be accessed with
+\link[=aes_eval]{delayed evaluation}.
 Variables computed by \code{stat_qq()}:
 \describe{
-\item{sample}{sample quantiles}
-\item{theoretical}{theoretical quantiles}
+\item{\code{after_stat(sample)}}{sample quantiles}
+\item{\code{after_stat(theoretical)}}{theoretical quantiles}
 }
 Variables computed by \code{stat_qq_line()}:
 \describe{
-\item{x}{x-coordinates of the endpoints of the line segment connecting the
-points at the chosen quantiles of the theoretical and the sample
-distributions}
-\item{y}{y-coordinates of the endpoints}
+\item{\code{after_stat(x)}}{x-coordinates of the endpoints of the line segment
+connecting the points at the chosen quantiles of the theoretical and the
+sample distributions}
+\item{\code{after_stat(y)}}{y-coordinates of the endpoints}
 }
 }
 

--- a/man/geom_qq.Rd
+++ b/man/geom_qq.Rd
@@ -152,19 +152,17 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with
-\link[=aes_eval]{delayed evaluation}.
-Variables computed by \code{stat_qq()}:
-\describe{
-\item{\code{after_stat(sample)}}{sample quantiles}
-\item{\code{after_stat(theoretical)}}{theoretical quantiles}
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}. \cr Variables computed by \code{stat_qq()}:
+\itemize{
+\item{\code{after_stat(sample)}\cr Sample quantiles.}
+\item{\code{after_stat(theoretical)}\cr Theoretical quantiles.}
 }
+
+
 Variables computed by \code{stat_qq_line()}:
-\describe{
-\item{\code{after_stat(x)}}{x-coordinates of the endpoints of the line segment
-connecting the points at the chosen quantiles of the theoretical and the
-sample distributions}
-\item{\code{after_stat(y)}}{y-coordinates of the endpoints}
+\itemize{
+\item{\code{after_stat(x)}\cr x-coordinates of the endpoints of the line segment connecting the  points at the chosen quantiles of the theoretical and the sample  distributions.}
+\item{\code{after_stat(y)}\cr y-coordinates of the endpoints.}
 }
 }
 

--- a/man/geom_qq.Rd
+++ b/man/geom_qq.Rd
@@ -154,15 +154,15 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}. \cr Variables computed by \code{stat_qq()}:
 \itemize{
-\item{\code{after_stat(sample)}\cr Sample quantiles.}
-\item{\code{after_stat(theoretical)}\cr Theoretical quantiles.}
+\item \code{after_stat(sample)}: Sample quantiles.
+\item \code{after_stat(theoretical)}: Theoretical quantiles.
 }
 
 
 Variables computed by \code{stat_qq_line()}:
 \itemize{
-\item{\code{after_stat(x)}\cr x-coordinates of the endpoints of the line segment connecting the  points at the chosen quantiles of the theoretical and the sample  distributions.}
-\item{\code{after_stat(y)}\cr y-coordinates of the endpoints.}
+\item \code{after_stat(x)}: x-coordinates of the endpoints of the line segment connecting the  points at the chosen quantiles of the theoretical and the sample  distributions.
+\item \code{after_stat(y)}: y-coordinates of the endpoints.
 }
 }
 

--- a/man/geom_quantile.Rd
+++ b/man/geom_quantile.Rd
@@ -120,10 +120,9 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with
-\link[=aes_eval]{delayed evaluation}.
-\describe{
-\item{\code{after_stat(quantile)}}{quantile of distribution}
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
+\itemize{
+\item{\code{after_stat(quantile)}\cr Quantile of distribution.}
 }
 }
 

--- a/man/geom_quantile.Rd
+++ b/man/geom_quantile.Rd
@@ -122,7 +122,7 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item{\code{after_stat(quantile)}\cr Quantile of distribution.}
+\item \code{after_stat(quantile)}: Quantile of distribution.
 }
 }
 

--- a/man/geom_quantile.Rd
+++ b/man/geom_quantile.Rd
@@ -120,8 +120,10 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
+These are calculated by the 'stat' part of layers and can be accessed with
+\link[=aes_eval]{delayed evaluation}.
 \describe{
-\item{quantile}{quantile of distribution}
+\item{\code{after_stat(quantile)}}{quantile of distribution}
 }
 }
 

--- a/man/geom_quantile.Rd
+++ b/man/geom_quantile.Rd
@@ -122,7 +122,7 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item \code{after_stat(quantile)}: Quantile of distribution.
+\item \code{after_stat(quantile)}\cr Quantile of distribution.
 }
 }
 

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -175,16 +175,12 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with
-\link[=aes_eval]{delayed evaluation}. \code{stat_smooth()} provides the following
-variables, some of which depend on the orientation:
-\describe{
-\item{\code{after_stat(y)} \emph{or} \code{after_stat(x)}}{predicted value}
-\item{\code{after_stat(ymin)} \emph{or} \code{after_stat(xmin)}}{lower pointwise
-confidence interval around the mean}
-\item{\code{after_stat(ymax)} \emph{or} \code{after_stat(xmax)}}{upper pointwise
-confidence interval around the mean}
-\item{\code{after_stat(se)}}{standard error}
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}. \code{stat_smooth()} provides the following variables, some of  which depend on the orientation:
+\itemize{
+\item{\code{after_stat(y)} \emph{or} \code{after_stat(x)}\cr Predicted value.}
+\item{\code{after_stat(ymin)} \emph{or} \code{after_stat(xmin)}\cr Lower pointwise confidence interval around the mean.}
+\item{\code{after_stat(ymax)} \emph{or} \code{after_stat(xmax)}\cr Upper pointwise confidence interval around the mean.}
+\item{\code{after_stat(se)}\cr Standard error.}
 }
 }
 

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -175,12 +175,16 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-\code{stat_smooth()} provides the following variables, some of which depend on the orientation:
+These are calculated by the 'stat' part of layers and can be accessed with
+\link[=aes_eval]{delayed evaluation}. \code{stat_smooth()} provides the following
+variables, some of which depend on the orientation:
 \describe{
-\item{y \emph{or} x}{predicted value}
-\item{ymin \emph{or} xmin}{lower pointwise confidence interval around the mean}
-\item{ymax \emph{or} xmax}{upper pointwise confidence interval around the mean}
-\item{se}{standard error}
+\item{\code{after_stat(y)} \emph{or} \code{after_stat(x)}}{predicted value}
+\item{\code{after_stat(ymin)} \emph{or} \code{after_stat(xmin)}}{lower pointwise
+confidence interval around the mean}
+\item{\code{after_stat(ymax)} \emph{or} \code{after_stat(xmax)}}{upper pointwise
+confidence interval around the mean}
+\item{\code{after_stat(se)}}{standard error}
 }
 }
 

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -177,10 +177,10 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}. \code{stat_smooth()} provides the following variables, some of  which depend on the orientation:
 \itemize{
-\item \code{after_stat(y)} \emph{or} \code{after_stat(x)}: Predicted value.
-\item \code{after_stat(ymin)} \emph{or} \code{after_stat(xmin)}: Lower pointwise confidence interval around the mean.
-\item \code{after_stat(ymax)} \emph{or} \code{after_stat(xmax)}: Upper pointwise confidence interval around the mean.
-\item \code{after_stat(se)}: Standard error.
+\item \code{after_stat(y)} \emph{or} \code{after_stat(x)}\cr Predicted value.
+\item \code{after_stat(ymin)} \emph{or} \code{after_stat(xmin)}\cr Lower pointwise confidence interval around the mean.
+\item \code{after_stat(ymax)} \emph{or} \code{after_stat(xmax)}\cr Upper pointwise confidence interval around the mean.
+\item \code{after_stat(se)}\cr Standard error.
 }
 }
 

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -177,10 +177,10 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}. \code{stat_smooth()} provides the following variables, some of  which depend on the orientation:
 \itemize{
-\item{\code{after_stat(y)} \emph{or} \code{after_stat(x)}\cr Predicted value.}
-\item{\code{after_stat(ymin)} \emph{or} \code{after_stat(xmin)}\cr Lower pointwise confidence interval around the mean.}
-\item{\code{after_stat(ymax)} \emph{or} \code{after_stat(xmax)}\cr Upper pointwise confidence interval around the mean.}
-\item{\code{after_stat(se)}\cr Standard error.}
+\item \code{after_stat(y)} \emph{or} \code{after_stat(x)}: Predicted value.
+\item \code{after_stat(ymin)} \emph{or} \code{after_stat(xmin)}: Lower pointwise confidence interval around the mean.
+\item \code{after_stat(ymax)} \emph{or} \code{after_stat(xmax)}: Upper pointwise confidence interval around the mean.
+\item \code{after_stat(se)}: Standard error.
 }
 }
 

--- a/man/geom_violin.Rd
+++ b/man/geom_violin.Rd
@@ -141,17 +141,14 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with
-\link[=aes_eval]{delayed evaluation}.
-\describe{
-\item{\code{after_stat(density)}}{density estimate}
-\item{\code{after_stat(scaled)}}{density estimate, scaled to maximum of 1}
-\item{\code{after_stat(count)}}{density * number of points - probably useless
-for violin plots}
-\item{\code{after_stat(violinwidth)}}{density scaled for the violin plot,
-according to area, counts or to a constant maximum width}
-\item{\code{after_stat(n)}}{number of points}
-\item{\code{after_stat(width)}}{width of violin bounding box}
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
+\itemize{
+\item{\code{after_stat(density)}\cr Density estimate.}
+\item{\code{after_stat(scaled)}\cr Density estimate, scaled to a maximum of 1.}
+\item{\code{after_stat(count)}\cr Density * number of points - probably useless for violin  plots.}
+\item{\code{after_stat(violinwidth)}\cr Density scaled for the violin plot, according to area,  counts or to a constant maximum width.}
+\item{\code{after_stat(n)}\cr Number of points.}
+\item{\code{after_stat(width)}\cr Width of violin bounding box.}
 }
 }
 

--- a/man/geom_violin.Rd
+++ b/man/geom_violin.Rd
@@ -143,12 +143,12 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item \code{after_stat(density)}: Density estimate.
-\item \code{after_stat(scaled)}: Density estimate, scaled to a maximum of 1.
-\item \code{after_stat(count)}: Density * number of points - probably useless for violin  plots.
-\item \code{after_stat(violinwidth)}: Density scaled for the violin plot, according to area,  counts or to a constant maximum width.
-\item \code{after_stat(n)}: Number of points.
-\item \code{after_stat(width)}: Width of violin bounding box.
+\item \code{after_stat(density)}\cr Density estimate.
+\item \code{after_stat(scaled)}\cr Density estimate, scaled to a maximum of 1.
+\item \code{after_stat(count)}\cr Density * number of points - probably useless for violin  plots.
+\item \code{after_stat(violinwidth)}\cr Density scaled for the violin plot, according to area,  counts or to a constant maximum width.
+\item \code{after_stat(n)}\cr Number of points.
+\item \code{after_stat(width)}\cr Width of violin bounding box.
 }
 }
 

--- a/man/geom_violin.Rd
+++ b/man/geom_violin.Rd
@@ -143,12 +143,12 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item{\code{after_stat(density)}\cr Density estimate.}
-\item{\code{after_stat(scaled)}\cr Density estimate, scaled to a maximum of 1.}
-\item{\code{after_stat(count)}\cr Density * number of points - probably useless for violin  plots.}
-\item{\code{after_stat(violinwidth)}\cr Density scaled for the violin plot, according to area,  counts or to a constant maximum width.}
-\item{\code{after_stat(n)}\cr Number of points.}
-\item{\code{after_stat(width)}\cr Width of violin bounding box.}
+\item \code{after_stat(density)}: Density estimate.
+\item \code{after_stat(scaled)}: Density estimate, scaled to a maximum of 1.
+\item \code{after_stat(count)}: Density * number of points - probably useless for violin  plots.
+\item \code{after_stat(violinwidth)}: Density scaled for the violin plot, according to area,  counts or to a constant maximum width.
+\item \code{after_stat(n)}: Number of points.
+\item \code{after_stat(width)}: Width of violin bounding box.
 }
 }
 

--- a/man/geom_violin.Rd
+++ b/man/geom_violin.Rd
@@ -141,14 +141,17 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
+These are calculated by the 'stat' part of layers and can be accessed with
+\link[=aes_eval]{delayed evaluation}.
 \describe{
-\item{density}{density estimate}
-\item{scaled}{density estimate, scaled to maximum of 1}
-\item{count}{density * number of points - probably useless for violin plots}
-\item{violinwidth}{density scaled for the violin plot, according to area, counts
-or to a constant maximum width}
-\item{n}{number of points}
-\item{width}{width of violin bounding box}
+\item{\code{after_stat(density)}}{density estimate}
+\item{\code{after_stat(scaled)}}{density estimate, scaled to maximum of 1}
+\item{\code{after_stat(count)}}{density * number of points - probably useless
+for violin plots}
+\item{\code{after_stat(violinwidth)}}{density scaled for the violin plot,
+according to area, counts or to a constant maximum width}
+\item{\code{after_stat(n)}}{number of points}
+\item{\code{after_stat(width)}}{width of violin bounding box}
 }
 }
 

--- a/man/stat_ecdf.Rd
+++ b/man/stat_ecdf.Rd
@@ -90,7 +90,7 @@ and will be output on the unused one.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item{\code{after_stat(y)}\cr Cumulative density corresponding to \code{x}.}
+\item \code{after_stat(y)}: Cumulative density corresponding to \code{x}.
 }
 }
 

--- a/man/stat_ecdf.Rd
+++ b/man/stat_ecdf.Rd
@@ -88,8 +88,10 @@ and will be output on the unused one.
 }
 \section{Computed variables}{
 
+These are calculated by the 'stat' part of layers and can be accessed with
+\link[=aes_eval]{delayed evaluation}.
 \describe{
-\item{y}{cumulative density corresponding x}
+\item{\code{after_stat(y)}}{cumulative density corresponding x}
 }
 }
 

--- a/man/stat_ecdf.Rd
+++ b/man/stat_ecdf.Rd
@@ -88,10 +88,9 @@ and will be output on the unused one.
 }
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with
-\link[=aes_eval]{delayed evaluation}.
-\describe{
-\item{\code{after_stat(y)}}{cumulative density corresponding x}
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
+\itemize{
+\item{\code{after_stat(y)}\cr Cumulative density corresponding to \code{x}.}
 }
 }
 

--- a/man/stat_ecdf.Rd
+++ b/man/stat_ecdf.Rd
@@ -90,7 +90,7 @@ and will be output on the unused one.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item \code{after_stat(y)}: Cumulative density corresponding to \code{x}.
+\item \code{after_stat(y)}\cr Cumulative density corresponding to \code{x}.
 }
 }
 

--- a/man/stat_sf_coordinates.Rd
+++ b/man/stat_sf_coordinates.Rd
@@ -102,8 +102,8 @@ dimension.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item \code{after_stat(x)}: X dimension of the simple feature.
-\item \code{after_stat(y)}: Y dimension of the simple feature.
+\item \code{after_stat(x)}\cr X dimension of the simple feature.
+\item \code{after_stat(y)}\cr Y dimension of the simple feature.
 }
 }
 

--- a/man/stat_sf_coordinates.Rd
+++ b/man/stat_sf_coordinates.Rd
@@ -100,11 +100,10 @@ dimension.
 }
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with
-\link[=aes_eval]{delayed evaluation}.
-\describe{
-\item{\code{after_stat(x)}}{X dimension of the simple feature}
-\item{\code{after_stat(y)}}{Y dimension of the simple feature}
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
+\itemize{
+\item{\code{after_stat(x)}\cr X dimension of the simple feature.}
+\item{\code{after_stat(y)}\cr Y dimension of the simple feature.}
 }
 }
 

--- a/man/stat_sf_coordinates.Rd
+++ b/man/stat_sf_coordinates.Rd
@@ -100,9 +100,11 @@ dimension.
 }
 \section{Computed variables}{
 
+These are calculated by the 'stat' part of layers and can be accessed with
+\link[=aes_eval]{delayed evaluation}.
 \describe{
-\item{x}{X dimension of the simple feature}
-\item{y}{Y dimension of the simple feature}
+\item{\code{after_stat(x)}}{X dimension of the simple feature}
+\item{\code{after_stat(y)}}{Y dimension of the simple feature}
 }
 }
 

--- a/man/stat_sf_coordinates.Rd
+++ b/man/stat_sf_coordinates.Rd
@@ -102,8 +102,8 @@ dimension.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item{\code{after_stat(x)}\cr X dimension of the simple feature.}
-\item{\code{after_stat(y)}\cr Y dimension of the simple feature.}
+\item \code{after_stat(x)}: X dimension of the simple feature.
+\item \code{after_stat(y)}: Y dimension of the simple feature.
 }
 }
 

--- a/man/stat_summary_2d.Rd
+++ b/man/stat_summary_2d.Rd
@@ -119,8 +119,8 @@ are summarised with \code{fun}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item \code{after_stat(x)}, \code{after_stat(y)}: Location.
-\item \code{after_stat(value)}: Value of summary statistic.
+\item \code{after_stat(x)}, \code{after_stat(y)}\cr Location.
+\item \code{after_stat(value)}\cr Value of summary statistic.
 }
 }
 

--- a/man/stat_summary_2d.Rd
+++ b/man/stat_summary_2d.Rd
@@ -119,8 +119,8 @@ are summarised with \code{fun}.
 
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
 \itemize{
-\item{\code{after_stat(x)}, \code{after_stat(y)}\cr Location.}
-\item{\code{after_stat(value)}\cr Value of summary statistic.}
+\item \code{after_stat(x)}, \code{after_stat(y)}: Location.
+\item \code{after_stat(value)}: Value of summary statistic.
 }
 }
 

--- a/man/stat_summary_2d.Rd
+++ b/man/stat_summary_2d.Rd
@@ -117,9 +117,11 @@ are summarised with \code{fun}.
 
 \section{Computed variables}{
 
+These are calculated by the 'stat' part of layers and can be accessed with
+\link[=aes_eval]{delayed evaluation}.
 \describe{
-\item{x,y}{Location}
-\item{value}{Value of summary statistic.}
+\item{\code{after_stat(x)},\code{after_stat(y)}}{Location}
+\item{\code{after_stat(value)}}{Value of summary statistic.}
 }
 }
 

--- a/man/stat_summary_2d.Rd
+++ b/man/stat_summary_2d.Rd
@@ -117,11 +117,10 @@ are summarised with \code{fun}.
 
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with
-\link[=aes_eval]{delayed evaluation}.
-\describe{
-\item{\code{after_stat(x)},\code{after_stat(y)}}{Location}
-\item{\code{after_stat(value)}}{Value of summary statistic.}
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}.
+\itemize{
+\item{\code{after_stat(x)}, \code{after_stat(y)}\cr Location.}
+\item{\code{after_stat(value)}\cr Value of summary statistic.}
 }
 }
 

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -56,6 +56,21 @@ test_that("ggsave can handle blank background", {
   expect_true(grepl("fill: none", bg))
 })
 
+test_that("ggsave warns about empty or multiple filenames", {
+  filenames <- c("plot1.png", "plot2.png")
+  plot <- ggplot(mtcars, aes(disp, mpg)) + geom_point()
+
+  withr::with_file(filenames, {
+    expect_warning(
+      suppressMessages(ggsave(filenames, plot)),
+      "`filename` must have length 1"
+    )
+    expect_error(
+      ggsave(character(), plot),
+      "`filename` cannot be empty."
+    )
+  })
+})
 
 # plot_dim ---------------------------------------------------------------
 

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -74,6 +74,7 @@ test_that("uses 7x7 if no graphics device open", {
 test_that("warned about large plot unless limitsize = FALSE", {
   expect_error(plot_dim(c(50, 50)), "exceed 50 inches")
   expect_equal(plot_dim(c(50, 50), limitsize = FALSE), c(50, 50))
+  expect_error(plot_dim(c(15000, 15000), units = "px"), "in pixels).")
 })
 
 test_that("scale multiplies height & width", {

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -56,21 +56,6 @@ test_that("ggsave can handle blank background", {
   expect_true(grepl("fill: none", bg))
 })
 
-test_that("ggsave warns about empty or multiple filenames", {
-  filenames <- c("plot1.png", "plot2.png")
-  plot <- ggplot(mtcars, aes(disp, mpg)) + geom_point()
-
-  withr::with_file(filenames, {
-    expect_warning(
-      suppressMessages(ggsave(filenames, plot)),
-      "`filename` must have length 1"
-    )
-    expect_error(
-      ggsave(character(), plot),
-      "`filename` cannot be empty."
-    )
-  })
-})
 
 # plot_dim ---------------------------------------------------------------
 


### PR DESCRIPTION
This PR aims to fix #4951

Briefly, in 'computed variables' sections there is now a pointer to the `?after_stat` page, and all variable names are wrapped in `after_stat()`. In addition, the `?after_stat` page has been restructured to more clearly articulate what to expect for each stage, as well as sprinkling around some extra, slightly more complicated examples.