### PR TITLE
Dotplots with discrete `y`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* When using `geom_dotplot(binaxis = "x")` with a discrete y-variable, dots are
+  now stacked from the y-position rather than from 0 (@teunbrand, #5462)
+
 * New function `check_device()` for testing the availability of advanced 
   graphics features introduced in R 4.1.0 onwards (@teunbrand, #5332).
 

--- a/R/geom-dotplot.R
+++ b/R/geom-dotplot.R
@@ -242,12 +242,12 @@ GeomDotplot <- ggproto("GeomDotplot", Geom,
       # ymin, ymax, xmin, and xmax define the bounding rectangle for each stack
       # Can't do bounding box per dot, because y position isn't real.
       # After position code is rewritten, each dot should have its own bounding box.
+      yoffset <- if (is_mapped_discrete(data$y)) data$y else 0
       data$xmin <- data$x - data$binwidth / 2
       data$xmax <- data$x + data$binwidth / 2
-      data$ymin <- stackaxismin
-      data$ymax <- stackaxismax
-      data$y    <- 0
-
+      data$ymin <- stackaxismin + yoffset
+      data$ymax <- stackaxismax + yoffset
+      data$y <- yoffset
     } else if (params$binaxis == "y") {
       # ymin, ymax, xmin, and xmax define the bounding rectangle for each stack
       # Can't do bounding box per dot, because x position isn't real.

--- a/tests/testthat/_snaps/geom-dotplot/bin-x-three-y-groups-stack-centerwhole.svg
+++ b/tests/testthat/_snaps/geom-dotplot/bin-x-three-y-groups-stack-centerwhole.svg
@@ -1,0 +1,143 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMjkuMzZ8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='29.36' y='22.78' width='685.16' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjkuMzZ8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='29.36' y='22.78' width='685.16' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='157.12' cy='447.18' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='157.12' cy='414.21' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='216.11' cy='480.14' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='216.11' cy='447.18' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='216.11' cy='414.21' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='216.11' cy='381.24' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='259.90' cy='480.14' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='259.90' cy='447.18' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='259.90' cy='414.21' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='259.90' cy='381.24' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='354.02' cy='513.11' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='354.02' cy='480.14' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='354.02' cy='447.18' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='354.02' cy='414.21' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='354.02' cy='381.24' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='354.02' cy='348.28' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='385.41' cy='480.14' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='385.41' cy='447.18' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='385.41' cy='414.21' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='385.41' cy='381.24' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='426.68' cy='480.14' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='426.68' cy='447.18' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='426.68' cy='414.21' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='426.68' cy='381.24' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='455.65' cy='447.18' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='517.44' cy='480.14' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='517.44' cy='447.18' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='517.44' cy='414.21' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='556.87' cy='447.18' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='651.79' cy='447.18' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='178.22' cy='283.95' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='237.06' cy='316.91' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='237.06' cy='283.95' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='237.06' cy='250.98' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='281.20' cy='316.91' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='281.20' cy='283.95' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='281.20' cy='250.98' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='281.20' cy='218.01' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='327.59' cy='316.91' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='327.59' cy='283.95' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='327.59' cy='250.98' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='363.62' cy='316.91' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='363.62' cy='283.95' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='363.62' cy='250.98' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='363.62' cy='218.01' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='400.88' cy='316.91' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='400.88' cy='283.95' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='400.88' cy='250.98' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='400.88' cy='218.01' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='449.44' cy='316.91' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='449.44' cy='283.95' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='449.44' cy='250.98' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='489.11' cy='283.95' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='489.11' cy='250.98' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='526.10' cy='316.91' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='526.10' cy='283.95' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='526.10' cy='250.98' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='569.80' cy='283.95' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='666.89' cy='283.95' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='666.89' cy='250.98' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='76.99' cy='120.72' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='170.43' cy='120.72' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='246.70' cy='153.69' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='246.70' cy='120.72' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='246.70' cy='87.75' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='286.82' cy='153.69' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='286.82' cy='120.72' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='286.82' cy='87.75' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='286.82' cy='54.79' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='314.50' cy='186.65' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='314.50' cy='153.69' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='314.50' cy='120.72' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='314.50' cy='87.75' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='314.50' cy='54.79' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='355.26' cy='153.69' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='355.26' cy='120.72' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='355.26' cy='87.75' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='392.06' cy='153.69' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='392.06' cy='120.72' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='392.06' cy='87.75' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='469.21' cy='186.65' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='469.21' cy='153.69' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='469.21' cy='120.72' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='469.21' cy='87.75' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='469.21' cy='54.79' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='469.21' cy='21.82' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='505.02' cy='153.69' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='505.02' cy='120.72' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='505.02' cy='87.75' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<circle cx='505.02' cy='54.79' r='16.48' style='stroke-width: 0.75; stroke-linecap: butt; fill: #000000;' />
+<rect x='29.36' y='22.78' width='685.16' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='24.43' y='450.20' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>A</text>
+<text x='24.43' y='286.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>B</text>
+<text x='24.43' y='123.75' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text>
+<polyline points='26.62,447.18 29.36,447.18 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='26.62,283.95 29.36,283.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='26.62,120.72 29.36,120.72 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='86.47,547.85 86.47,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='218.33,547.85 218.33,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='350.20,547.85 350.20,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='482.07,547.85 482.07,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='613.94,547.85 613.94,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='86.47' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='218.33' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='350.20' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='482.07' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='613.94' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='371.94' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text x='29.36' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='232.63px' lengthAdjust='spacingAndGlyphs'>bin x, three y groups, stack centerwhole</text>
+</g>
+</svg>

--- a/tests/testthat/test-geom-dotplot.R
+++ b/tests/testthat/test-geom-dotplot.R
@@ -154,6 +154,9 @@ test_that("geom_dotplot draws correctly", {
   # Binning along y, with multiple grouping factors
   dat2 <- data_frame(x = rep(factor(LETTERS[1:3]), 30), y = rnorm(90), g = rep(factor(LETTERS[1:2]), 45))
 
+  expect_doppelganger("bin x, three y groups, stack centerwhole",
+    ggplot(dat2, aes(y, x)) + geom_dotplot(binwidth = .25, binaxis = "x", stackdir = "centerwhole")
+  )
   expect_doppelganger("bin y, three x groups, stack centerwhole",
     ggplot(dat2, aes(x, y)) + geom_dotplot(binwidth = .25, binaxis = "y", stackdir = "centerwhole")
   )


### PR DESCRIPTION
This PR aims to fix #5462.

Briefly, it brings the behaviour of swapping `x` and `y` in `geom_dotplot()` closer to what `coord_flip()` does.

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

swapped <- ggplot(data = iris) +
  geom_dotplot(aes(x = Sepal.Length, y = Species), binaxis = "x") +
  ggtitle("Swapped aesthetics")

flipped <- ggplot(data = iris) +
  geom_dotplot(aes(x = Species, y = Sepal.Length), binaxis = "y") +
  coord_flip() +
  ggtitle("With `coord_flip()`")

library(patchwork)
swapped + flipped
#> Bin width defaults to 1/30 of the range of the data. Pick better value with
#> `binwidth`.
#> Bin width defaults to 1/30 of the range of the data. Pick better value with
#> `binwidth`.
```

![](https://i.imgur.com/lo8f8Ls.png)<!-- -->

<sup>Created on 2023-10-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
