### PR TITLE
Fix typos part III

### DIFF
--- a/R/coord-cartesian-.R
+++ b/R/coord-cartesian-.R
@@ -43,7 +43,7 @@
 #' # limits. You can set the limits precisely by setting expand = FALSE
 #' p + coord_cartesian(xlim = c(325, 500), expand = FALSE)
 #'
-#' # Simiarly, we can use expand = FALSE to turn off expansion with the
+#' # Similarly, we can use expand = FALSE to turn off expansion with the
 #' # default limits
 #' p + coord_cartesian(expand = FALSE)
 #'

--- a/R/geom-tile.R
+++ b/R/geom-tile.R
@@ -15,7 +15,7 @@
 #'
 #' @details
 #' `geom_rect()` and `geom_tile()`'s respond differently to scale
-#' transformations due to their parametrisation. In `geom_rect()`, the scale
+#' transformations due to their parameterisation. In `geom_rect()`, the scale
 #' transformation is applied to the corners of the rectangles. In `geom_tile()`,
 #' the transformation is applied only to the centres and its size is determined
 #' after transformation.

--- a/R/guide-.R
+++ b/R/guide-.R
@@ -1,6 +1,6 @@
 #' Guide constructor
 #'
-#' A constructor function for guides, which performs some standard compatability
+#' A constructor function for guides, which performs some standard compatibility
 #' checks between the guide and provided arguments.
 #'
 #' @param ... Named arguments that match the parameters of `super$params` or

--- a/R/guide-colorsteps.R
+++ b/R/guide-colorsteps.R
@@ -13,7 +13,7 @@
 #'   shown irrespective of the value of `show.limits`.
 #' @param ticks A theme object for rendering tick marks at the colourbar.
 #'   Usually, the object of `element_line()` is expected. If `element_blank()`
-#'   (default), no tick marks are drawn. For backward compatability, can also
+#'   (default), no tick marks are drawn. For backward compatibility, can also
 #'   be a logical which translates `TRUE` to `element_line()` and `FALSE` to
 #'   `element_blank()`.
 #' @inheritDotParams guide_colourbar -nbin -raster -ticks -available_aes

--- a/R/layer.R
+++ b/R/layer.R
@@ -49,7 +49,7 @@
 #' @param params Additional parameters to the `geom` and `stat`.
 #' @param key_glyph A legend key drawing function or a string providing the
 #'   function name minus the `draw_key_` prefix. See [draw_key] for details.
-#' @param layer_class The type of layer object to be constructued. This is
+#' @param layer_class The type of layer object to be constructed. This is
 #'   intended for ggplot2 internal use only.
 #' @keywords internal
 #' @examples

--- a/R/position-dodge.R
+++ b/R/position-dodge.R
@@ -5,7 +5,7 @@
 #' be specified in the global or `geom_*` layer. Unlike `position_dodge()`,
 #' `position_dodge2()` works without a grouping variable in a layer.
 #' `position_dodge2()` works with bars and rectangles, but is
