### PR TITLE
Contour removes duplicates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* `stat_contour()` and `stat_contour_filled()` now warn about and remove
+  duplicated coordinates (@teunbrand, #5215).
 * `annotation_logticks()` skips drawing ticks when the scale range is non-finite
   instead of throwing an error (@teunbrand, #5229).
 * Fixed spurious warnings when the `weight` was used in `stat_bin_2d()`, 

--- a/tests/testthat/test-stat-contour.R
+++ b/tests/testthat/test-stat-contour.R
@@ -80,3 +80,23 @@ test_that("basic stat_contour_filled() plot builds", {
   # implementation in isoband
   expect_silent(ggplot_build(p))
 })
+
+test_that("stat_contour() removes duplicated coordinates", {
+
+  df <- data_frame0(
+    x = c(1, 1, 2, 2, 1, 1, 2, 2),
+    y = c(1, 2, 1, 2, 1, 2, 1, 2),
+    z = c(1, 0, 0, 1, 1, 0, 0, 1),
+    group = c(1, 1, 1, 1, 2, 2, 2, 2)
+  )
+
+  layer <- stat_contour()
+
+  expect_silent(layer$stat$setup_data(df))
+  expect_warning(
+    new <- layer$stat$setup_data(transform(df, group = 1)),
+    "has duplicated"
+  )
+  expect_equal(new, df[1:4,], ignore_attr = TRUE)
+})
+


### PR DESCRIPTION
This PR aims to fix #5215.

Briefly, `stat_contour()` and `stat_contour_filled()` will now remove duplicated x,y positions with a warning.

Duplicate values were already implicitly removed here:

https://github.com/tidyverse/ggplot2/blob/962fb743281618da1e85f7692fbf8a0c9dcc9a38/R/stat-contour.R#L250-L251

This PR just does it explicitly, compatible with the previous implicit method, and warns the user.