### PR TITLE
Negative tick strips

### DIFF
--- a/R/facet-grid-.R
+++ b/R/facet-grid-.R
@@ -367,14 +367,10 @@ FacetGrid <- ggproto("FacetGrid", Facet,
       theme$panel.spacing.y %||% theme$panel.spacing)
 
     # Add axes
-    axis_height_top <- max_height(axes$x$top)
-    axis_height_bottom <- max_height(axes$x$bottom)
-    axis_width_left <- max_width(axes$y$left)
-    axis_width_right <- max_width(axes$y$right)
-    panel_table <- gtable_add_rows(panel_table, axis_height_top, 0)
-    panel_table <- gtable_add_rows(panel_table, axis_height_bottom, -1)
-    panel_table <- gtable_add_cols(panel_table, axis_width_left, 0)
-    panel_table <- gtable_add_cols(panel_table, axis_width_right, -1)
+    panel_table <- gtable_add_rows(panel_table, max_height(axes$x$top),     0)
+    panel_table <- gtable_add_rows(panel_table, max_height(axes$x$bottom), -1)
+    panel_table <- gtable_add_cols(panel_table, max_width(axes$y$left),     0)
+    panel_table <- gtable_add_cols(panel_table, max_width(axes$y$right),   -1)
     panel_pos_col <- panel_cols(panel_table)
     panel_pos_rows <- panel_rows(panel_table)
 
@@ -392,7 +388,7 @@ FacetGrid <- ggproto("FacetGrid", Facet,
     panel_pos_col <- panel_cols(panel_table)
     if (switch_x) {
       if (!is.null(strips$x$bottom)) {
-        if (inside_x || as.numeric(axis_height_bottom) == 0) {
+        if (inside_x || all(vapply(axes$x$bottom, is.zero, logical(1)))) {
           panel_table <- gtable_add_rows(panel_table, max_height(strips$x$bottom), -2)
           panel_table <- gtable_add_grob(panel_table, strips$x$bottom, -2, panel_pos_col$l, clip = "on", name = paste0("strip-b-", seq_along(strips$x$bottom)), z = 2)
         } else {
@@ -403,7 +399,7 @@ FacetGrid <- ggproto("FacetGrid", Facet,
       }
     } else {
       if (!is.null(strips$x$top)) {
-        if (inside_x || as.numeric(axis_height_top) == 0) {
+        if (inside_x || all(vapply(axes$x$top, is.zero, logical(1)))) {
           panel_table <- gtable_add_rows(panel_table, max_height(strips$x$top), 1)
           panel_table <- gtable_add_grob(panel_table, strips$x$top, 2, panel_pos_col$l, clip = "on", name = paste0("strip-t-", seq_along(strips$x$top)), z = 2)
         } else {
@@ -416,7 +412,7 @@ FacetGrid <- ggproto("FacetGrid", Facet,
     panel_pos_rows <- panel_rows(panel_table)
     if (switch_y) {
       if (!is.null(strips$y$left)) {
-        if (inside_y || as.numeric(axis_width_left) == 0) {
+        if (inside_y || all(vapply(axes$y$left, is.zero, logical(1)))) {
           panel_table <- gtable_add_cols(panel_table, max_width(strips$y$left), 1)
           panel_table <- gtable_add_grob(panel_table, strips$y$left, panel_pos_rows$t, 2, clip = "on", name = paste0("strip-l-", seq_along(strips$y$left)), z = 2)
         } else {
@@ -427,7 +423,7 @@ FacetGrid <- ggproto("FacetGrid", Facet,
       }
     } else {
       if (!is.null(strips$y$right)) {
-        if (inside_y || as.numeric(axis_width_right) == 0) {
+        if (inside_y || all(vapply(axes$y$right, is.zero, logical(1)))) {
           panel_table <- gtable_add_cols(panel_table, max_width(strips$y$right), -2)
           panel_table <- gtable_add_grob(panel_table, strips$y$right, panel_pos_rows$t, -2, clip = "on", name = paste0("strip-r-", seq_along(strips$y$right)), z = 2)
         } else {

--- a/tests/testthat/test-facet-strips.R
+++ b/tests/testthat/test-facet-strips.R
@@ -159,6 +159,14 @@ test_that("padding is only added if axis is present", {
   pg <- ggplotGrob(p + scale_x_continuous(position = "top"))
   expect_equal(length(pg$heights), 14)
   expect_equal(as.character(pg$heights[7]), "1cm")
+
+  # Also add padding with negative ticks and no text (#5251)
+  pg <- ggplotGrob(
+    p + scale_x_continuous(labels = NULL, position = "top") +
+      theme(axis.ticks.length.x.top = unit(-2, "mm"))
+  )
+  expect_equal(length(pg$heights), 14)
+  expect_equal(as.character(pg$heights[7]), "1cm")
 })
 
 test_that("y strip labels are rotated when strips are switched", {


### PR DESCRIPTION
This PR aims to fix #5251.

In brief, whether strip padding was necessary depended on whether the size of the axis was 0. With this PR, that now depends on whether there is a relevant axis present. This fixes a problem with axis placement when the axis had acquired 0-size due to missing text and negative tick length (which begets the ticks a 0-size slot in the axis gtable for text alignment reasons).

Although, this example below might 'look' like there should be no padding between axis and strip, this behaviour is consistent with axes with normal dimensions.

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

ggplot(mpg, aes(displ, hwy)) +
  facet_grid("foo" ~ drv, switch = "both") +
  theme(
    strip.placement = "outside",
    axis.ticks.length = unit(-3, "pt"),
    axis.text = element_blank()
  )
```

![](https://i.imgur.com/kVOKTnH.png)<!-- -->

<sup>Created on 2023-04-03 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
