### PR TITLE
Fix typo for `compute_panel_` to remove the trailing underscore

### DIFF
--- a/R/stat-.r
+++ b/R/stat-.r
@@ -14,7 +14,7 @@
 #'     `compute_panel(self, data, scales, ...)`, or
 #'     `compute_group(self, data, scales, ...)`.
 #'
-#'     `compute_layer()` is called once per layer, `compute_panel_()`
+#'     `compute_layer()` is called once per layer, `compute_panel()`
 #'     is called once per panel, and `compute_group()` is called once per
 #'     group. All must return a data frame.
 #'

--- a/man/ggplot2-ggproto.Rd
+++ b/man/ggplot2-ggproto.Rd
@@ -327,7 +327,7 @@ override one or more of the following:
 \code{compute_panel(self, data, scales, ...)}, or
 \code{compute_group(self, data, scales, ...)}.
 
-\code{compute_layer()} is called once per layer, \code{compute_panel_()}
+\code{compute_layer()} is called once per layer, \code{compute_panel()}
 is called once per panel, and \code{compute_group()} is called once per
 group. All must return a data frame.
 


### PR DESCRIPTION
I think that this is a typo in the documentation.  If not, then can the difference between `compute_panel` and `compute_panel_` please be clarified?