### PR TITLE
Warn when using constant aesthetics

### DIFF
--- a/R/geom-abline.R
+++ b/R/geom-abline.R
@@ -147,5 +147,7 @@ GeomAbline <- ggproto("GeomAbline", Geom,
 
   draw_key = draw_key_abline,
 
-  rename_size = TRUE
+  rename_size = TRUE,
+
+  check_constant_aes = FALSE
 )

--- a/R/geom-hline.R
+++ b/R/geom-hline.R
@@ -60,5 +60,7 @@ GeomHline <- ggproto("GeomHline", Geom,
 
   draw_key = draw_key_path,
 
-  rename_size = TRUE
+  rename_size = TRUE,
+
+  check_constant_aes = FALSE
 )

--- a/R/geom-vline.R
+++ b/R/geom-vline.R
@@ -60,5 +60,7 @@ GeomVline <- ggproto("GeomVline", Geom,
 
   draw_key = draw_key_vline,
 
-  rename_size = TRUE
+  rename_size = TRUE,
+
+  check_constant_aes = FALSE
 )

--- a/R/layer.R
+++ b/R/layer.R
@@ -304,10 +304,9 @@ Layer <- ggproto("Layer", NULL,
     if ((self$geom$check_constant_aes %||% TRUE)
         && length(aes_n) > 0 && all(aes_n == 1) && n > 1) {
       cli::cli_warn(c(
-        paste0("All aesthetics have length 1, but the data has {n} rows ",
-               "in {.fn {self$constructor[1]}}."),
+        "All aesthetics have length 1, but the data has {n} rows.",
         i = "Did you mean to use {.fn annotate}?"
-      ))
+      ), call = self$constructor)
     }
     check_aesthetics(evaled, n)
 

--- a/R/layer.R
+++ b/R/layer.R
@@ -301,9 +301,11 @@ Layer <- ggproto("Layer", NULL,
         n <- if (min(aes_n) == 0) 0L else max(aes_n)
       }
     }
-    if (length(aes_n) > 1 && all(aes_n == 1) && n > 1) {
+    if ((self$geom$check_constant_aes %||% TRUE)
+        && length(aes_n) > 0 && all(aes_n == 1) && n > 1) {
       cli::cli_warn(c(
-        "All aesthetics have length 1, but the data has {n} rows.",
+        paste0("All aesthetics have length 1, but the data has {n} rows ",
+               "in {.fn {self$constructor[1]}}."),
         i = "Did you mean to use {.fn annotate}?"
       ))
     }

--- a/R/layer.R
+++ b/R/layer.R
@@ -292,14 +292,20 @@ Layer <- ggproto("Layer", NULL,
     }
 
     n <- nrow(data)
+    aes_n <- lengths(evaled)
     if (n == 0) {
       # No data, so look at longest evaluated aesthetic
       if (length(evaled) == 0) {
         n <- 0
       } else {
-        aes_n <- lengths(evaled)
         n <- if (min(aes_n) == 0) 0L else max(aes_n)
       }
+    }
+    if (length(aes_n) > 1 && all(aes_n == 1) && n > 1) {
+      cli::cli_warn(c(
+        "All aesthetics have length 1, but the data has {n} rows.",
+        i = "Did you mean to use {.fn annotate}?"
+      ))
     }
     check_aesthetics(evaled, n)
 

--- a/tests/testthat/_snaps/layer.md
+++ b/tests/testthat/_snaps/layer.md
@@ -84,6 +84,11 @@
     ! Can only draw one boxplot per group
     i Did you forget `aes(group = ...)`?
 
+# layer warns for constant aesthetics
+
+    All aesthetics have length 1, but the data has 32 rows in `geom_point()`.
+    i Did you mean to use `annotate()`?
+
 # layer_data returns a data.frame
 
     `layer_data()` must return a <data.frame>

--- a/tests/testthat/_snaps/layer.md
+++ b/tests/testthat/_snaps/layer.md
@@ -86,7 +86,7 @@
 
 # layer warns for constant aesthetics
 
-    All aesthetics have length 1, but the data has 32 rows in `geom_point()`.
+    All aesthetics have length 1, but the data has 32 rows.
     i Did you mean to use `annotate()`?
 
 # layer_data returns a data.frame

--- a/tests/testthat/test-layer.R
+++ b/tests/testthat/test-layer.R
@@ -123,6 +123,14 @@ test_that("layer reports the error with correct index etc", {
   expect_snapshot_error(ggplotGrob(p))
 })
 
+test_that("layer warns for constant aesthetics", {
+  p <- ggplot(mtcars, aes(x = seq_along(mpg))) + geom_point(aes(y = 2))
+  expect_silent(ggplot_build(p))
+
+  p <- ggplot(mtcars, aes(x = 1)) + geom_point(aes(y = 2))
+  expect_snapshot_warning(ggplot_build(p))
+})
+
 # Data extraction ---------------------------------------------------------
 
 test_that("layer_data returns a data.frame", {


### PR DESCRIPTION
This PR aims to fix #5253.

Briefly, it adds a warning when using an all-constant mapping in a layer:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

p <- ggplot(mtcars, aes(x = 1)) +
  geom_point(aes(y = 2))
b <- ggplot_build(p)
#> Warning: All aesthetics have length 1, but the data has 32 rows in `geom_point()`.
#> ℹ Did you mean to use `annotate()`?
```

It does take into account inherited aesthetics, so no warning is issued here:

``` r
p <- ggplot(mtcars, aes(x = seq_along(mpg))) +
  geom_point(aes(y = 2))
b <- ggplot_build(p)
```

There is an ambiguous case where I was unsure a warning should be emitted. If a layer inherits an aesthetic that it does not use, should the warning been thrown for the aesthetics it does use?

``` r
# To warn or not to warn?
p <- ggplot(mtcars, aes(label = cyl)) +
  geom_point(aes(x = 1, y = 1))
b <- ggplot_build(p)
```

<sup>Created on 2023-04-01 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

The `geom_abline()`/`geom_vline()`/`geom_hline()` are excluded from this check. Extenders can exclude their geoms from this check by using the same exclusion flag (`check_constant_aes = FALSE` in the geom's ggproto fields).
