### PR TITLE
Add type check to `theme_set()`

### DIFF
--- a/R/theme-current.R
+++ b/R/theme-current.R
@@ -90,6 +90,7 @@ theme_get <- function() {
 #' @param new new theme (a list of theme elements)
 #' @export
 theme_set <- function(new) {
+  check_object(new, is.theme, "a {.cls theme} object")
   old <- ggplot_global$theme_current
   ggplot_global$theme_current <- new
   invisible(old)

--- a/tests/testthat/_snaps/theme.md
+++ b/tests/testthat/_snaps/theme.md
@@ -20,6 +20,10 @@
 
     Theme element `test` has "NULL" property without default: fill, colour, linewidth, and linetype
 
+---
+
+    `new` must be a <theme> object, not the string "foo".
+
 # element tree can be modified
 
     The `blablabla` theme element is not defined in the element hierarchy.

--- a/tests/testthat/test-theme.R
+++ b/tests/testthat/test-theme.R
@@ -264,6 +264,7 @@ test_that("incorrect theme specifications throw meaningful errors", {
   expect_snapshot_error(calc_element("line", theme(line = element_rect())))
   register_theme_elements(element_tree = list(test = el_def("element_rect")))
   expect_snapshot_error(calc_element("test", theme_gray() + theme(test = element_rect())))
+  expect_snapshot_error(theme_set("foo"))
 })
 
 test_that("element tree can be modified", {


### PR DESCRIPTION
This PR aims to fix #3117.

It adds a type check to `theme_set()`, that is all it does.

Examples (backtraces omitted):

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

# Fine
theme_set(theme_bw())

# Oops forgot parentheses
theme_set(theme_bw)
#> Error in `theme_set()`:
#> ! `new` must be a <theme> object, not a function.

# Plain wrong input
theme_set("foo")
#> Error in `theme_set()`:
#> ! `new` must be a <theme> object, not the string "foo".
```

<sup>Created on 2023-03-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
