### PR TITLE
Fix typos

### DIFF
--- a/R/stat-ellipse.R
+++ b/R/stat-ellipse.R
@@ -6,7 +6,7 @@
 #' @references John Fox and Sanford Weisberg (2011). An \R Companion to
 #'   Applied Regression, Second Edition. Thousand Oaks CA: Sage. URL:
 #'   \url{https://socialsciences.mcmaster.ca/jfox/Books/Companion/}
-#' @refereces Michael Friendly. Georges Monette. John Fox. "Elliptical Insights: Understanding Statistical Methods through Elliptical Geometry." 
+#' @references Michael Friendly. Georges Monette. John Fox. "Elliptical Insights: Understanding Statistical Methods through Elliptical Geometry."
 #' Statist. Sci. 28 (1) 1 - 39, February 2013. URL: \url{https://projecteuclid.org/journals/statistical-science/volume-28/issue-1/Elliptical-Insights-Understanding-Statistical-Methods-through-Elliptical-Geometry/10.1214/12-STS402.full}
 #'
 #' @param level The level at which to draw an ellipse,

--- a/man/stat_ellipse.Rd
+++ b/man/stat_ellipse.Rd
@@ -81,7 +81,7 @@ the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 }
 \description{
 The method for calculating the ellipses has been modified from
-\code{car::dataEllipse} (Fox and Weisberg, 2011)
+\code{car::dataEllipse} (Fox and Weisberg 2011, Friendly and Monette 2013)
 }
 \examples{
 ggplot(faithful, aes(waiting, eruptions)) +
@@ -110,4 +110,7 @@ ggplot(faithful, aes(waiting, eruptions, fill = eruptions > 3)) +
 John Fox and Sanford Weisberg (2011). An \R Companion to
 Applied Regression, Second Edition. Thousand Oaks CA: Sage. URL:
 \url{https://socialsciences.mcmaster.ca/jfox/Books/Companion/}
+
+Michael Friendly. Georges Monette. John Fox. "Elliptical Insights: Understanding Statistical Methods through Elliptical Geometry."
+Statist. Sci. 28 (1) 1 - 39, February 2013. URL: \url{https://projecteuclid.org/journals/statistical-science/volume-28/issue-1/Elliptical-Insights-Understanding-Statistical-Methods-through-Elliptical-Geometry/10.1214/12-STS402.full}
 }

--- a/vignettes/articles/faq-axes.Rmd
+++ b/vignettes/articles/faq-axes.Rmd
@@ -473,7 +473,7 @@ ggplot(mpg, aes(drv)) +
 ```
 
 However note that this removes the padding at the bottom of the bars as well as on top.
-By default, ggplot2 The expands the scale by 5% on each side for continuous variables and by 0.6 units on each side for discrete variables.
+By default, ggplot2 expands the scale by 5% on each side for continuous variables and by 0.6 units on each side for discrete variables.
 To keep the default expansion on top while removing it at the bottom, you can use the following.
 The `mult` argument in `expansion()` takes a multiplicative range expansion factors.
 Given a vector of length 2, the lower limit is expanded by `mult[1]` (in this case 0) and the upper limit is expanded by `mult[2]` (in this case 0.05).


### PR DESCRIPTION
This PR fixes two typos:
* A typo introduced in #4803 where a roxygen tag was incorrect.
* Typo indicated in #5120 (the commit message has a typo of my own making: it mentions the wrong issue)