### PR TITLE
Fix `right` description in binned scales

### DIFF
--- a/R/scale-.r
+++ b/R/scale-.r
@@ -237,8 +237,11 @@ discrete_scale <- function(aesthetics, scale_name, palette, name = waiver(),
 #'   the scale will ask the transformation object to create breaks, and this
 #'   may result in a different number of breaks than requested. Ignored if
 #'   breaks are given explicitly.
-#' @param right Should values on the border between bins be part of the right
-#'   (upper) bin?
+#' @param right Should the intervals be closed on the right (`TRUE`, default) or
+#'   should the intervals be closed on the left (`FALSE`)? 'Closed on the right'
+#'   means that values at break positions are part of the lower bin (open on the
+#'   left), whereas they are part of the upper bin when intervals are closed on
+#'   the left (open on the right).
 #' @param show.limits should the limits of the scale appear as ticks
 #' @keywords internal
 binned_scale <- function(aesthetics, scale_name, palette, name = waiver(),

--- a/man/binned_scale.Rd
+++ b/man/binned_scale.Rd
@@ -113,8 +113,11 @@ the scale will ask the transformation object to create breaks, and this
 may result in a different number of breaks than requested. Ignored if
 breaks are given explicitly.}
 
-\item{right}{Should values on the border between bins be part of the right
-(upper) bin?}
+\item{right}{Should the intervals be closed on the right (\code{TRUE}, default) or
+should the intervals be closed on the left (\code{FALSE})? 'Closed on the right'
+means that values at break positions are part of the lower bin (open on the
+left), whereas they are part of the upper bin when intervals are closed on
+the left (open on the right).}
 
 \item{trans}{For continuous scales, the name of a transformation object
 or the object itself. Built-in transformations include "asn", "atanh",

--- a/man/scale_binned.Rd
+++ b/man/scale_binned.Rd
@@ -110,8 +110,11 @@ bounds values with \code{NA}.
 
 \item{na.value}{Missing values will be replaced with this value.}
 
-\item{right}{Should values on the border between bins be part of the right
-(upper) bin?}
+\item{right}{Should the intervals be closed on the right (\code{TRUE}, default) or
+should the intervals be closed on the left (\code{FALSE})? 'Closed on the right'
+means that values at break positions are part of the lower bin (open on the
+left), whereas they are part of the upper bin when intervals are closed on
+the left (open on the right).}
 
 \item{show.limits}{should the limits of the scale appear as ticks}
 

--- a/man/scale_steps.Rd
+++ b/man/scale_steps.Rd
@@ -89,8 +89,11 @@ instead of exactly evenly spaced between the limits. If \code{TRUE} (default)
 the scale will ask the transformation object to create breaks, and this
 may result in a different number of breaks than requested. Ignored if
 breaks are given explicitly.}
-    \item{\code{right}}{Should values on the border between bins be part of the right
-(upper) bin?}
+    \item{\code{right}}{Should the intervals be closed on the right (\code{TRUE}, default) or
+should the intervals be closed on the left (\code{FALSE})? 'Closed on the right'
+means that values at break positions are part of the lower bin (open on the
+left), whereas they are part of the upper bin when intervals are closed on
+the left (open on the right).}
     \item{\code{show.limits}}{should the limits of the scale appear as ticks}
     \item{\code{name}}{The name of the scale. Used as the axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first


### PR DESCRIPTION
This PR aims to fix #5092.

Contains no code changes, just a documentation change.