### PR TITLE
Fix warning regression in `geom_dotplot()`

### DIFF
--- a/R/stat-bindot.R
+++ b/R/stat-bindot.R
@@ -126,7 +126,7 @@ StatBindot <- ggproto("StatBindot", Stat,
     return(data)
   },
 
-  dropped_aes = "weight"
+  dropped_aes = c("weight", "bin", "bincenter")
 )
 
 


### PR DESCRIPTION
This PR aims to fix a regression from #5267.

Briefly, `geom_dotplot()`/`stat_bindot()` started emitting warnings when these functions shouldn't. For example:
``` r
library(ggplot2) # current main branch

dat <- data_frame(x = rnorm(20), g = rep(LETTERS[1:2], 10))

ggplot(dat, aes(x, fill = g)) + 
  geom_dotplot(binwidth = .4, alpha = .4, binpositions = "all")
#> Warning: The following aesthetics were dropped during statistical transformation: bin,
#> bincenter
#> ℹ This can happen when ggplot fails to infer the correct grouping structure in
#>   the data.
#> ℹ Did you forget to specify a `group` aesthetic or to convert a numerical
#>   variable into a factor?
```

<sup>Created on 2023-04-19 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

This PR fixes that spurious warning by adding `bin` and `bincenter` to the `dropped_aes` field.