### PR TITLE
Silence new `density()` warning

### DIFF
--- a/R/stat-density.R
+++ b/R/stat-density.R
@@ -226,13 +226,13 @@ precompute_bw = function(x, bw = "nrd0") {
     bw <- arg_match0(bw, c("nrd0", "nrd", "ucv", "bcv", "sj", "sj-ste", "sj-dpi"))
     bw <- switch(
       to_lower_ascii(bw),
-      nrd0 = bw.nrd0(x),
-      nrd  = bw.nrd(x),
-      ucv  = bw.ucv(x),
-      bcv  = bw.bcv(x),
+      nrd0 = stats::bw.nrd0(x),
+      nrd  = stats::bw.nrd(x),
+      ucv  = stats::bw.ucv(x),
+      bcv  = stats::bw.bcv(x),
       sj   = ,
-      `sj-ste` = bw.SJ(x, method = "ste"),
-      `sj-dpi` = bw.SJ(x, method = "dpi")
+      `sj-ste` = stats::bw.SJ(x, method = "ste"),
+      `sj-dpi` = stats::bw.SJ(x, method = "dpi")
     )
   }
   if (!is.numeric(bw) || bw <= 0 || !is.finite(bw)) {

--- a/R/stat-density.R
+++ b/R/stat-density.R
@@ -217,7 +217,9 @@ reflect_density <- function(dens, bounds, from, to) {
   list(x = out_x, y = out_y)
 }
 
-# Similar on stats::density.default
+# Similar to stats::density.default
+# Once R4.3.0 is the lowest supported version, this function can be replaced by
+# using `density(..., warnWbw = FALSE)`.
 precompute_bw = function(x, bw = "nrd0") {
   bw <- bw[1]
   if (is.character(bw)) {

--- a/man/geom_density.Rd
+++ b/man/geom_density.Rd
@@ -96,7 +96,8 @@ upper and lower lines, \code{"upper"}/\code{"lower"} draws the respective lines 
 \item{bw}{The smoothing bandwidth to be used.
 If numeric, the standard deviation of the smoothing kernel.
 If character, a rule to choose the bandwidth, as listed in
-\code{\link[stats:bandwidth]{stats::bw.nrd()}}.}
+\code{\link[stats:bandwidth]{stats::bw.nrd()}}. Note that automatic calculation of the bandwidth does
+not take weights into account.}
 
 \item{adjust}{A multiplicate bandwidth adjustment. This makes it possible
 to adjust the bandwidth while still using the a bandwidth estimator.

--- a/man/geom_violin.Rd
+++ b/man/geom_violin.Rd
@@ -104,7 +104,8 @@ the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 \item{bw}{The smoothing bandwidth to be used.
 If numeric, the standard deviation of the smoothing kernel.
 If character, a rule to choose the bandwidth, as listed in
-\code{\link[stats:bandwidth]{stats::bw.nrd()}}.}
+\code{\link[stats:bandwidth]{stats::bw.nrd()}}. Note that automatic calculation of the bandwidth does
+not take weights into account.}
 
 \item{adjust}{A multiplicate bandwidth adjustment. This makes it possible
 to adjust the bandwidth while still using the a bandwidth estimator.

--- a/tests/testthat/_snaps/stat-density.md
+++ b/tests/testthat/_snaps/stat-density.md
@@ -5,3 +5,11 @@
     Caused by error in `setup_params()`:
     ! `stat_density()` requires an x or y aesthetic.
 
+# precompute_bandwidth() errors appropriately
+
+    `bw` must be one of "nrd0", "nrd", "ucv", "bcv", "sj", "sj-ste", or "sj-dpi", not "foobar".
+
+---
+
+    `bw` must be a finite, positive number, not `Inf`.
+

--- a/tests/testthat/test-stat-density.R
+++ b/tests/testthat/test-stat-density.R
@@ -19,7 +19,7 @@ test_that("stat_density can make weighted density estimation", {
   df <- mtcars
   df$weight <- mtcars$cyl / sum(mtcars$cyl)
 
-  dens <- stats::density(df$mpg, weights = df$weight)
+  dens <- stats::density(df$mpg, weights = df$weight, bw = bw.nrd0(df$mpg))
   expected_density_fun <- stats::approxfun(data.frame(x = dens$x, y = dens$y))
 
   plot <- ggplot(df, aes(mpg, weight = weight)) + stat_density()
@@ -117,4 +117,11 @@ test_that("compute_density returns useful df and throws warning when <2 values",
   expect_equal(nrow(dens), 1)
   expect_equal(names(dens), c("x", "density", "scaled", "ndensity", "count", "n"))
   expect_type(dens$x, "double")
+})
+
+test_that("precompute_bandwidth() errors appropriately", {
+  expect_silent(precompute_bw(1:10))
+  expect_equal(precompute_bw(1:10, 5), 5)
+  expect_snapshot_error(precompute_bw(1:10, bw = "foobar"))
+  expect_snapshot_error(precompute_bw(1:10, bw = Inf))
 })


### PR DESCRIPTION
This PR aims to prevent a newly introduced warning.

From the R4.3.0 [NEWS](https://cran.r-project.org/bin/windows/base/NEWS.R-4.3.0.html) bullets:

> density(x, weights = *) now warns if automatic bandwidth selection happens without using weights; new optional warnWbw may suppress the warning. Prompted by Christoph Dalitz' [PR#18490](https://bugs.r-project.org/show_bug.cgi?id=18490) and its discussants.

This affects ggplot2 when it uses weights:

``` r
library(ggplot2)

cutoff <- min(mtcars$mpg)

p <- ggplot(mtcars, aes(mpg, weight = cyl)) +
  stat_density()
invisible(ggplotGrob(p))
#> Warning in density.default(x, weights = w, bw = bw, adjust = adjust, kernel =
#> kernel, : Selecting bandwidth *not* using 'weights'
```

<sup>Created on 2023-04-22 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Because of backwards compatibility with older R versions, we cannot use the `warnWbw` argument.  This PR prevents this warning by precomputing the `bw` argument of `density()` and noting in the docs that weights are ignored for bandwidth calculation (as they always have been, it is just stated now).