### PR TITLE
Fix custom strip test

### DIFF
--- a/tests/testthat/_snaps/theme/custom-strip-elements-can-render.svg
+++ b/tests/testthat/_snaps/theme/custom-strip-elements-can-render.svg
@@ -21,122 +21,122 @@
 <rect x='0.000000000000064' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMzUuMjR8MjU4LjAxfDM5LjQzfDU0NS4xMQ=='>
-    <rect x='35.24' y='39.43' width='222.77' height='505.68' />
+  <clipPath id='cpMzUuMjR8MjU4LjAxfDUxLjEzfDU0NS4xMQ=='>
+    <rect x='35.24' y='51.13' width='222.77' height='493.98' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzUuMjR8MjU4LjAxfDM5LjQzfDU0NS4xMQ==)'>
-<rect x='35.24' y='39.43' width='222.77' height='505.68' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
-<polyline points='35.24,464.66 258.01,464.66 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='35.24,349.74 258.01,349.74 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='35.24,234.81 258.01,234.81 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='35.24,119.88 258.01,119.88 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='70.68,545.11 70.68,39.43 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='121.31,545.11 121.31,39.43 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='171.94,545.11 171.94,39.43 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='222.57,545.11 222.57,39.43 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='35.24,522.13 258.01,522.13 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='35.24,407.20 258.01,407.20 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='35.24,292.27 258.01,292.27 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='35.24,177.35 258.01,177.35 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='35.24,62.42 258.01,62.42 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='45.36,545.11 45.36,39.43 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='95.99,545.11 95.99,39.43 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='146.63,545.11 146.63,39.43 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='197.26,545.11 197.26,39.43 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='247.89,545.11 247.89,39.43 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<circle cx='45.36' cy='522.13' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<g clip-path='url(#cpMzUuMjR8MjU4LjAxfDUxLjEzfDU0NS4xMQ==)'>
+<rect x='35.24' y='51.13' width='222.77' height='493.98' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='35.24,466.52 258.01,466.52 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='35.24,354.26 258.01,354.26 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='35.24,241.99 258.01,241.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='35.24,129.72 258.01,129.72 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='70.68,545.11 70.68,51.13 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='121.31,545.11 121.31,51.13 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='171.94,545.11 171.94,51.13 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='222.57,545.11 222.57,51.13 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='35.24,522.66 258.01,522.66 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='35.24,410.39 258.01,410.39 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='35.24,298.12 258.01,298.12 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='35.24,185.85 258.01,185.85 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='35.24,73.58 258.01,73.58 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='45.36,545.11 45.36,51.13 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='95.99,545.11 95.99,51.13 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='146.63,545.11 146.63,51.13 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='197.26,545.11 197.26,51.13 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='247.89,545.11 247.89,51.13 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<circle cx='45.36' cy='522.66' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjYzLjQ5fDQ4Ni4yN3wzOS40M3w1NDUuMTE='>
-    <rect x='263.49' y='39.43' width='222.77' height='505.68' />
+  <clipPath id='cpMjYzLjQ5fDQ4Ni4yN3w1MS4xM3w1NDUuMTE='>
+    <rect x='263.49' y='51.13' width='222.77' height='493.98' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjYzLjQ5fDQ4Ni4yN3wzOS40M3w1NDUuMTE=)'>
-<rect x='263.49' y='39.43' width='222.77' height='505.68' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
-<polyline points='263.49,464.66 486.27,464.66 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='263.49,349.74 486.27,349.74 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='263.49,234.81 486.27,234.81 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='263.49,119.88 486.27,119.88 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='298.93,545.11 298.93,39.43 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='349.56,545.11 349.56,39.43 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='400.19,545.11 400.19,39.43 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='450.83,545.11 450.83,39.43 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='263.49,522.13 486.27,522.13 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='263.49,407.20 486.27,407.20 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='263.49,292.27 486.27,292.27 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='263.49,177.35 486.27,177.35 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='263.49,62.42 486.27,62.42 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='273.62,545.11 273.62,39.43 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='324.25,545.11 324.25,39.43 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='374.88,545.11 374.88,39.43 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='425.51,545.11 425.51,39.43 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='476.14,545.11 476.14,39.43 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<circle cx='374.88' cy='292.27' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<g clip-path='url(#cpMjYzLjQ5fDQ4Ni4yN3w1MS4xM3w1NDUuMTE=)'>
+<rect x='263.49' y='51.13' width='222.77' height='493.98' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='263.49,466.52 486.27,466.52 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='263.49,354.26 486.27,354.26 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='263.49,241.99 486.27,241.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='263.49,129.72 486.27,129.72 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='298.93,545.11 298.93,51.13 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='349.56,545.11 349.56,51.13 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='400.19,545.11 400.19,51.13 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='450.83,545.11 450.83,51.13 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='263.49,522.66 486.27,522.66 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='263.49,410.39 486.27,410.39 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='263.49,298.12 486.27,298.12 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='263.49,185.85 486.27,185.85 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='263.49,73.58 486.27,73.58 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='273.62,545.11 273.62,51.13 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='324.25,545.11 324.25,51.13 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='374.88,545.11 374.88,51.13 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='425.51,545.11 425.51,51.13 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='476.14,545.11 476.14,51.13 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<circle cx='374.88' cy='298.12' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDkxLjc1fDcxNC41MnwzOS40M3w1NDUuMTE='>
-    <rect x='491.75' y='39.43' width='222.77' height='505.68' />
+  <clipPath id='cpNDkxLjc1fDcxNC41Mnw1MS4xM3w1NDUuMTE='>
+    <rect x='491.75' y='51.13' width='222.77' height='493.98' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDkxLjc1fDcxNC41MnwzOS40M3w1NDUuMTE=)'>
-<rect x='491.75' y='39.43' width='222.77' height='505.68' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
-<polyline points='491.75,464.66 714.52,464.66 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='491.75,349.74 714.52,349.74 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='491.75,234.81 714.52,234.81 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='491.75,119.88 714.52,119.88 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='527.19,545.11 527.19,39.43 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='577.82,545.11 577.82,39.43 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='628.45,545.11 628.45,39.43 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='679.08,545.11 679.08,39.43 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='491.75,522.13 714.52,522.13 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='491.75,407.20 714.52,407.20 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='491.75,292.27 714.52,292.27 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='491.75,177.35 714.52,177.35 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='491.75,62.42 714.52,62.42 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='501.87,545.11 501.87,39.43 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='552.50,545.11 552.50,39.43 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='603.13,545.11 603.13,39.43 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='653.76,545.11 653.76,39.43 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='704.39,545.11 704.39,39.43 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
-<circle cx='704.39' cy='62.42' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<g clip-path='url(#cpNDkxLjc1fDcxNC41Mnw1MS4xM3w1NDUuMTE=)'>
+<rect x='491.75' y='51.13' width='222.77' height='493.98' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='491.75,466.52 714.52,466.52 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='491.75,354.26 714.52,354.26 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='491.75,241.99 714.52,241.99 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='491.75,129.72 714.52,129.72 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='527.19,545.11 527.19,51.13 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='577.82,545.11 577.82,51.13 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='628.45,545.11 628.45,51.13 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='679.08,545.11 679.08,51.13 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='491.75,522.66 714.52,522.66 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='491.75,410.39 714.52,410.39 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='491.75,298.12 714.52,298.12 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='491.75,185.85 714.52,185.85 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='491.75,73.58 714.52,73.58 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='501.87,545.11 501.87,51.13 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='552.50,545.11 552.50,51.13 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='603.13,545.11 603.13,51.13 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='653.76,545.11 653.76,51.13 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='704.39,545.11 704.39,51.13 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<circle cx='704.39' cy='73.58' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzUuMjR8MjU4LjAxfDIyLjc4fDM5LjQz'>
-    <rect x='35.24' y='22.78' width='222.77' height='16.65' />
+  <clipPath id='cpMzUuMjR8MjU4LjAxfDIyLjc4fDUxLjEz'>
+    <rect x='35.24' y='22.78' width='222.77' height='28.35' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzUuMjR8MjU4LjAxfDIyLjc4fDM5LjQz)'>
-<rect x='35.24' y='22.78' width='222.77' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
-<text x='146.63' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>a</text>
+<g clip-path='url(#cpMzUuMjR8MjU4LjAxfDIyLjc4fDUxLjEz)'>
+<rect x='35.24' y='22.78' width='222.77' height='28.35' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<rect x='132.45' y='22.78' width='28.35' height='28.35' style='stroke-width: 0.75; fill: #FFFFFF;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjYzLjQ5fDQ4Ni4yN3wyMi43OHwzOS40Mw=='>
-    <rect x='263.49' y='22.78' width='222.77' height='16.65' />
+  <clipPath id='cpMjYzLjQ5fDQ4Ni4yN3wyMi43OHw1MS4xMw=='>
+    <rect x='263.49' y='22.78' width='222.77' height='28.35' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjYzLjQ5fDQ4Ni4yN3wyMi43OHwzOS40Mw==)'>
-<rect x='263.49' y='22.78' width='222.77' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
-<text x='374.88' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text>
+<g clip-path='url(#cpMjYzLjQ5fDQ4Ni4yN3wyMi43OHw1MS4xMw==)'>
+<rect x='263.49' y='22.78' width='222.77' height='28.35' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<rect x='360.71' y='22.78' width='28.35' height='28.35' style='stroke-width: 0.75; fill: #FFFFFF;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDkxLjc1fDcxNC41MnwyMi43OHwzOS40Mw=='>
-    <rect x='491.75' y='22.78' width='222.77' height='16.65' />
+  <clipPath id='cpNDkxLjc1fDcxNC41MnwyMi43OHw1MS4xMw=='>
+    <rect x='491.75' y='22.78' width='222.77' height='28.35' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDkxLjc1fDcxNC41MnwyMi43OHwzOS40Mw==)'>
-<rect x='491.75' y='22.78' width='222.77' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
-<text x='603.13' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.40px' lengthAdjust='spacingAndGlyphs'>c</text>
+<g clip-path='url(#cpNDkxLjc1fDcxNC41MnwyMi43OHw1MS4xMw==)'>
+<rect x='491.75' y='22.78' width='222.77' height='28.35' style='stroke-width: 1.07; stroke: none; fill: #D9D9D9;' />
+<rect x='588.96' y='22.78' width='28.35' height='28.35' style='stroke-width: 0.75; fill: #FFFFFF;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <polyline points='45.36,547.85 45.36,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
@@ -169,18 +169,18 @@
 <text x='603.13' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
 <text x='653.76' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
 <text x='704.39' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
