### PR TITLE
Mark `aes()` and `vars()` as <data-masking>

### DIFF
--- a/R/aes.r
+++ b/R/aes.r
@@ -22,13 +22,14 @@ NULL
 #' programming vignette](https://dplyr.tidyverse.org/articles/programming.html)
 #' to learn more about these techniques.
 #'
-#' @param x,y,... List of name-value pairs in the form `aesthetic = variable`
-#'   describing which variables in the layer data should be mapped to which
-#'   aesthetics used by the paired geom/stat. The expression `variable` is
-#'   evaluated within the layer data, so there is no need to refer to
-#'   the original dataset (i.e., use `ggplot(df, aes(variable))`
-#'   instead of `ggplot(df, aes(df$variable))`). The names for x and y aesthetics
-#'   are typically omitted because they are so common; all other aesthetics must be named.
+#' @param x,y,... <[`data-masking`][rlang::topic-data-mask]> List of name-value
+#'   pairs in the form `aesthetic = variable` describing which variables in the
+#'   layer data should be mapped to which aesthetics used by the paired
+#'   geom/stat. The expression `variable` is evaluated within the layer data, so
+#'   there is no need to refer to the original dataset (i.e., use
+#'   `ggplot(df, aes(variable))` instead of `ggplot(df, aes(df$variable))`).
+#'   The names for x and y aesthetics are typically omitted because they are so
+#'   common; all other aesthetics must be named.
 #' @seealso [vars()] for another quoting function designed for
 #'   faceting specifications.
 #'

--- a/R/facet-.r
+++ b/R/facet-.r
@@ -185,9 +185,10 @@ Facet <- ggproto("Facet", NULL,
 #' represents or the results of the expressions) are used to form
 #' faceting groups.
 #'
-#' @param ... Variables or expressions automatically quoted. These are
-#'   evaluated in the context of the data to form faceting groups. Can
-#'   be named (the names are passed to a [labeller][labellers]).
+#' @param ... <[`data-masking`][rlang::topic-data-mask]> Variables or
+#'   expressions automatically quoted. These are evaluated in the context of the
+#'   data to form faceting groups. Can be named (the names are passed to a
+#'   [labeller][labellers]).
 #'
 #' @seealso [aes()], [facet_wrap()], [facet_grid()]
 #' @export

--- a/man/aes.Rd
+++ b/man/aes.Rd
@@ -7,13 +7,14 @@
 aes(x, y, ...)
 }
 \arguments{
-\item{x, y, ...}{List of name-value pairs in the form \code{aesthetic = variable}
-describing which variables in the layer data should be mapped to which
-aesthetics used by the paired geom/stat. The expression \code{variable} is
-evaluated within the layer data, so there is no need to refer to
-the original dataset (i.e., use \code{ggplot(df, aes(variable))}
-instead of \code{ggplot(df, aes(df$variable))}). The names for x and y aesthetics
-are typically omitted because they are so common; all other aesthetics must be named.}
+\item{x, y, ...}{<\code{\link[rlang:topic-data-mask]{data-masking}}> List of name-value
+pairs in the form \code{aesthetic = variable} describing which variables in the
+layer data should be mapped to which aesthetics used by the paired
+geom/stat. The expression \code{variable} is evaluated within the layer data, so
+there is no need to refer to the original dataset (i.e., use
+\code{ggplot(df, aes(variable))} instead of \code{ggplot(df, aes(df$variable))}).
+The names for x and y aesthetics are typically omitted because they are so
+common; all other aesthetics must be named.}
 }
 \value{
 A list with class \code{uneval}. Components of the list are either

--- a/man/vars.Rd
+++ b/man/vars.Rd
@@ -7,9 +7,10 @@
 vars(...)
 }
 \arguments{
-\item{...}{Variables or expressions automatically quoted. These are
-evaluated in the context of the data to form faceting groups. Can
-be named (the names are passed to a \link[=labellers]{labeller}).}
+\item{...}{<\code{\link[rlang:topic-data-mask]{data-masking}}> Variables or
+expressions automatically quoted. These are evaluated in the context of the
+data to form faceting groups. Can be named (the names are passed to a
+\link[=labellers]{labeller}).}
 }
 \description{
 Just like \code{\link[=aes]{aes()}}, \code{vars()} is a \link[rlang:topic-defuse]{quoting function}


### PR DESCRIPTION
This PR aims to fix #4998.

This simply reflects the docs of `?after_stat`: https://github.com/tidyverse/ggplot2/blob/2c5a78cbf1cbba8dac090dff4d7de467df6cb22b/R/aes-evaluation.r#L20