### PR TITLE
Improve error message when `plot.title.position` is not correctly mentioned.

### DIFF
--- a/R/plot-build.R
+++ b/R/plot-build.R
@@ -276,16 +276,19 @@ ggplot_gtable.ggplot_built <- function(data) {
   # positioning of caption is governed by plot.caption.position
   #   "panel" means align to the panel(s)
   #   "plot" means align to the entire plot (except margins and tag)
-  title_pos <- theme$plot.title.position %||% "panel"
+  title_pos <- arg_match0(
+    theme$plot.title.position %||% "panel",
+    c("panel", "plot"),
+    arg_nm = "plot.title.position",
+    error_call = expr(theme())
+  )
 
-  if (!(title_pos %in% c("panel", "plot"))) {
-    cli::cli_abort("{.var plot.title.position} should be either {.val panel} or {.val plot}.")
-  }
-
-  caption_pos <- theme$plot.caption.position %||% "panel"
-  if (!(caption_pos %in% c("panel", "plot"))) {
-    cli::cli_abort("{.var plot.caption.position} should be either {.val panel} or {.val plot}.")
-  }
+  caption_pos <- arg_match0(
+    theme$plot.caption.position %||% "panel",
+    values = c("panel", "plot"),
+    arg_nm = "plot.caption.position",
+    error_call = expr(theme())
+  )
 
   pans <- plot_table$layout[grepl("^panel", plot_table$layout$name), , drop = FALSE]
   if (title_pos == "panel") {

--- a/R/plot-build.R
+++ b/R/plot-build.R
@@ -277,12 +277,14 @@ ggplot_gtable.ggplot_built <- function(data) {
   #   "panel" means align to the panel(s)
   #   "plot" means align to the entire plot (except margins and tag)
   title_pos <- theme$plot.title.position %||% "panel"
+
   if (!(title_pos %in% c("panel", "plot"))) {
-    cli::cli_abort('{.var plot.title.position} should be either {.val "panel"} or {.val "plot"}.')
+    cli::cli_abort('{.var plot.title.position} should be either {.val panel} or {.val plot}.', call = frame_call())
   }
+
   caption_pos <- theme$plot.caption.position %||% "panel"
   if (!(caption_pos %in% c("panel", "plot"))) {
-    cli::cli_abort('{.var plot.caption.position} should be either {.val "panel"} or {.val "plot"}.')
+    cli::cli_abort('{.var plot.caption.position} should be either {.val panel} or {.val plot}.')
   }
 
   pans <- plot_table$layout[grepl("^panel", plot_table$layout$name), , drop = FALSE]

--- a/R/plot-build.R
+++ b/R/plot-build.R
@@ -279,12 +279,12 @@ ggplot_gtable.ggplot_built <- function(data) {
   title_pos <- theme$plot.title.position %||% "panel"
 
   if (!(title_pos %in% c("panel", "plot"))) {
-    cli::cli_abort('{.var plot.title.position} should be either {.val panel} or {.val plot}.', call = frame_call())
+    cli::cli_abort("{.var plot.title.position} should be either {.val panel} or {.val plot}.")
   }
 
   caption_pos <- theme$plot.caption.position %||% "panel"
   if (!(caption_pos %in% c("panel", "plot"))) {
-    cli::cli_abort('{.var plot.caption.position} should be either {.val panel} or {.val plot}.')
+    cli::cli_abort("{.var plot.caption.position} should be either {.val panel} or {.val plot}.")
   }
 
   pans <- plot_table$layout[grepl("^panel", plot_table$layout$name), , drop = FALSE]

--- a/tests/testthat/_snaps/theme.md
+++ b/tests/testthat/_snaps/theme.md
@@ -42,11 +42,11 @@
 
 # Theme elements are checked during build
 
-    `plot.title.position` should be either "panel" or "plot".
+    `plot.title.position` must be one of "panel" or "plot", not "test".
 
 ---
 
-    `plot.caption.position` should be either "panel" or "plot".
+    `plot.caption.position` must be one of "panel" or "plot", not "test".
 
 ---
 

--- a/tests/testthat/_snaps/theme.md
+++ b/tests/testthat/_snaps/theme.md
@@ -42,11 +42,11 @@
 
 # Theme elements are checked during build
 
-    `plot.title.position` should be either "\"panel\"" or "\"plot\"".
+    `plot.title.position` should be either "panel" or "plot".
 
 ---
 
-    `plot.caption.position` should be either "\"panel\"" or "\"plot\"".
+    `plot.caption.position` should be either "panel" or "plot".
 
 ---
 

--- a/tests/testthat/test-stat-summary.R
+++ b/tests/testthat/test-stat-summary.R
@@ -68,6 +68,7 @@ test_that("stat_summary_(2d|hex) work with lambda expressions", {
 
   # stat_summary_hex
   # this plot is a bit funky, but easy to reason through
+  skip_if_not_installed("hexbin")
   p1 <- ggplot(dat, aes(x, y, z = z)) +
     stat_summary_hex(fun = function(x) mean(x))
 


### PR DESCRIPTION
Before this PR

```r
ggplot() +theme(plot.title.position = "Null")
Error in `ggplot_gtable()`:
! `plot.title.position` should be either
  "\"panel\"" or "\"plot\"".
```
With this PR

```r
ggplot() +theme(plot.title.position = "Null")
Error in `ggplot_gtable()` 
! `plot.title.position` should be either "panel" or "plot".
```

I wonder how we could better improve this message, so it becomes:

```r
ggplot() +theme(plot.title.position = "Null")
Error in `theme()` 
! `plot.title.position` should be either "panel" or "plot".
```

But I don't know how to do that.

Edit: I added suggestion to use `rlang::arg_match()` to get rid of the `if ()`, but this doesn't solve the error call.
