### PR TITLE
use tempfiles for plots

### DIFF
--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -57,12 +57,11 @@ test_that("ggsave can handle blank background", {
 })
 
 test_that("ggsave warns about empty or multiple filenames", {
-  filenames <- c(tempfile(fileext = ".png"), tempfile(fileext = ".png"))
   plot <- ggplot(mtcars, aes(disp, mpg)) + geom_point()
 
-  withr::with_file(filenames, {
+  withr::with_tempfile(c("file1", "file2"), fileext = ".png", {
     expect_warning(
-      suppressMessages(ggsave(filenames, plot)),
+      suppressMessages(ggsave(c(file1, file2), plot)),
       "`filename` must have length 1"
     )
   })

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -57,7 +57,7 @@ test_that("ggsave can handle blank background", {
 })
 
 test_that("ggsave warns about empty or multiple filenames", {
-  filenames <- c(tempfile(), tempfile())
+  filenames <- c(tempfile(fileext = ".png"), tempfile(fileext = ".png"))
   plot <- ggplot(mtcars, aes(disp, mpg)) + geom_point()
 
   withr::with_file(filenames, {

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -57,7 +57,7 @@ test_that("ggsave can handle blank background", {
 })
 
 test_that("ggsave warns about empty or multiple filenames", {
-  filenames <- c("plot1.png", "plot2.png")
+  filenames <- c(tempfile(), tempfile())
   plot <- ggplot(mtcars, aes(disp, mpg)) + geom_point()
 
   withr::with_file(filenames, {
@@ -65,11 +65,12 @@ test_that("ggsave warns about empty or multiple filenames", {
       suppressMessages(ggsave(filenames, plot)),
       "`filename` must have length 1"
     )
-    expect_error(
-      ggsave(character(), plot),
-      "`filename` cannot be empty."
-    )
   })
+
+  expect_error(
+    ggsave(character(), plot),
+    "`filename` cannot be empty."
+  )
 })
 
 # plot_dim ---------------------------------------------------------------


### PR DESCRIPTION
I think it's not strictly necessary for CRAN, but it is consistent with the rest of the suite.

(discovered because we run tests without local write permissions, this is the only test in the suite with this issue)

Also moved one test out of the `withr()` environment because it's independent of it, I think it's for the best.