### PR TITLE
Fix `makeContext.dotstackGrob()` method inconsistency

### DIFF
--- a/R/grob-dotstack.R
+++ b/R/grob-dotstack.R
@@ -25,7 +25,7 @@ dotstackGrob <- function(
 is_npc <- function(x) isTRUE(grepl('^[^+^-^\\*]*[^s]npc$', as.character(x)))
 
 #' @export
-makeContext.dotstackGrob <- function(x, recording = TRUE) {
+makeContext.dotstackGrob <- function(x) {
   # Need absolute coordinates because when using npc coords with circleGrob,
   # the radius is in the _smaller_ of the two axes. We need the radius
   # to instead be defined in terms of the non-stack axis.


### PR DESCRIPTION
The `makeContext()` function in {grid} has only one argument: `x`.
The proposed change will remove the argument `recording` from `makeContext.dotstackGrob`, which didn't seem to be used anyway. 
This brings the method in line with the generic.

Tested on r-devel/4.3.0 on Windows