### PR TITLE
Update documentation and example in scale-brewer.R to reflect scale_*_distiller's non-intuitive "direction"

### DIFF
--- a/R/scale-brewer.R
+++ b/R/scale-brewer.R
@@ -8,14 +8,14 @@
 #'
 #' @note
 #' The `distiller` scales extend `brewer` scales by smoothly
-#' interpolating 7 colours from any palette to a continuous scale. The `fermenter`
-#' scales provide binned versions of the `brewer` scales.
+#' interpolating 7 colours from any palette to a continuous scale. 
+#' The `distiller` scales have a default direction = -1. To reverse, use direction = 1.
+#' The `fermenter` scales provide binned versions of the `brewer` scales.
 #'
 #' @details
 #' The `brewer` scales were carefully designed and tested on discrete data.
 #' They were not designed to be extended to continuous data, but results often
 #' look good. Your mileage may vary.
-#' The `distiller` scales have a default direction = -1. To reverse, use direction = 1.
 #'
 #' @section Palettes:
 #' The following palettes are available for use with these scales:

--- a/R/scale-brewer.R
+++ b/R/scale-brewer.R
@@ -15,6 +15,7 @@
 #' The `brewer` scales were carefully designed and tested on discrete data.
 #' They were not designed to be extended to continuous data, but results often
 #' look good. Your mileage may vary.
+#' The `distiller` scales have a default direction = -1. To reverse, use direction = 1.
 #'
 #' @section Palettes:
 #' The following palettes are available for use with these scales:
@@ -75,6 +76,8 @@
 #' v
 #' v + scale_fill_distiller()
 #' v + scale_fill_distiller(palette = "Spectral")
+#' # the order of colour can be reversed, but with scale_*_distiller(), the default direction = -1, so to reverse, use direction = 1.
+#' v + scale_fill_distiller(palette = "Spectral", direction = 1)
 #'
 #' # or use blender variants to discretise continuous data
 #' v + scale_fill_fermenter()

--- a/man/scale_brewer.Rd
+++ b/man/scale_brewer.Rd
@@ -119,8 +119,9 @@ look good. Your mileage may vary.
 }
 \note{
 The \code{distiller} scales extend \code{brewer} scales by smoothly
-interpolating 7 colours from any palette to a continuous scale. The \code{fermenter}
-scales provide binned versions of the \code{brewer} scales.
+interpolating 7 colours from any palette to a continuous scale.
+The \code{distiller} scales have a default direction = -1. To reverse, use direction = 1.
+The \code{fermenter} scales provide binned versions of the \code{brewer} scales.
 }
 \section{Palettes}{
 
@@ -168,6 +169,8 @@ v <- ggplot(faithfuld) +
 v
 v + scale_fill_distiller()
 v + scale_fill_distiller(palette = "Spectral")
+# the order of colour can be reversed, but with scale_*_distiller(), the default direction = -1, so to reverse, use direction = 1.
+v + scale_fill_distiller(palette = "Spectral", direction = 1)
 
 # or use blender variants to discretise continuous data
 v + scale_fill_fermenter()


### PR DESCRIPTION
Capturing in documentation that scale_*_distiller has a non-intuitive default direction = -1, and that to reverse, user needs to specify direction = 1

Source:
https://github.com/tidyverse/ggplot2/issues/1439
https://github.com/tidyverse/ggplot2/issues/4444