### PR TITLE
Fix partial matching in `geom_violin()`

### DIFF
--- a/R/stat-ydensity.R
+++ b/R/stat-ydensity.R
@@ -95,8 +95,11 @@ StatYdensity <- ggproto("StatYdensity", Stat,
     range <- range(data$y, na.rm = TRUE)
     modifier <- if (trim) 0 else 3
     bw <- calc_bw(data$y, bw)
-    dens <- compute_density(data$y, data$w, from = range[1] - modifier*bw, to = range[2] + modifier*bw,
-      bw = bw, adjust = adjust, kernel = kernel)
+    dens <- compute_density(
+      data$y, data[["weight"]],
+      from = range[1] - modifier * bw, to = range[2] + modifier * bw,
+      bw = bw, adjust = adjust, kernel = kernel
+    )
 
     dens$y <- dens$x
     dens$x <- mean(range(data$x))


### PR DESCRIPTION
This PR aims to fix #5374.

Briefly, it solves a partial matching bug that would accept `weights` as the `weight` aesthetic.
Specifying `weights` now just throws a warning, instead of being accidentally used as the `weight` aesthetic.

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2
options(warnPartialMatchDollar = TRUE)

p <- ggplot(iris, aes(Species, Sepal.Width)) + 
  geom_violin(aes(weights = Sepal.Length))
#> Warning in geom_violin(aes(weights = Sepal.Length)): Ignoring unknown
#> aesthetics: weights
```

<sup>Created on 2023-08-02 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
