### PR TITLE
Friendlier error when supplying extension-less files

### DIFF
--- a/R/save.r
+++ b/R/save.r
@@ -238,6 +238,9 @@ plot_dev <- function(device, filename = NULL, dpi = 300, call = caller_env()) {
 
   if (is.null(device)) {
     device <- to_lower_ascii(tools::file_ext(filename))
+    if (identical(device, "")) {
+      cli::cli_abort("{.arg filename} has no file extension and {.arg device} is {.val NULL}.", call = call)
+    }
   }
 
   if (!is.character(device) || length(device) != 1) {


### PR DESCRIPTION
The error when trying `ggsave(p, tempfile())` is head-cocking:

```
Error in `ggsave(filenames, plot)`: Unknown graphics device ""
```

This should error should help fix the issue faster.