### PR TITLE
`annotation_logticks()` skips ticks it hasn't found

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* Fixed bug in `annotation_logticks()` when no suitable tick positions could
+  be found (@teunbrand, #5248).
 * To improve `width` calculation in bar plots with empty factor levels, 
   `resolution()` considers `mapped_discrete` values as having resolution 1 
   (@teunbrand, #5211)

--- a/R/annotation-logticks.R
+++ b/R/annotation-logticks.R
@@ -159,14 +159,14 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
         xticks$end = -xticks$end
 
       # Make the grobs
-      if (grepl("b", sides)) {
+      if (grepl("b", sides) && nrow(xticks) > 0) {
         ticks$x_b <- with(data, segmentsGrob(
           x0 = unit(xticks$x, "native"), x1 = unit(xticks$x, "native"),
           y0 = unit(xticks$start, "cm"), y1 = unit(xticks$end, "cm"),
           gp = gpar(col = alpha(colour, alpha), lty = linetype, lwd = size * .pt)
         ))
       }
-      if (grepl("t", sides)) {
+      if (grepl("t", sides) && nrow(xticks) > 0) {
         ticks$x_t <- with(data, segmentsGrob(
           x0 = unit(xticks$x, "native"), x1 = unit(xticks$x, "native"),
           y0 = unit(1, "npc") - unit(xticks$start, "cm"), y1 = unit(1, "npc") - unit(xticks$end, "cm"),
@@ -197,14 +197,14 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
         yticks$end = -yticks$end
 
       # Make the grobs
-      if (grepl("l", sides)) {
+      if (grepl("l", sides) && nrow(yticks) > 0) {
         ticks$y_l <- with(data, segmentsGrob(
           y0 = unit(yticks$y, "native"), y1 = unit(yticks$y, "native"),
           x0 = unit(yticks$start, "cm"), x1 = unit(yticks$end, "cm"),
           gp = gpar(col = alpha(colour, alpha), lty = linetype, lwd = size * .pt)
         ))
       }
-      if (grepl("r", sides)) {
+      if (grepl("r", sides) && nrow(yticks) > 0) {
         ticks$y_r <- with(data, segmentsGrob(
           y0 = unit(yticks$y, "native"), y1 = unit(yticks$y, "native"),
           x0 = unit(1, "npc") - unit(yticks$start, "cm"), x1 = unit(1, "npc") - unit(yticks$end, "cm"),


### PR DESCRIPTION
This PR aims to fix #5248.

Briefly, it adds checks to ensure that there are ticks to be drawn before attempting to draw them.