### PR TITLE
fix: obtain expected quantity values from manual scale

### DIFF
--- a/R/scale-manual.R
+++ b/R/scale-manual.R
@@ -180,7 +180,7 @@ manual_scale <- function(aesthetic, values = NULL, breaks = waiver(), ...,
     if (n > length(values)) {
       cli::cli_abort("Insufficient values in manual scale. {n} needed but only {length(values)} provided.")
     }
-    values
+    unname(values[seq_len(n)])
   }
   discrete_scale(aesthetic, "manual", pal, breaks = breaks, limits = limits, ...)
 }

--- a/tests/testthat/test-scale-manual.R
+++ b/tests/testthat/test-scale-manual.R
@@ -21,6 +21,16 @@ test_that("names of values used in manual scales", {
    )
 })
 
+test_that("obtain expected quantity values from manual scale", {
+  for (aesthetics in .all_aesthetics) {
+    s <- scale_discrete_manual(aesthetics = aesthetics, values = c("8" = "c", "4" = "a", "6" = "b"))
+    expect_equal(s$palette(1), c("c"))
+    expect_equal(s$palette(2), c("c", "a"))
+    expect_equal(s$palette(3), c("c", "a", "b"))
+    expect_error(s$palette(4), "Insufficient values")
+  }
+})
+
 
 dat <- data_frame(g = c("B","A","A"))
 p <- ggplot(dat, aes(g, fill = g)) + geom_bar()


### PR DESCRIPTION
This pull request fixes a bug in the code and adds corresponding unit tests.

When we use `manual_scale` to create a `discrete_scale`, the `palette` should be a function that can return the specified number of `values`.

Here is the parameter description quoted from `scale-.R`:

> @param palette A palette function that, when called with a single integer argument (the number of levels in the scale), returns the values that they should take (e.g., [scales::hue_pal()]).

The original `manual_scale` method simply returns all the `values`, whereas the modified method will return the first n `values` specified.