### PR TITLE
Use text margin to space apart key-labels and guide-title

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # ggplot2 (development version)
 
+* The spacing between legend keys and their labels, in addition to legends
+  and their titles, is now controlled by the text's `margin` setting. Not
+  specifying margins will automatically add appropriate text margins. This
+  leaves the `legend.spacing` dedicated to controlling the spacing between
+  different keys (#5455).
+
 * New function `check_device()` for testing the availability of advanced 
   graphics features introduced in R 4.1.0 onwards (@teunbrand, #5332).
 

--- a/R/guide-colorbar.R
+++ b/R/guide-colorbar.R
@@ -429,17 +429,10 @@ GuideColourbar <- ggproto(
       return(list(labels = zeroGrob()))
     }
 
-    just <- if (params$direction == "horizontal") {
-      elements$text$vjust
-    } else {
-      elements$text$hjust
-    }
-
     list(labels = flip_element_grob(
       elements$text,
       label = validate_labels(key$.label),
       x = unit(key$.value, "npc"),
-      y = rep(just, nrow(key)),
       margin_x = FALSE,
       margin_y = TRUE,
       flip = params$direction == "vertical"

--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -532,8 +532,8 @@ GuideLegend <- ggproto(
     hgap <- elements$hgap %||% 0
     widths <- switch(
       params$label.position,
-      "left"   = list(label_widths, hgap, widths, hgap),
-      "right"  = list(widths, hgap, label_widths, hgap),
+      "left"   = list(label_widths, widths, hgap),
+      "right"  = list(widths, label_widths, hgap),
       list(pmax(label_widths, widths), hgap * (!byrow))
     )
     widths  <- head(vec_interleave(!!!widths),  -1)
@@ -541,8 +541,8 @@ GuideLegend <- ggproto(
     vgap <- elements$vgap %||% 0
     heights <- switch(
       params$label.position,
-      "top"    = list(label_heights, vgap, heights, vgap),
-      "bottom" = list(heights, vgap, label_heights, vgap),
+      "top"    = list(label_heights, heights, vgap),
+      "bottom" = list(heights, label_heights, vgap),
       list(pmax(label_heights, heights), vgap * (byrow))
     )
     heights <- head(vec_interleave(!!!heights), -1)
@@ -554,14 +554,14 @@ GuideLegend <- ggproto(
     # Combine title with rest of the sizes based on its position
     widths <- switch(
       params$title.position,
-      "left"  = c(title_width, hgap, widths),
-      "right" = c(widths, hgap, title_width),
+      "left"  = c(title_width, widths),
+      "right" = c(widths, title_width),
       c(widths, max(0, title_width - sum(widths)))
     )
     heights <- switch(
       params$title.position,
-      "top"    = c(title_height, vgap, heights),
-      "bottom" = c(heights, vgap, title_height),
+      "top"    = c(title_height, heights),
+      "bottom" = c(heights, title_height),
       c(heights, max(0, title_height - sum(heights)))
     )
 
@@ -596,20 +596,20 @@ GuideLegend <- ggproto(
     switch(
       params$label.position,
       "top" = {
-        key_row   <- key_row   * 2
-        label_row <- label_row * 2 - 2
+        key_row   <- key_row + df$R
+        label_row <- key_row - 1
       },
       "bottom" = {
-        key_row   <- key_row   * 2 - 2
-        label_row <- label_row * 2
+        key_row   <- key_row + df$R - 1
+        label_row <- key_row + 1
       },
       "left" = {
-        key_col   <- key_col   * 2
-        label_col <- label_col * 2 - 2
+        key_col   <- key_col + df$C
+        label_col <- key_col - 1
       },
       "right" = {
-        key_col   <- key_col   * 2 - 2
-        label_col <- label_col * 2
+        key_col   <- key_col + df$C - 1
+        label_col <- key_col + 1
       }
     )
 
@@ -617,8 +617,8 @@ GuideLegend <- ggproto(
     switch(
       params$title.position,
       "top" = {
-        key_row   <- key_row   + 2
-        label_row <- label_row + 2
+        key_row   <- key_row   + 1
+        label_row <- label_row + 1
         title_row <- 2
         title_col <- seq_along(sizes$widths) + 1
       },
@@ -627,8 +627,8 @@ GuideLegend <- ggproto(
         title_col <- seq_along(sizes$widths) + 1
       },
       "left" = {
-        key_col   <- key_col   + 2
-        label_col <- label_col + 2
+        key_col   <- key_col   + 1
+        label_col <- label_col + 1
         title_row <- seq_along(sizes$heights) + 1
         title_col <- 2
       },

--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -437,6 +437,17 @@ GuideLegend <- ggproto(
       "cm", valueOnly = TRUE
     )
 
+    if (is.null(params$label.theme$margin %||% theme$legend.text$margin) &&
+        !inherits(elements$text, "element_blank")) {
+      i <- match(params$label.position, .trbl[c(3, 4, 1, 2)])
+      elements$text$margin[i] <- elements$text$margin[i] + gap
+    }
+    if (is.null(params$title.theme$margin %||% theme$legend.title$margin) &&
+        !inherits(elements$title, "element_blank")) {
+      i <- match(params$title.position, .trbl[c(3, 4, 1, 2)])
+      elements$title$margin[i] <- elements$title$margin[i] + gap
+    }
+
     # Evaluate backgrounds early
     if (!is.null(elements$background)) {
       elements$background <- ggname(

--- a/tests/testthat/_snaps/guides/rotated-guide-titles-and-labels.svg
+++ b/tests/testthat/_snaps/guides/rotated-guide-titles-and-labels.svg
@@ -79,11 +79,11 @@
 <polyline points='651.72,330.58 655.18,330.58 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
 <polyline points='651.72,309.05 655.18,309.05 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
 <polyline points='651.72,287.52 655.18,287.52 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<text transform='translate(672.37,373.63) rotate(-270)' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
-<text transform='translate(672.37,352.10) rotate(-270)' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
-<text transform='translate(672.37,330.58) rotate(-270)' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
-<text transform='translate(672.37,309.05) rotate(-270)' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>12.5</text>
-<text transform='translate(672.37,287.52) rotate(-270)' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>15.0</text>
+<text transform='translate(676.31,373.63) rotate(-270)' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text transform='translate(676.31,352.10) rotate(-270)' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
+<text transform='translate(676.31,330.58) rotate(-270)' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<text transform='translate(676.31,309.05) rotate(-270)' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>12.5</text>
+<text transform='translate(676.31,287.52) rotate(-270)' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>15.0</text>
 <text x='40.13' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='171.72px' lengthAdjust='spacingAndGlyphs'>rotated guide titles and labels</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/guides/vertical-gap-of-1cm-between-guide-title-and-guide.svg
+++ b/tests/testthat/_snaps/guides/vertical-gap-of-1cm-between-guide-title-and-guide.svg
@@ -55,35 +55,35 @@
 <text x='634.67' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
 <text x='349.23' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
 <text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
-<rect x='674.17' y='162.45' width='34.99' height='124.60' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='674.17' y='171.17' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
-<image width='17.28' height='86.40' x='674.17' y='200.65' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAmElEQVQ4ja2UQRLDMAgDd3hk/tnX5agcknFaCoa0vnkMCEnGsL12GQhDYDpPwoDrpBFlRDWi/9Wu6AHC9FkLYLrzlhD3oJ3mDvRHRYy7IC8A7bCK8gpWKYDzeQVArDcDyD2YAnSofZvzaOA6Q7Oahp/dmRuVTQ0xU5TGP2o8Waool1obVuv1q8qP9xPvg633XlGLDtfIhNUBcBeA5ss0BXMAAAAASUVORK5CYII='/>
-<polyline points='691.45,286.91 688.00,286.91 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='691.45,265.38 688.00,265.38 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='691.45,243.85 688.00,243.85 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='691.45,222.33 688.00,222.33 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='691.45,200.80 688.00,200.80 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='674.17,286.91 677.63,286.91 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='674.17,265.38 677.63,265.38 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='674.17,243.85 677.63,243.85 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='674.17,222.33 677.63,222.33 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<polyline points='674.17,200.80 677.63,200.80 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<text x='696.93' y='289.94' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='696.93' y='268.41' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
-<text x='696.93' y='246.88' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
-<text x='696.93' y='225.35' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
-<text x='696.93' y='203.83' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
-<rect x='674.17' y='315.40' width='40.35' height='90.04' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='674.17' y='324.11' style='font-size: 11.00px; font-family: sans;' textLength='40.35px' lengthAdjust='spacingAndGlyphs'>factor(x)</text>
-<rect x='674.17' y='353.60' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<circle cx='682.81' cy='362.24' r='1.95' style='stroke-width: 0.71; stroke: #F8766D;' />
-<rect x='674.17' y='370.88' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<circle cx='682.81' cy='379.52' r='1.95' style='stroke-width: 0.71; stroke: #00BA38;' />
-<rect x='674.17' y='388.16' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<circle cx='682.81' cy='396.80' r='1.95' style='stroke-width: 0.71; stroke: #619CFF;' />
-<text x='696.93' y='365.27' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='696.93' y='382.55' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='696.93' y='399.83' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<rect x='674.17' y='171.15' width='34.99' height='124.60' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='674.17' y='179.86' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
+<image width='17.28' height='86.40' x='674.17' y='209.35' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAmElEQVQ4ja2UQRLDMAgDd3hk/tnX5agcknFaCoa0vnkMCEnGsL12GQhDYDpPwoDrpBFlRDWi/9Wu6AHC9FkLYLrzlhD3oJ3mDvRHRYy7IC8A7bCK8gpWKYDzeQVArDcDyD2YAnSofZvzaOA6Q7Oahp/dmRuVTQ0xU5TGP2o8Waool1obVuv1q8qP9xPvg633XlGLDtfIhNUBcBeA5ss0BXMAAAAASUVORK5CYII='/>
+<polyline points='691.45,295.60 688.00,295.60 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='691.45,274.08 688.00,274.08 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='691.45,252.55 688.00,252.55 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='691.45,231.02 688.00,231.02 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='691.45,209.49 688.00,209.49 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='674.17,295.60 677.63,295.60 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='674.17,274.08 677.63,274.08 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='674.17,252.55 677.63,252.55 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='674.17,231.02 677.63,231.02 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='674.17,209.49 677.63,209.49 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='696.93' y='298.63' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='696.93' y='277.10' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='696.93' y='255.58' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text x='696.93' y='234.05' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='696.93' y='212.52' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<rect x='674.17' y='306.71' width='40.35' height='90.04' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='674.17' y='315.42' style='font-size: 11.00px; font-family: sans;' textLength='40.35px' lengthAdjust='spacingAndGlyphs'>factor(x)</text>
+<rect x='674.17' y='344.91' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='682.81' cy='353.55' r='1.95' style='stroke-width: 0.71; stroke: #F8766D;' />
+<rect x='674.17' y='362.19' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='682.81' cy='370.83' r='1.95' style='stroke-width: 0.71; stroke: #00BA38;' />
+<rect x='674.17' y='379.47' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='682.81' cy='388.11' r='1.95' style='stroke-width: 0.71; stroke: #619CFF;' />
+<text x='696.93' y='356.58' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='696.93' y='373.86' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='696.93' y='391.14' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
 <text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='286.21px' lengthAdjust='spacingAndGlyphs'>vertical gap of 1cm between guide title and guide</text>
 </g>
 </svg>

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -601,10 +601,10 @@ test_that("guides title and text are positioned correctly", {
       scale_fill_continuous(name = "the\ncontinuous\ncolorscale")
   )
   expect_doppelganger("vertical gap of 1cm between guide title and guide",
-    p + theme(legend.spacing.y = grid::unit(1, "cm"))
+    p + theme(legend.title = element_text(margin = margin(b = 1, unit = "cm")))
   )
   expect_doppelganger("horizontal gap of 1cm between guide and guide text",
-    p + theme(legend.spacing.x = grid::unit(1, "cm"))
+    p + theme(legend.text = element_text(margin = margin(l = 1, unit = "cm")))
   )
 
   # now test label positioning, alignment, etc
@@ -619,8 +619,8 @@ test_that("guides title and text are positioned correctly", {
 
   expect_doppelganger("guide title and text positioning and alignment via themes",
     p + theme(
-      legend.title = element_text(hjust = 0.5, margin = margin(t = 30)),
-      legend.text = element_text(hjust = 1, margin = margin(l = 5, t = 10, b = 10))
+      legend.title = element_text(hjust = 0.5, margin = margin(t = 30, b = 5.5)),
+      legend.text = element_text(hjust = 1, margin = margin(l = 10.5, t = 10, b = 10))
     )
   )
 


### PR DESCRIPTION
This PR is a first step at refactoring #5283 to be less aggressive in terms of visual changes.
Inadvertently, it also fixes #5455.

![image](https://github.com/tidyverse/ggplot2/assets/49372158/74906047-8ed8-4277-a289-2e0e6cb950c5)

Briefly, this PR detaches the spacing from keys to labels and from titles to guides from the `legend.spacing.{x/y}` setting. Instead, the legend text/title's `margin` argument controls this particular spacing. It technically introduces a visual change, but keeps the defaults close to what they are.

Some details; this idea was coined by Claus in https://github.com/tidyverse/ggplot2/issues/3587#issuecomment-546700387. The gist of this PR is that it looks if user declared an explicit margin in the theme or guide, and if they didn't, it sets a default margin that is visually equivalent to current defaults. Since it now omits `legend.spacing.{x/y}` between key and label, this means `legend.spacing.{x/y}` is solely dedicated to the spacing between key-label pairs. In contrast to #5283, this wouldn't need to introduce a new text spacing concept, as it is captured in the margins.

There are two visual changes in the tests:
* One related to fixing #5455.
* One related to guide-to-guide spacing, which I don't quite understand at the moment.