-#' particulary useful for arranging box plots, which
+#' particularly useful for arranging box plots, which
 #' can have variable widths.
 #'
 #' @param width Dodging width, when different to the width of the individual

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -375,7 +375,7 @@ binned_scale <- function(aesthetics, scale_name, palette, name = waiver(),
 #' - `dimension()` For continuous scales, the dimension is the same concept as the limits.
 #'   For discrete scales, `dimension()` returns a continuous range, where the limits
 #'   would be placed at integer positions. `dimension()` optionally expands
-#'   this range given an expantion of length 4 (see [expansion()]).
+#'   this range given an expansion of length 4 (see [expansion()]).
 #'
 #' - `break_info()` Returns a `list()` with calculated values needed for the `Coord`
 #'   to transform values in transformed data space. Axis and grid guides also use

--- a/R/scale-brewer.R
+++ b/R/scale-brewer.R
@@ -69,7 +69,7 @@
 #'   theme_dark()
 #' }
 #'
-#' # Use distiller variant with continous data
+#' # Use distiller variant with continuous data
 #' v <- ggplot(faithfuld) +
 #'   geom_tile(aes(waiting, eruptions, fill = density))
 #' v

--- a/R/scale-colour.R
+++ b/R/scale-colour.R
@@ -44,7 +44,7 @@
 #' palette) are not suitable to support all viewers, especially those with
 #' color vision deficiencies. Using `viridis` type, which is perceptually
 #' uniform in both colour and black-and-white display is an easy option to
-#' ensure good perceptive properties of your visulizations.
+#' ensure good perceptive properties of your visualizations.
 #' The colorspace package offers functionalities
 #' - to generate color palettes with good perceptive properties,
 #' - to analyse a given color palette, like emulating color blindness,

--- a/R/scale-manual.R
+++ b/R/scale-manual.R
@@ -40,7 +40,7 @@
 #' palette) are not suitable to support all viewers, especially those with
 #' color vision deficiencies. Using `viridis` type, which is perceptually
 #' uniform in both colour and black-and-white display is an easy option to
-#' ensure good perceptive properties of your visulizations.
+#' ensure good perceptive properties of your visualizations.
 #' The colorspace package offers functionalities
 #' - to generate color palettes with good perceptive properties,
 #' - to analyse a given color palette, like emulating color blindness,

--- a/R/scale-viridis.R
+++ b/R/scale-viridis.R
@@ -49,7 +49,7 @@
 #' # the order of colour can be reversed
 #' p + scale_fill_viridis_d(direction = -1)
 #'
-#' # Use viridis_c with continous data
+#' # Use viridis_c with continuous data
 #' (v <- ggplot(faithfuld) +
 #'   geom_tile(aes(waiting, eruptions, fill = density)))
 #' v + scale_fill_viridis_c()

--- a/R/stat-contour.R
+++ b/R/stat-contour.R
@@ -5,7 +5,7 @@
 #' @eval rd_aesthetics("stat", "contour_filled")
 #' @eval rd_computed_vars(
 #'   .details = "The computed variables differ somewhat for contour lines
-#'   (compbuted by `stat_contour()`) and contour bands (filled contours,
+#'   (computed by `stat_contour()`) and contour bands (filled contours,
 #'   computed by `stat_contour_filled()`). The variables `nlevel` and `piece`
 #'   are available for both, whereas `level_low`, `level_high`, and `level_mid`
 #'   are only available for bands. The variable `level` is a numeric or a factor

--- a/R/stat-sf-coordinates.R
+++ b/R/stat-sf-coordinates.R
@@ -19,7 +19,7 @@
 #' For the first step, you can use an arbitrary function via `fun.geometry`.
 #' By default, `function(x) sf::st_point_on_surface(sf::st_zm(x))` is used;
 #' `sf::st_point_on_surface()` seems more appropriate than `sf::st_centroid()`
-#' since lables and text usually are intended to be put within the polygon or
+#' since labels and text usually are intended to be put within the polygon or
 #' the line. `sf::st_zm()` is needed to drop Z and M dimension beforehand,
 #' otherwise `sf::st_point_on_surface()` may fail when the geometries have M
 #' dimension.

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -429,11 +429,11 @@ switch_orientation <- function(aesthetics) {
 #' features in the data correspond to:
 #'
 #' - `main_is_orthogonal`: This argument controls how the existence of only a `x`
-#'   or `y` aesthetic is understood. If `TRUE` then the exisiting aesthetic
+#'   or `y` aesthetic is understood. If `TRUE` then the existing aesthetic
 #'   would be then secondary axis. This behaviour is present in [stat_ydensity()]
 #'   and [stat_boxplot()]. If `FALSE` then the exisiting aesthetic is the main
 #'   axis as seen in e.g. [stat_bin()], [geom_count()], and [stat_density()].
-#' - `range_is_orthogonal`: This argument controls whether the existance of
+#' - `range_is_orthogonal`: This argument controls whether the existence of
 #'   range-like aesthetics (e.g. `xmin` and `xmax`) represents the main or
 #'   secondary axis. If `TRUE` then the range is given for the secondary axis as
 #'   seen in e.g. [geom_ribbon()] and [geom_linerange()].

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -431,7 +431,7 @@ switch_orientation <- function(aesthetics) {
 #' - `main_is_orthogonal`: This argument controls how the existence of only a `x`
 #'   or `y` aesthetic is understood. If `TRUE` then the existing aesthetic
 #'   would be then secondary axis. This behaviour is present in [stat_ydensity()]
-#'   and [stat_boxplot()]. If `FALSE` then the exisiting aesthetic is the main
+#'   and [stat_boxplot()]. If `FALSE` then the existing aesthetic is the main
 #'   axis as seen in e.g. [stat_bin()], [geom_count()], and [stat_density()].
 #' - `range_is_orthogonal`: This argument controls whether the existence of
 #'   range-like aesthetics (e.g. `xmin` and `xmax`) represents the main or

--- a/man/bidirection.Rd
+++ b/man/bidirection.Rd
@@ -81,7 +81,7 @@ features in the data correspond to:
 \item \code{main_is_orthogonal}: This argument controls how the existence of only a \code{x}
 or \code{y} aesthetic is understood. If \code{TRUE} then the existing aesthetic
 would be then secondary axis. This behaviour is present in \code{\link[=stat_ydensity]{stat_ydensity()}}
-and \code{\link[=stat_boxplot]{stat_boxplot()}}. If \code{FALSE} then the exisiting aesthetic is the main
+and \code{\link[=stat_boxplot]{stat_boxplot()}}. If \code{FALSE} then the existing aesthetic is the main
 axis as seen in e.g. \code{\link[=stat_bin]{stat_bin()}}, \code{\link[=geom_count]{geom_count()}}, and \code{\link[=stat_density]{stat_density()}}.
 \item \code{range_is_orthogonal}: This argument controls whether the existence of
 range-like aesthetics (e.g. \code{xmin} and \code{xmax}) represents the main or

--- a/man/bidirection.Rd
+++ b/man/bidirection.Rd
@@ -79,11 +79,11 @@ How the layer data should be interpreted depends on its specific features.
 features in the data correspond to:
 \itemize{
 \item \code{main_is_orthogonal}: This argument controls how the existence of only a \code{x}
-or \code{y} aesthetic is understood. If \code{TRUE} then the exisiting aesthetic
+or \code{y} aesthetic is understood. If \code{TRUE} then the existing aesthetic
 would be then secondary axis. This behaviour is present in \code{\link[=stat_ydensity]{stat_ydensity()}}
 and \code{\link[=stat_boxplot]{stat_boxplot()}}. If \code{FALSE} then the exisiting aesthetic is the main
 axis as seen in e.g. \code{\link[=stat_bin]{stat_bin()}}, \code{\link[=geom_count]{geom_count()}}, and \code{\link[=stat_density]{stat_density()}}.
-\item \code{range_is_orthogonal}: This argument controls whether the existance of
+\item \code{range_is_orthogonal}: This argument controls whether the existence of
 range-like aesthetics (e.g. \code{xmin} and \code{xmax}) represents the main or
 secondary axis. If \code{TRUE} then the range is given for the secondary axis as
 seen in e.g. \code{\link[=geom_ribbon]{geom_ribbon()}} and \code{\link[=geom_linerange]{geom_linerange()}}.

--- a/man/coord_cartesian.Rd
+++ b/man/coord_cartesian.Rd
@@ -60,7 +60,7 @@ p + coord_cartesian(xlim = c(325, 500))
 # limits. You can set the limits precisely by setting expand = FALSE
 p + coord_cartesian(xlim = c(325, 500), expand = FALSE)
 
-# Simiarly, we can use expand = FALSE to turn off expansion with the
+# Similarly, we can use expand = FALSE to turn off expansion with the
 # default limits
 p + coord_cartesian(expand = FALSE)
 

--- a/man/geom_contour.Rd
+++ b/man/geom_contour.Rd
@@ -208,7 +208,7 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 
 \section{Computed variables}{
 
-These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}. The computed variables differ somewhat for contour lines  (compbuted by \code{stat_contour()}) and contour bands (filled contours,  computed by \code{stat_contour_filled()}). The variables \code{nlevel} and \code{piece}  are available for both, whereas \code{level_low}, \code{level_high}, and \code{level_mid}  are only available for bands. The variable \code{level} is a numeric or a factor  depending on whether lines or bands are calculated.
+These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}. The computed variables differ somewhat for contour lines  (computed by \code{stat_contour()}) and contour bands (filled contours,  computed by \code{stat_contour_filled()}). The variables \code{nlevel} and \code{piece}  are available for both, whereas \code{level_low}, \code{level_high}, and \code{level_mid}  are only available for bands. The variable \code{level} is a numeric or a factor  depending on whether lines or bands are calculated.
 \itemize{
 \item \code{after_stat(level)}\cr Height of contour. For contour lines, this is a numeric vector  that represents bin boundaries. For contour bands, this is an ordered  factor that represents bin ranges.
 \item \code{after_stat(level_low)}, \code{after_stat(level_high)}, \code{after_stat(level_mid)}\cr (contour bands only) Lower and upper  bin boundaries for each band, as well as the mid point between boundaries.

--- a/man/geom_tile.Rd
+++ b/man/geom_tile.Rd
@@ -113,7 +113,7 @@ performance special case for when all the tiles are the same size.
 }
 \details{
 \code{geom_rect()} and \code{geom_tile()}'s respond differently to scale
-transformations due to their parametrisation. In \code{geom_rect()}, the scale
+transformations due to their parameterisation. In \code{geom_rect()}, the scale
 transformation is applied to the corners of the rectangles. In \code{geom_tile()},
 the transformation is applied only to the centres and its size is determined
 after transformation.

--- a/man/ggplot2-ggproto.Rd
+++ b/man/ggplot2-ggproto.Rd
@@ -491,7 +491,7 @@ These methods are only valid for position (x and y) scales:
 \item \code{dimension()} For continuous scales, the dimension is the same concept as the limits.
 For discrete scales, \code{dimension()} returns a continuous range, where the limits
 would be placed at integer positions. \code{dimension()} optionally expands
-this range given an expantion of length 4 (see \code{\link[=expansion]{expansion()}}).
+this range given an expansion of length 4 (see \code{\link[=expansion]{expansion()}}).
 \item \code{break_info()} Returns a \code{list()} with calculated values needed for the \code{Coord}
 to transform values in transformed data space. Axis and grid guides also use
 these values to draw guides. This is called with

--- a/man/guide_coloursteps.Rd
+++ b/man/guide_coloursteps.Rd
@@ -31,7 +31,7 @@ shown irrespective of the value of \code{show.limits}.}
 
 \item{ticks}{A theme object for rendering tick marks at the colourbar.
 Usually, the object of \code{element_line()} is expected. If \code{element_blank()}
-(default), no tick marks are drawn. For backward compatability, can also
+(default), no tick marks are drawn. For backward compatibility, can also
 be a logical which translates \code{TRUE} to \code{element_line()} and \code{FALSE} to
 \code{element_blank()}.}
 

--- a/man/layer.Rd
+++ b/man/layer.Rd
@@ -74,7 +74,7 @@ display.}
 \item{key_glyph}{A legend key drawing function or a string providing the
 function name minus the \code{draw_key_} prefix. See \link{draw_key} for details.}
 
-\item{layer_class}{The type of layer object to be constructued. This is
+\item{layer_class}{The type of layer object to be constructed. This is
 intended for ggplot2 internal use only.}
 }
 \description{

--- a/man/new_guide.Rd
+++ b/man/new_guide.Rd
@@ -20,7 +20,7 @@ Guide class object.}
 A \code{Guide} ggproto object.
 }
 \description{
-A constructor function for guides, which performs some standard compatability
+A constructor function for guides, which performs some standard compatibility
 checks between the guide and provided arguments.
 }
 \keyword{internal}

--- a/man/position_dodge.Rd
+++ b/man/position_dodge.Rd
@@ -34,7 +34,7 @@ horizontal position. \code{position_dodge()} requires the grouping variable to b
 be specified in the global or \verb{geom_*} layer. Unlike \code{position_dodge()},
 \code{position_dodge2()} works without a grouping variable in a layer.
 \code{position_dodge2()} works with bars and rectangles, but is
-particulary useful for arranging box plots, which
+particularly useful for arranging box plots, which
 can have variable widths.
 }
 \examples{

--- a/man/scale_brewer.Rd
+++ b/man/scale_brewer.Rd
@@ -162,7 +162,7 @@ p +
   theme_dark()
 }
 
