### PR TITLE
`mapped_discrete` has resolution of 1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* To improve `width` calculation in bar plots with empty factor levels, 
+  `resolution()` considers `mapped_discrete` values as having resolution 1 
+  (@teunbrand, #5211)
 * `coord_flip()` has been marked as superseded. The recommended alternative is
   to swap the `x` and `y` aesthetic and/or using the `orientation` argument in
   a layer (@teunbrand, #5130).

--- a/R/utilities-resolution.R
+++ b/R/utilities-resolution.R
@@ -18,8 +18,10 @@
 #' resolution(c(2, 10, 20, 50))
 #' resolution(c(2L, 10L, 20L, 50L))
 resolution <- function(x, zero = TRUE) {
-  if (is.integer(x) || zero_range(range(x, na.rm = TRUE)))
+  if (is.integer(x) || is_mapped_discrete(x) ||
+      zero_range(range(x, na.rm = TRUE))) {
     return(1)
+  }
 
   x <- unique0(as.numeric(x))
   if (zero) {

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -166,3 +166,11 @@ test_that("vec_rbind0 can combined ordered factors", {
   expect_equal(levels(test$a), c("A", "B", "C"))
 
 })
+
+test_that("resolution() gives correct answers", {
+  expect_equal(resolution(c(4,  6)), 2)
+  expect_equal(resolution(c(4L, 6L)), 1L)
+  expect_equal(resolution(mapped_discrete(c(4, 6))), 1L)
+  expect_equal(resolution(c(0, 0)), 1L)
+  expect_equal(resolution(c(0.5,  1.5), zero = TRUE), 0.5)
+})


### PR DESCRIPTION
This PR aims to fix #5211.

It does so by having `resolution()` consider the `mapped_discrete` class as it does integers, where the resolution is set to 1.
I've added some tests so that it becomes easier to see if `resolution()` breaks in the future.