### PR TITLE
Legend spacing

### DIFF
--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -435,12 +435,13 @@ GuideLegend <- ggproto(
     }
 
     # Spacing
-    gap <- title$size %||% elements$theme.title$size %||%
+    tgap <- title$size %||% elements$theme.title$size %||%
       elements$text$size %||% 11
-    gap <- unit(gap * 0.5, "pt")
-    # Should maybe be elements$spacing.{x/y} instead of the theme's spacing?
-    elements$hgap <- width_cm( theme$legend.spacing.x %||% gap)
-    elements$vgap <- height_cm(theme$legend.spacing.y %||% gap)
+    tgap <- unit(tgap * 0.5, "pt")
+    elements$hgap <- width_cm( elements$spacing.x %||% tgap)
+    elements$vgap <- height_cm(elements$spacing.y %||% tgap)
+    elements$tgap <- convertUnit(tgap, "cm", valueOnly = TRUE)
+
     elements$padding <- convertUnit(
       elements$margin %||% margin(),
       "cm", valueOnly = TRUE
@@ -520,23 +521,23 @@ GuideLegend <- ggproto(
     ), 1, max)
 
     # Interleave gaps between keys and labels, which depends on the label
-    # position. For unclear reasons, we need to adjust some gaps based on the
-    # `byrow` parameter (see also #4352).
+    # position.
     hgap <- elements$hgap %||% 0
+    tgap <- elements$tgap %||% 0
     widths <- switch(
       params$label.position,
-      "left"   = list(label_widths, hgap, widths, hgap),
-      "right"  = list(widths, hgap, label_widths, hgap),
-      list(pmax(label_widths, widths), hgap * (!byrow))
+      "left"   = list(label_widths, tgap, widths, hgap),
+      "right"  = list(widths, tgap, label_widths, hgap),
+      list(pmax(label_widths, widths), hgap)
     )
     widths  <- head(vec_interleave(!!!widths),  -1)
 
     vgap <- elements$vgap %||% 0
     heights <- switch(
       params$label.position,
-      "top"    = list(label_heights, vgap, heights, vgap),
-      "bottom" = list(heights, vgap, label_heights, vgap),
-      list(pmax(label_heights, heights), vgap * (byrow))
+      "top"    = list(label_heights, tgap, heights, vgap),
+      "bottom" = list(heights, tgap, label_heights, vgap),
+      list(pmax(label_heights, heights), vgap)
     )
     heights <- head(vec_interleave(!!!heights), -1)
 
@@ -547,14 +548,14 @@ GuideLegend <- ggproto(
     # Combine title with rest of the sizes based on its position
     widths <- switch(
       params$title.position,
-      "left"  = c(title_width, hgap, widths),
-      "right" = c(widths, hgap, title_width),
+      "left"  = c(title_width, tgap, widths),
+      "right" = c(widths, tgap, title_width),
       c(widths, max(0, title_width - sum(widths)))
     )
     heights <- switch(
       params$title.position,
-      "top"    = c(title_height, vgap, heights),
-      "bottom" = c(heights, vgap, title_height),
+      "top"    = c(title_height, tgap, heights),
+      "bottom" = c(heights, tgap, title_height),
       c(heights, max(0, title_height - sum(heights)))
     )
 

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -555,10 +555,10 @@ test_that("guides title and text are positioned correctly", {
       scale_fill_continuous(name = "the\ncontinuous\ncolorscale")
   )
   expect_doppelganger("vertical gap of 1cm between guide title and guide",
-    p + theme(legend.spacing.y = grid::unit(1, "cm"))
+    p + theme(legend.title = element_text(margin = margin(0, 0, 1, 0, "cm")))
   )
   expect_doppelganger("horizontal gap of 1cm between guide and guide text",
-    p + theme(legend.spacing.x = grid::unit(1, "cm"))
+    p + theme(legend.text = element_text(margin = margin(0, 0, 0, 1, "cm")))
   )
 
   # now test label positioning, alignment, etc


### PR DESCRIPTION
This PR aims to fix #4352 and fix #4977 and entails a visual change.

To recap the issue: whether the `legend.spacing.{x/y}` was adhered to between keys was strangely dependent on the `guide_legend(byrow = ...)` setting. This made setting vertical spacing very unintuitive. With guides having been recently rewritten, there is no better time to justify visual changes.

This PR currently does three things:
* The `legend.spacing.{x/y}` inherits from the `legend.spacing` theme setting.
* The effect of `byrow` on spacing is nullified.
* It discriminates the text-to-something spacing, from key spacing.

There are a few things I'd like some input on:
* Should we expose the text-to-something spacing to users, as a `legend.spacing.text` theme setting? Note that for finetuning text-to-something spacing, the `margin` argument is available.
* Under defaults, the proposed change is aggressively noticeable. Should we change some theme settings to come closer to the previous plots?

This PR breaks a bunch of visual tests, so I've not committed these changes yet in anticipation of further changes.

A visual example of the new spacing:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

p <- ggplot(mpg, aes(displ, hwy)) +
  geom_point(aes(colour = class)) +
  guides(colour = guide_legend(ncol = 2))
p
```

![](https://i.imgur.com/mtuuYdG.png)<!-- -->

Removing the spacing brings the plot closer to previous plots.

``` r
p + theme(legend.spacing.y = unit(0, "pt"))
```

![](https://i.imgur.com/QbJS1y2.png)<!-- -->

<sup>Created on 2023-04-24 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
