### PR TITLE
Correct length() usage in geom-boxplot

### DIFF
--- a/R/geom-boxplot.R
+++ b/R/geom-boxplot.R
@@ -268,7 +268,7 @@ GeomBoxplot <- ggproto("GeomBoxplot", Geom,
     )
     box <- flip_data(box, flipped_aes)
 
-    if (!is.null(data$outliers) && length(data$outliers[[1]] >= 1)) {
+    if (!is.null(data$outliers) && length(data$outliers[[1]]) >= 1) {
       outliers <- data_frame0(
         y = data$outliers[[1]],
         x = data$x[1],


### PR DESCRIPTION
Testing out the new `lintr::length_test_linter()` (https://github.com/r-lib/lintr/pull/2124) came across this. I think the code does as intended "by accident", but it's better to use the "correct" code instead and not rely on some coercions producing the right answer incidentally.