### PR TITLE
Hotfix 3.4.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-# ggplot2 (development version)
+# ggplot2 3.4.4
+
+This hotfix release adapts to a change in r-devel's `base::is.atomic()` and 
+the upcoming retirement of maptools.
 
 * `fortify()` for sp objects (e.g., `SpatialPolygonsDataFrame`) is now deprecated
   and will be removed soon in support of [the upcoming retirement of rproj, rgeos,

--- a/R/aes-evaluation.R
+++ b/R/aes-evaluation.R
@@ -226,7 +226,7 @@ is_calculated <- function(x, warn = FALSE) {
     return(TRUE)
   }
   # Support of old recursive behaviour
-  if (is.atomic(x)) {
+  if (is.atomic(x) || is.null(x)) {
     FALSE
   } else if (is.symbol(x)) {
     res <- is_dotted_var(as.character(x))
@@ -266,7 +266,7 @@ is_staged <- function(x) {
 
 # Strip dots from expressions
 strip_dots <- function(expr, env, strip_pronoun = FALSE) {
-  if (is.atomic(expr)) {
+  if (is.atomic(expr) || is.null(expr)) {
     expr
   } else if (is.name(expr)) {
     expr_ch <- as.character(expr)
@@ -323,7 +323,7 @@ strip_stage <- function(expr) {
 make_labels <- function(mapping) {
   default_label <- function(aesthetic, mapping) {
     # e.g., geom_smooth(aes(colour = "loess")) or aes(y = NULL)
-    if (is.atomic(mapping)) {
+    if (is.atomic(mapping) || is.null(mapping)) {
       return(aesthetic)
     }
     mapping <- strip_stage(mapping)

--- a/R/aes.R
+++ b/R/aes.R
@@ -280,7 +280,7 @@ aes_ <- function(x, y, ...) {
   as_quosure_aes <- function(x) {
     if (is.formula(x) && length(x) == 2) {
       as_quosure(x)
-    } else if (is.call(x) || is.name(x) || is.atomic(x)) {
+    } else if (is.call(x) || is.name(x) || is.atomic(x) || is.null(x)) {
       new_aesthetic(x, caller_env)
     } else {
       cli::cli_abort("Aesthetic must be a one-sided formula, call, name, or constant.")

--- a/R/ggproto.R
+++ b/R/ggproto.R
@@ -298,7 +298,7 @@ object_summaries <- function(x, exclude = NULL, flat = TRUE) {
     else if (is.ggproto(obj)) format(obj, flat = flat)
     else if (is.environment(obj)) "environment"
     else if (is.null(obj)) "NULL"
-    else if (is.atomic(obj)) trim(paste(as.character(obj), collapse = " "))
+    else if (is.atomic(obj) || is.null(obj)) trim(paste(as.character(obj), collapse = " "))
     else paste(class(obj), collapse = ", ")
   }, FUN.VALUE = character(1))
 


### PR DESCRIPTION
This PR contains the changes needed for #5437.
Mostly, it just replaces `is.atomic(x)` by `is.atomic(x) || is.null(x)`. The one exception is in `check_breaks_labels()` where NULL can be matched with an atomic vector without problems.