### PR TITLE
Add "Get started" section on the pkgdown site

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -285,7 +285,7 @@ news:
 
 navbar:
   structure:
-    left: [reference, news, articles, extensions]
+    left: [intro, reference, news, articles, extensions]
   components:
     extensions:
       text: Extensions


### PR DESCRIPTION
A followup of #5159

cf. https://pkgdown.r-lib.org/reference/build_site.html#navigation-bar