### PR TITLE
Remove lattice from the dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,6 @@ Suggests:
     hexbin,
     Hmisc,
     knitr,
-    lattice,
     mapproj,
     maps,
     maptools,


### PR DESCRIPTION
As I commented on https://github.com/tidyverse/ggplot2/issues/5230#issuecomment-1475221409, lattice used to be used for documenting how the users can migrate from lattice code to `qplot()` code, but the document was removed when we deprecated `qplot()` in https://github.com/tidyverse/ggplot2/pull/4079. So, it's used nowhere.