### PR TITLE
Update `ggsave()`'s docs

### DIFF
--- a/R/save.R
+++ b/R/save.R
@@ -26,13 +26,16 @@
 #' @param plot Plot to save, defaults to last plot displayed.
 #' @param device Device to use. Can either be a device function
 #'   (e.g. [png]), or one of "eps", "ps", "tex" (pictex),
-#'   "pdf", "jpeg", "tiff", "png", "bmp", "svg" or "wmf" (windows only).
+#'   "pdf", "jpeg", "tiff", "png", "bmp", "svg" or "wmf" (windows only). If
+#'   `NULL` (default), the device is guessed based on the `filename` extension.
 #' @param path Path of the directory to save plot to: `path` and `filename`
 #'   are combined to create the fully qualified file name. Defaults to the
 #'   working directory.
 #' @param scale Multiplicative scaling factor.
-#' @param width,height,units Plot size in `units` ("in", "cm", "mm", or "px").
-#'   If not supplied, uses the size of current graphics device.
+#' @param width,height Plot size in units expressed by the `units` argument.
+#'   If not supplied, uses the size of the current graphics device.
+#' @param units One of the following units in which the `width` and `height`
+#'   arguments are expressed: `"in"`, `"cm"`, `"mm"` or `"px"`.
 #' @param dpi Plot resolution. Also accepts a string input: "retina" (320),
 #'   "print" (300), or "screen" (72). Applies only to raster output types.
 #' @param limitsize When `TRUE` (the default), `ggsave()` will not
@@ -48,11 +51,16 @@
 #' ggplot(mtcars, aes(mpg, wt)) +
 #'   geom_point()
 #'
+#' # here, the device is inferred from the filename extension
 #' ggsave("mtcars.pdf")
 #' ggsave("mtcars.png")
 #'
+#' # setting dimensions of the plot
 #' ggsave("mtcars.pdf", width = 4, height = 4)
 #' ggsave("mtcars.pdf", width = 20, height = 20, units = "cm")
+#'
+#' # passing device-specific arguments to '...'
+#' ggsave("mtcars.pdf", colormodel = "cmyk")
 #'
 #' # delete files with base::unlink()
 #' unlink("mtcars.pdf")
@@ -138,7 +146,6 @@ parse_dpi <- function(dpi, call = caller_env()) {
 
 plot_dim <- function(dim = c(NA, NA), scale = 1, units = "in",
                      limitsize = TRUE, dpi = 300, call = caller_env()) {
-
   units <- arg_match0(units, c("in", "cm", "mm", "px"))
   to_inches <- function(x) x / c(`in` = 1, cm = 2.54, mm = 2.54 * 10, px = dpi)[units]
   from_inches <- function(x) x * c(`in` = 1, cm = 2.54, mm = 2.54 * 10, px = dpi)[units]

--- a/man/ggsave.Rd
+++ b/man/ggsave.Rd
@@ -26,7 +26,8 @@ ggsave(
 
 \item{device}{Device to use. Can either be a device function
 (e.g. \link{png}), or one of "eps", "ps", "tex" (pictex),
-"pdf", "jpeg", "tiff", "png", "bmp", "svg" or "wmf" (windows only).}
+"pdf", "jpeg", "tiff", "png", "bmp", "svg" or "wmf" (windows only). If
+\code{NULL} (default), the device is guessed based on the \code{filename} extension.}
 
 \item{path}{Path of the directory to save plot to: \code{path} and \code{filename}
 are combined to create the fully qualified file name. Defaults to the
@@ -34,8 +35,11 @@ working directory.}
 
 \item{scale}{Multiplicative scaling factor.}
 
-\item{width, height, units}{Plot size in \code{units} ("in", "cm", "mm", or "px").
-If not supplied, uses the size of current graphics device.}
+\item{width, height}{Plot size in units expressed by the \code{units} argument.
+If not supplied, uses the size of the current graphics device.}
+
+\item{units}{One of the following units in which the \code{width} and \code{height}
+arguments are expressed: \code{"in"}, \code{"cm"}, \code{"mm"} or \code{"px"}.}
 
 \item{dpi}{Plot resolution. Also accepts a string input: "retina" (320),
 "print" (300), or "screen" (72). Applies only to raster output types.}
@@ -81,11 +85,16 @@ examples section.
 ggplot(mtcars, aes(mpg, wt)) +
   geom_point()
 
+# here, the device is inferred from the filename extension
 ggsave("mtcars.pdf")
 ggsave("mtcars.png")
 
+# setting dimensions of the plot
 ggsave("mtcars.pdf", width = 4, height = 4)
 ggsave("mtcars.pdf", width = 20, height = 20, units = "cm")
+
+# passing device-specific arguments to '...'
+ggsave("mtcars.pdf", colormodel = "cmyk")
 
 # delete files with base::unlink()
 unlink("mtcars.pdf")


### PR DESCRIPTION
This PR aims to fix #5341.

Briefly, the old argument description was somewhat suggestive that `ggsave()`'s width and height arguments should be supplied as `grid::unit()` objects. This PR separates the description of width/height from the unit description to be more clear about the expected input.

In addition, it was suggested in https://github.com/tidyverse/ggplot2/issues/5323#issuecomment-1615228420 that the docs could clarify that the device may be guessed from the filename extension and that there was no example of passing device arguments through `...`. This is also included.