### PR TITLE
Removes usage of stat_bin2d

### DIFF
--- a/R/coord-cartesian-.R
+++ b/R/coord-cartesian-.R
@@ -49,7 +49,7 @@
 #'
 #' # You can see the same thing with this 2d histogram
 #' d <- ggplot(diamonds, aes(carat, price)) +
-#'   stat_bin2d(bins = 25, colour = "white")
+#'   stat_bin_2d(bins = 25, colour = "white")
 #' d
 #'
 #' # When zooming the scale, the we get 25 new bins that are the same

--- a/R/geom-hex.R
+++ b/R/geom-hex.R
@@ -6,7 +6,7 @@
 #' the very regular alignment of [geom_bin2d()].
 #'
 #' @eval rd_aesthetics("geom", "hex")
-#' @seealso [stat_bin2d()] for rectangular binning
+#' @seealso [stat_bin_2d()] for rectangular binning
 #' @param geom,stat Override the default connection between `geom_hex()` and
 #'   `stat_binhex()`.
 #' @export

--- a/R/geom-tile.R
+++ b/R/geom-tile.R
@@ -60,8 +60,8 @@
 #' # Inspired by the image-density plots of Ken Knoblauch
 #' cars <- ggplot(mtcars, aes(mpg, factor(cyl)))
 #' cars + geom_point()
-#' cars + stat_bin2d(aes(fill = after_stat(count)), binwidth = c(3,1))
-#' cars + stat_bin2d(aes(fill = after_stat(density)), binwidth = c(3,1))
+#' cars + stat_bin_2d(aes(fill = after_stat(count)), binwidth = c(3,1))
+#' cars + stat_bin_2d(aes(fill = after_stat(density)), binwidth = c(3,1))
 #'
 #' cars +
 #'   stat_density(

--- a/R/stat-summary-2d.R
+++ b/R/stat-summary-2d.R
@@ -21,7 +21,7 @@
 #'   \item{`z`}{After binning, the z values of individual data points are no longer available.}
 #' }
 #' @seealso [stat_summary_hex()] for hexagonal summarization.
-#'   [stat_bin2d()] for the binning options.
+#'   [stat_bin_2d()] for the binning options.
 #' @inheritParams layer
 #' @inheritParams geom_point
 #' @inheritParams stat_bin_2d

--- a/man/coord_cartesian.Rd
+++ b/man/coord_cartesian.Rd
@@ -66,7 +66,7 @@ p + coord_cartesian(expand = FALSE)
 
 # You can see the same thing with this 2d histogram
 d <- ggplot(diamonds, aes(carat, price)) +
-  stat_bin2d(bins = 25, colour = "white")
+  stat_bin_2d(bins = 25, colour = "white")
 d
 
 # When zooming the scale, the we get 25 new bins that are the same

--- a/man/geom_hex.Rd
+++ b/man/geom_hex.Rd
@@ -133,5 +133,5 @@ d + geom_hex(binwidth = c(.1, 500))
 }
 }
 \seealso{
-\code{\link[=stat_bin2d]{stat_bin2d()}} for rectangular binning
+\code{\link[=stat_bin_2d]{stat_bin_2d()}} for rectangular binning
 }

--- a/man/geom_tile.Rd
+++ b/man/geom_tile.Rd
@@ -178,8 +178,8 @@ ggplot(df, aes(x, y, fill = z)) +
 # Inspired by the image-density plots of Ken Knoblauch
 cars <- ggplot(mtcars, aes(mpg, factor(cyl)))
 cars + geom_point()
