### PR TITLE
Bug-fix: text justification with rotation not implemented in `geom_label()` 

### DIFF
--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -74,10 +74,10 @@ GeomLabel <- ggproto("GeomLabel", Geom,
 
     data <- coord$transform(data, panel_params)
     if (is.character(data$vjust)) {
-      data$vjust <- compute_just(data$vjust, data$y)
+      data$vjust <- compute_just(data$vjust, data$y, data$x, data$angle)
     }
     if (is.character(data$hjust)) {
-      data$hjust <- compute_just(data$hjust, data$x)
+      data$hjust <- compute_just(data$hjust, data$x, data$y, data$angle)
     }
     if (!inherits(label.padding, "margin")) {
       label.padding <- rep(label.padding, length.out = 4)


### PR DESCRIPTION
The code in `geom_label()` should pass to `compute_just()` the same arguments that `geom_text()` passes, including both `x` and `y` and `angle` in each of the two calls, one for `hjust` and one for `vjust`. This affects the handling of `"inward"` and `"outward"` justification that depending on the angle require different numerical values for justification.

Reprex run AFTER applying this bug fix.

(There is a separate problem in `compute_just()`, affecting both geometries as `vjust` for the 90 degrees rotated text seems to be "outward" instead of "inward", while `hjust` is correct. I will try fix this separate problem and make a separate pull request in a few days.)

``` r
library(ggplot2)

df <- data.frame(
  x = c(0, 0, 1, 1, 0.5),
  y = c(0, 1, 0, 1, 0.5),
  text = c("bottom-left", "top-left", "bottom-right", "top-right", "center-middle")
)

ggplot(df, aes(x, y, label = text)) +
  geom_text(hjust = "inward", vjust = "inward", angle = 90)
```

![](https://i.imgur.com/JX3ok4U.png)<!-- -->

``` r

ggplot(df, aes(x, y, label = text)) +
  geom_text(hjust = "inward", vjust = "inward", angle = -90)
```

![](https://i.imgur.com/hKXRlB0.png)<!-- -->

``` r

ggplot(df, aes(x, y, label = text)) +
  geom_label(hjust = "inward", vjust = "inward", angle = 90)
```

![](https://i.imgur.com/XB3aV4X.png)<!-- -->

``` r

ggplot(df, aes(x, y, label = text)) +
  geom_label(hjust = "inward", vjust = "inward", angle = -90)
```

![](https://i.imgur.com/xeAmfRQ.png)<!-- -->

<sup>Created on 2023-09-15 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
