### PR TITLE
Peformance: vec_unique_count

### DIFF
--- a/R/axis-secondary.R
+++ b/R/axis-secondary.R
@@ -193,7 +193,7 @@ AxisSecondary <- ggproto("AxisSecondary", NULL,
     full_range <- self$transform_range(old_range)
 
     # Test for monotonicity
-    if (length(unique0(sign(diff(full_range)))) != 1)
+    if (!is_unique(sign(diff(full_range))))
       cli::cli_abort("Transformation for secondary axes must be monotonic")
   },
 

--- a/R/facet-.r
+++ b/R/facet-.r
@@ -119,10 +119,10 @@ Facet <- ggproto("Facet", NULL,
     }
   },
   draw_back = function(data, layout, x_scales, y_scales, theme, params) {
-    rep(list(zeroGrob()), length(unique0(layout$PANEL)))
+    rep(list(zeroGrob()), vec_unique_count(layout$PANEL))
   },
   draw_front = function(data, layout, x_scales, y_scales, theme, params) {
-    rep(list(zeroGrob()), length(unique0(layout$PANEL)))
+    rep(list(zeroGrob()), vec_unique_count(layout$PANEL))
   },
   draw_panels = function(panels, layout, x_scales, y_scales, ranges, coord, data, theme, params) {
     cli::cli_abort("Not implemented")

--- a/R/guides-axis.r
+++ b/R/guides-axis.r
@@ -440,7 +440,7 @@ warn_for_guide_position <- function(guide) {
     return()
   }
 
-  if (length(unique0(guide$key[[position_aes]][breaks_are_unique])) == 1) {
+  if (is_unique(guide$key[[position_aes]][breaks_are_unique])) {
     cli::cli_warn(c(
       "Position guide is perpendicular to the intended axis",
       "i" = "Did you mean to specify a different guide {.arg position}?"

--- a/R/position-collide.r
+++ b/R/position-collide.r
@@ -48,7 +48,7 @@ collide <- function(data, width = NULL, name, strategy,
   intervals <- as.numeric(t(unique0(data[c("xmin", "xmax")])))
   intervals <- intervals[!is.na(intervals)]
 
-  if (length(unique0(intervals)) > 1 & any(diff(scale(intervals)) < -1e-6)) {
+  if (vec_unique_count(intervals) > 1 & any(diff(scale(intervals)) < -1e-6)) {
     cli::cli_warn("{.fn {name}} requires non-overlapping {.field x} intervals")
     # This is where the algorithm from [L. Wilkinson. Dot plots.
     # The American Statistician, 1999.] should be used

--- a/R/position-dodge.r
+++ b/R/position-dodge.r
@@ -144,7 +144,7 @@ PositionDodge <- ggproto("PositionDodge", Position,
 # Assumes that each set has the same horizontal position.
 pos_dodge <- function(df, width, n = NULL) {
   if (is.null(n)) {
-    n <- length(unique0(df$group))
+    n <- vec_unique_count(df$group)
   }
 
   if (n == 1)

--- a/R/position-jitterdodge.R
+++ b/R/position-jitterdodge.R
@@ -53,7 +53,7 @@ PositionJitterdodge <- ggproto("PositionJitterdodge", Position,
       cli::cli_abort("{.fn position_jitterdodge} requires at least one aesthetic to dodge by")
     }
     ndodge    <- lapply(data[dodgecols], levels)  # returns NULL for numeric, i.e. non-dodge layers
-    ndodge    <- length(unique0(unlist(ndodge)))
+    ndodge    <- vec_unique_count(unlist(ndodge))
 
     list(
       dodge.width = self$dodge.width,

--- a/R/stat-.r
+++ b/R/stat-.r
@@ -143,7 +143,7 @@ Stat <- ggproto("Stat",
 
       # Then, check whether the rest of the columns have constant values (type 2)
       # or not (type 3).
-      non_constant <- vapply(old, function(x) length(unique0(x)) > 1, logical(1L))
+      non_constant <- vapply(old, vec_unique_count, integer(1)) > 1L
 
       # Record the non-constant columns.
       non_constant_columns <<- c(non_constant_columns, names(old)[non_constant])

--- a/R/stat-align.R
+++ b/R/stat-align.R
@@ -56,7 +56,7 @@ StatAlign <- ggproto("StatAlign", Stat,
 
   compute_group = function(data, scales, flipped_aes = NA, unique_loc = NULL, adjust = 0) {
     data <- flip_data(data, flipped_aes)
-    if (length(unique(data$x)) == 1) {
+    if (is_unique(data$x)) {
       # Not enough data to align
       return(new_data_frame())
     }

--- a/R/stat-boxplot.r
+++ b/R/stat-boxplot.r
@@ -108,7 +108,7 @@ StatBoxplot <- ggproto("StatBoxplot", Stat,
       stats[c(1, 5)] <- range(c(stats[2:4], data$y[!outliers]), na.rm = TRUE)
     }
 
-    if (length(unique0(data$x)) > 1)
+    if (vec_unique_count(data$x) > 1)
       width <- diff(range(data$x)) * 0.9
 
     df <- data_frame0(!!!as.list(stats))

--- a/R/stat-smooth.r
+++ b/R/stat-smooth.r
@@ -130,7 +130,7 @@ StatSmooth <- ggproto("StatSmooth", Stat,
                            xseq = NULL, level = 0.95, method.args = list(),
                            na.rm = FALSE, flipped_aes = NA) {
     data <- flip_data(data, flipped_aes)
-    if (length(unique0(data$x)) < 2) {
+    if (vec_unique_count(data$x) < 2) {
       # Not enough data to perform fit
       return(data_frame0())
     }

--- a/R/stat-ydensity.r
+++ b/R/stat-ydensity.r
@@ -87,7 +87,7 @@ StatYdensity <- ggproto("StatYdensity", Stat,
     dens$x <- mean(range(data$x))
 
     # Compute width if x has multiple values
-    if (length(unique0(data$x)) > 1) {
+    if (vec_unique_count(data$x) > 1) {
       width <- diff(range(data$x)) * 0.9
     }
     dens$width <- width

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -61,7 +61,7 @@ clist <- function(l) {
 #
 # @keyword internal
 uniquecols <- function(df) {
-  df <- df[1, sapply(df, function(x) length(unique0(x)) == 1), drop = FALSE]
+  df <- df[1, sapply(df, is_unique), drop = FALSE]
   rownames(df) <- 1:nrow(df)
   df
 }
@@ -353,6 +353,9 @@ data_frame0 <- function(...) data_frame(..., .name_repair = "minimal")
 
 # Wrapping unique0() to accept NULL
 unique0 <- function(x, ...) if (is.null(x)) x else vec_unique(x, ...)
+
+# Code readability checking for uniqueness
+is_unique <- function(x) vec_unique_count(x) == 1L
 
 # Check inputs with tibble but allow column vectors (see #2609 and #2374)
 as_gg_data_frame <- function(x) {

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -548,14 +548,14 @@ has_flipped_aes <- function(data, params = list(), main_is_orthogonal = NA,
   if (group_has_equal) {
     if (has_x) {
       if (length(x) == 1) return(FALSE)
-      x_groups <- vapply(split(data$x, data$group), function(x) length(unique0(x)), integer(1))
+      x_groups <- vapply(split(data$x, data$group), vec_unique_count, integer(1))
       if (all(x_groups == 1)) {
         return(FALSE)
       }
     }
     if (has_y) {
       if (length(y) == 1) return(TRUE)
-      y_groups <- vapply(split(data$y, data$group), function(x) length(unique0(x)), integer(1))
+      y_groups <- vapply(split(data$y, data$group), vec_unique_count, integer(1))
       if (all(y_groups == 1)) {
         return(TRUE)
       }

--- a/tests/testthat/test-aes-grouping.r
+++ b/tests/testthat/test-aes-grouping.r
@@ -5,7 +5,7 @@ df <- data_frame(
 )
 
 group <- function(x) as.vector(layer_data(x, 1)$group)
-groups <- function(x) length(unique(group(x)))
+groups <- function(x) vec_unique_count(group(x))
 
 
 test_that("one group per combination of discrete vars", {

--- a/tests/testthat/test-facet-.r
+++ b/tests/testthat/test-facet-.r
@@ -193,12 +193,12 @@ test_that("facets with free scales scale independently", {
   l2 <- p + facet_grid(. ~ z, scales = "free")
   d2 <- cdata(l2)[[1]]
   expect_true(sd(d2$x) < 1e-10)
-  expect_equal(length(unique(d2$y)), 3)
+  expect_length(unique(d2$y), 3)
 
   # LHS of facet_grid()
   l3 <- p + facet_grid(z ~ ., scales = "free")
   d3 <- cdata(l3)[[1]]
-  expect_equal(length(unique(d3$x)), 3)
+  expect_length(unique(d3$x), 3)
   expect_true(sd(d3$y) < 1e-10)
 })
 


### PR DESCRIPTION
I've noticed that `length(unique0(x))` is a common pattern in ggplot2 code. However, up to vectors with 1000 members, `vctrs::vec_unique_count()` seems to be faster (they perform about equal thereafter). For small vectors, the memory footprint is also better and about equal for larger vectors. The improvement is small, but the pattern is common enough that I thought this was warranted to save a few microseconds per plot.

A benchmark:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

lengths <- 2^(0:24)

bms <- lapply(lengths, function(n) {
  x <- sample(LETTERS, n, TRUE)
  bench::mark(
    length(unique0(x)),
    vec_unique_count(x), 
    iterations = 50
  )
})
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.

df <- do.call(rbind, bms)
df$n <- rep(lengths, each = 2)

ggplot(df, aes(n, as.numeric(median), colour = as.character(expression))) +
  geom_line() +
  scale_y_log10() +
  scale_x_log10() +
  labs(
    x = "Length of vector",
    y = "Seconds",
    colour = "Pattern"
  )
```

![](https://i.imgur.com/PCKFjNs.png)<!-- -->

<sup>Created on 2023-01-24 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
