### PR TITLE
Update missing value warning

### DIFF
--- a/R/geom-path.R
+++ b/R/geom-path.R
@@ -140,7 +140,10 @@ GeomPath <- ggproto("GeomPath", Geom,
     data <- data[kept, ]
 
     if (!all(kept) && !params$na.rm) {
-      cli::cli_warn("Removed {sum(!kept)} row{?s} containing missing values ({.fn {snake_class(self)}}).")
+      cli::cli_warn(paste0(
+        "Removed {sum(!kept)} row{?s} containing missing ",
+        "or excluded values ({.fn {snake_class(self)}})."
+      ))
     }
 
     data

--- a/R/geom-path.R
+++ b/R/geom-path.R
@@ -141,8 +141,8 @@ GeomPath <- ggproto("GeomPath", Geom,
 
     if (!all(kept) && !params$na.rm) {
       cli::cli_warn(paste0(
-        "Removed {sum(!kept)} row{?s} containing missing ",
-        "or excluded values ({.fn {snake_class(self)}})."
+        "Removed {sum(!kept)} row{?s} containing missing values or values ",
+        "outside the scale range ({.fn {snake_class(self)}})."
       ))
     }
 

--- a/R/geom-sf.R
+++ b/R/geom-sf.R
@@ -177,8 +177,8 @@ sf_grob <- function(x, lineend = "butt", linejoin = "round", linemitre = 10,
   if (any(remove)) {
     if (!na.rm) {
       cli::cli_warn(paste0(
-        "Removed {sum(remove)} row{?s} containing missing ",
-        "or excluded values ({.fn geom_sf})."
+        "Removed {sum(remove)} row{?s} containing missing values or values ",
+        "outside the scale range ({.fn geom_sf})."
       ))
     }
     x <- x[!remove, , drop = FALSE]

--- a/R/geom-sf.R
+++ b/R/geom-sf.R
@@ -176,7 +176,10 @@ sf_grob <- function(x, lineend = "butt", linejoin = "round", linemitre = 10,
   remove[is_other] <- detect_missing(x, c(GeomPolygon$required_aes, GeomPolygon$non_missing_aes))[is_other]
   if (any(remove)) {
     if (!na.rm) {
-      cli::cli_warn("Removed {sum(remove)} row{?s} containing missing values ({.fn geom_sf})")
+      cli::cli_warn(paste0(
+        "Removed {sum(remove)} row{?s} containing missing ",
+        "or excluded values ({.fn geom_sf})."
+      ))
     }
     x <- x[!remove, , drop = FALSE]
     type_ind <- type_ind[!remove]

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -91,8 +91,8 @@ remove_missing <- function(df, na.rm = FALSE, vars = names(df), name = "",
     if (!na.rm) {
       if (name != "") name <- paste(" ({.fn ", name, "})", sep = "")
       msg <- paste0(
-        "Removed {sum(missing)} rows containing ",
-        if (finite) "non-finite" else "missing",
+        "Removed {sum(missing)} row{?s} containing ",
+        if (finite) "non-finite" else "missing or excluded",
         " values", name, "."
       )
       cli::cli_warn(msg)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -92,8 +92,8 @@ remove_missing <- function(df, na.rm = FALSE, vars = names(df), name = "",
       if (name != "") name <- paste(" ({.fn ", name, "})", sep = "")
       msg <- paste0(
         "Removed {sum(missing)} row{?s} containing ",
-        if (finite) "non-finite" else "missing or excluded",
-        " values", name, "."
+        if (finite) "non-finite" else "missing values or values",
+        " outside the scale range", name, "."
       )
       cli::cli_warn(msg)
     }

--- a/tests/testthat/_snaps/geom-dotplot.md
+++ b/tests/testthat/_snaps/geom-dotplot.md
@@ -1,6 +1,6 @@
 # NA's result in warning from stat_bindot
 
-    Removed 2 rows containing missing values (`stat_bindot()`).
+    Removed 2 rows containing missing or excluded values (`stat_bindot()`).
 
 # weight aesthetic is checked
 

--- a/tests/testthat/_snaps/geom-dotplot.md
+++ b/tests/testthat/_snaps/geom-dotplot.md
@@ -1,6 +1,6 @@
 # NA's result in warning from stat_bindot
 
-    Removed 2 rows containing missing or excluded values (`stat_bindot()`).
+    Removed 2 rows containing missing values or values outside the scale range (`stat_bindot()`).
 
 # weight aesthetic is checked
 

--- a/tests/testthat/_snaps/stat-boxplot.md
+++ b/tests/testthat/_snaps/stat-boxplot.md
@@ -1,10 +1,10 @@
 # stat_boxplot drops missing rows with a warning
 
-    Removed 10 rows containing missing values (`stat_boxplot()`).
+    Removed 10 rows containing missing or excluded values (`stat_boxplot()`).
 
 ---
 
-    Removed 10 rows containing missing values (`stat_boxplot()`).
+    Removed 10 rows containing missing or excluded values (`stat_boxplot()`).
 
 # stat_boxplot errors with missing x/y aesthetics
 

--- a/tests/testthat/_snaps/stat-boxplot.md
+++ b/tests/testthat/_snaps/stat-boxplot.md
@@ -1,10 +1,10 @@
 # stat_boxplot drops missing rows with a warning
 
-    Removed 10 rows containing missing or excluded values (`stat_boxplot()`).
+    Removed 10 rows containing missing values or values outside the scale range (`stat_boxplot()`).
 
 ---
 
-    Removed 10 rows containing missing or excluded values (`stat_boxplot()`).
+    Removed 10 rows containing missing values or values outside the scale range (`stat_boxplot()`).
 
 # stat_boxplot errors with missing x/y aesthetics
 

--- a/tests/testthat/test-geom-bar.R
+++ b/tests/testthat/test-geom-bar.R
@@ -5,7 +5,7 @@ test_that("geom_bar removes bars with parts outside the plot limits", {
 
   expect_warning( # warning created at render stage
     ggplotGrob(p + ylim(0, 2.5)),
-    "Removed 1 row containing missing or excluded values"
+    "Removed 1 row containing missing values or values outside the scale range"
   )
 })
 

--- a/tests/testthat/test-geom-bar.R
+++ b/tests/testthat/test-geom-bar.R
@@ -5,7 +5,7 @@ test_that("geom_bar removes bars with parts outside the plot limits", {
 
   expect_warning( # warning created at render stage
     ggplotGrob(p + ylim(0, 2.5)),
-    "Removed 1 rows containing missing values"
+    "Removed 1 row containing missing or excluded values"
   )
 })
 

--- a/tests/testthat/test-geom-col.R
+++ b/tests/testthat/test-geom-col.R
@@ -5,11 +5,11 @@ test_that("geom_col removes columns with parts outside the plot limits", {
 
   expect_warning( # warning created at render stage
     ggplotGrob(p + ylim(0.5, 4)),
-    "Removed 3 rows containing missing values"
+    "Removed 3 rows containing missing or excluded values"
   )
   expect_warning( # warning created at build stage
     ggplot_build(p + ylim(0, 2.5)),
-    "Removed 1 rows containing missing values"
+    "Removed 1 row containing missing or excluded values"
   )
 })
 

--- a/tests/testthat/test-geom-col.R
+++ b/tests/testthat/test-geom-col.R
@@ -5,11 +5,11 @@ test_that("geom_col removes columns with parts outside the plot limits", {
 
   expect_warning( # warning created at render stage
     ggplotGrob(p + ylim(0.5, 4)),
-    "Removed 3 rows containing missing or excluded values"
+    "Removed 3 rows containing missing values or values outside the scale range"
   )
   expect_warning( # warning created at build stage
     ggplot_build(p + ylim(0, 2.5)),
-    "Removed 1 row containing missing or excluded values"
+    "Removed 1 row containing missing values or values outside the scale range"
   )
 })
 

--- a/tests/testthat/test-geom-path.R
+++ b/tests/testthat/test-geom-path.R
@@ -95,6 +95,6 @@ test_that("NA linetype is dropped with warning", {
       "NA linetype",
       ggplot(df, aes(x, y)) + geom_path(linetype = NA)
     ),
-    "containing missing or excluded values"
+    "containing missing values or values outside the scale range"
   )
 })

--- a/tests/testthat/test-geom-path.R
+++ b/tests/testthat/test-geom-path.R
@@ -95,6 +95,6 @@ test_that("NA linetype is dropped with warning", {
       "NA linetype",
       ggplot(df, aes(x, y)) + geom_path(linetype = NA)
     ),
-    "containing missing values"
+    "containing missing or excluded values"
   )
 })

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -102,17 +102,17 @@ test_that("geom_sf() removes rows containing missing aes", {
   p <- ggplot(pts)
   expect_warning(
     expect_identical(grob_xy_length(p + geom_sf(aes(size = size))), c(1L, 1L)),
-    "Removed 1 row containing missing values"
+    "Removed 1 row containing missing or excluded values"
   )
   expect_warning(
     expect_identical(grob_xy_length(p + geom_sf(aes(shape = shape))), c(1L, 1L)),
-    "Removed 1 row containing missing values"
+    "Removed 1 row containing missing or excluded values"
   )
   # default colour scale maps a colour even to a NA, so identity scale is needed to see if NA is removed
   expect_warning(
     expect_identical(grob_xy_length(p + geom_sf(aes(colour = colour)) + scale_colour_identity()),
                      c(1L, 1L)),
-    "Removed 1 row containing missing values"
+    "Removed 1 row containing missing or excluded values"
   )
 })
 

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -102,17 +102,17 @@ test_that("geom_sf() removes rows containing missing aes", {
   p <- ggplot(pts)
   expect_warning(
     expect_identical(grob_xy_length(p + geom_sf(aes(size = size))), c(1L, 1L)),
-    "Removed 1 row containing missing or excluded values"
+    "Removed 1 row containing missing values or values outside the scale range"
   )
   expect_warning(
     expect_identical(grob_xy_length(p + geom_sf(aes(shape = shape))), c(1L, 1L)),
-    "Removed 1 row containing missing or excluded values"
+    "Removed 1 row containing missing values or values outside the scale range"
   )
   # default colour scale maps a colour even to a NA, so identity scale is needed to see if NA is removed
   expect_warning(
     expect_identical(grob_xy_length(p + geom_sf(aes(colour = colour)) + scale_colour_identity()),
                      c(1L, 1L)),
-    "Removed 1 row containing missing or excluded values"
+    "Removed 1 row containing missing values or values outside the scale range"
   )
 })
 

--- a/tests/testthat/test-scales.R
+++ b/tests/testthat/test-scales.R
@@ -112,9 +112,9 @@ test_that("oob affects position values", {
   base + scale_y_continuous(limits = c(-0,5))
 
   expect_warning(low_censor <- cdata(base + y_scale(c(0, 5), censor)),
-    "Removed 1 row containing missing or excluded values")
+    "Removed 1 row containing missing values or values outside the scale range")
   expect_warning(mid_censor <- cdata(base + y_scale(c(3, 7), censor)),
-    "Removed 2 rows containing missing or excluded values")
+    "Removed 2 rows containing missing values or values outside the scale range")
 
   low_squish <- cdata(base + y_scale(c(0, 5), squish))
   mid_squish <- cdata(base + y_scale(c(3, 7), squish))

--- a/tests/testthat/test-scales.R
+++ b/tests/testthat/test-scales.R
@@ -112,9 +112,9 @@ test_that("oob affects position values", {
   base + scale_y_continuous(limits = c(-0,5))
 
   expect_warning(low_censor <- cdata(base + y_scale(c(0, 5), censor)),
-    "Removed 1 rows containing missing values")
+    "Removed 1 row containing missing or excluded values")
   expect_warning(mid_censor <- cdata(base + y_scale(c(3, 7), censor)),
-    "Removed 2 rows containing missing values")
+    "Removed 2 rows containing missing or excluded values")
 
   low_squish <- cdata(base + y_scale(c(0, 5), squish))
   mid_squish <- cdata(base + y_scale(c(3, 7), squish))


### PR DESCRIPTION
This PR aims to fix #5250.

Briefly, it updates the warning message that is omitted by `Geom$handle_na()` and their kin to read:
```r
#> Warning message:
#> Removed 10 rows containing missing or excluded values (`stat_boxplot()`). 
```
Where the 'or excluded' is new. This is to better reflect that values might have been excluded by the out-of-bounds functions, in addition to being properly missing.