### PR TITLE
Omit rownames from aesthetic usage check

### DIFF
--- a/R/aes.R
+++ b/R/aes.R
@@ -436,7 +436,7 @@ extract_target_is_likely_data <- function(x, data, env) {
 
   tryCatch({
     data_eval <- eval_tidy(x[[2]], data, env)
-    identical(data_eval, data)
+    identical(unrowname(data_eval), unrowname(data))
   }, error = function(err) FALSE)
 }
 

--- a/tests/testthat/test-aes.R
+++ b/tests/testthat/test-aes.R
@@ -128,6 +128,14 @@ test_that("warn_for_aes_extract_usage() warns for discouraged uses of $ and [[ w
     warn_for_aes_extract_usage(aes(df[["x"]]), df),
     'Use of `df\\[\\["x"\\]\\]` is discouraged'
   )
+
+  # Check that rownames are ignored (#5392)
+  df2 <- df
+  rownames(df2) <- LETTERS[seq_len(nrow(df))]
+  expect_warning(
+    warn_for_aes_extract_usage(aes(df$x), df2),
+    "Use of `df\\$x` is discouraged"
+  )
 })
 
 test_that("warn_for_aes_extract_usage() does not evaluate function calls", {


### PR DESCRIPTION
This PR aims to fix #5392. It calls `unrowname()` on the data before checking.