-cars + stat_bin2d(aes(fill = after_stat(count)), binwidth = c(3,1))
-cars + stat_bin2d(aes(fill = after_stat(density)), binwidth = c(3,1))
+cars + stat_bin_2d(aes(fill = after_stat(count)), binwidth = c(3,1))
+cars + stat_bin_2d(aes(fill = after_stat(density)), binwidth = c(3,1))
 
 cars +
   stat_density(

--- a/man/hmisc.Rd
+++ b/man/hmisc.Rd
@@ -29,10 +29,10 @@ These are wrappers around functions from \pkg{Hmisc} designed to make them
 easier to use with \code{\link[=stat_summary]{stat_summary()}}. See the Hmisc documentation
 for more details:
 \itemize{
-\item \code{\link[Hmisc:smean.sd]{Hmisc::smean.cl.boot()}}
-\item \code{\link[Hmisc:smean.sd]{Hmisc::smean.cl.normal()}}
-\item \code{\link[Hmisc:smean.sd]{Hmisc::smean.sdl()}}
-\item \code{\link[Hmisc:smean.sd]{Hmisc::smedian.hilow()}}
+\item \code{\link[Hmisc:smean.cl.boot]{Hmisc::smean.cl.boot()}}
+\item \code{\link[Hmisc:smean.cl.normal]{Hmisc::smean.cl.normal()}}
+\item \code{\link[Hmisc:smean.sdl]{Hmisc::smean.sdl()}}
+\item \code{\link[Hmisc:smedian.hilow]{Hmisc::smedian.hilow()}}
 }
 }
 \examples{

--- a/man/stat_summary_2d.Rd
+++ b/man/stat_summary_2d.Rd
@@ -148,5 +148,5 @@ d + stat_summary_hex(fun = ~ sum(.x^2))
 }
 \seealso{
 \code{\link[=stat_summary_hex]{stat_summary_hex()}} for hexagonal summarization.
-\code{\link[=stat_bin2d]{stat_bin2d()}} for the binning options.
+\code{\link[=stat_bin_2d]{stat_bin_2d()}} for the binning options.
 }

--- a/tests/testthat/test-stat-bin2d.R
+++ b/tests/testthat/test-stat-bin2d.R
@@ -1,7 +1,7 @@
 test_that("binwidth is respected", {
   df <- data_frame(x = c(1, 1, 1, 2), y = c(1, 1, 1, 2))
   base <- ggplot(df, aes(x, y)) +
-    stat_bin2d(geom = "tile", binwidth = 0.25)
+    stat_bin_2d(geom = "tile", binwidth = 0.25)
 
   out <- layer_data(base)
   expect_equal(nrow(out), 2)
@@ -10,11 +10,11 @@ test_that("binwidth is respected", {
   expect_equal(out$xmax, c(1.25, 2), tolerance = 1e-7)
 
   p <- ggplot(df, aes(x, y)) +
-    stat_bin2d(geom = "tile", binwidth = c(0.25, 0.5, 0.75))
+    stat_bin_2d(geom = "tile", binwidth = c(0.25, 0.5, 0.75))
   expect_snapshot_warning(ggplot_build(p))
 
   p <- ggplot(df, aes(x, y)) +
-    stat_bin2d(geom = "tile", origin = c(0.25, 0.5, 0.75))
+    stat_bin_2d(geom = "tile", origin = c(0.25, 0.5, 0.75))
   expect_snapshot_warning(ggplot_build(p))
 })
 
@@ -26,7 +26,7 @@ test_that("breaks override binwidth", {
 
   df <- data_frame(x = 0:3, y = 0:3)
   base <- ggplot(df, aes(x, y)) +
-    stat_bin2d(
+    stat_bin_2d(
       breaks = list(x = integer_breaks, y = NULL),
       binwidth = c(0.5, 0.5)
     )


### PR DESCRIPTION
`stat_bin2d()` was renamed to `stat_bin_2d()` in 3c19a96a70c4c2595640fa5d8f7b39c81b72905b for consistency with other functions (#1274). Traces of this functions are still in the documentation. This PR removes them. 

A small issue is that the documentation still reads:

`stat_bin2d() understands the following aesthetics (required aesthetics are in bold):`

I think this is an issue with the name of the stat being `StatBin2d`, which is then "snakeyfied" to `stat_bin2d`. The fix is probably not trivial and I don't know if it's worth it. 
