### PR TITLE
POC: `ignore()` for aesthetic evaluation.

### DIFF
--- a/R/aes-evaluation.R
+++ b/R/aes-evaluation.R
@@ -204,6 +204,12 @@ stage_scaled <- function(start = NULL, after_stat = NULL, after_scale = NULL) {
   after_scale
 }
 
+#' @rdname aes_eval
+#' @export
+ignore <- function(x) {
+  x
+}
+
 # Regex to determine if an identifier refers to a calculated aesthetic
 match_calculated_aes <- "^\\.\\.([a-zA-Z._]+)\\.\\.$"
 
@@ -221,6 +227,10 @@ is_scaled_aes <- function(aesthetics) {
 is_staged_aes <- function(aesthetics) {
   vapply(aesthetics, is_staged, logical(1), USE.NAMES = FALSE)
 }
+is_ignored_aes <- function(aesthetics) {
+  vapply(aesthetics, is_ignored, logical(1), USE.NAMES = FALSE)
+}
+
 is_calculated <- function(x, warn = FALSE) {
   if (is_call(get_expr(x), "after_stat")) {
     return(TRUE)
@@ -262,6 +272,9 @@ is_scaled <- function(x) {
 }
 is_staged <- function(x) {
   is_call(get_expr(x), "stage")
+}
+is_ignored <- function(x) {
+  is_call(get_expr(x), "ignore")
 }
 
 # Strip dots from expressions

--- a/R/layer.R
+++ b/R/layer.R
@@ -344,7 +344,8 @@ Layer <- ggproto("Layer", NULL,
     aesthetics <- defaults(aesthetics, self$stat$default_aes)
     aesthetics <- compact(aesthetics)
 
-    new <- strip_dots(aesthetics[is_calculated_aes(aesthetics) | is_staged_aes(aesthetics)])
+    new <- aesthetics[!is_ignored_aes(aesthetics)]
+    new <- strip_dots(new[is_calculated_aes(new) | is_staged_aes(new)])
     if (length(new) == 0) return(data)
 
     # data needs to be non-scaled

--- a/R/layer.R
+++ b/R/layer.R
@@ -432,15 +432,13 @@ Layer <- ggproto("Layer", NULL,
 
     ignored <- self$ignored_aesthetics()
     if (any(ignored %in% c(ggplot_global$x_aes, ggplot_global$y_aes))) {
-      # Temporarily override global x/y aesthetics
-      old_x <- ggplot_global$x_aes
-      old_y <- ggplot_global$y_aes
-      on.exit({
-        ggplot_global$x_aes <- old_x
-        ggplot_global$y_aes <- old_y
-      }, add = TRUE)
-      ggplot_global$x_aes <- setdiff(old_x, ignored)
-      ggplot_global$y_aes <- setdiff(old_y, ignored)
+      # We temporarily redefine x/y aesthetics to have coords skip
+      # transformation of ignored aesthetics
+      local_bindings(
+        x_aes = setdiff(ggplot_global$x_aes, ignored),
+        y_aes = setdiff(ggplot_global$y_aes, ignored),
+        .env = ggplot_global
+      )
     }
 
     self$geom$draw_layer(data, self$computed_geom_params, layout, layout$coord)

--- a/R/layer.R
+++ b/R/layer.R
@@ -430,6 +430,22 @@ Layer <- ggproto("Layer", NULL,
 
     data <- self$geom$handle_na(data, self$computed_geom_params)
     self$geom$draw_layer(data, self$computed_geom_params, layout, layout$coord)
+  },
+
+  apply_ignore = function(self, data) {
+    aesthetics <- self$computed_mapping
+    ignored <- names(aesthetics)[is_ignored_aes(aesthetics)]
+    ignored <- names(data) %in% ignored
+    names(data)[ignored] <- paste0(".ignored_", names(data)[ignored])
+    data
+  },
+
+  undo_ignore = function(self, data) {
+    aesthetics <- self$computed_mapping
+    ignored <- names(aesthetics)[is_ignored_aes(aesthetics)]
+    ignored <- names(data) %in% paste0(".ignored_", ignored)
+    names(data)[ignored] <- gsub("^\\.ignored_", "", names(data)[ignored])
+    data
   }
 )
 

--- a/R/layer.R
+++ b/R/layer.R
@@ -432,17 +432,20 @@ Layer <- ggproto("Layer", NULL,
     self$geom$draw_layer(data, self$computed_geom_params, layout, layout$coord)
   },
 
-  apply_ignore = function(self, data) {
+  ignored_aesthetics = function(self) {
     aesthetics <- self$computed_mapping
-    ignored <- names(aesthetics)[is_ignored_aes(aesthetics)]
+    names(aesthetics)[is_ignored_aes(aesthetics)]
+  },
+
+  apply_ignore = function(self, data) {
+    ignored <- self$ignored_aesthetics()
     ignored <- names(data) %in% ignored
     names(data)[ignored] <- paste0(".ignored_", names(data)[ignored])
     data
   },
 
   undo_ignore = function(self, data) {
-    aesthetics <- self$computed_mapping
-    ignored <- names(aesthetics)[is_ignored_aes(aesthetics)]
+    ignored <- self$ignored_aesthetics()
     ignored <- names(data) %in% paste0(".ignored_", ignored)
     names(data)[ignored] <- gsub("^\\.ignored_", "", names(data)[ignored])
     data

--- a/R/layer.R
+++ b/R/layer.R
@@ -429,6 +429,20 @@ Layer <- ggproto("Layer", NULL,
     }
 
     data <- self$geom$handle_na(data, self$computed_geom_params)
+
+    ignored <- self$ignored_aesthetics()
+    if (any(ignored %in% c(ggplot_global$x_aes, ggplot_global$y_aes))) {
+      # Temporarily override global x/y aesthetics
+      old_x <- ggplot_global$x_aes
+      old_y <- ggplot_global$y_aes
+      on.exit({
+        ggplot_global$x_aes <- old_x
+        ggplot_global$y_aes <- old_y
+      }, add = TRUE)
+      ggplot_global$x_aes <- setdiff(old_x, ignored)
+      ggplot_global$y_aes <- setdiff(old_y, ignored)
+    }
+
     self$geom$draw_layer(data, self$computed_geom_params, layout, layout$coord)
   },
 

--- a/R/plot-build.R
+++ b/R/plot-build.R
@@ -51,6 +51,7 @@ ggplot_build.ggplot <- function(plot) {
 
   # Compute aesthetics to produce data with generalised variable names
   data <- by_layer(function(l, d) l$compute_aesthetics(d, plot), layers, data, "computing aesthetics")
+  data <- by_layer(function(l, d) l$apply_ignore(d), layers, data, "ignoring aesthetics")
 
   # Transform all scales
   data <- lapply(data, scales$transform_df)
@@ -62,6 +63,7 @@ ggplot_build.ggplot <- function(plot) {
 
   layout$train_position(data, scale_x(), scale_y())
   data <- layout$map_position(data)
+  data <- by_layer(function(l, d) l$undo_ignore(d), layers, data, "unignoring aesthetics")
 
   # Apply and map statistics
   data <- by_layer(function(l, d) l$compute_statistic(d, layout), layers, data, "computing stat")
@@ -79,6 +81,7 @@ ggplot_build.ggplot <- function(plot) {
   # Reset position scales, then re-train and map.  This ensures that facets
   # have control over the range of a plot: is it generated from what is
   # displayed, or does it include the range of underlying data
+  data <- by_layer(function(l, d) l$apply_ignore(d), layers, data, "ignoring aesthetics")
   layout$reset_scales()
   layout$train_position(data, scale_x(), scale_y())
   layout$setup_panel_params()
@@ -90,6 +93,7 @@ ggplot_build.ggplot <- function(plot) {
     lapply(data, npscales$train_df)
     data <- lapply(data, npscales$map_df)
   }
+  data <- by_layer(function(l, d) l$undo_ignore(d), layers, data, "unignoring aesthetics")
 
   # Fill in defaults etc.
   data <- by_layer(function(l, d) l$compute_geom_2(d), layers, data, "setting up geom aesthetics")

--- a/R/position-.R
+++ b/R/position-.R
@@ -78,13 +78,14 @@ transform_position <- function(df, trans_x = NULL, trans_y = NULL, ...) {
   # Treat df as list during transformation for faster set/get
   oldclass <- class(df)
   df <- unclass(df)
-  scales <- aes_to_scale(names(df))
 
   if (!is.null(trans_x)) {
-    df[scales == "x"] <- lapply(df[scales == "x"], trans_x, ...)
+    is_x <- names(df) %in% ggplot_global$x_aes
+    df[is_x] <- lapply(df[is_x], trans_x, ...)
   }
   if (!is.null(trans_y)) {
-    df[scales == "y"] <- lapply(df[scales == "y"], trans_y, ...)
+    is_y <- names(df) %in% ggplot_global$y_aes
+    df[is_y] <- lapply(df[is_y], trans_y, ...)
   }
 
   class(df) <- oldclass

--- a/R/scales-.R
+++ b/R/scales-.R
@@ -145,7 +145,7 @@ ScalesList <- ggproto("ScalesList", NULL,
     if (is.null(aesthetics)) {
       return()
     }
-    aesthetics <- aesthetics[is_ignored_aes(aesthetics)]
+    aesthetics <- aesthetics[!is_ignored_aes(aesthetics)]
     names(aesthetics) <- unlist(lapply(names(aesthetics), aes_to_scale))
 
     new_aesthetics <- setdiff(names(aesthetics), self$input())

--- a/R/scales-.R
+++ b/R/scales-.R
@@ -145,6 +145,7 @@ ScalesList <- ggproto("ScalesList", NULL,
     if (is.null(aesthetics)) {
       return()
     }
+    aesthetics <- aesthetics[is_ignored_aes(aesthetics)]
     names(aesthetics) <- unlist(lapply(names(aesthetics), aes_to_scale))
 
     new_aesthetics <- setdiff(names(aesthetics), self$input())


### PR DESCRIPTION
This PR explores https://github.com/tidyverse/ggplot2/pull/5290#issuecomment-1698603368.

While #5290 tackles the same issue on the data side of things, this PR aims to use mechanics similar to `after_scale()`.
Briefly, this PR introduces `ignore()` as an aesthetic evaluation modifier, which then causes scales to skip doing anything with or calculating anything from these modified aesthetics.

Here are some notes:
* The information on which aesthetics are ignored are stored in `Layer$computed_mapping`. Scales have plenty of opportunities to read/write from/to `data` independent of the layer. This caused an issue on how to transfer that information to the scales.
* The solution in this PR is to rename the ignored columns any time data interacts with scales. Scales match column names based on their aesthetics, so this effectively lets these ignored aesthetics be ignored. Any time the layer wants to compute anything on the data (stat, position, geom etc.), the columns are renamed back to their original names.
* That renaming strategy kind-of works until we arrive at coord transformation, which is typically under control of a `Layer$geom$draw_*()` function, which needs the original names. The 'solution' in this PR is to temporarily redefine the definition of position aesthetics in the `Layer$draw_geom()` method.
* I took some additional care in `annotate()` to preserve `ignore()`'d variables.

At a first glance, results are pretty similar to #5290.

``` r
devtools::load_all("~/packages/ggplot2") # This PR
#> ℹ Loading ggplot2

df <- data.frame(t = seq(0, 2*pi, length.out = 100))

ggplot(mpg) +
  geom_point(aes(displ, hwy, colour = factor(cyl))) +
  geom_path(
    data = df, 
    aes(x = ignore(cos(t) / 2.1 + 0.5), 
        y = ignore(sin(t) / 2.1 + 0.5),
        colour = ignore(2))
  ) +
  annotate(
    "text", x = ignore(0.5), y = ignore(0.5),
    label = "I'm in the middle",
    colour = 4, size = 10
  )
```

![](https://i.imgur.com/ZQ8N3Qs.png)<!-- -->

<sup>Created on 2023-09-13 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

However, this is only the case for very straightforward layers that do not reparametrize anything. For example, if you'd have to translate x/width parameters to xmin/xmax parameters, this approach doesn't keep track of what should be ignored.

``` r
devtools::load_all("~/packages/ggplot2") # This PR
#> ℹ Loading ggplot2
df <- data.frame(x = c(0.3, 0.5, 0.7), y = c(1, 2, 3))

ggplot(df, aes(ignore(x), y)) +
  geom_col() +
  xlim(0, 10)
```

![](https://i.imgur.com/dAFKy01.png)<!-- -->

<sup>Created on 2023-09-13 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Whereas #5290's approach bakes the ignoring part into the data, which begets the intended effect for these bars.

``` r
devtools::load_all("~/packages/ggplot2") # PR #5290
df <- data.frame(x = c(0.3, 0.5, 0.7), y = c(1, 2, 3))

ggplot(df, aes(I(x), y)) +
  geom_col() +
  xlim(0, 10)
```

![](https://i.imgur.com/tgY3GuZ.png)<!-- -->

<sup>Created on 2023-09-13 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

At this point, I think #5290 has more benefits than this approach.

