### PR TITLE
Do not require Hmisc on the CI with R < 4.1

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -63,7 +63,7 @@ jobs:
           cache-version: 3
           extra-packages: >
             any::rcmdcheck,
-            Hmisc=?ignore-before-r=3.6.0,
+            Hmisc=?ignore-before-r=4.1.0,
             quantreg=?ignore-before-r=3.6.0,
           needs: check
 


### PR DESCRIPTION
Related: https://github.com/tidyverse/ggplot2/issues/5230

Now Hmisc cannot be installed on R < 4.1. This pull request make the CI ignore the installation failure on these old versions.