### PR TITLE
Deprecate `facets`

### DIFF
--- a/R/facet-grid-.r
+++ b/R/facet-grid-.r
@@ -57,7 +57,7 @@ NULL
 #'   default). If `TRUE`, margins are included for all faceting
 #'   variables. If specified as a character vector, it is the names of
 #'   variables for which margins are to be created.
-#' @param facets This argument is soft-deprecated, please use `rows`
+#' @param facets `r lifecycle::badge("deprecated")` Please use `rows`
 #'   and `cols` instead.
 #' @export
 #' @examples

--- a/R/facet-grid-.r
+++ b/R/facet-grid-.r
@@ -112,11 +112,13 @@ facet_grid <- function(rows = NULL, cols = NULL, scales = "fixed",
                        space = "fixed", shrink = TRUE,
                        labeller = "label_value", as.table = TRUE,
                        switch = NULL, drop = TRUE, margins = FALSE,
-                       facets = NULL) {
-  # `facets` is soft-deprecated and renamed to `rows`
-  if (!is.null(facets)) {
-    rows <- facets
+                       facets = deprecated()) {
+  # `facets` is deprecated and renamed to `rows`
+  if (lifecycle::is_present(facets)) {
+    deprecate_warn0("2.2.0", "facet_grid(facets)", "facet_grid(rows)")
+    row <- facets
   }
+
   # Should become a warning in a future release
   if (is.logical(cols)) {
     margins <- cols

--- a/man/facet_grid.Rd
+++ b/man/facet_grid.Rd
@@ -15,7 +15,7 @@ facet_grid(
   switch = NULL,
   drop = TRUE,
   margins = FALSE,
-  facets = NULL
+  facets = deprecated()
 )
 }
 \arguments{
@@ -77,7 +77,7 @@ default). If \code{TRUE}, margins are included for all faceting
 variables. If specified as a character vector, it is the names of
 variables for which margins are to be created.}
 
-\item{facets}{This argument is soft-deprecated, please use \code{rows}
+\item{facets}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Please use \code{rows}
 and \code{cols} instead.}
 }
 \description{


### PR DESCRIPTION
This PR aims to fix #5189.

Briefly, the `facet_grid(facets = ...)` argument has been silently and informally deprecated since ggplot2 2.2.0 based on the git blame. This PR uses the lifecycle deprecation system to also start emitting warnings. Example:

``` r
library(ggplot2)

# Current ggplot2 emits no warning
f <- facet_grid(facets = vars(cyl))

devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

f <- facet_grid(facets = vars(cyl))
#> Warning: The `facets` argument of `facet_grid()` is deprecated as of ggplot2 2.2.0.
#> ℹ Please use the `rows` argument instead.
```

<sup>Created on 2023-02-20 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