-<text x='30.31' y='525.16' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='30.31' y='410.23' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
-<text x='30.31' y='295.30' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
-<text x='30.31' y='180.37' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='30.31' y='65.45' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
-<polyline points='32.50,522.13 35.24,522.13 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='32.50,407.20 35.24,407.20 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='32.50,292.27 35.24,292.27 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='32.50,177.35 35.24,177.35 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='32.50,62.42 35.24,62.42 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='30.31' y='525.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='30.31' y='413.42' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='30.31' y='301.15' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text x='30.31' y='188.88' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='30.31' y='76.61' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<polyline points='32.50,522.66 35.24,522.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,410.39 35.24,410.39 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,298.12 35.24,298.12 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,185.85 35.24,185.85 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,73.58 35.24,73.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <text x='374.88' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
-<text transform='translate(13.05,292.27) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
+<text transform='translate(13.05,298.12) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
 <text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='195.19px' lengthAdjust='spacingAndGlyphs'>custom strip elements can render</text>
 </g>
 </svg>

--- a/tests/testthat/test-theme.R
+++ b/tests/testthat/test-theme.R
@@ -660,6 +660,8 @@ test_that("Strips can render custom elements", {
   element_grob.element_test <- function(element, label = "", x = NULL, y = NULL, ...) {
     rectGrob(width = unit(1, "cm"), height = unit(1, "cm"))
   }
+  registerS3method("element_grob", "element_test", element_grob.element_test)
+
   df <- data_frame(x = 1:3, y = 1:3, a = letters[1:3])
   plot <- ggplot(df, aes(x, y)) +
     geom_point() +


### PR DESCRIPTION
It recently came to my attention in https://github.com/tidyverse/ggplot2/pull/5273#discussion_r1169222970 that a visual test wasn't testing what it should.

Briefly, the test is supposed to test whether custom `element_*()` classes can be drawn in strips. However, the `element_grob.element_test()` method wasn't recognised in the `expect_doppelganger()` test. This PR fixes the test by registering the method.