### PR TITLE
`annotation_logticks()` skips panels with non-finite range

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* `annotation_logticks()` skips drawing ticks when the scale range is non-finite
+  instead of throwing an error (@teunbrand, #5229).
 * The `layer_data()`, `layer_scales()` and `layer_grob()` now have the default
   `plot = last_plot()` (@teunbrand, #5166).
 * To prevent changing the plotting order, `stat_sf()` is now computed per panel 

--- a/R/annotation-logticks.R
+++ b/R/annotation-logticks.R
@@ -135,7 +135,7 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
     mid   <- convertUnit(mid,   "cm", valueOnly = TRUE)
     long  <- convertUnit(long,  "cm", valueOnly = TRUE)
 
-    if (grepl("[b|t]", sides)) {
+    if (grepl("[b|t]", sides) && all(is.finite(panel_params$x.range))) {
 
       # Get positions of x tick marks
       xticks <- calc_logticks(
@@ -175,7 +175,7 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
       }
     }
 
-    if (grepl("[l|r]", sides)) {
+    if (grepl("[l|r]", sides) && all(is.finite(panel_params$y.range))) {
       yticks <- calc_logticks(
         base = base,
         minpow = floor(panel_params$y.range[1]),


### PR DESCRIPTION
This PR aims to fix #5229.

Briefly, it adds two checks to ensure the x/y range is finite before drawing ticks and erroring in the calculation.