### PR TITLE
Integers as valid input to theme

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Integers are once again valid input to theme arguments that expect numeric
+  input (@teunbrand, #5369)
+
 * Nicer error messages for xlim/ylim arguments in coord-* functions
   (@92amartins, #4601, #5297).
 

--- a/R/theme-elements.R
+++ b/R/theme-elements.R
@@ -476,12 +476,12 @@ el_def <- function(class = NULL, inherit = NULL, description = NULL) {
   legend.key.height   = el_def("unit", "legend.key.size"),
   legend.key.width    = el_def("unit", "legend.key.size"),
   legend.text         = el_def("element_text", "text"),
-  legend.text.align   = el_def("numeric"),
+  legend.text.align   = el_def(c("numeric", "integer")),
   legend.title        = el_def("element_text", "title"),
-  legend.title.align  = el_def("numeric"),
-  legend.position     = el_def(c("character", "numeric")),
+  legend.title.align  = el_def(c("numeric", "integer")),
+  legend.position     = el_def(c("character", "numeric", "integer")),
   legend.direction    = el_def("character"),
-  legend.justification = el_def(c("character", "numeric")),
+  legend.justification = el_def(c("character", "numeric", "integer")),
   legend.box          = el_def("character"),
   legend.box.just     = el_def("character"),
   legend.box.margin   = el_def("margin"),
@@ -522,11 +522,11 @@ el_def <- function(class = NULL, inherit = NULL, description = NULL) {
   plot.caption        = el_def("element_text", "title"),
   plot.caption.position = el_def("character"),
   plot.tag            = el_def("element_text", "title"),
-  plot.tag.position   = el_def(c("character", "numeric")),  # Need to also accept numbers
+  plot.tag.position   = el_def(c("character", "numeric", "integer")),  # Need to also accept numbers
   plot.tag.location   = el_def("character"),
   plot.margin         = el_def("margin"),
 
-  aspect.ratio        = el_def("numeric")
+  aspect.ratio        = el_def(c("numeric", "integer"))
 )
 
 # Check that an element object has the proper class

--- a/tests/testthat/_snaps/labels.md
+++ b/tests/testthat/_snaps/labels.md
@@ -1,6 +1,6 @@
 # plot.tag.position rejects invalid input
 
-    The `plot.tag.position` theme element must be a <character/numeric> object.
+    The `plot.tag.position` theme element must be a <character/numeric/integer> object.
 
 ---
 

--- a/tests/testthat/_snaps/theme.md
+++ b/tests/testthat/_snaps/theme.md
@@ -53,3 +53,7 @@
     `plot.tag.position` must be one of "topleft", "top", "topright", "left", "right", "bottomleft", "bottom", or "bottomright", not "test".
     i Did you mean "left"?
 
+# Theme validation behaves as expected
+
+    The `aspect.ratio` theme element must be a <numeric/integer> object.
+

--- a/tests/testthat/test-theme.R
+++ b/tests/testthat/test-theme.R
@@ -492,6 +492,13 @@ test_that("Theme elements are checked during build", {
   expect_snapshot_error(ggplotGrob(p))
 })
 
+test_that("Theme validation behaves as expected", {
+  tree <- get_element_tree()
+  expect_silent(validate_element(1,  "aspect.ratio", tree))
+  expect_silent(validate_element(1L, "aspect.ratio", tree))
+  expect_snapshot_error(validate_element("A", "aspect.ratio", tree))
+})
+
 # Visual tests ------------------------------------------------------------
 
 test_that("aspect ratio is honored", {


### PR DESCRIPTION
This PR aims to fix #5369.

Briefly, in the element tree, some elements were expect to be `"numeric"`. In `inherits()`, this is interpreted as 'double', not 'integer or double' as one would expect in `is.numeric()`. This PR explicitly permits these elements to inherit from 'numeric' or 'integer'.