### PR TITLE
Smarter keys

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,11 @@
     * More informative error for mismatched 
      `direction`/`theme(legend.direction = ...)` arguments (#4364, #4930).
     * `guide_coloursteps()` and `guide_bins()` sort breaks (#5152).
+    * `guide_legend()` now omits inappropriate key glyphs: if there isn't any
+      layer data matching a key value, the key isn't drawn. To show keys in the
+      legend regardless of whether the value occurs in the data 
+      (the old behaviour), you can use `show.legend = c({aesthetic} = TRUE)` 
+      (@teunbrand, #3648).
 
 * `geom_label()` now uses the `angle` aesthetic (@teunbrand, #2785)
 * 'lines' units in `geom_label()`, often used in the `label.padding` argument, 

--- a/R/guide-.R
+++ b/R/guide-.R
@@ -175,7 +175,7 @@ Guide <- ggproto(
 
   # Function for extracting information from the layers.
   # Mostly applies to `guide_legend()` and `guide_binned()`
-  get_layer_key = function(params, layers) {
+  get_layer_key = function(params, layers, key_data) {
     return(params)
   },
 

--- a/R/guide-colorbar.R
+++ b/R/guide-colorbar.R
@@ -373,7 +373,7 @@ GuideColourbar <- ggproto(
     return(list(guide = self, params = params))
   },
 
-  get_layer_key = function(params, layers) {
+  get_layer_key = function(params, layers, key_data) {
 
     guide_layers <- lapply(layers, function(layer) {
 

--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -472,7 +472,12 @@ GuideLegend <- ggproto(
     draw <- function(i) {
       bg <- elements$key
       keys <- lapply(decor, function(g) {
-        g$draw_key(vec_slice(g$data, i), g$params, key_size)
+        data <- vec_slice(g$data, i)
+        if (data$.draw %||% TRUE) {
+          g$draw_key(data, g$params, key_size)
+        } else {
+          zeroGrob()
+        }
       })
       c(list(bg), keys)
     }

--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -322,7 +322,7 @@ GuideLegend <- ggproto(
               "Failed to apply {.fn after_scale} modifications to legend",
               parent = cnd
             )
-            layer$geom$use_defaults(params$key[matched], layer_params, list())
+            layer$geom$use_defaults(params$key[matched_aes], layer_params, list())
           }
         )
       } else {

--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -294,7 +294,7 @@ GuideLegend <- ggproto(
   },
 
   # Arrange common data for vertical and horizontal legends
-  get_layer_key = function(params, layers) {
+  get_layer_key = function(params, layers, key_data) {
 
     decor <- lapply(layers, function(layer) {
 

--- a/R/guides-.R
+++ b/R/guides-.R
@@ -244,7 +244,7 @@ Guides <- ggproto(
   #      arrange all guide grobs
 
   build = function(self, scales, layers, default_mapping,
-                   position, theme, labels) {
+                   position, theme, labels, key_data) {
 
     position  <- legend_position(position)
     no_guides <- zeroGrob()
@@ -279,7 +279,7 @@ Guides <- ggproto(
 
     # Merge and process layers
     guides$merge()
-    guides$process_layers(layers)
+    guides$process_layers(layers, key_data)
     if (length(guides$guides) == 0) {
       return(no_guides)
     }
@@ -438,9 +438,9 @@ Guides <- ggproto(
   },
 
   # Loop over guides to let them extract information from layers
-  process_layers = function(self, layers) {
+  process_layers = function(self, layers, key_data) {
     self$params <- Map(
-      function(guide, param) guide$get_layer_key(param, layers),
+      function(guide, param) guide$get_layer_key(param, layers, key_data),
       guide = self$guides,
       param = self$params
     )

--- a/R/plot-build.R
+++ b/R/plot-build.R
@@ -89,6 +89,7 @@ ggplot_build.ggplot <- function(plot) {
   if (npscales$n() > 0) {
     lapply(data, npscales$train_df)
     data <- lapply(data, npscales$map_df)
+    plot$key_data <- npscales$key_data(data)
   }
 
   # Fill in defaults etc.
@@ -178,7 +179,8 @@ ggplot_gtable.ggplot_built <- function(data) {
   }
 
   legend_box <- plot$guides$build(
-    plot$scales, plot$layers, plot$mapping, position, theme, plot$labels
+    plot$scales, plot$layers, plot$mapping, position, theme, plot$labels,
+    plot$key_data
   )
 
   if (is.zero(legend_box)) {

--- a/tests/testthat/_snaps/draw-key/legend-key-selection.svg
+++ b/tests/testthat/_snaps/draw-key/legend-key-selection.svg
@@ -1,0 +1,89 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzIuNzl8NjU1LjI3fDIyLjc4fDU0NS4xMQ=='>
+    <rect x='32.79' y='22.78' width='622.48' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzIuNzl8NjU1LjI3fDIyLjc4fDU0NS4xMQ==)'>
+<rect x='32.79' y='22.78' width='622.48' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='186.57' cy='307.19' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='186.57' cy='307.19' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='113.17' cy='270.81' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='324.91' cy='299.10' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='278.32' cy='365.78' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='167.80' cy='238.48' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='159.47' cy='270.81' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='197.30' cy='343.56' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='197.30' cy='371.84' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='71.82' cy='76.83' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='67.58' cy='117.25' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='61.09' cy='46.53' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='130.25' cy='297.08' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='72.24' cy='179.89' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='130.54' cy='206.15' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='94.96' cy='117.25' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='165.40' cy='333.45' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='131.52' cy='299.10' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<polyline points='186.57,307.19 186.57,307.19 324.91,299.10 278.32,365.78 197.30,343.56 197.30,371.84 165.40,333.45 ' style='stroke-width: 1.07; stroke: #00BA38; stroke-linecap: butt;' />
+<polyline points='468.88,353.66 468.88,442.57 350.03,400.13 350.03,381.95 350.03,424.38 626.98,521.37 610.04,521.37 581.81,434.48 409.60,418.32 389.84,424.38 454.77,462.77 525.34,343.56 456.18,412.26 385.60,428.42 ' style='stroke-width: 1.07; stroke: #619CFF; stroke-linecap: butt;' />
+<rect x='32.79' y='22.78' width='622.48' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='27.86' y='532.48' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='27.86' y='431.45' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='27.86' y='330.42' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='27.86' y='229.39' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='27.86' y='128.36' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='27.86' y='27.33' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
+<polyline points='30.05,529.45 32.79,529.45 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,428.42 32.79,428.42 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,327.39 32.79,327.39 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,226.36 32.79,226.36 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,125.33 32.79,125.33 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,24.30 32.79,24.30 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='101.88,547.85 101.88,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='243.04,547.85 243.04,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='384.19,547.85 384.19,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='525.34,547.85 525.34,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='101.88' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='243.04' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='384.19' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text x='525.34' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
+<text x='344.03' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='20.18px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<rect x='666.23' y='250.36' width='48.29' height='67.17' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='666.23' y='259.07' style='font-size: 11.00px; font-family: sans;' textLength='48.29px' lengthAdjust='spacingAndGlyphs'>factor(cyl)</text>
+<rect x='666.23' y='265.69' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='674.87' cy='274.33' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<rect x='666.23' y='282.97' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='674.87' cy='291.61' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<line x1='667.96' y1='291.61' x2='681.78' y2='291.61' style='stroke-width: 1.07; stroke: #00BA38; stroke-linecap: butt;' />
+<rect x='666.23' y='300.25' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='667.96' y1='308.89' x2='681.78' y2='308.89' style='stroke-width: 1.07; stroke: #619CFF; stroke-linecap: butt;' />
+<text x='688.99' y='277.36' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='688.99' y='294.64' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='688.99' y='311.92' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='32.79' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='119.63px' lengthAdjust='spacingAndGlyphs'>legend key selection</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/draw-key/partial-legend-key-selection.svg
+++ b/tests/testthat/_snaps/draw-key/partial-legend-key-selection.svg
@@ -1,0 +1,90 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzIuNzl8NjU1LjI3fDIyLjc4fDU0NS4xMQ=='>
+    <rect x='32.79' y='22.78' width='622.48' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzIuNzl8NjU1LjI3fDIyLjc4fDU0NS4xMQ==)'>
+<rect x='32.79' y='22.78' width='622.48' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='186.57' cy='307.19' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='186.57' cy='307.19' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='113.17' cy='270.81' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='324.91' cy='299.10' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='278.32' cy='365.78' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='167.80' cy='238.48' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='159.47' cy='270.81' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='197.30' cy='343.56' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='197.30' cy='371.84' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='71.82' cy='76.83' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='67.58' cy='117.25' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='61.09' cy='46.53' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='130.25' cy='297.08' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='72.24' cy='179.89' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='130.54' cy='206.15' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='94.96' cy='117.25' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='165.40' cy='333.45' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='131.52' cy='299.10' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<polyline points='186.57,307.19 186.57,307.19 324.91,299.10 278.32,365.78 197.30,343.56 197.30,371.84 165.40,333.45 ' style='stroke-width: 1.07; stroke: #00BA38; stroke-linecap: butt;' />
+<polyline points='468.88,353.66 468.88,442.57 350.03,400.13 350.03,381.95 350.03,424.38 626.98,521.37 610.04,521.37 581.81,434.48 409.60,418.32 389.84,424.38 454.77,462.77 525.34,343.56 456.18,412.26 385.60,428.42 ' style='stroke-width: 1.07; stroke: #619CFF; stroke-linecap: butt;' />
+<rect x='32.79' y='22.78' width='622.48' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='27.86' y='532.48' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='27.86' y='431.45' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='27.86' y='330.42' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='27.86' y='229.39' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='27.86' y='128.36' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='27.86' y='27.33' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
+<polyline points='30.05,529.45 32.79,529.45 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,428.42 32.79,428.42 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,327.39 32.79,327.39 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,226.36 32.79,226.36 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,125.33 32.79,125.33 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,24.30 32.79,24.30 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='101.88,547.85 101.88,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='243.04,547.85 243.04,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='384.19,547.85 384.19,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='525.34,547.85 525.34,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='101.88' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='243.04' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='384.19' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text x='525.34' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
+<text x='344.03' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='20.18px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<rect x='666.23' y='250.36' width='48.29' height='67.17' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='666.23' y='259.07' style='font-size: 11.00px; font-family: sans;' textLength='48.29px' lengthAdjust='spacingAndGlyphs'>factor(cyl)</text>
+<rect x='666.23' y='265.69' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='674.87' cy='274.33' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<rect x='666.23' y='282.97' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='674.87' cy='291.61' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<line x1='667.96' y1='291.61' x2='681.78' y2='291.61' style='stroke-width: 1.07; stroke: #00BA38; stroke-linecap: butt;' />
+<rect x='666.23' y='300.25' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='674.87' cy='308.89' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
+<line x1='667.96' y1='308.89' x2='681.78' y2='308.89' style='stroke-width: 1.07; stroke: #619CFF; stroke-linecap: butt;' />
+<text x='688.99' y='277.36' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='688.99' y='294.64' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='688.99' y='311.92' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='32.79' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='159.25px' lengthAdjust='spacingAndGlyphs'>partial legend key selection</text>
+</g>
+</svg>

--- a/tests/testthat/test-draw-key.R
+++ b/tests/testthat/test-draw-key.R
@@ -18,6 +18,88 @@ test_that("alternative key glyphs work", {
   )
 })
 
+test_that("keep_key_data give expected output", {
+
+  key <- data_frame0(
+    colour = c("red", "green", "blue"),
+    label = c("A", "B", "C")
+  )
+
+  data <- list(
+    list(
+      aesthetics = "colour",
+      data = data_frame0(
+        pal = c("red", "green", "blue", "orange"),
+        member = matrix(c(
+          TRUE, TRUE, FALSE, FALSE,
+          FALSE, TRUE, TRUE, TRUE
+        ), 4, 2)
+      )
+    )
+  )
+
+  expect_equal( # show = TRUE, so keep everything
+    keep_key_data(key, data, "colour", show = TRUE, index = 1),
+    TRUE
+  )
+  expect_equal( # check for first index
+    keep_key_data(key, data, "colour", show = NA, index = 1),
+    c(TRUE, TRUE, FALSE)
+  )
+  expect_equal( # check for second index
+    keep_key_data(key, data, "colour", show = NA, index = 2),
+    c(FALSE, TRUE, TRUE)
+  )
+  expect_equal( # colour = TRUE, not NA, so keep everything
+    keep_key_data(key, data, "colour", show = c(label = NA, colour = TRUE), index = 1),
+    TRUE
+  )
+  expect_equal( # colour = NA, so check for colour matches
+    keep_key_data(key, data, "colour", show = c(label = TRUE, colour = NA), index = 1),
+    c(TRUE, TRUE, FALSE)
+  )
+  expect_equal( # No relevant key data, keep everything
+    keep_key_data(key, data, "label", show = c(label = NA), index = 1),
+    TRUE
+  )
+  data[[2]] <- list(
+    aesthetics = "label",
+    data = data_frame0(
+      pal = c("A", "B", "C"),
+      member = matrix(c(
+        TRUE,  FALSE, TRUE,
+        FALSE, FALSE, TRUE
+      ), 3, 2)
+    )
+  )
+  expect_equal( # All keys: colour matches first two, label the third key
+    keep_key_data(key, data, c("colour", "label"), show = NA, index = 1),
+    c(TRUE, TRUE, TRUE)
+  )
+  expect_equal( # First key matches neither, so give 1st FALSE
+    keep_key_data(key, data, c("colour", "label"), show = NA, index = 2),
+    c(FALSE, TRUE, TRUE)
+  )
+})
+
+test_that("key selection works appropriately", {
+
+  data46 <- subset(mtcars, cyl %in% c(4, 6))
+  data68 <- subset(mtcars, cyl %in% c(6, 8))
+
+  p <- ggplot(mapping = aes(disp, mpg, colour = factor(cyl))) +
+    geom_point(data = data46) +
+    geom_path(data  = data68)
+
+  expect_doppelganger("legend key selection", p)
+
+  p <- ggplot(mapping = aes(disp, mpg, colour = factor(cyl))) +
+    geom_point(data = data46, show.legend = TRUE) +
+    geom_path(data  = data68)
+
+  expect_doppelganger("partial legend key selection", p)
+})
+
 # Orientation-aware key glyphs --------------------------------------------
 
 test_that("horizontal key glyphs work", {


### PR DESCRIPTION
This PR aims to fix #3648. This PR is mutually incompatible with #3649.

Briefly, it automatically checks whether the key value is actually in the data and doesn't draw keys when it isn't. This contrasts with the approach taken in #3649, where the user is given more control.

Less briefly: it performs this check when `show.legend = NA`, which is the default. When `show.legend = TRUE`, is draws the keys regardless of presence in the layer data. To get back the old behaviour and you have multiple legends, you'd have to be specific to include a layer in the keys of a particular legend, for example `show.legend = c(colour = TRUE)`.

A small demo from https://github.com/tidyverse/ggplot2/issues/3648#issue-530627481. Note how there is no point displayed for the 'regression line' key, and no line for the 'points' key.

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

ggplot(mtcars, aes(disp, mpg)) + 
  geom_point(aes(color = "points")) +
  geom_smooth(aes(color = "regression line"))
#> `geom_smooth()` using method = 'loess' and formula = 'y ~ x'
```

![](https://i.imgur.com/lgMypAE.png)<!-- -->

<sup>Created on 2023-05-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
