### PR TITLE
Named shapes "dot" and "blank"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* Added `"dot"` and `"blank"` to list of named shapes, representing 
+  `shape = "."` and `shape = NA` respectively (@teunbrand, #5088).
 * Using two ordered factors as facetting variables in 
   `facet_grid(..., as.table = FALSE)` now throws a warning instead of an
   error (@teunbrand, #5109).

--- a/R/geom-point.r
+++ b/R/geom-point.r
@@ -176,7 +176,9 @@ translate_shape_string <- function(shape_string) {
     "square filled"         = 22,
     "diamond filled"        = 23,
     "triangle filled"       = 24,
-    "triangle down filled"  = 25
+    "triangle down filled"  = 25,
+    "dot"                   = 46,
+    "blank"                 = NA
   )
 
   shape_match <- charmatch(shape_string, names(pch_table))

--- a/vignettes/ggplot2-specs.Rmd
+++ b/vignettes/ggplot2-specs.Rmd
@@ -172,13 +172,13 @@ Shapes take five types of values:
       "diamond", paste("diamond", c("open", "filled", "plus")),
       "triangle", paste("triangle", c("open", "filled", "square")),
       paste("triangle down", c("open", "filled")),
-      "plus", "cross", "asterisk"
+      "plus", "cross", "asterisk", "dot", "blank"
     )
     
     shapes <- data.frame(
       shape_names = shape_names,
-      x = c(1:7, 1:6, 1:3, 5, 1:3, 6, 2:3, 1:3),
-      y = -rep(1:6, c(7, 6, 4, 4, 2, 3))
+      x = c(1:7, 1:6, 1:3, 5, 1:3, 6, 2:3, 1:5),
+      y = -rep(1:6, c(7, 6, 4, 4, 2, 5))
     )
     
     ggplot(shapes, aes(x, y)) +


### PR DESCRIPTION
This PR implements the suggestion in https://github.com/tidyverse/ggplot2/issues/5088#issuecomment-1364554410 to fix #5088.

Briefly, it adds `"dot"` and `"blank"` as valid names for shapes in `geom_point()` that get translated to `shape = "."` and `shape = NA` respectively. The specs vignette was also updated to reflect this.