### PR TITLE
Add scale transformation note to `geom_tile()`/`geom_rect()`

### DIFF
--- a/R/geom-tile.R
+++ b/R/geom-tile.R
@@ -12,6 +12,14 @@
 #' @inheritParams geom_point
 #' @inheritParams geom_segment
 #' @export
+#'
+#' @details
+#' `geom_rect()` and `geom_tile()`'s respond differently to scale
+#' transformations due to their parametrisation. In `geom_rect()`, the scale
+#' transformation is applied to the corners of the rectangles. In `geom_tile()`,
+#' the transformation is applied only to the centres and its size is determined
+#' after transformation.
+#'
 #' @examples
 #' # The most common use for rectangles is to draw a surface. You always want
 #' # to use geom_raster here because it's so much faster, and produces

--- a/man/geom_tile.Rd
+++ b/man/geom_tile.Rd
@@ -111,6 +111,13 @@ corners (\code{xmin}, \code{xmax}, \code{ymin} and \code{ymax}), while
 \code{y}, \code{width}, \code{height}). \code{geom_raster()} is a high
 performance special case for when all the tiles are the same size.
 }
+\details{
+\code{geom_rect()} and \code{geom_tile()}'s respond differently to scale
+transformations due to their parametrisation. In \code{geom_rect()}, the scale
+transformation is applied to the corners of the rectangles. In \code{geom_tile()},
+the transformation is applied only to the centres and its size is determined
+after transformation.
+}
 \section{Aesthetics}{
 
 \code{geom_tile()} understands the following aesthetics (required aesthetics are in bold):


### PR DESCRIPTION
This PR aims to fix #5257.

It adds a details section to the documentation of `geom_tile()`/`geom_rect()` that mentions how the geoms respond to scale transformations.