### PR TITLE
Absent legend titles take up no space

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* Legend titles no longer take up space if they've been removed by setting 
+  `legend.title = element_blank()` (@teunbrand, #3587).
+
 * New function `check_device()` for testing the availability of advanced 
   graphics features introduced in R 4.1.0 onwards (@teunbrand, #5332).
 

--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -536,28 +536,32 @@ GuideLegend <- ggproto(
     )
     heights <- head(vec_interleave(!!!heights), -1)
 
-    # Measure title
-    title_width  <- width_cm(grobs$title)
-    title_height <- height_cm(grobs$title)
+    has_title <- !is.zero(grobs$title)
+    if (has_title) {
+      # Measure title
+      title_width  <- width_cm(grobs$title)
+      title_height <- height_cm(grobs$title)
 
-    # Combine title with rest of the sizes based on its position
-    widths <- switch(
-      params$title.position,
-      "left"  = c(title_width, hgap, widths),
-      "right" = c(widths, hgap, title_width),
-      c(widths, max(0, title_width - sum(widths)))
-    )
-    heights <- switch(
-      params$title.position,
-      "top"    = c(title_height, vgap, heights),
-      "bottom" = c(heights, vgap, title_height),
-      c(heights, max(0, title_height - sum(heights)))
-    )
+      # Combine title with rest of the sizes based on its position
+      widths <- switch(
+        params$title.position,
+        "left"  = c(title_width, hgap, widths),
+        "right" = c(widths, hgap, title_width),
+        c(widths, max(0, title_width - sum(widths)))
+      )
+      heights <- switch(
+        params$title.position,
+        "top"    = c(title_height, vgap, heights),
+        "bottom" = c(heights, vgap, title_height),
+        c(heights, max(0, title_height - sum(heights)))
+      )
+    }
 
     list(
       widths  = widths,
       heights = heights,
-      padding = elements$padding
+      padding = elements$padding,
+      has_title = has_title
     )
   },
 
@@ -603,29 +607,34 @@ GuideLegend <- ggproto(
     )
 
     # Offset layout based on title position
-    switch(
-      params$title.position,
-      "top" = {
-        key_row   <- key_row   + 2
-        label_row <- label_row + 2
-        title_row <- 2
-        title_col <- seq_along(sizes$widths) + 1
-      },
-      "bottom" = {
-        title_row <- length(sizes$heights)   + 1
-        title_col <- seq_along(sizes$widths) + 1
-      },
-      "left" = {
-        key_col   <- key_col   + 2
-        label_col <- label_col + 2
-        title_row <- seq_along(sizes$heights) + 1
-        title_col <- 2
-      },
-      "right" = {
-        title_row <- seq_along(sizes$heights) + 1
-        title_col <- length(sizes$widths)     + 1
-      }
-    )
+    if (sizes$has_title) {
+      switch(
+        params$title.position,
+        "top" = {
+          key_row   <- key_row   + 2
+          label_row <- label_row + 2
+          title_row <- 2
+          title_col <- seq_along(sizes$widths) + 1
+        },
+        "bottom" = {
+          title_row <- length(sizes$heights)   + 1
+          title_col <- seq_along(sizes$widths) + 1
+        },
+        "left" = {
+          key_col   <- key_col   + 2
+          label_col <- label_col + 2
+          title_row <- seq_along(sizes$heights) + 1
+          title_col <- 2
+        },
+        "right" = {
+          title_row <- seq_along(sizes$heights) + 1
+          title_col <- length(sizes$widths)     + 1
+        }
+      )
+    } else {
+      title_row <- NA
+      title_col <- NA
+    }
 
     df <- cbind(df, key_row, key_col, label_row, label_col)
 

--- a/tests/testthat/_snaps/guides/left-aligned-legend-key.svg
+++ b/tests/testthat/_snaps/guides/left-aligned-legend-key.svg
@@ -1,0 +1,119 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzIuNzl8NzE0LjUyfDUxLjAyfDU0NS4xMQ=='>
+    <rect x='32.79' y='51.02' width='681.73' height='494.09' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzIuNzl8NzE0LjUyfDUxLjAyfDU0NS4xMQ==)'>
+<rect x='32.79' y='51.02' width='681.73' height='494.09' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='32.79,482.51 714.52,482.51 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,386.95 714.52,386.95 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,291.38 714.52,291.38 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,195.81 714.52,195.81 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,100.24 714.52,100.24 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='185.75,545.11 185.75,51.02 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='340.34,545.11 340.34,51.02 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='494.93,545.11 494.93,51.02 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='649.52,545.11 649.52,51.02 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,530.30 714.52,530.30 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,434.73 714.52,434.73 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,339.16 714.52,339.16 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,243.59 714.52,243.59 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,148.02 714.52,148.02 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='32.79,52.46 714.52,52.46 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='108.46,545.11 108.46,51.02 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='263.05,545.11 263.05,51.02 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='417.64,545.11 417.64,51.02 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='572.23,545.11 572.23,51.02 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<circle cx='201.21' cy='320.05' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='201.21' cy='320.05' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='120.82' cy='285.64' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='352.71' cy='312.40' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='510.39' cy='364.01' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
+<circle cx='301.70' cy='375.48' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='510.39' cy='448.11' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
+<circle cx='180.65' cy='255.06' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='171.53' cy='285.64' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='212.96' cy='354.45' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='212.96' cy='381.21' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='380.23' cy='407.97' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
+<circle cx='380.23' cy='390.77' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
+<circle cx='380.23' cy='430.91' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
+<circle cx='683.53' cy='522.65' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
+<circle cx='664.98' cy='522.65' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
+<circle cx='634.06' cy='440.46' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
+<circle cx='75.53' cy='102.15' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='70.89' cy='140.38' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='63.78' cy='73.48' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='139.53' cy='310.49' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='445.46' cy='425.17' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
+<circle cx='423.82' cy='430.91' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
+<circle cx='494.93' cy='467.22' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
+<circle cx='572.23' cy='354.45' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
+<circle cx='75.99' cy='199.63' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='139.84' cy='224.48' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='100.88' cy='140.38' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='496.48' cy='419.44' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
+<circle cx='178.02' cy='344.90' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='419.18' cy='434.73' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
+<circle cx='140.92' cy='312.40' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='32.79,545.11 32.79,51.02 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<text x='27.86' y='533.33' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='27.86' y='437.76' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='27.86' y='342.19' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='27.86' y='246.62' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='27.86' y='151.05' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='27.86' y='55.48' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>35</text>
+<polyline points='30.05,530.30 32.79,530.30 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,434.73 32.79,434.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,339.16 32.79,339.16 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,243.59 32.79,243.59 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,148.02 32.79,148.02 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='30.05,52.46 32.79,52.46 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.79,545.11 714.52,545.11 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<polyline points='108.46,547.85 108.46,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='263.05,547.85 263.05,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='417.64,547.85 417.64,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='572.23,547.85 572.23,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='108.46' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='263.05' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
+<text x='417.64' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>300</text>
+<text x='572.23' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>400</text>
+<text x='373.66' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='20.18px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text transform='translate(13.05,298.07) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<rect x='32.79' y='22.78' width='88.44' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='32.79' y='22.78' width='17.28' height='17.28' style='stroke-width: 1.07; fill: #F2F2F2;' />
+<circle cx='41.43' cy='31.42' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<rect x='63.74' y='22.78' width='17.28' height='17.28' style='stroke-width: 1.07; fill: #F2F2F2;' />
+<circle cx='72.38' cy='31.42' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<rect x='94.68' y='22.78' width='17.28' height='17.28' style='stroke-width: 1.07; fill: #F2F2F2;' />
+<circle cx='103.32' cy='31.42' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
+<text x='54.46' y='34.45' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='85.40' y='34.45' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='116.34' y='34.45' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='32.79' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='131.37px' lengthAdjust='spacingAndGlyphs'>left aligned legend key</text>
+</g>
+</svg>

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -495,6 +495,22 @@ test_that("Axis titles won't be blown away by coord_*()", {
   # expect_doppelganger("guide titles with coord_sf()", plot + coord_sf())
 })
 
+test_that("absent titles don't take up space", {
+
+  p <- ggplot(mtcars, aes(disp, mpg, colour = factor(cyl))) +
+    geom_point() +
+    theme(
+      legend.title = element_blank(),
+      legend.margin = margin(),
+      legend.position = "top",
+      legend.justification = "left",
+      legend.key = element_rect(colour = "black"),
+      axis.line = element_line(colour = "black")
+    )
+
+  expect_doppelganger("left-aligned legend key", plot + coord_trans())
+})
+
 test_that("axis guides can be capped", {
   p <- ggplot(mtcars, aes(hp, disp)) +
     geom_point() +

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -508,7 +508,7 @@ test_that("absent titles don't take up space", {
       axis.line = element_line(colour = "black")
     )
 
-  expect_doppelganger("left-aligned legend key", plot + coord_trans())
+  expect_doppelganger("left aligned legend key", p)
 })
 
 test_that("axis guides can be capped", {


### PR DESCRIPTION
This PR aims to fix #3587.

Briefly, if the legend title produces a `<zeroGrob>` object, such as by setting `theme(legend.title = element_blank())`, it now no longer takes up space. This makes it easier to align legends to plot panels.

The implementation is pretty straightforward: all title-specific adjustments are made conditional.