### PR TITLE
Silence additional weight warnings

### DIFF
--- a/R/geom-dotplot.R
+++ b/R/geom-dotplot.R
@@ -188,7 +188,8 @@ GeomDotplot <- ggproto("GeomDotplot", Geom,
   required_aes = c("x", "y"),
   non_missing_aes = c("size", "shape"),
 
-  default_aes = aes(colour = "black", fill = "black", alpha = NA, stroke = 1, linetype = "solid"),
+  default_aes = aes(colour = "black", fill = "black", alpha = NA,
+                    stroke = 1, linetype = "solid", weight = 1),
 
   setup_data = function(data, params) {
     data$width <- data$width %||%

--- a/R/stat-bindot.R
+++ b/R/stat-bindot.R
@@ -124,7 +124,9 @@ StatBindot <- ggproto("StatBindot", Stat,
       data$x <- midline
     }
     return(data)
-  }
+  },
+
+  dropped_aes = "weight"
 )
 
 

--- a/R/stat-ydensity.R
+++ b/R/stat-ydensity.R
@@ -138,8 +138,9 @@ StatYdensity <- ggproto("StatYdensity", Stat,
     )
     data$flipped_aes <- flipped_aes
     flip_data(data, flipped_aes)
-  }
+  },
 
+  dropped_aes = "weight"
 )
 
 calc_bw <- function(x, bw) {

--- a/man/geom_dotplot.Rd
+++ b/man/geom_dotplot.Rd
@@ -137,6 +137,7 @@ to match the number of dots.
 \item \code{\link[=aes_group_order]{group}}
 \item \code{\link[=aes_linetype_size_shape]{linetype}}
 \item \code{stroke}
+\item \code{weight}
 }
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 }


### PR DESCRIPTION
This PR aims to fix #5263.

It continuous the saga of silencing dropped weight warnings, like #5071 and #5218 before it.

I also found `geom_dotplot()` to use a `weight` aesthetic, but it reports it doesn't and throws a warning about dropped weights when present. I fixed this by promoting it to a visible aesthetic and silencing the warning. In the example below, only the bin width warnings persist.

``` r
library(ggplot2)

p <- ggplot(mtcars, aes(x = mpg))
p1 <- p + geom_dotplot(aes(weight = cyl))
#> Warning in geom_dotplot(aes(weight = cyl)): Ignoring unknown aesthetics: weight
p2 <- p + geom_dotplot()
patchwork::wrap_plots(p1, p2)
#> Bin width defaults to 1/30 of the range of the data. Pick better value with
#> `binwidth`.
#> Warning: The following aesthetics were dropped during statistical transformation: weight
#> ℹ This can happen when ggplot fails to infer the correct grouping structure in
#>   the data.
#> ℹ Did you forget to specify a `group` aesthetic or to convert a numerical
#>   variable into a factor?
#> Bin width defaults to 1/30 of the range of the data. Pick better value with
#> `binwidth`.
```

![](https://i.imgur.com/GzDDg3x.png)<!-- -->

<sup>Created on 2023-04-12 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
