### PR TITLE
`geom_text()` drops rows with `angle = NA`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          cache-version: 2
+          cache-version: 3
           extra-packages: >
             any::rcmdcheck,
             Hmisc=?ignore-before-r=3.6.0,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* `geom_text()` drops observations where `angle = NA` instead of throwing an
+  error (@teunbrand, #2757).
 * Using two ordered factors as facetting variables in 
   `facet_grid(..., as.table = FALSE)` now throws a warning instead of an
   error (@teunbrand, #5109).

--- a/R/geom-text.r
+++ b/R/geom-text.r
@@ -198,6 +198,8 @@ geom_text <- function(mapping = NULL, data = NULL,
 GeomText <- ggproto("GeomText", Geom,
   required_aes = c("x", "y", "label"),
 
+  non_missing_aes = "angle",
+
   default_aes = aes(
     colour = "black", size = 3.88, angle = 0, hjust = 0.5,
     vjust = 0.5, alpha = NA, family = "", fontface = 1, lineheight = 1.2

--- a/tests/testthat/test-geom-text.R
+++ b/tests/testthat/test-geom-text.R
@@ -2,6 +2,22 @@ test_that("geom_text() checks input", {
   expect_snapshot_error(geom_text(position = "jitter", nudge_x = 0.5))
 })
 
+test_that("geom_text() drops missing angles", {
+
+  df <- data_frame0(x = 1, y = 1, label = "A", angle = 0)
+  geom <- geom_text()
+
+  expect_silent(
+    geom$geom$handle_na(df, geom$geom_params)
+  )
+
+  df$angle <- NA
+  expect_warning(
+    geom$geom$handle_na(df, geom$geom_params),
+    "Removed 1 row"
+  )
+})
+
 # compute_just ------------------------------------------------------------
 
 test_that("vertical and horizontal positions are equivalent", {


### PR DESCRIPTION
This PR aims to fix #2757.

Briefly, it adds the angle to the non-missing aesthetics, causing the `GeomText$handle_na()` method to drop these observations with missing angles.