### PR TITLE
Require R >= 3.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ License: MIT + file LICENSE
 URL: https://ggplot2.tidyverse.org, https://github.com/tidyverse/ggplot2
 BugReports: https://github.com/tidyverse/ggplot2/issues
 Depends:
-    R (>= 3.3)
+    R (>= 3.5)
 Imports: 
     cli,
     glue,


### PR DESCRIPTION
As reported in #5421, ggplot2 now actually requires R >= 3.5 for rlang. Let's reflect it to the DESCRIPTION.