### PR TITLE
Add default aesthetic values to geom docs

### DIFF
--- a/R/utilities-help.R
+++ b/R/utilities-help.R
@@ -28,10 +28,14 @@ rd_aesthetics_item <- function(x) {
   optional_aes <- setdiff(x$aesthetics(), req_aes)
   all <- union(req, sort(optional_aes))
   docs <- rd_match_docpage(all)
+  default_values <- ifelse(all %in% names(x$default_aes),
+    paste0(": \\code{", x$default_aes[all], "}"),
+    ""
+  )
 
   item <- ifelse(all %in% req,
     paste0("\\strong{\\code{", docs, "}}"),
-    paste0("\\code{", docs, "}")
+    paste0("\\code{", docs, "}", default_values)
   )
 }
 


### PR DESCRIPTION
A common problem, especially for beginner users, is that you make a plot using default aesthetic values, but then you want to adjust them by a relative amount. For example, you make a plot with `geom_point()`, but you want the points to be 50% larger. Is the default size 1? 0.01 (proportion of the chart size)? 10 (pixels)? If you don't know the default value, it's tough to know even what order of magnitude to set the new value to.

**So, this update adds the default value next to each aesthetic listed in the docs.**

It'll impact every geom's documentation, so I wanted to discuss it here before pushing all the generated .RD files.

Questions:
* Any reason not to?
* How should the default value to appear?

Here are some options for listing the default value (screenshots from RStudio):

descriptive: ![image](https://github.com/tidyverse/ggplot2/assets/2257540/2e31d8f8-c16d-4055-b30e-2f9fbf9b71e7)

low clutter: ![image](https://github.com/tidyverse/ggplot2/assets/2257540/002a6008-4f8f-4919-ae1d-56e863b9f08c)

low clutter with message at bottom: ![image](https://github.com/tidyverse/ggplot2/assets/2257540/3ef9b86b-265c-4c57-8506-9f759133ad19)
