### PR TITLE
Optional segment end

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # ggplot2 (development version)
 
+* You can now omit either `xend` or `yend` from `geom_segment()` as only one
+  of these is now required. If one is missing, it will be filled from the `x`
+  and `y` aesthetics respectively. This makes drawing horizontal or vertical
+  segments a little bit more convenient (@teunbrand, #5140).
 * Using two ordered factors as facetting variables in 
   `facet_grid(..., as.table = FALSE)` now throws a warning instead of an
   error (@teunbrand, #5109).

--- a/R/geom-segment.r
+++ b/R/geom-segment.r
@@ -102,11 +102,13 @@ geom_segment <- function(mapping = NULL, data = NULL,
 #' @usage NULL
 #' @export
 GeomSegment <- ggproto("GeomSegment", Geom,
-  required_aes = c("x", "y", "xend", "yend"),
+  required_aes = c("x", "y", "xend|yend"),
   non_missing_aes = c("linetype", "linewidth", "shape"),
   default_aes = aes(colour = "black", linewidth = 0.5, linetype = 1, alpha = NA),
   draw_panel = function(self, data, panel_params, coord, arrow = NULL, arrow.fill = NULL,
                         lineend = "butt", linejoin = "round", na.rm = FALSE) {
+    data$xend <- data$xend %||% data$x
+    data$yend <- data$yend %||% data$y
     data <- check_linewidth(data, snake_class(self))
     data <- remove_missing(data, na.rm = na.rm,
       c("x", "y", "xend", "yend", "linetype", "linewidth", "shape"),


### PR DESCRIPTION
This PR aims to fix #5140, fix #3627 and fix #3617.

Briefly, it makes one of `xend`/`yend` optional in `geom_segment()`. The missing aesthetic gets filled by `x` and `y` respectively.

Visual demo:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

df <- data.frame(x = c("a", "b", "c"), y = c(2.3, 1.9, 3.2))

ggplot(df) + geom_segment(aes(x, y, yend = 0))
```

![](https://i.imgur.com/PfM3PzM.png)<!-- -->

``` r
ggplot(df) + geom_segment(aes(x, y, xend = 0))
```

![](https://i.imgur.com/4qSUtuH.png)<!-- -->

``` r

set.seed(42)
df <- data.frame(
  x = rep(letters[1:3], each = 2),
  y = rpois(6, 10),
  group = rep(LETTERS[1:2], 3)
)

p <- ggplot(df, aes(x, y, colour = group))

# Want the ends stay stable? Define them.
p + geom_segment(
  aes(xend = x, yend = 0),
  position = position_dodge(width = 0.9)
)
```

![](https://i.imgur.com/i0mu7is.png)<!-- -->

``` r

# Want the ends to be dodged too? Omit one
p + geom_segment(aes(yend = 0), position = position_dodge(width = 0.8))
```

![](https://i.imgur.com/JGdpOmP.png)<!-- -->

<sup>Created on 2023-01-21 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

