### PR TITLE
Axis caps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@
     * More informative error for mismatched 
      `direction`/`theme(legend.direction = ...)` arguments (#4364, #4930).
     * `guide_coloursteps()` and `guide_bins()` sort breaks (#5152).
+    * `guide_axis()` gains a `cap` argument that can be used to trim the
+      axis line to extreme breaks (#4907).
 
 * `geom_label()` now uses the `angle` aesthetic (@teunbrand, #2785)
 * 'lines' units in `geom_label()`, often used in the `label.padding` argument, 

--- a/R/guide-axis.R
+++ b/R/guide-axis.R
@@ -14,6 +14,11 @@
 #' @param n.dodge The number of rows (for vertical axes) or columns (for
 #'   horizontal axes) that should be used to render the labels. This is
 #'   useful for displaying labels that would otherwise overlap.
+#' @param cap A `character` to cut the axis line back to the last breaks. Can
+#'   be `"none"` (default) to draw the axis line along the whole panel, or
+#'   `"upper"` and `"lower"` to draw the axis to the upper or lower break, or
+#'   `"both"` to only draw the line in between the most extreme breaks. `TRUE`
+#'   and `FALSE` are shorthand for `"both"` and `"none"` respectively.
 #' @param order A positive `integer` of length 1 that specifies the order of
 #'   this guide among multiple guides. This controls in which order guides are
 #'   merged if there are multiple guides for the same position. If 0 (default),

--- a/R/guide-axis.R
+++ b/R/guide-axis.R
@@ -239,10 +239,17 @@ GuideAxis <- ggproto(
 
   # The decor in the axis guide is the axis line
   build_decor = function(decor, grobs, elements, params) {
+    x <- c(0, 1)
+    if (params$cap %in% c("both", "upper")) {
+      x[2] <- max(params$key[[params$aes]], na.rm = TRUE)
+    }
+    if (params$cap %in% c("both", "lower")) {
+      x[1] <- min(params$key[[params$aes]], na.rm = TRUE)
+    }
     exec(
       element_grob,
       element = elements$line,
-      !!params$aes := unit(c(0, 1), "npc"),
+      !!params$aes := unit(x, "npc"),
       !!params$orth_aes := unit(rep(params$orth_side, 2), "npc")
     )
   },

--- a/R/guide-axis.R
+++ b/R/guide-axis.R
@@ -37,7 +37,16 @@
 #' # can also be used to add a duplicate guide
 #' p + guides(x = guide_axis(n.dodge = 2), y.sec = guide_axis())
 guide_axis <- function(title = waiver(), check.overlap = FALSE, angle = NULL,
-                       n.dodge = 1, order = 0, position = waiver()) {
+                       n.dodge = 1, cap = "none", order = 0,
+                       position = waiver()) {
+
+  if (is.logical(cap)) {
+    check_bool(cap)
+    cap <- if (cap) "both" else "none"
+  }
+  cap <- arg_match0(cap, c("none", "both", "upper", "lower"))
+
+
   new_guide(
     title = title,
 
@@ -45,6 +54,7 @@ guide_axis <- function(title = waiver(), check.overlap = FALSE, angle = NULL,
     check.overlap = check.overlap,
     angle = angle,
     n.dodge = n.dodge,
+    cap = cap,
 
     # parameter
     available_aes = c("x", "y"),
@@ -72,6 +82,7 @@ GuideAxis <- ggproto(
     direction = NULL,
     angle     = NULL,
     n.dodge   = 1,
+    cap       = "none",
     order     = 0,
     check.overlap = FALSE
   ),

--- a/man/guide_axis.Rd
+++ b/man/guide_axis.Rd
@@ -9,6 +9,7 @@ guide_axis(
   check.overlap = FALSE,
   angle = NULL,
   n.dodge = 1,
+  cap = "none",
   order = 0,
   position = waiver()
 )
@@ -29,6 +30,12 @@ you probably want.}
 \item{n.dodge}{The number of rows (for vertical axes) or columns (for
 horizontal axes) that should be used to render the labels. This is
 useful for displaying labels that would otherwise overlap.}
+
+\item{cap}{A \code{character} to cut the axis line back to the last breaks. Can
+be \code{"none"} (default) to draw the axis line along the whole panel, or
+\code{"upper"} and \code{"lower"} to draw the axis to the upper or lower break, or
+\code{"both"} to only draw the line in between the most extreme breaks. \code{TRUE}
+and \code{FALSE} are shorthand for \code{"both"} and \code{"none"} respectively.}
 
 \item{order}{A positive \code{integer} of length 1 that specifies the order of
 this guide among multiple guides. This controls in which order guides are

--- a/tests/testthat/_snaps/guides/axis-guides-with-capped-ends.svg
+++ b/tests/testthat/_snaps/guides/axis-guides-with-capped-ends.svg
@@ -1,0 +1,114 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzcuNjl8Njk0LjkxfDM1LjYwfDU0NS4xMQ=='>
+    <rect x='37.69' y='35.60' width='657.22' height='509.51' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzcuNjl8Njk0LjkxfDM1LjYwfDU0NS4xMQ==)'>
+<rect x='37.69' y='35.60' width='657.22' height='509.51' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='37.69,430.79 694.91,430.79 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='37.69,315.25 694.91,315.25 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='37.69,199.72 694.91,199.72 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='37.69,84.18 694.91,84.18 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='63.34,545.11 63.34,35.60 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='274.46,545.11 274.46,35.60 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='485.58,545.11 485.58,35.60 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='37.69,488.56 694.91,488.56 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='37.69,373.02 694.91,373.02 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='37.69,257.48 694.91,257.48 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='37.69,141.95 694.91,141.95 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='168.90,545.11 168.90,35.60 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='380.02,545.11 380.02,35.60 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='591.14,545.11 591.14,35.60 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<circle cx='190.01' cy='419.24' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='190.01' cy='419.24' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='154.12' cy='479.32' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='190.01' cy='306.01' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='327.24' cy='188.16' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='179.46' cy='344.14' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='475.02' cy='188.16' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='88.67' cy='434.61' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='158.34' cy='441.42' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='217.46' cy='410.46' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='217.46' cy='410.46' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='337.80' cy='285.44' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='337.80' cy='285.44' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='337.80' cy='285.44' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='390.58' cy='58.76' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='411.69' cy='72.62' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='443.36' cy='95.73' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='97.12' cy='513.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='67.56' cy='516.64' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='95.01' cy='521.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='162.57' cy='465.34' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='274.46' cy='236.69' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='274.46' cy='252.86' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='475.02' cy='199.72' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='327.24' cy='141.95' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='97.12' cy='512.83' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='149.90' cy='465.11' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='196.34' cy='494.22' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='515.14' cy='198.56' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='327.24' cy='436.57' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='665.03' cy='256.33' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='187.90' cy='464.30' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='37.69,35.60 694.91,35.60 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='168.90,32.86 168.90,35.60 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='380.02,32.86 380.02,35.60 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='591.14,32.86 591.14,35.60 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='168.90' y='30.67' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='380.02' y='30.67' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='591.14' y='30.67' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
+<polyline points='37.69,545.11 37.69,141.95 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='32.76' y='491.59' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='32.76' y='376.05' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='32.76' y='260.51' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text x='32.76' y='144.97' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
+<polyline points='34.95,488.56 37.69,488.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,373.02 37.69,373.02 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,257.48 37.69,257.48 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.95,141.95 37.69,141.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='694.91,488.56 694.91,35.60 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='697.65,488.56 694.91,488.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='697.65,373.02 694.91,373.02 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='697.65,257.48 694.91,257.48 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='697.65,141.95 694.91,141.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='699.84' y='491.59' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='699.84' y='376.05' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='699.84' y='260.51' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text x='699.84' y='144.97' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
+<polyline points='168.90,545.11 591.14,545.11 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='168.90,547.85 168.90,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='380.02,547.85 380.02,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='591.14,547.85 591.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='168.90' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='380.02' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='591.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text x='366.30' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>hp</text>
+<text transform='translate(13.05,290.36) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='20.18px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text x='37.69' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='172.47px' lengthAdjust='spacingAndGlyphs'>axis guides with capped ends</text>
+</g>
+</svg>

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -462,6 +462,19 @@ test_that("Axis titles won't be blown away by coord_*()", {
   # expect_doppelganger("guide titles with coord_sf()", plot + coord_sf())
 })
 
+test_that("axis guides can be capped", {
+  p <- ggplot(mtcars, aes(hp, disp)) +
+    geom_point() +
+    theme(axis.line = element_line()) +
+    guides(
+      x = guide_axis(cap = "both"),
+      y = guide_axis(cap = "upper"),
+      y.sec = guide_axis(cap = "lower"),
+      x.sec = guide_axis(cap = "none")
+    )
+  expect_doppelganger("axis guides with capped ends", p)
+})
+
 test_that("guides are positioned correctly", {
   df <- data_frame(x = 1, y = 1, z = factor("a"))
 


### PR DESCRIPTION
This PR aims to fix #4907.

Briefly, it adds a `cap` argument to `guide_axis()` that truncates the axis line to the breaks. There are 4 different options, presented below. Also `TRUE/FALSE` are shortcuts for `"both"/"none"`.

I've thought about allowing user-defined coordinates as the capping points, either by function or input on data values, but that'd complicate the implementation quite a bit. I also thought that this is probably simple enough not to separate out to a separate guide.

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

ggplot(mtcars, aes(hp, disp)) +
  geom_point() +
  theme(axis.line = element_line()) +
  guides(
    x = guide_axis(cap = "both"),
    y = guide_axis(cap = "upper"),
    y.sec = guide_axis(cap = "lower"),
    x.sec = guide_axis(cap = "none")
  )
```

![](https://i.imgur.com/qTgOsId.png)<!-- -->

<sup>Created on 2023-04-26 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
