### PR TITLE
More aesthetics for `geom_label()`

### DIFF
--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -2,7 +2,7 @@
 #' @rdname geom_text
 #' @param label.padding Amount of padding around label. Defaults to 0.25 lines.
 #' @param label.r Radius of rounded corners. Defaults to 0.15 lines.
-#' @param label.size `r lifecycle::badge("deprecated")` Please use `linewidth` to set the size of the border.
+#' @param label.size `r lifecycle::badge("deprecated")` Please use `linewidth` to set the width of the border.
 #' @param border.colour Colour of the label's border. If `NULL`, it will fall back to the text colour.
 #' @param border.color An alias for `border.colour`.
 geom_label <- function(mapping = NULL, data = NULL,

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -4,6 +4,7 @@
 #' @param label.r Radius of rounded corners. Defaults to 0.15 lines.
 #' @param label.size `r lifecycle::badge("deprecated")` Please use `linewidth` to set the size of the border.
 #' @param border_colour Colour of the label's border. If `NULL`, it will fall back to the text colour.
+#' @param border_color An alias for `border_colour`.
 geom_label <- function(mapping = NULL, data = NULL,
                        stat = "identity", position = "identity",
                        ...,

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -3,6 +3,7 @@
 #' @param label.padding Amount of padding around label. Defaults to 0.25 lines.
 #' @param label.r Radius of rounded corners. Defaults to 0.15 lines.
 #' @param label.size `r lifecycle::badge("deprecated")` Please use `linewidth`. Size of label border, in mm.
+#' @param border_colour Colour of the label's border. If `NULL`, it will fall back to the text colour.
 geom_label <- function(mapping = NULL, data = NULL,
                        stat = "identity", position = "identity",
                        ...,
@@ -13,9 +14,11 @@ geom_label <- function(mapping = NULL, data = NULL,
                        label.r = unit(0.15, "lines"),
                        label.size = 0.25,
                        size.unit = "mm",
+                       border_colour = NULL,
                        na.rm = FALSE,
                        show.legend = NA,
-                       inherit.aes = TRUE) {
+                       inherit.aes = TRUE,
+                       border_color = border_colour) {
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
       cli::cli_abort(c(
@@ -45,6 +48,7 @@ geom_label <- function(mapping = NULL, data = NULL,
       label.r = label.r,
       label.size = label.size,
       size.unit = size.unit,
+      border_colour = border_colour %||% border_color,
       na.rm = na.rm,
       ...
     )
@@ -71,8 +75,7 @@ GeomLabel <- ggproto("GeomLabel", Geom,
                         label.r = unit(0.15, "lines"),
                         label.size = 0.25,
                         size.unit = "mm",
-                        border_colour = NULL,
-                        border_color = border_colour) {
+                        border_colour = NULL) {
     lab <- data$label
     if (parse) {
       lab <- parse_safe(as.character(lab))
@@ -108,7 +111,7 @@ GeomLabel <- ggproto("GeomLabel", Geom,
           lineheight = row$lineheight
         ),
         rect.gp = gpar(
-          col = ifelse(row$linewidth == 0, NA, border_colour %||% border_color %||% row$colour),
+          col = ifelse(row$linewidth == 0, NA, border_colour %||% row$colour),
           fill = alpha(row$fill, row$alpha),
           lty = row$linetype,
           lwd = (row$linewidth %||% label.size) * .pt

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -62,7 +62,7 @@ GeomLabel <- ggproto("GeomLabel", Geom,
   default_aes = aes(
     colour = "black", fill = "white", size = 3.88, angle = 0,
     hjust = 0.5, vjust = 0.5, alpha = NA, family = "", fontface = 1,
-    lineheight = 1.2, linetype = "solid", linewidth = 0.25
+    lineheight = 1.2, linetype = 1, linewidth = 0.25
   ),
 
   draw_panel = function(self, data, panel_params, coord, parse = FALSE,

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -27,8 +27,8 @@ geom_label <- function(mapping = NULL, data = NULL,
     position <- position_nudge(nudge_x, nudge_y)
   }
 
-  if (!missing(label.size)) {
-    message("`label.size` is deprecated. Please use `linewidth` in the future.")
+  if (lifecycle::is_present(label.size)) {
+    deprecate_warn0("3.5.0", "geom_label(label.size)", "geom_label(linewidth)")
   }
 
   layer(

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -3,8 +3,8 @@
 #' @param label.padding Amount of padding around label. Defaults to 0.25 lines.
 #' @param label.r Radius of rounded corners. Defaults to 0.15 lines.
 #' @param label.size `r lifecycle::badge("deprecated")` Please use `linewidth` to set the size of the border.
-#' @param border_colour Colour of the label's border. If `NULL`, it will fall back to the text colour.
-#' @param border_color An alias for `border_colour`.
+#' @param border.colour Colour of the label's border. If `NULL`, it will fall back to the text colour.
+#' @param border.color An alias for `border.colour`.
 geom_label <- function(mapping = NULL, data = NULL,
                        stat = "identity", position = "identity",
                        ...,
@@ -15,11 +15,11 @@ geom_label <- function(mapping = NULL, data = NULL,
                        label.r = unit(0.15, "lines"),
                        label.size = deprecated(),
                        size.unit = "mm",
-                       border_colour = NULL,
+                       border.colour = NULL,
                        na.rm = FALSE,
                        show.legend = NA,
                        inherit.aes = TRUE,
-                       border_color = border_colour) {
+                       border.color = border.colour) {
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
       cli::cli_abort(c(
@@ -48,7 +48,7 @@ geom_label <- function(mapping = NULL, data = NULL,
       label.padding = label.padding,
       label.r = label.r,
       size.unit = size.unit,
-      border_colour = border_colour %||% border_color,
+      border.colour = border.colour %||% border.color,
       na.rm = na.rm,
       ...
     )
@@ -74,7 +74,7 @@ GeomLabel <- ggproto("GeomLabel", Geom,
                         label.padding = unit(0.25, "lines"),
                         label.r = unit(0.15, "lines"),
                         size.unit = "mm",
-                        border_colour = NULL) {
+                        border.colour = NULL) {
     lab <- data$label
     if (parse) {
       lab <- parse_safe(as.character(lab))
@@ -110,7 +110,7 @@ GeomLabel <- ggproto("GeomLabel", Geom,
           lineheight = row$lineheight
         ),
         rect.gp = gpar(
-          col = ifelse(row$linewidth == 0, NA, border_colour %||% row$colour),
+          col = ifelse(row$linewidth == 0, NA, border.colour %||% row$colour),
           fill = alpha(row$fill, row$alpha),
           lty = row$linetype,
           lwd = row$linewidth * .pt

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -2,7 +2,7 @@
 #' @rdname geom_text
 #' @param label.padding Amount of padding around label. Defaults to 0.25 lines.
 #' @param label.r Radius of rounded corners. Defaults to 0.15 lines.
-#' @param label.size `r lifecycle::badge("deprecated")` Please use `linewidth`. Size of label border, in mm.
+#' @param label.size `r lifecycle::badge("deprecated")` Please use `linewidth` to set the size of the border.
 #' @param border_colour Colour of the label's border. If `NULL`, it will fall back to the text colour.
 geom_label <- function(mapping = NULL, data = NULL,
                        stat = "identity", position = "identity",
@@ -12,7 +12,7 @@ geom_label <- function(mapping = NULL, data = NULL,
                        nudge_y = 0,
                        label.padding = unit(0.25, "lines"),
                        label.r = unit(0.15, "lines"),
-                       label.size = 0.25,
+                       label.size = deprecated(),
                        size.unit = "mm",
                        border_colour = NULL,
                        na.rm = FALSE,
@@ -46,7 +46,6 @@ geom_label <- function(mapping = NULL, data = NULL,
       parse = parse,
       label.padding = label.padding,
       label.r = label.r,
-      label.size = label.size,
       size.unit = size.unit,
       border_colour = border_colour %||% border_color,
       na.rm = na.rm,
@@ -73,7 +72,6 @@ GeomLabel <- ggproto("GeomLabel", Geom,
                         na.rm = FALSE,
                         label.padding = unit(0.25, "lines"),
                         label.r = unit(0.15, "lines"),
-                        label.size = 0.25,
                         size.unit = "mm",
                         border_colour = NULL) {
     lab <- data$label
@@ -114,7 +112,7 @@ GeomLabel <- ggproto("GeomLabel", Geom,
           col = ifelse(row$linewidth == 0, NA, border_colour %||% row$colour),
           fill = alpha(row$fill, row$alpha),
           lty = row$linetype,
-          lwd = (row$linewidth %||% label.size) * .pt
+          lwd = row$linewidth * .pt
         )
       )
     })

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -3,8 +3,7 @@
 #' @param label.padding Amount of padding around label. Defaults to 0.25 lines.
 #' @param label.r Radius of rounded corners. Defaults to 0.15 lines.
 #' @param label.size `r lifecycle::badge("deprecated")` Please use `linewidth` to set the width of the border.
-#' @param border.colour Colour of the label's border. If `NULL`, it will fall back to the text colour.
-#' @param border.color An alias for `border.colour`.
+#' @param border.colour,border.color Colour of the label's border. If `NULL` (default), it will fall back to the text colour. `border.color` is an alias.
 geom_label <- function(mapping = NULL, data = NULL,
                        stat = "identity", position = "identity",
                        ...,

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -2,7 +2,7 @@
 #' @rdname geom_text
 #' @param label.padding Amount of padding around label. Defaults to 0.25 lines.
 #' @param label.r Radius of rounded corners. Defaults to 0.15 lines.
-#' @param label.size Size of label border, in mm.
+#' @param label.size `r lifecycle::badge("deprecated")` Please use `linewidth`. Size of label border, in mm.
 geom_label <- function(mapping = NULL, data = NULL,
                        stat = "identity", position = "identity",
                        ...,
@@ -25,6 +25,10 @@ geom_label <- function(mapping = NULL, data = NULL,
     }
 
     position <- position_nudge(nudge_x, nudge_y)
+  }
+
+  if (!missing(label.size)) {
+    message("`label.size` is deprecated. Please use `linewidth` in the future.")
   }
 
   layer(
@@ -58,7 +62,7 @@ GeomLabel <- ggproto("GeomLabel", Geom,
   default_aes = aes(
     colour = "black", fill = "white", size = 3.88, angle = 0,
     hjust = 0.5, vjust = 0.5, alpha = NA, family = "", fontface = 1,
-    lineheight = 1.2
+    lineheight = 1.2, linetype = "solid", linewidth = 0.25
   ),
 
   draw_panel = function(self, data, panel_params, coord, parse = FALSE,
@@ -66,7 +70,9 @@ GeomLabel <- ggproto("GeomLabel", Geom,
                         label.padding = unit(0.25, "lines"),
                         label.r = unit(0.15, "lines"),
                         label.size = 0.25,
-                        size.unit = "mm") {
+                        size.unit = "mm",
+                        border_colour = NULL,
+                        border_color = border_colour) {
     lab <- data$label
     if (parse) {
       lab <- parse_safe(as.character(lab))
@@ -102,9 +108,10 @@ GeomLabel <- ggproto("GeomLabel", Geom,
           lineheight = row$lineheight
         ),
         rect.gp = gpar(
-          col = if (isTRUE(all.equal(label.size, 0))) NA else row$colour,
+          col = ifelse(row$linewidth == 0, NA, border_colour %||% border_color %||% row$colour),
           fill = alpha(row$fill, row$alpha),
-          lwd = label.size * .pt
+          lty = row$linetype,
+          lwd = (row$linewidth %||% label.size) * .pt
         )
       )
     })

--- a/R/geom-text.R
+++ b/R/geom-text.R
@@ -92,7 +92,7 @@
 #' # Use geom_label's border aesthetics to add highlights
 #' p + geom_label(
 #'   aes(fill = factor(cyl), linetype = qsec < 15),
-#'   border_colour = "black", color = "white", linewidth = 1) +
+#'   border.colour = "black", color = "white", linewidth = 1) +
 #' scale_linetype_manual(values=c("solid", "blank"), limits = TRUE, labels = "1/4 mi < 15s", name = NULL)
 #'
 #' # Multiple border aesthetics can be used
@@ -117,7 +117,7 @@
 #'     color = factor(x%%3),
 #'     linewidth = x%%2,
 #'     linetype = factor(x%%3)),
-#'     border_color = "red",
+#'     border.color = "red",
 #'     fill = NA) +
 #' scale_linewidth(range = c(0.5, 1.5)) +
 #' scale_linetype_manual(values = c("solid", "blank", "dotted"))

--- a/R/geom-text.R
+++ b/R/geom-text.R
@@ -89,38 +89,17 @@
 #'   scale_colour_discrete(l = 40)
 #' p + geom_label(aes(fill = factor(cyl)), colour = "white", fontface = "bold")
 #'
-#' # Use geom_label's border aesthetics to add highlights
+#' # If border.color is NULL or not set, the border will use the text color
+#' p + geom_label(aes(color = factor(cyl)))
+#'
+#' # Alternatively, border.color can have a static value
+#' p + geom_label(aes(color = factor(cyl)), border.color = "black")
+#'
+#' # Use linetype and linewidth aesthetics to add highlights
 #' p + geom_label(
 #'   aes(fill = factor(cyl), linetype = qsec < 15),
 #'   border.colour = "black", color = "white", linewidth = 1) +
 #' scale_linetype_manual(values=c("solid", "blank"), limits = TRUE, labels = "1/4 mi < 15s", name = NULL)
-#'
-#' # Multiple border aesthetics can be used
-#' ggplot(data.frame(x = 1:10, y = 1:10)) +
-#'   geom_label(aes(
-#'     label = month.abb[x],
-#'     x = x,
-#'     y = y,
-#'     color = factor(x%%3),
-#'     linewidth = x%%2,
-#'     linetype = factor(x%%3)),
-#'     fill = NA) +
-#' scale_linewidth(range = c(0.5, 1.5)) +
-#' scale_linetype_manual(values = c("solid", "blank", "dotted"))
-#'
-#' # Override the border color
-#' ggplot(data.frame(x = 1:10, y = 1:10)) +
-#'   geom_label(aes(
-#'     label = month.abb[x],
-#'     x = x,
-#'     y = y,
-#'     color = factor(x%%3),
-#'     linewidth = x%%2,
-#'     linetype = factor(x%%3)),
-#'     border.color = "red",
-#'     fill = NA) +
-#' scale_linewidth(range = c(0.5, 1.5)) +
-#' scale_linetype_manual(values = c("solid", "blank", "dotted"))
 #'
 #' p + geom_text(aes(size = wt))
 #' # Scale height of text, rather than sqrt(height)

--- a/R/geom-text.R
+++ b/R/geom-text.R
@@ -96,10 +96,12 @@
 #' p + geom_label(aes(colour = factor(cyl)), border.colour = "black")
 #'
 #' # Use linetype and linewidth aesthetics to add highlights
-#' p + geom_label(
-#'   aes(fill = factor(cyl), linetype = qsec < 15),
-#'   border.colour = "black", color = "white", linewidth = 1) +
-#' scale_linetype_manual(values=c("solid", "blank"), limits = TRUE, labels = "1/4 mi < 15s", name = NULL)
+#' p + 
+#'  geom_label(
+#'    aes(fill = factor(cyl), linetype = qsec < 15),
+#'    border.colour = "black", colour = "white"
+#'  ) +
+#'  scale_linetype_manual(values = c("solid", "blank"), limits = TRUE)
 #'
 #' p + geom_text(aes(size = wt))
 #' # Scale height of text, rather than sqrt(height)

--- a/R/geom-text.R
+++ b/R/geom-text.R
@@ -89,7 +89,13 @@
 #'   scale_colour_discrete(l = 40)
 #' p + geom_label(aes(fill = factor(cyl)), colour = "white", fontface = "bold")
 #'
-#' # Add aesthetics to the border for geom_label
+#' # Use geom_label's border aesthetics to add highlights
+#' p + geom_label(
+#'   aes(fill = factor(cyl), linetype = qsec < 15),
+#'   border_colour = "black", color = "white", linewidth = 1) +
+#' scale_linetype_manual(values=c("solid", "blank"), limits = TRUE, labels = "1/4 mi < 15s", name = NULL)
+#'
+#' # Multiple border aesthetics can be used
 #' ggplot(data.frame(x = 1:10, y = 1:10)) +
 #'   geom_label(aes(
 #'     label = month.abb[x],

--- a/R/geom-text.R
+++ b/R/geom-text.R
@@ -89,6 +89,35 @@
 #'   scale_colour_discrete(l = 40)
 #' p + geom_label(aes(fill = factor(cyl)), colour = "white", fontface = "bold")
 #'
+#' # Add aesthetics to the border for geom_label
+#' data.frame(x = 1:10, y = 1:10) |>
+#' ggplot() +
+#'   geom_label(aes(
+#'     label=month.abb[x],
+#'     x=x,
+#'     y=y,
+#'     color = factor(x%%3),
+#'     linewidth = x%%2,
+#'     linetype = factor(x%%3)),
+#'     fill = NA) +
+#' scale_linewidth(range=c(0.5, 1.5)) +
+#' scale_linetype_manual(values=c("solid", "blank", "dotted"))
+#'
+#' # Override the border color
+#' data.frame(x = 1:10, y = 1:10) |>
+#' ggplot() +
+#'   geom_label(aes(
+#'     label=month.abb[x],
+#'     x=x,
+#'     y=y,
+#'     color = factor(x%%3),
+#'     linewidth=x%%2,
+#'     linetype=factor(x%%3)),
+#'     border_color = "red",
+#'     fill=NA) +
+#' scale_linewidth(range=c(0.5, 1.5)) +
+#' scale_linetype_manual(values=c("solid", "blank", "dotted"))
+#'
 #' p + geom_text(aes(size = wt))
 #' # Scale height of text, rather than sqrt(height)
 #' p +

--- a/R/geom-text.R
+++ b/R/geom-text.R
@@ -90,8 +90,7 @@
 #' p + geom_label(aes(fill = factor(cyl)), colour = "white", fontface = "bold")
 #'
 #' # Add aesthetics to the border for geom_label
-#' data.frame(x = 1:10, y = 1:10) |>
-#' ggplot() +
+#' ggplot(data.frame(x = 1:10, y = 1:10)) +
 #'   geom_label(aes(
 #'     label=month.abb[x],
 #'     x=x,
@@ -104,8 +103,7 @@
 #' scale_linetype_manual(values=c("solid", "blank", "dotted"))
 #'
 #' # Override the border color
-#' data.frame(x = 1:10, y = 1:10) |>
-#' ggplot() +
+#' ggplot(data.frame(x = 1:10, y = 1:10)) +
 #'   geom_label(aes(
 #'     label=month.abb[x],
 #'     x=x,

--- a/R/geom-text.R
+++ b/R/geom-text.R
@@ -90,10 +90,10 @@
 #' p + geom_label(aes(fill = factor(cyl)), colour = "white", fontface = "bold")
 #'
 #' # If border.color is NULL or not set, the border will use the text color
-#' p + geom_label(aes(color = factor(cyl)))
+#' p + geom_label(aes(colour = factor(cyl)))
 #'
 #' # Alternatively, border.color can have a static value
-#' p + geom_label(aes(color = factor(cyl)), border.color = "black")
+#' p + geom_label(aes(colour = factor(cyl)), border.colour = "black")
 #'
 #' # Use linetype and linewidth aesthetics to add highlights
 #' p + geom_label(

--- a/R/geom-text.R
+++ b/R/geom-text.R
@@ -92,29 +92,29 @@
 #' # Add aesthetics to the border for geom_label
 #' ggplot(data.frame(x = 1:10, y = 1:10)) +
 #'   geom_label(aes(
-#'     label=month.abb[x],
-#'     x=x,
-#'     y=y,
+#'     label = month.abb[x],
+#'     x = x,
+#'     y = y,
 #'     color = factor(x%%3),
 #'     linewidth = x%%2,
 #'     linetype = factor(x%%3)),
 #'     fill = NA) +
-#' scale_linewidth(range=c(0.5, 1.5)) +
-#' scale_linetype_manual(values=c("solid", "blank", "dotted"))
+#' scale_linewidth(range = c(0.5, 1.5)) +
+#' scale_linetype_manual(values = c("solid", "blank", "dotted"))
 #'
 #' # Override the border color
 #' ggplot(data.frame(x = 1:10, y = 1:10)) +
 #'   geom_label(aes(
-#'     label=month.abb[x],
-#'     x=x,
-#'     y=y,
+#'     label = month.abb[x],
+#'     x = x,
+#'     y = y,
 #'     color = factor(x%%3),
-#'     linewidth=x%%2,
-#'     linetype=factor(x%%3)),
+#'     linewidth = x%%2,
+#'     linetype = factor(x%%3)),
 #'     border_color = "red",
-#'     fill=NA) +
-#' scale_linewidth(range=c(0.5, 1.5)) +
-#' scale_linetype_manual(values=c("solid", "blank", "dotted"))
+#'     fill = NA) +
+#' scale_linewidth(range = c(0.5, 1.5)) +
+#' scale_linetype_manual(values = c("solid", "blank", "dotted"))
 #'
 #' p + geom_text(aes(size = wt))
 #' # Scale height of text, rather than sqrt(height)

--- a/R/legend-draw.R
+++ b/R/legend-draw.R
@@ -269,7 +269,7 @@ draw_key_label <- function(data, params, size) {
       fontsize = (data$size %||% 3.88) * .pt
     ),
     rect.gp = gpar(
-      col = alpha(params$border_colour %||% params$border_color %||% "black", data$alpha),
+      col = alpha(params$border_colour %||% params$border_color %||% data$colour %||% "black", data$alpha),
       fill = alpha(data$fill %||% "white", data$alpha),
       lty = data$linetype,
       lwd = data$linewidth * .pt

--- a/R/legend-draw.R
+++ b/R/legend-draw.R
@@ -272,7 +272,7 @@ draw_key_label <- function(data, params, size) {
       col = alpha(params$border_colour %||% params$border_color %||% "black", data$alpha),
       fill = alpha(data$fill %||% "white", data$alpha),
       lty = data$linetype,
-      lwd = (data$linewidth %||%  params$label.size) * .pt
+      lwd = data$linewidth * .pt
     ),
     vp = NULL
   )

--- a/R/legend-draw.R
+++ b/R/legend-draw.R
@@ -252,17 +252,15 @@ draw_key_text <- function(data, params, size) {
 #' @export
 #' @rdname draw_key
 draw_key_label <- function(data, params, size) {
-  if(is.null(data$label))         data$label <- "a"
-  if(is.null(data$label.r))       data$label.r <- unit(0.1, "snpc")
   if(is.null(params$label.padding)) params$label.padding <- unit(0.25, "lines")
   if(length(params$label.padding) == 1) params$label.padding[2:4] <- params$label.padding
 
   labelGrob(
-    label = data$label,
+    label = data$label %||% "a",
     x = 0.5,
     y = 0.5,
     padding = params$label.padding,
-    r = data$label.r,
+    r = data$label.r %||% unit(0.1, "snpc"),
     angle = data$angle %||% 0,
     text.gp = gpar(
       col = alpha(data$colour %||% "white", data$alpha),

--- a/R/legend-draw.R
+++ b/R/legend-draw.R
@@ -269,7 +269,7 @@ draw_key_label <- function(data, params, size) {
       fontsize = (data$size %||% 3.88) * .pt
     ),
     rect.gp = gpar(
-      col = alpha(params$border_colour %||% params$border_color %||% data$colour %||% "black", data$alpha),
+      col = alpha(params$border.colour %||% params$border.color %||% data$colour %||% "black", data$alpha),
       fill = alpha(data$fill %||% "white", data$alpha),
       lty = data$linetype,
       lwd = data$linewidth * .pt

--- a/R/legend-draw.R
+++ b/R/legend-draw.R
@@ -252,9 +252,31 @@ draw_key_text <- function(data, params, size) {
 #' @export
 #' @rdname draw_key
 draw_key_label <- function(data, params, size) {
-  grobTree(
-    draw_key_rect(data, list()),
-    draw_key_text(data, list())
+  if(is.null(data$label))         data$label <- "a"
+  if(is.null(data$label.r))       data$label.r <- unit(0.1, "snpc")
+  if(is.null(params$label.padding)) params$label.padding <- unit(0.25, "lines")
+  if(length(params$label.padding) == 1) params$label.padding[2:4] <- params$label.padding
+
+  labelGrob(
+    label = data$label,
+    x = 0.5,
+    y = 0.5,
+    padding = params$label.padding,
+    r = data$label.r,
+    angle = data$angle %||% 0,
+    text.gp = gpar(
+      col = alpha(data$colour %||% "white", data$alpha),
+      fontfamily = data$family %||% "",
+      fontface = data$fontface %||% 1,
+      fontsize = (data$size %||% 3.88) * .pt
+    ),
+    rect.gp = gpar(
+      col = alpha(params$border_colour %||% params$border_color %||% "black", data$alpha),
+      fill = alpha(data$fill %||% "white", data$alpha),
+      lty = data$linetype,
+      lwd = (data$linewidth %||%  params$label.size) * .pt
+    ),
+    vp = NULL
   )
 }
 

--- a/man/geom_text.Rd
+++ b/man/geom_text.Rd
@@ -18,9 +18,11 @@ geom_label(
   label.r = unit(0.15, "lines"),
   label.size = 0.25,
   size.unit = "mm",
+  border_colour = NULL,
   na.rm = FALSE,
   show.legend = NA,
-  inherit.aes = TRUE
+  inherit.aes = TRUE,
+  border_color = border_colour
 )
 
 geom_text(
@@ -90,6 +92,8 @@ Cannot be jointly specified with \code{position}.}
 \item{size.unit}{How the \code{size} aesthetic is interpreted: as millimetres
 (\code{"mm"}, default), points (\code{"pt"}), centimetres (\code{"cm"}), inches (\code{"in"}),
 or picas (\code{"pc"}).}
+
+\item{border_colour}{Colour of the label's border. If \code{NULL}, it will fall back to the text colour.}
 
 \item{na.rm}{If \code{FALSE}, the default, missing values are removed with
 a warning. If \code{TRUE}, missing values are silently removed.}

--- a/man/geom_text.Rd
+++ b/man/geom_text.Rd
@@ -85,7 +85,7 @@ Cannot be jointly specified with \code{position}.}
 
 \item{label.r}{Radius of rounded corners. Defaults to 0.15 lines.}
 
-\item{label.size}{Size of label border, in mm.}
+\item{label.size}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Please use \code{linewidth}. Size of label border, in mm.}
 
 \item{size.unit}{How the \code{size} aesthetic is interpreted: as millimetres
 (\code{"mm"}, default), points (\code{"pt"}), centimetres (\code{"cm"}), inches (\code{"in"}),
@@ -206,6 +206,35 @@ p + geom_text(aes(colour = factor(cyl)))
 p + geom_text(aes(colour = factor(cyl))) +
   scale_colour_discrete(l = 40)
 p + geom_label(aes(fill = factor(cyl)), colour = "white", fontface = "bold")
+
+# Add aesthetics to the border for geom_label
+data.frame(x = 1:10, y = 1:10) |>
+ggplot() +
+  geom_label(aes(
+    label=month.abb[x],
+    x=x,
+    y=y,
+    color = factor(x\%\%3),
+    linewidth = x\%\%2,
+    linetype = factor(x\%\%3)),
+    fill = NA) +
+scale_linewidth(range=c(0.5, 1.5)) +
+scale_linetype_manual(values=c("solid", "blank", "dotted"))
+
+# Override the border color
+data.frame(x = 1:10, y = 1:10) |>
+ggplot() +
+  geom_label(aes(
+    label=month.abb[x],
+    x=x,
+    y=y,
+    color = factor(x\%\%3),
+    linewidth=x\%\%2,
+    linetype=factor(x\%\%3)),
+    border_color = "red",
+    fill=NA) +
+scale_linewidth(range=c(0.5, 1.5)) +
+scale_linetype_manual(values=c("solid", "blank", "dotted"))
 
 p + geom_text(aes(size = wt))
 # Scale height of text, rather than sqrt(height)

--- a/man/geom_text.Rd
+++ b/man/geom_text.Rd
@@ -213,7 +213,13 @@ p + geom_text(aes(colour = factor(cyl))) +
   scale_colour_discrete(l = 40)
 p + geom_label(aes(fill = factor(cyl)), colour = "white", fontface = "bold")
 
-# Add aesthetics to the border for geom_label
+# Use geom_label's border aesthetics to add highlights
+p + geom_label(
+  aes(fill = factor(cyl), linetype = qsec < 15),
+  border_colour = "black", color = "white", linewidth = 1) +
+scale_linetype_manual(values=c("solid", "blank"), limits = TRUE, labels = "1/4 mi < 15s", name = NULL)
+
+# Multiple border aesthetics can be used
 ggplot(data.frame(x = 1:10, y = 1:10)) +
   geom_label(aes(
     label = month.abb[x],

--- a/man/geom_text.Rd
+++ b/man/geom_text.Rd
@@ -213,38 +213,17 @@ p + geom_text(aes(colour = factor(cyl))) +
   scale_colour_discrete(l = 40)
 p + geom_label(aes(fill = factor(cyl)), colour = "white", fontface = "bold")
 
-# Use geom_label's border aesthetics to add highlights
+# If border.color is NULL or not set, the border will use the text color
+p + geom_label(aes(color = factor(cyl)))
+
+# Alternatively, border.color can have a static value
+p + geom_label(aes(color = factor(cyl)), border.color = "black")
+
+# Use linetype and linewidth aesthetics to add highlights
 p + geom_label(
   aes(fill = factor(cyl), linetype = qsec < 15),
   border.colour = "black", color = "white", linewidth = 1) +
 scale_linetype_manual(values=c("solid", "blank"), limits = TRUE, labels = "1/4 mi < 15s", name = NULL)
-
-# Multiple border aesthetics can be used
-ggplot(data.frame(x = 1:10, y = 1:10)) +
-  geom_label(aes(
-    label = month.abb[x],
-    x = x,
-    y = y,
-    color = factor(x\%\%3),
-    linewidth = x\%\%2,
-    linetype = factor(x\%\%3)),
-    fill = NA) +
-scale_linewidth(range = c(0.5, 1.5)) +
-scale_linetype_manual(values = c("solid", "blank", "dotted"))
-
-# Override the border color
-ggplot(data.frame(x = 1:10, y = 1:10)) +
-  geom_label(aes(
-    label = month.abb[x],
-    x = x,
-    y = y,
-    color = factor(x\%\%3),
-    linewidth = x\%\%2,
-    linetype = factor(x\%\%3)),
-    border.color = "red",
-    fill = NA) +
-scale_linewidth(range = c(0.5, 1.5)) +
-scale_linetype_manual(values = c("solid", "blank", "dotted"))
 
 p + geom_text(aes(size = wt))
 # Scale height of text, rather than sqrt(height)

--- a/man/geom_text.Rd
+++ b/man/geom_text.Rd
@@ -214,29 +214,29 @@ p + geom_label(aes(fill = factor(cyl)), colour = "white", fontface = "bold")
 # Add aesthetics to the border for geom_label
 ggplot(data.frame(x = 1:10, y = 1:10)) +
   geom_label(aes(
-    label=month.abb[x],
-    x=x,
-    y=y,
+    label = month.abb[x],
+    x = x,
+    y = y,
     color = factor(x\%\%3),
     linewidth = x\%\%2,
     linetype = factor(x\%\%3)),
     fill = NA) +
-scale_linewidth(range=c(0.5, 1.5)) +
-scale_linetype_manual(values=c("solid", "blank", "dotted"))
+scale_linewidth(range = c(0.5, 1.5)) +
+scale_linetype_manual(values = c("solid", "blank", "dotted"))
 
 # Override the border color
 ggplot(data.frame(x = 1:10, y = 1:10)) +
   geom_label(aes(
-    label=month.abb[x],
-    x=x,
-    y=y,
+    label = month.abb[x],
+    x = x,
+    y = y,
     color = factor(x\%\%3),
-    linewidth=x\%\%2,
-    linetype=factor(x\%\%3)),
+    linewidth = x\%\%2,
+    linetype = factor(x\%\%3)),
     border_color = "red",
-    fill=NA) +
-scale_linewidth(range=c(0.5, 1.5)) +
-scale_linetype_manual(values=c("solid", "blank", "dotted"))
+    fill = NA) +
+scale_linewidth(range = c(0.5, 1.5)) +
+scale_linetype_manual(values = c("solid", "blank", "dotted"))
 
 p + geom_text(aes(size = wt))
 # Scale height of text, rather than sqrt(height)

--- a/man/geom_text.Rd
+++ b/man/geom_text.Rd
@@ -109,6 +109,8 @@ rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 
+\item{border_color}{An alias for \code{border_colour}.}
+
 \item{check_overlap}{If \code{TRUE}, text that overlaps previous text in the
 same layer will not be plotted. \code{check_overlap} happens at draw time and in
 the order of the data. Therefore data should be arranged by the label

--- a/man/geom_text.Rd
+++ b/man/geom_text.Rd
@@ -16,7 +16,7 @@ geom_label(
   nudge_y = 0,
   label.padding = unit(0.25, "lines"),
   label.r = unit(0.15, "lines"),
-  label.size = 0.25,
+  label.size = deprecated(),
   size.unit = "mm",
   border_colour = NULL,
   na.rm = FALSE,
@@ -87,7 +87,7 @@ Cannot be jointly specified with \code{position}.}
 
 \item{label.r}{Radius of rounded corners. Defaults to 0.15 lines.}
 
-\item{label.size}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Please use \code{linewidth}. Size of label border, in mm.}
+\item{label.size}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Please use \code{linewidth} to set the size of the border.}
 
 \item{size.unit}{How the \code{size} aesthetic is interpreted: as millimetres
 (\code{"mm"}, default), points (\code{"pt"}), centimetres (\code{"cm"}), inches (\code{"in"}),

--- a/man/geom_text.Rd
+++ b/man/geom_text.Rd
@@ -208,8 +208,7 @@ p + geom_text(aes(colour = factor(cyl))) +
 p + geom_label(aes(fill = factor(cyl)), colour = "white", fontface = "bold")
 
 # Add aesthetics to the border for geom_label
-data.frame(x = 1:10, y = 1:10) |>
-ggplot() +
+ggplot(data.frame(x = 1:10, y = 1:10)) +
   geom_label(aes(
     label=month.abb[x],
     x=x,
@@ -222,8 +221,7 @@ scale_linewidth(range=c(0.5, 1.5)) +
 scale_linetype_manual(values=c("solid", "blank", "dotted"))
 
 # Override the border color
-data.frame(x = 1:10, y = 1:10) |>
-ggplot() +
+ggplot(data.frame(x = 1:10, y = 1:10)) +
   geom_label(aes(
     label=month.abb[x],
     x=x,

--- a/man/geom_text.Rd
+++ b/man/geom_text.Rd
@@ -18,11 +18,11 @@ geom_label(
   label.r = unit(0.15, "lines"),
   label.size = deprecated(),
   size.unit = "mm",
-  border_colour = NULL,
+  border.colour = NULL,
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE,
-  border_color = border_colour
+  border.color = border.colour
 )
 
 geom_text(
@@ -93,7 +93,7 @@ Cannot be jointly specified with \code{position}.}
 (\code{"mm"}, default), points (\code{"pt"}), centimetres (\code{"cm"}), inches (\code{"in"}),
 or picas (\code{"pc"}).}
 
-\item{border_colour}{Colour of the label's border. If \code{NULL}, it will fall back to the text colour.}
+\item{border.colour}{Colour of the label's border. If \code{NULL}, it will fall back to the text colour.}
 
 \item{na.rm}{If \code{FALSE}, the default, missing values are removed with
 a warning. If \code{TRUE}, missing values are silently removed.}
@@ -109,7 +109,7 @@ rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 
-\item{border_color}{An alias for \code{border_colour}.}
+\item{border.color}{An alias for \code{border.colour}.}
 
 \item{check_overlap}{If \code{TRUE}, text that overlaps previous text in the
 same layer will not be plotted. \code{check_overlap} happens at draw time and in
@@ -216,7 +216,7 @@ p + geom_label(aes(fill = factor(cyl)), colour = "white", fontface = "bold")
 # Use geom_label's border aesthetics to add highlights
 p + geom_label(
   aes(fill = factor(cyl), linetype = qsec < 15),
-  border_colour = "black", color = "white", linewidth = 1) +
+  border.colour = "black", color = "white", linewidth = 1) +
 scale_linetype_manual(values=c("solid", "blank"), limits = TRUE, labels = "1/4 mi < 15s", name = NULL)
 
 # Multiple border aesthetics can be used
@@ -241,7 +241,7 @@ ggplot(data.frame(x = 1:10, y = 1:10)) +
     color = factor(x\%\%3),
     linewidth = x\%\%2,
     linetype = factor(x\%\%3)),
-    border_color = "red",
+    border.color = "red",
     fill = NA) +
 scale_linewidth(range = c(0.5, 1.5)) +
 scale_linetype_manual(values = c("solid", "blank", "dotted"))

--- a/man/ggsf.Rd
+++ b/man/ggsf.Rd
@@ -236,7 +236,7 @@ Cannot be jointly specified with \code{position}.}
 
 \item{label.r}{Radius of rounded corners. Defaults to 0.15 lines.}
 
-\item{label.size}{Size of label border, in mm.}
+\item{label.size}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Please use \code{linewidth} to set the size of the border.}
 
 \item{fun.geometry}{A function that takes a \code{sfc} object and returns a \code{sfc_POINT} with the
 same length as the input. If \code{NULL}, \code{function(x) sf::st_point_on_surface(sf::st_zm(x))}


### PR DESCRIPTION
# Updates to `geom_label()`'s aesthetics and parameters

1. The legend keys for `geom_label()` now have the same rounded rectangle shape and aesthetics as the labels.  (See questions below)

**Old:** ![image](https://github.com/tidyverse/ggplot2/assets/2257540/3f03286a-db9c-4745-8bc6-6268814f2f3e)     **New:** ![image](https://github.com/tidyverse/ggplot2/assets/2257540/05480df3-eb43-4810-ba59-25c6ea8378bd)

2. Deprecated `label.size`. Use `linewidth` instead, which is more consistent with the rest of ggplot. ~~If `linewidth` is not set, it'll fall back to `label.size`, so nothing should break.~~ Update: setting up a soft deprecation fallback was too messy when going from an argument to an aesthetic, so I fully deprecated `label.size`.

3. New aesthetic: `linetype` for the label border. Default: "solid". Addresses #5365

4. New parameter: `border_colour` is the color of the label's border and is decoupled from the text color. If the value is `NULL` or not set, it will fall back to the text color, which is how it worked previously. Hopefully, that will avoid any breaking changes.

5. I added three examples to the docs. The mtcars graphs are too crowded to show off all the new aesthetics, so I made a dummy dataset for the latter two:

```r
ggplot(mtcars, aes(wt, mpg, label = rownames(mtcars))) +
geom_label(
  aes(fill = factor(cyl), linetype = qsec < 15),
  border_colour = "black", color = "white", linewidth = 1) +
scale_linetype_manual(values=c("solid", "blank"), limits = TRUE, labels = "1/4 mi < 15s", name = NULL)
```
![image](https://github.com/tidyverse/ggplot2/assets/2257540/c337fed7-2632-4455-8ffe-5172a95759c4)


```r
# Add aesthetics to the border for geom_label
data.frame(x = 1:10, y = 1:10) |>
ggplot() +
  geom_label(aes(
    label=month.abb[x],
    x=x,
    y=y,
    color = factor(x%%3),
    linewidth = x%%2,
    linetype = factor(x%%3)),
    fill = NA) +
scale_linewidth(range=c(0.5, 1.5)) +
scale_linetype_manual(values=c("solid", "blank", "dotted"))
```
![image](https://github.com/tidyverse/ggplot2/assets/2257540/fbf6fb35-2aca-4833-a8b4-b7343912371a)

```r

# Override the border color
data.frame(x = 1:10, y = 1:10) |>
ggplot() +
  geom_label(aes(
    label=month.abb[x],
    x=x,
    y=y,
    color = factor(x%%3),
    linewidth=x%%2,
    linetype=factor(x%%3)),
    border_color = "red",
    fill=NA) +
scale_linewidth(range=c(0.5, 1.5)) +
scale_linetype_manual(values=c("solid", "blank", "dotted"))
```
![image](https://github.com/tidyverse/ggplot2/assets/2257540/ebd3e4ce-72f0-4fba-abe4-0f5b86a5de8c)


# Questions:
1. ~~Does the deprecated messaging look right for label.size?~~
1. There is a bug where the key_glyph is cropped at the bottom. Can anyone help with that?
1. ~~Are the aliases border_colour/border_color dealt with appropriately?~~