### PR TITLE
Remove rgeos from the dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,7 +63,6 @@ Suggests:
     quantreg,
     ragg,
     RColorBrewer,
-    rgeos,
     rmarkdown,
     rpart,
     sf (>= 0.7-3),


### PR DESCRIPTION
(See https://github.com/tidyverse/ggplot2/issues/5230#issuecomment-1475217544)

rgoes is used nowhere. I couldn't find how it was used. We can find the name "rgoes" only in this NEWS item of ggplot2 v0.9.2. My guess is that `SpatialPolygonsDataFrame` was living in rgeos at that time (now in sp)?

> * Dependency on `gpclib` removed, and `fortify.SpatialPolygonsDataFrame` will
  now use `rgeos` if available - this is particularly useful if you're not
  able to use the non-free `gpclib`.

It seems rgeos already became unused in 2015, so anyway I believe it's safe to remove rgoes now.

https://github.com/tidyverse/ggplot2/pull/1098