### PR TITLE
fix: obtain expected quantity values from manual scale

### DIFF
--- a/R/scale-manual.R
+++ b/R/scale-manual.R
@@ -180,7 +180,7 @@ manual_scale <- function(aesthetic, values = NULL, breaks = waiver(), ...,
     if (n > length(values)) {
       cli::cli_abort("Insufficient values in manual scale. {n} needed but only {length(values)} provided.")
     }
-    values
+    unname(values[seq_len(n)])
   }
   discrete_scale(aesthetic, "manual", pal, breaks = breaks, limits = limits, ...)
 }

--- a/R/scale-manual.R
+++ b/R/scale-manual.R
@@ -180,7 +180,12 @@ manual_scale <- function(aesthetic, values = NULL, breaks = waiver(), ...,
     if (n > length(values)) {
       cli::cli_abort("Insufficient values in manual scale. {n} needed but only {length(values)} provided.")
     }
-    unname(values[seq_len(n)])
+
+    if (is.null(names(values))) {
+      values[seq_len(n)]
+    } else {
+      values
+    }
   }
   discrete_scale(aesthetic, "manual", pal, breaks = breaks, limits = limits, ...)
 }

--- a/tests/testthat/test-scale-manual.R
+++ b/tests/testthat/test-scale-manual.R
@@ -23,7 +23,7 @@ test_that("names of values used in manual scales", {
 
 test_that("obtain expected quantity values from manual scale", {
   for (aesthetics in .all_aesthetics) {
-    s <- scale_discrete_manual(aesthetics = aesthetics, values = c("8" = "c", "4" = "a", "6" = "b"))
+    s <- scale_discrete_manual(aesthetics = aesthetics, values = c("c", "a", "b"))
     expect_equal(s$palette(1), c("c"))
     expect_equal(s$palette(2), c("c", "a"))
     expect_equal(s$palette(3), c("c", "a", "b"))

--- a/tests/testthat/test-scale-manual.R
+++ b/tests/testthat/test-scale-manual.R
@@ -21,6 +21,16 @@ test_that("names of values used in manual scales", {
    )
 })
 
+test_that("obtain expected quantity values from manual scale", {
+  for (aesthetics in .all_aesthetics) {
+    s <- scale_discrete_manual(aesthetics = aesthetics, values = c("8" = "c", "4" = "a", "6" = "b"))
+    expect_equal(s$palette(1), c("c"))
+    expect_equal(s$palette(2), c("c", "a"))
+    expect_equal(s$palette(3), c("c", "a", "b"))
+    expect_error(s$palette(4), "Insufficient values")
+  }
+})
+
 
 dat <- data_frame(g = c("B","A","A"))
 p <- ggplot(dat, aes(g, fill = g)) + geom_bar()


### PR DESCRIPTION
This PR fixes an error in the code and adds corresponding unit tests.

When using `manual_scale` to create a `discrete_scale`, the `palette` should be a function that can return the specified number of `values` when called with a single integer argument.

Here is the parameter description excerpt from `scale-.R`:

>@param palette A palette function that when called with a single integer argument (the number of levels in the scale) returns the values that they should take (e.g., [scales::hue_pal()]).

In the original `manual_scale` method, it simply returned all the `values`. However, when `values` are not named, we only need to return the corresponding first 'n' values. Therefore, the modified code includes a condition to handle this case.