-# Use distiller variant with continous data
+# Use distiller variant with continuous data
 v <- ggplot(faithfuld) +
   geom_tile(aes(waiting, eruptions, fill = density))
 v

--- a/man/scale_colour_continuous.Rd
+++ b/man/scale_colour_continuous.Rd
@@ -62,7 +62,7 @@ Many color palettes derived from RGB combinations (like the "rainbow" color
 palette) are not suitable to support all viewers, especially those with
 color vision deficiencies. Using \code{viridis} type, which is perceptually
 uniform in both colour and black-and-white display is an easy option to
-ensure good perceptive properties of your visulizations.
+ensure good perceptive properties of your visualizations.
 The colorspace package offers functionalities
 \itemize{
 \item to generate color palettes with good perceptive properties,

--- a/man/scale_manual.Rd
+++ b/man/scale_manual.Rd
@@ -125,7 +125,7 @@ Many color palettes derived from RGB combinations (like the "rainbow" color
 palette) are not suitable to support all viewers, especially those with
 color vision deficiencies. Using \code{viridis} type, which is perceptually
 uniform in both colour and black-and-white display is an easy option to
-ensure good perceptive properties of your visulizations.
+ensure good perceptive properties of your visualizations.
 The colorspace package offers functionalities
 \itemize{
 \item to generate color palettes with good perceptive properties,

--- a/man/scale_viridis.Rd
+++ b/man/scale_viridis.Rd
@@ -172,7 +172,7 @@ p + scale_fill_viridis_d()
 # the order of colour can be reversed
 p + scale_fill_viridis_d(direction = -1)
 
-# Use viridis_c with continous data
+# Use viridis_c with continuous data
 (v <- ggplot(faithfuld) +
   geom_tile(aes(waiting, eruptions, fill = density)))
 v + scale_fill_viridis_c()

--- a/man/stat_sf_coordinates.Rd
+++ b/man/stat_sf_coordinates.Rd
@@ -93,7 +93,7 @@ or \code{sf::st_point_on_surface()}.
 For the first step, you can use an arbitrary function via \code{fun.geometry}.
 By default, \code{function(x) sf::st_point_on_surface(sf::st_zm(x))} is used;
 \code{sf::st_point_on_surface()} seems more appropriate than \code{sf::st_centroid()}
-since lables and text usually are intended to be put within the polygon or
+since labels and text usually are intended to be put within the polygon or
 the line. \code{sf::st_zm()} is needed to drop Z and M dimension beforehand,
 otherwise \code{sf::st_point_on_surface()} may fail when the geometries have M
 dimension.


### PR DESCRIPTION
This PR continues #5307, fixing typos in doc strings that needed to be re-documented.