### PR TITLE
Performance: use `lengths()`

### DIFF
--- a/R/annotation.r
+++ b/R/annotation.r
@@ -56,7 +56,7 @@ annotate <- function(geom, x = NULL, y = NULL, xmin = NULL, xmax = NULL,
   aesthetics <- c(position, list(...))
 
   # Check that all aesthetic have compatible lengths
-  lengths <- vapply(aesthetics, length, integer(1))
+  lengths <- lengths(aesthetics)
   n <- unique0(lengths)
 
   # if there is more than one unique length, ignore constants

--- a/R/compat-plyr.R
+++ b/R/compat-plyr.R
@@ -91,7 +91,7 @@ id <- function(.variables, drop = FALSE) {
     nrows <- nrow(.variables)
     .variables <- unclass(.variables)
   }
-  lengths <- vapply(.variables, length, integer(1))
+  lengths <- lengths(.variables)
   .variables <- .variables[lengths != 0]
   if (length(.variables) == 0) {
     n <- nrows %||% 0L

--- a/R/geom-.r
+++ b/R/geom-.r
@@ -230,7 +230,7 @@ NULL
 .stroke <- 96 / 25.4
 
 check_aesthetics <- function(x, n) {
-  ns <- vapply(x, length, integer(1))
+  ns <- lengths(x)
   good <- ns == 1L | ns == n
 
   if (all(good)) {

--- a/R/guide-bins.R
+++ b/R/guide-bins.R
@@ -240,7 +240,7 @@ guide_geom.bins <- function(guide, layers, default_mapping) {
 
     if (length(matched) > 0) {
       # Filter out set aesthetics that can't be applied to the legend
-      n <- vapply(layer$aes_params, length, integer(1))
+      n <- lengths(layer$aes_params)
       params <- layer$aes_params[n == 1]
 
       aesthetics <- layer$computed_mapping

--- a/R/guide-legend.r
+++ b/R/guide-legend.r
@@ -259,7 +259,7 @@ guide_geom.legend <- function(guide, layers, default_mapping) {
 
     if (length(matched) > 0) {
       # Filter out set aesthetics that can't be applied to the legend
-      n <- vapply(layer$aes_params, length, integer(1))
+      n <- lengths(layer$aes_params)
       params <- layer$aes_params[n == 1]
 
       aesthetics <- layer$computed_mapping

--- a/R/layer.r
+++ b/R/layer.r
@@ -297,7 +297,7 @@ Layer <- ggproto("Layer", NULL,
       if (length(evaled) == 0) {
         n <- 0
       } else {
-        aes_n <- vapply(evaled, length, integer(1))
+        aes_n <- lengths(evaled)
         n <- if (min(aes_n) == 0) 0L else max(aes_n)
       }
     }

--- a/R/limits.r
+++ b/R/limits.r
@@ -189,7 +189,7 @@ expand_limits <- function(...) {
   data <- unlist(c(list(data[!data_dfs]), data[data_dfs]), recursive = FALSE)
 
   # Repeat vectors up to max length and collect to data frame
-  n_rows <- max(vapply(data, length, integer(1)))
+  n_rows <- max(lengths(data))
   data <- lapply(data, rep, length.out = n_rows)
   data <- data_frame0(!!!data)
 

--- a/R/scale-.r
+++ b/R/scale-.r
@@ -747,7 +747,7 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
     }
     if (is.list(labels)) {
       # Guard against list with empty elements
-      labels[vapply(labels, length, integer(1)) == 0] <- ""
+      labels[lengths(labels) == 0] <- ""
       # Make sure each element is scalar
       labels <- lapply(labels, `[`, 1)
 

--- a/R/scale-hue.r
+++ b/R/scale-hue.r
@@ -176,7 +176,7 @@ qualitative_pal <- function(type, h, c, l, h.start, direction) {
     if (!all(vapply(type_list, is.character, logical(1)))) {
       cli::cli_abort("{.arg type} must be a character vector or a list of character vectors")
     }
-    type_lengths <- vapply(type_list, length, integer(1))
+    type_lengths <- lengths(type_list)
     # If there are more levels than color codes default to hue_pal()
     if (max(type_lengths) < n) {
       return(scales::hue_pal(h, c, l, h.start, direction)(n))

--- a/R/stat-summary-2d.r
+++ b/R/stat-summary-2d.r
@@ -134,7 +134,7 @@ tapply_df <- function(x, index, fun, ..., drop = TRUE) {
   out$value <- unlist(lapply(grps, fun, ...))
 
   if (drop) {
-    n <- vapply(grps, length, integer(1))
+    n <- lengths(grps)
     out <- out[n > 0, , drop = FALSE]
   }
 

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -27,7 +27,7 @@ check_required_aesthetics <- function(required, present, name, call = caller_env
   if (is.null(required)) return()
 
   required <- strsplit(required, "|", fixed = TRUE)
-  if (any(vapply(required, length, integer(1)) > 1)) {
+  if (any(lengths(required) > 1)) {
     required <- lapply(required, rep_len, 2)
     required <- list(
       vapply(required, `[`, character(1), 1),
@@ -37,7 +37,7 @@ check_required_aesthetics <- function(required, present, name, call = caller_env
     required <- list(unlist(required))
   }
   missing_aes <- lapply(required, setdiff, present)
-  if (any(vapply(missing_aes, length, integer(1)) == 0)) return()
+  if (any(lengths(missing_aes) == 0)) return()
   message <- "{.fn {name}} requires the following missing aesthetics: {.field {missing_aes[[1]]}}"
   if (length(missing_aes) > 1) {
     message <- paste0(message, " {.strong or} {.field {missing_aes[[2]]}}")


### PR DESCRIPTION
A common pattern in the codebase was to use `vapply(x, length, integer(1)` to get the length of every member in a list. That can be replaced by the consistently faster (and more readable) `lengths()` function. Overall, I don't think it makes a ton of difference, but may shave the occasional microsecond off a plot.

``` r
library(ggplot2)

lengths <- 2^(0:20)

set.seed(42)
lens <- sample(0:1000, max(lengths), replace = TRUE)

my_list <- lapply(lens, rnorm)

bms <- lapply(lengths, function(n) {
  x <- my_list[seq_len(n)]
  bench::mark(
    lengths(x),
    vapply(x, length, integer(1)), 
    iterations = 50
  )
})
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.

df <- do.call(rbind, bms)
df$n <- rep(lengths, each = 2)

ggplot(df, aes(n, as.numeric(median), colour = as.character(expression))) +
  geom_line() +
  scale_y_log10() +
  scale_x_log10() +
  labs(
    x = "Length of list",
    y = "Seconds",
    colour = "Pattern"
  )
```

![](https://i.imgur.com/qqQXeQY.png)<!-- -->

<sup>Created on 2023-02-27 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
