### PR TITLE
Add a minor note about the difference of the unit of size to FAQ

### DIFF
--- a/vignettes/articles/faq-customising.Rmd
+++ b/vignettes/articles/faq-customising.Rmd
@@ -505,7 +505,7 @@ GeomLabel$default_aes$size
 
 You can change the size using the `size` argument in `geom_text()` for a single plot. If you want to use the same updated size, you can set this with `update_geom_defaults()`, e.g. `update_geom_defaults("text", list(size = 6))`.
 
-Note that this `size` is in **mm** while the `size` in `element_text()` is in pt. So, if you want to match `geom_text()`'s font size to the theme's, you need to divide the number by `.pt`. Please refer to ["Font size " section of Aesthetic specifications](https://ggplot2.tidyverse.org/articles/ggplot2-specs.html#font-size) for more details.
+Note that this `size` is in **mm** while the `size` in `element_text()` is in pt. So, if you want to match `geom_text()`'s font size to the theme's, you need to divide the number by `.pt`. Please refer to ["Font size" section of the aesthetic specifications](https://ggplot2.tidyverse.org/articles/ggplot2-specs.html#font-size) for more details.
 
 <details>
 

--- a/vignettes/articles/faq-customising.Rmd
+++ b/vignettes/articles/faq-customising.Rmd
@@ -505,6 +505,8 @@ GeomLabel$default_aes$size
 
 You can change the size using the `size` argument in `geom_text()` for a single plot. If you want to use the same updated size, you can set this with `update_geom_defaults()`, e.g. `update_geom_defaults("text", list(size = 6))`.
 
+Note that this `size` is in **mm** while the `size` in `element_text()` is in pt. So, if you want to match the font size of `geom_text()` to theme, you need to divide the number by `.pt`. Please refer to ["Font size " section of Aesthetic specifications](https://ggplot2.tidyverse.org/articles/ggplot2-specs.html#font-size) for more details.
+
 <details>
 
 <summary>See example</summary>

--- a/vignettes/articles/faq-customising.Rmd
+++ b/vignettes/articles/faq-customising.Rmd
@@ -505,7 +505,7 @@ GeomLabel$default_aes$size
 
 You can change the size using the `size` argument in `geom_text()` for a single plot. If you want to use the same updated size, you can set this with `update_geom_defaults()`, e.g. `update_geom_defaults("text", list(size = 6))`.
 
-Note that this `size` is in **mm** while the `size` in `element_text()` is in pt. So, if you want to match the font size of `geom_text()` to theme, you need to divide the number by `.pt`. Please refer to ["Font size " section of Aesthetic specifications](https://ggplot2.tidyverse.org/articles/ggplot2-specs.html#font-size) for more details.
+Note that this `size` is in **mm** while the `size` in `element_text()` is in pt. So, if you want to match `geom_text()`'s font size to the theme's, you need to divide the number by `.pt`. Please refer to ["Font size " section of Aesthetic specifications](https://ggplot2.tidyverse.org/articles/ggplot2-specs.html#font-size) for more details.
 
 <details>
 

--- a/vignettes/articles/faq-customising.Rmd
+++ b/vignettes/articles/faq-customising.Rmd
@@ -505,7 +505,11 @@ GeomLabel$default_aes$size
 
 You can change the size using the `size` argument in `geom_text()` for a single plot. If you want to use the same updated size, you can set this with `update_geom_defaults()`, e.g. `update_geom_defaults("text", list(size = 6))`.
 
-Note that this `size` is in **mm** while the `size` of `element_text()` is in pt. So, if you want to match `geom_text()`'s font size to the theme's, you need to divide the number by `.pt`. Please refer to ["Font size" section of the aesthetic specifications](https://ggplot2.tidyverse.org/articles/ggplot2-specs.html#font-size) for more details.
+One tricky thing is that this `size` is in **mm** while the `size` of `element_text()` is in pt.
+If you want to match `geom_text()`'s font size to the theme's size,
+specify `size.unit = "pt"` in `geom_text()` for a single plot,
+or divide the number by the `.pt` constant variable for `update_geom_defaults()`.
+Please refer to ["Font size" section of the aesthetic specifications](https://ggplot2.tidyverse.org/articles/ggplot2-specs.html#font-size) for more details.
 
 <details>
 

--- a/vignettes/articles/faq-customising.Rmd
+++ b/vignettes/articles/faq-customising.Rmd
@@ -505,7 +505,7 @@ GeomLabel$default_aes$size
 
 You can change the size using the `size` argument in `geom_text()` for a single plot. If you want to use the same updated size, you can set this with `update_geom_defaults()`, e.g. `update_geom_defaults("text", list(size = 6))`.
 
-Note that this `size` is in **mm** while the `size` in `element_text()` is in pt. So, if you want to match `geom_text()`'s font size to the theme's, you need to divide the number by `.pt`. Please refer to ["Font size" section of the aesthetic specifications](https://ggplot2.tidyverse.org/articles/ggplot2-specs.html#font-size) for more details.
+Note that this `size` is in **mm** while the `size` of `element_text()` is in pt. So, if you want to match `geom_text()`'s font size to the theme's, you need to divide the number by `.pt`. Please refer to ["Font size" section of the aesthetic specifications](https://ggplot2.tidyverse.org/articles/ggplot2-specs.html#font-size) for more details.
 
 <details>
 


### PR DESCRIPTION
I think it's a common case that the user wants to customize both the size of theme and that of geoms. So, probably this FAQ should have some mention about the difference of the unit.

https://ggplot2.tidyverse.org/articles/faq-customising.html#fonts