### PR TITLE
`geom_pointrange()` passes on `na.rm`

### DIFF
--- a/R/geom-pointrange.R
+++ b/R/geom-pointrange.R
@@ -47,14 +47,22 @@ GeomPointrange <- ggproto("GeomPointrange", Geom,
     GeomLinerange$setup_data(data, params)
   },
 
-  draw_panel = function(data, panel_params, coord, lineend = "butt", fatten = 4, flipped_aes = FALSE) {
+  draw_panel = function(data, panel_params, coord, lineend = "butt", fatten = 4,
+                        flipped_aes = FALSE, na.rm = FALSE) {
+    line_grob <- GeomLinerange$draw_panel(
+      data, panel_params, coord, lineend = lineend, flipped_aes = flipped_aes,
+      na.rm = na.rm
+    )
     if (is.null(data[[flipped_names(flipped_aes)$y]]))
-      return(GeomLinerange$draw_panel(data, panel_params, coord, lineend = lineend, flipped_aes = flipped_aes))
+      return(line_grob)
 
     ggname("geom_pointrange",
       gTree(children = gList(
-        GeomLinerange$draw_panel(data, panel_params, coord, lineend = lineend, flipped_aes = flipped_aes),
-        GeomPoint$draw_panel(transform(data, size = size * fatten), panel_params, coord)
+        line_grob,
+        GeomPoint$draw_panel(
+          transform(data, size = size * fatten),
+          panel_params, coord, na.rm = na.rm
+        )
       ))
     )
   }


### PR DESCRIPTION
This PR aims to fix #5261.

It now passes on the `na.rm` parameter to downstream drawing functions.

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

# Based on example from docs
df <- data.frame(
  trt = factor(c(1, 1, 2, 2)),
  resp = c(1, 5, 3, 4),
  group = factor(c(1, 2, 1, 2)),
  upper = c(1.1, NA_real_, 3.3, NA_real_),
  lower = c(0.8, NA_real_, 2.4, NA_real_)
)

p <- ggplot(df, aes(trt, resp, colour = group))

# Throws warning
p + geom_pointrange(aes(ymin = lower, ymax = upper), na.rm = FALSE)
#> Warning: Removed 2 rows containing missing values (`geom_segment()`).
```

![](https://i.imgur.com/xmb1IMO.png)<!-- -->

``` r

# Stays silent
p + geom_pointrange(aes(ymin = lower, ymax = upper), na.rm = TRUE)
```

![](https://i.imgur.com/NtICKVV.png)<!-- -->

<sup>Created on 2023-04-12 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
