### PR TITLE
Move CRS responsibility from GuideAxis to CoordSf

### DIFF
--- a/R/coord-sf.R
+++ b/R/coord-sf.R
@@ -261,7 +261,7 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
       graticule = graticule,
       crs = params$crs,
       default_crs = params$default_crs,
-      !!viewscales
+      !!!viewscales
     )
   },
 

--- a/R/coord-sf.R
+++ b/R/coord-sf.R
@@ -255,19 +255,24 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
     graticule$y_start <- sf_rescale01_x(graticule$y_start, y_range)
     graticule$y_end <- sf_rescale01_x(graticule$y_end, y_range)
 
-    list(
+    list2(
       x_range = x_range,
       y_range = y_range,
       graticule = graticule,
       crs = params$crs,
       default_crs = params$default_crs,
-      viewscales = viewscales
+      !!viewscales
     )
   },
 
-  setup_panel_guides = function(self, panel_params, guides, params = list()) {
-    params <- Coord$setup_panel_guides(panel_params$viewscales, guides, params)
-    c(params, panel_params)
+  train_panel_guides = function(self, panel_params, layers, params = list()) {
+    # The guide positions are already in the target CRS, so we mask the default
+    # CRS to prevent a double transformation.
+    panel_params$guides <- ggproto_parent(Coord, self)$train_panel_guides(
+      vec_assign(panel_params, "default_crs", panel_params["crs"]),
+      layers, params
+    )$guides
+    panel_params
   },
 
   backtransform_range = function(self, panel_params) {

--- a/R/guide-axis.R
+++ b/R/guide-axis.R
@@ -135,11 +135,6 @@ GuideAxis <- ggproto(
       return(params)
     }
 
-    if (inherits(coord, "CoordSf")) {
-      # Positions already given in target crs
-      panel_params$default_crs <- panel_params$crs
-    }
-
     aesthetics <- names(key)[!grepl("^\\.", names(key))]
     if (!all(c("x", "y") %in% aesthetics)) {
       other_aesthetic <- setdiff(c("x", "y"), aesthetics)


### PR DESCRIPTION
This PR doesn't fix any issue, but it amends #5293.

I have become mildly frustrated by the lines below in the axis guide:

https://github.com/tidyverse/ggplot2/blob/69e74305386094cb1fc0b10495d18492cec5b012/R/guide-axis.R#L138-L141

Which I believe should be the coord's responsibility, not the axis' responsibility. This PR moves that ressponsibility from the axis to the coord.