### PR TITLE
Violin resolution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* `stat_ydensity()` with incomplete groups calculates the default `width` 
+  parameter more stably (@teunbrand, #5396)
+
 * `geom_boxplot()` gains a new argument, `staplewidth` that can draw staples
   at the ends of whiskers (@teunbrand, #5126)
 

--- a/R/stat-ydensity.R
+++ b/R/stat-ydensity.R
@@ -102,11 +102,14 @@ StatYdensity <- ggproto("StatYdensity", Stat,
     )
 
     dens$y <- dens$x
-    dens$x <- mean(range(data$x))
 
     # Compute width if x has multiple values
     if (vec_unique_count(data$x) > 1) {
+      dens$x <- mean(range(data$x))
       width <- diff(range(data$x)) * 0.9
+    } else {
+      # Explicitly repeat to preserve data$x's mapped_discrete class
+      dens$x <- vec_rep(data$x[1], nrow(dens))
     }
     dens$width <- width
 

--- a/tests/testthat/test-stat-ydensity.R
+++ b/tests/testthat/test-stat-ydensity.R
@@ -25,3 +25,19 @@ test_that("`drop = FALSE` preserves groups with 1 observations", {
   )
   expect_equal(length(unique(ld$x)), 4)
 })
+
+test_that("mapped_discrete class is preserved", {
+
+  df <- data_frame0(
+    x = factor(rep(c("A", "C"), each = 3), c("A", "B", "C")),
+    y = 1:6
+  )
+
+  ld <- layer_data(
+    ggplot(df, aes(x, y)) + geom_violin() +
+      scale_x_discrete(drop = FALSE)
+  )
+
+  expect_s3_class(ld$x, "mapped_discrete")
+  expect_equal(unique(ld$x), c(1, 3))
+})


### PR DESCRIPTION
This PR aims to fix #5396.

Briefly, `geom_violin()` calls `resolution()` to determine the default width of a violin. 
In `resolution()`, we're (correctly) making an exception for integers and 'mapped_discrete' vectors to have resolution 1.

However, the 'mapped_discrete' class got dropped from `data$x` due to a `mean()` operation.
In this PR, we skip the mean calculation when `data$x` only has 1 unique value, thereby preserving the 'mapped_discrete' class that gets forwarded to `resolution()`.

Small demo:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

dplyr::filter(diamonds, cut %in% c("Ideal", "Good")) |>
  ggplot(aes(price, cut)) +
  geom_violin() +
  scale_y_discrete(drop = FALSE)
```

![](https://i.imgur.com/pNLGODt.png)<!-- -->

<sup>Created on 2023-08-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
