### PR TITLE
Don't attach Suggests package in test

### DIFF
--- a/tests/testthat/test-annotate.R
+++ b/tests/testthat/test-annotate.R
@@ -33,7 +33,6 @@ test_that("annotation_* has dummy data assigned and don't inherit aes", {
   skip_if(packageVersion("base") < "3.5.0")
   custom <- annotation_custom(zeroGrob())
   logtick <- annotation_logticks()
-  library(maps)
   usamap <- map_data("state")
   map <- annotation_map(usamap)
   rainbow <- matrix(hcl(seq(0, 360, length.out = 50 * 50), 80, 70), nrow = 50)


### PR DESCRIPTION
Doing so makes tests less hermetic since `library()` has permanent side effects (of course, `loadNamespace()` does too, but generally less serious).