### PR TITLE
Use `.tif` as synonym to `.tiff`

### DIFF
--- a/R/save.R
+++ b/R/save.R
@@ -233,7 +233,8 @@ plot_dev <- function(device, filename = NULL, dpi = 300, call = caller_env()) {
     jpg =  function(...) jpeg_dev(..., res = dpi, units = "in"),
     jpeg = function(...) jpeg_dev(..., res = dpi, units = "in"),
     bmp =  function(...) grDevices::bmp(..., res = dpi, units = "in"),
-    tiff = function(...) tiff_dev(..., res = dpi, units = "in")
+    tiff = function(...) tiff_dev(..., res = dpi, units = "in"),
+    tif  = function(...) tiff_dev(..., res = dpi, units = "in")
   )
 
   if (is.null(device)) {


### PR DESCRIPTION
This PR aims to fix part of #5323.

Just as `.jpg` is synonymous to `.jpeg`, so is `.tif` synonymous to `.tiff`.
This updates the device list to recognise `.tif` extensions in filenames.