### PR TITLE
Ignoring `AsIs` objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # ggplot2 (development version)
 
+* Plot scales now ignore `AsIs` objects constructed with `I(x)`, instead of
+  invoking the identity scale. This allows these columns to co-exist with other
+  layers that need a non-identity scale for the same aesthetic. Also, it makes
+  it easy to specify relative positions (@teunbrand, #5142).
+
 * `geom_text()` and `geom_label()` gained a `size.unit` parameter that set the 
   text size to millimetres, points, centimetres, inches or picas 
   (@teunbrand, #3799).

--- a/R/facet-.R
+++ b/R/facet-.R
@@ -102,16 +102,18 @@ Facet <- ggproto("Facet", NULL,
     # loop over each layer, training x and y scales in turn
     for (layer_data in data) {
       match_id <- match(layer_data$PANEL, layout$PANEL)
+      names <- names(layer_data)
+      names <- names[!vapply(layer_data, inherits, what = "AsIs", logical(1))]
 
       if (!is.null(x_scales)) {
-        x_vars <- intersect(x_scales[[1]]$aesthetics, names(layer_data))
+        x_vars <- intersect(x_scales[[1]]$aesthetics, names)
         SCALE_X <- layout$SCALE_X[match_id]
 
         scale_apply(layer_data, x_vars, "train", SCALE_X, x_scales)
       }
 
       if (!is.null(y_scales)) {
-        y_vars <- intersect(y_scales[[1]]$aesthetics, names(layer_data))
+        y_vars <- intersect(y_scales[[1]]$aesthetics, names)
         SCALE_Y <- layout$SCALE_Y[match_id]
 
         scale_apply(layer_data, y_vars, "train", SCALE_Y, y_scales)

--- a/R/geom-path.R
+++ b/R/geom-path.R
@@ -135,7 +135,7 @@ GeomPath <- ggproto("GeomPath", Geom,
   handle_na = function(self, data, params) {
     # Drop missing values at the start or end of a line - can't drop in the
     # middle since you expect those to be shown by a break in the line
-    complete <- stats::complete.cases(data[names(data) %in% c("x", "y", "linewidth", "colour", "linetype")])
+    complete <- vec_detect_complete(data[names(data) %in% c("x", "y", "linewidth", "colour", "linetype")])
     kept <- stats::ave(complete, data$group, FUN = keep_mid_true)
     data <- data[kept, ]
 

--- a/R/layout.R
+++ b/R/layout.R
@@ -152,16 +152,18 @@ Layout <- ggproto("Layout", NULL,
 
     lapply(data, function(layer_data) {
       match_id <- match(layer_data$PANEL, layout$PANEL)
+      names <- names(layer_data)
+      names <- names[!vapply(layer_data, inherits, what = "AsIs", logical(1))]
 
       # Loop through each variable, mapping across each scale, then joining
       # back together
-      x_vars <- intersect(self$panel_scales_x[[1]]$aesthetics, names(layer_data))
+      x_vars <- intersect(self$panel_scales_x[[1]]$aesthetics, names)
       names(x_vars) <- x_vars
       SCALE_X <- layout$SCALE_X[match_id]
       new_x <- scale_apply(layer_data, x_vars, "map", SCALE_X, self$panel_scales_x)
       layer_data[, x_vars] <- new_x
 
-      y_vars <- intersect(self$panel_scales_y[[1]]$aesthetics, names(layer_data))
+      y_vars <- intersect(self$panel_scales_y[[1]]$aesthetics, names)
       names(y_vars) <- y_vars
       SCALE_Y <- layout$SCALE_Y[match_id]
       new_y <- scale_apply(layer_data, y_vars, "map", SCALE_Y, self$panel_scales_y)

--- a/R/position-.R
+++ b/R/position-.R
@@ -79,6 +79,7 @@ transform_position <- function(df, trans_x = NULL, trans_y = NULL, ...) {
   oldclass <- class(df)
   df <- unclass(df)
   scales <- aes_to_scale(names(df))
+  scales[vapply(df, inherits, what = "AsIs", logical(1))] <- "ignored"
 
   if (!is.null(trans_x)) {
     df[scales == "x"] <- lapply(df[scales == "x"], trans_x, ...)

--- a/R/scale-type.R
+++ b/R/scale-type.R
@@ -68,7 +68,7 @@ scale_type.default <- function(x) {
 scale_type.list <- function(x) "identity"
 
 #' @export
-scale_type.AsIs <- function(x) "identity"
+scale_type.AsIs <- function(x) NULL
 
 #' @export
 scale_type.logical <- function(x) "discrete"

--- a/R/scales-.R
+++ b/R/scales-.R
@@ -65,17 +65,18 @@ ScalesList <- ggproto("ScalesList", NULL,
     if (empty(df) || length(self$scales) == 0) {
       return()
     }
-    lapply(self$scales, function(scale) scale$train_df(df = df))
+    ignore <- vapply(df, inherits, what = "AsIs", logical(1))
+    lapply(self$scales, function(scale) scale$train_df(df = df[!ignore]))
   },
 
   map_df = function(self, df) {
     if (empty(df) || length(self$scales) == 0) {
       return(df)
     }
-
+    ignore <- vapply(df, inherits, what = "AsIs", logical(1))
     mapped <- unlist(lapply(
       self$scales,
-      function(scale) scale$map_df(df = df)
+      function(scale) scale$map_df(df = df[!ignore])
     ), recursive = FALSE)
 
     data_frame0(!!!mapped, df[setdiff(names(df), names(mapped))])
@@ -98,9 +99,10 @@ ScalesList <- ggproto("ScalesList", NULL,
       return(df)
     }
 
+    ignore <- vapply(df, inherits, what = "AsIs", logical(1))
     transformed <- unlist(lapply(
       scales,
-      function(scale) scale$transform_df(df = df)
+      function(scale) scale$transform_df(df = df[!ignore])
     ), recursive = FALSE)
 
     data_frame0(!!!transformed, df[setdiff(names(df), names(transformed))])
@@ -122,10 +124,11 @@ ScalesList <- ggproto("ScalesList", NULL,
       return(df)
     }
 
+    ignore <- vapply(df, inherits, what = "AsIs", logical(1))
     backtransformed <- unlist(lapply(
       scales,
       function(scale) {
-        aesthetics <- intersect(scale$aesthetics, names(df))
+        aesthetics <- intersect(scale$aesthetics, names(df[!ignore]))
         if (length(aesthetics) == 0) {
           return()
         }

--- a/tests/testthat/_snaps/scales.md
+++ b/tests/testthat/_snaps/scales.md
@@ -49,3 +49,7 @@
     Output
       [1]        NA   1.00000  20.08554 403.42879
 
+# discrete I() objects are rejected as position aesthetics
+
+    Position aesthetics x and y provided as <AsIs> objects cannot be discrete.
+

--- a/tests/testthat/_snaps/scales/scales-ignore-i.svg
+++ b/tests/testthat/_snaps/scales/scales-ignore-i.svg
@@ -1,0 +1,74 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMTguMDd8NzE0LjUyfDIyLjc4fDU1Ny45Mw=='>
+    <rect x='18.07' y='22.78' width='696.45' height='535.14' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTguMDd8NzE0LjUyfDIyLjc4fDU1Ny45Mw==)'>
+<rect x='18.07' y='22.78' width='696.45' height='535.14' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='655.19' cy='74.14' r='1.95' style='stroke-width: 0.71; stroke: #00FFFF;' />
+<polygon points='670.70,480.66 673.33,485.22 668.06,485.22 ' style='stroke-width: 0.71; stroke: #3300FF; fill: none;' />
+<line x1='214.59' y1='28.73' x2='220.12' y2='28.73' style='stroke-width: 0.71; stroke: #00FF19;' />
+<line x1='217.35' y1='31.49' x2='217.35' y2='25.96' style='stroke-width: 0.71; stroke: #00FF19;' />
+<line x1='594.48' y1='53.28' x2='598.39' y2='49.37' style='stroke-width: 0.71; stroke: #FFE500;' />
+<line x1='594.48' y1='49.37' x2='598.39' y2='53.28' style='stroke-width: 0.71; stroke: #FFE500;' />
+<polygon points='462.25,513.81 465.02,511.05 467.78,513.81 465.02,516.58 ' style='stroke-width: 0.71; stroke: #CC00FF; fill: none;' />
+<polygon points='379.60,285.79 382.23,281.23 376.96,281.23 ' style='stroke-width: 0.71; stroke: #80FF00; fill: none;' />
+<rect x='529.11' y='347.16' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #FF4D00;' />
+<line x1='529.11' y1='351.07' x2='533.02' y2='347.16' style='stroke-width: 0.71; stroke: #FF4D00;' />
+<line x1='529.11' y1='347.16' x2='533.02' y2='351.07' style='stroke-width: 0.71; stroke: #FF4D00;' />
+<line x1='109.91' y1='75.18' x2='113.82' y2='71.27' style='stroke-width: 0.71; stroke: #0066FF;' />
+<line x1='109.91' y1='71.27' x2='113.82' y2='75.18' style='stroke-width: 0.71; stroke: #0066FF;' />
+<line x1='109.10' y1='73.23' x2='114.63' y2='73.23' style='stroke-width: 0.71; stroke: #0066FF;' />
+<line x1='111.86' y1='75.99' x2='111.86' y2='70.46' style='stroke-width: 0.71; stroke: #0066FF;' />
+<line x1='472.87' y1='318.73' x2='478.40' y2='318.73' style='stroke-width: 0.71; stroke: #00B3FF;' />
+<line x1='475.63' y1='321.50' x2='475.63' y2='315.97' style='stroke-width: 0.71; stroke: #00B3FF;' />
+<polygon points='472.87,318.73 475.63,315.97 478.40,318.73 475.63,321.50 ' style='stroke-width: 0.71; stroke: #00B3FF; fill: none;' />
+<circle cx='509.11' cy='110.54' r='1.95' style='stroke-width: 0.71; stroke: #CCFF00;' />
+<line x1='507.16' y1='110.54' x2='511.07' y2='110.54' style='stroke-width: 0.71; stroke: #CCFF00;' />
+<line x1='509.11' y1='112.50' x2='509.11' y2='108.59' style='stroke-width: 0.71; stroke: #CCFF00;' />
+<polygon points='336.87,166.25 339.50,160.93 334.23,160.93 ' style='stroke-width: 0.71; stroke: #7F00FF; fill: none;' />
+<polygon points='336.87,160.17 339.50,165.49 334.23,165.49 ' style='stroke-width: 0.71; stroke: #7F00FF; fill: none;' />
+<line x1='516.94' y1='123.90' x2='520.85' y2='123.90' style='stroke-width: 0.71; stroke: #001AFF;' />
+<line x1='518.90' y1='125.85' x2='518.90' y2='121.94' style='stroke-width: 0.71; stroke: #001AFF;' />
+<rect x='516.94' y='121.94' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #001AFF;' />
+<circle cx='669.02' cy='350.23' r='1.95' style='stroke-width: 0.71; stroke: #FF00E6;' />
+<line x1='667.07' y1='352.19' x2='670.98' y2='348.28' style='stroke-width: 0.71; stroke: #FF00E6;' />
+<line x1='667.07' y1='348.28' x2='670.98' y2='352.19' style='stroke-width: 0.71; stroke: #FF00E6;' />
+<polygon points='195.97,189.31 197.92,193.22 194.01,193.22 ' style='stroke-width: 0.71; stroke: #00FF66; fill: none;' />
+<rect x='194.01' y='189.31' width='3.91' height='3.91' style='stroke-width: 0.71; stroke: #00FF66;' />
+<polygon points='338.08,557.77 341.99,557.77 341.99,553.86 338.08,553.86 ' style='stroke-width: 0.71; stroke: none; fill: #FF9900;' />
+<circle cx='672.74' cy='112.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #FF0000;' />
+<polygon points='699.36,550.96 701.99,555.52 696.72,555.52 ' style='stroke-width: 0.71; stroke: none; fill: #FF004D;' />
+<polygon points='97.94,446.80 99.90,444.84 101.85,446.80 99.90,448.75 ' style='stroke-width: 0.71; stroke: none; fill: #33FF00;' />
+<circle cx='348.88' cy='72.77' r='1.95' style='stroke-width: 0.71; stroke: #FF0099; fill: #FF0099;' />
+<circle cx='408.32' cy='230.54' r='1.30' style='stroke-width: 0.71; stroke: #00FFB2; fill: #00FFB2;' />
+<rect x='18.07' y='22.78' width='696.45' height='535.14' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='366.30' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='15.89px' lengthAdjust='spacingAndGlyphs'>I(x)</text>
+<text transform='translate(13.05,290.36) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='15.89px' lengthAdjust='spacingAndGlyphs'>I(y)</text>
+<text x='18.07' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='93.92px' lengthAdjust='spacingAndGlyphs'>scales ignore I()</text>
+</g>
+</svg>

--- a/tests/testthat/test-scales.R
+++ b/tests/testthat/test-scales.R
@@ -541,3 +541,11 @@ test_that("scales ignore I()/AsIs vectors", {
 
   expect_doppelganger("scales ignore I()", p)
 })
+
+test_that("discrete I() objects are rejected as position aesthetics", {
+
+  p <- ggplot(mapping = aes(x = I("foo"), y = I("bar"))) +
+    geom_point()
+  expect_snapshot_error(ggplotGrob(p))
+
+})

--- a/tests/testthat/test-scales.R
+++ b/tests/testthat/test-scales.R
@@ -521,3 +521,23 @@ test_that("numeric scale transforms can produce breaks", {
   expect_equal(test_breaks("sqrt", limits = c(0, 10)),
                seq(0, 10, by = 2.5))
 })
+
+test_that("scales ignore I()/AsIs vectors", {
+  set.seed(42)
+  df <- data.frame(
+    x = runif(20),
+    y = runif(20),
+    colour = sample(rainbow(20)),
+    shape = 1:20
+  )
+
+  p <- ggplot(df, aes(I(x), I(y), colour = I(colour), shape = I(shape))) +
+    geom_point()
+  data <- layer_data(p)
+  expect_identical(df$x, unclass(data$x))
+  expect_identical(df$y, unclass(data$y))
+  expect_identical(df$colour, unclass(data$colour))
+  expect_identical(df$shape, unclass(data$shape))
+
+  expect_doppelganger("scales ignore I()", p)
+})

--- a/tests/testthat/test-scales.R
+++ b/tests/testthat/test-scales.R
@@ -524,7 +524,7 @@ test_that("numeric scale transforms can produce breaks", {
 
 test_that("scales ignore I()/AsIs vectors", {
   set.seed(42)
-  df <- data.frame(
+  df <- data_frame0(
     x = runif(20),
     y = runif(20),
     colour = sample(rainbow(20)),


### PR DESCRIPTION
This PR aims to fix #5142.

Briefly, all scales ignore `AsIs` objects instead of invoking an identity scale.

Contrary to my expectation, I only had to edit `ScalesList` methods (and their position equivalents) and no individual scales, so no deep rewrite was needed.
While in #5142 I expressed worry about how position aesthetics would play with this, I've grown to love ignored position aesthetics. No more `annotation_custom()` or awkward manual transformations if you want to make relative annotations!

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

df <- data.frame(t = seq(0, 2*pi, length.out = 100))

ggplot(mpg) +
  geom_point(aes(displ, hwy)) +
  geom_path(
    data = df, 
    aes(x = I(cos(t) / 2.1 + 0.5), 
        y = I(sin(t) / 2.1 + 0.5),
        colour = I(2))
  ) +
  annotate(
    "text", x = I(0.5), y = I(0.5),
    label = "I'm in the middle",
    colour = 4, size = 10
  )
```

![](https://i.imgur.com/b0n82lj.png)<!-- -->

<sup>Created on 2023-04-26 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
