### PR TITLE
Calculate `stat_align()` per panel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* `stat_align()` is now applied per panel instead of globally, preventing issues
+  when facets have different ranges (@teunbrand, #5227).
+* A stacking bug in `stat_align()` was fixed (@teunbrand, #5176).
 * `annotation_logticks()` skips drawing ticks when the scale range is non-finite
   instead of throwing an error (@teunbrand, #5229).
 * Fixed spurious warnings when the `weight` was used in `stat_bin_2d()`, 


### PR DESCRIPTION
This PR aims to fix #5227 and fix #5176, thereby superseding #5177.

Briefly, to prevent the small offset `adjust` taking on too large values, we calculate the unique x-locations ± offset per panel instead of globally. I think it comes with the following trade-offs.

* \- It has to be computed for every panel, possibly being less efficient than doing it once globally.
* \+ To compensate, I tried making determining the unique x-positions faster, by
    * Not taking into account 0-crossings when there is only one group and no stacking needs to occur
    * Unlooping the groupwise 0-crossings calculation for efficiency
