### PR TITLE
Update `aes_string()` info bullets

### DIFF
--- a/R/aes.r
+++ b/R/aes.r
@@ -298,7 +298,10 @@ aes_string <- function(x, y, ...) {
   deprecate_soft0(
     "3.0.0",
     "aes_string()",
-    details = "Please use tidy evaluation ideoms with `aes()`"
+    details = c(
+      "Please use tidy evaluation idioms with `aes()`. ",
+      'See also `vignette("ggplot2-in-packages")` for more information.'
+    )
   )
   mapping <- list(...)
   if (!missing(x)) mapping["x"] <- list(x)


### PR DESCRIPTION
This PR aims to fix #5194.

Briefly, it updates the deprecation message to the following:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

aes_string()
#> Warning: `aes_string()` was deprecated in ggplot2 3.0.0.
#> ℹ Please use tidy evaluation idioms with `aes()`.
#> ℹ See also `vignette("ggplot2-in-packages")` for more information.
#> Aesthetic mapping: 
#> <empty>
```

<sup>Created on 2023-02-21 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

