### PR TITLE
Proposal: factory pattern for color scales

### DIFF
--- a/R/scale-colour.R
+++ b/R/scale-colour.R
@@ -38,7 +38,6 @@
 #'
 #'   The documentation on [colour aesthetics][aes_colour_fill_alpha].
 #' @family colour scales
-#' @rdname scale_colour_continuous
 #' @section Color Blindness:
 #' Many color palettes derived from RGB combinations (like the "rainbow" color
 #' palette) are not suitable to support all viewers, especially those with
@@ -76,7 +75,7 @@
 #' options(ggplot2.continuous.fill = tmp) # restore previous setting
 
 scale_colour_continuous_factory <- function(aesthetic) {
-  function(..., type = getOption(glue("ggplot2.continuous.{aesthetic}"))) {
+  function(..., type = getOption("ggplot2.continuous.colour")) {
     type <- type %||% "gradient"
     args <- list2(...)
     args$call <- args$call %||% current_call()
@@ -85,11 +84,11 @@ scale_colour_continuous_factory <- function(aesthetic) {
       if (!any(c("...", "call") %in% fn_fmls_names(type))) {
         args$call <- NULL
       }
-      check_scale_type(exec(type, !!!args), glue("scale_{aesthetic}_continuous"), aesthetic)
+      check_scale_type(exec(type, !!!args), "scale_colour_continuous", aesthetic)
     } else if (identical(type, "gradient")) {
-      exec(glue("scale_{aesthetic}_gradient"), !!!args)
+      exec("scale_colour_gradient", !!!args, aesthetics = aesthetic)
     } else if (identical(type, "viridis")) {
-      exec(glue("scale_{aesthetic}_viridis_c"), !!!args)
+      exec("scale_colour_viridis_c", !!!args, aesthetics = aesthetic)
     } else {
       cli::cli_abort(c(
         "Unknown scale type: {.val {type}}",
@@ -100,16 +99,16 @@ scale_colour_continuous_factory <- function(aesthetic) {
 }
 
 scale_colour_binned_factory <- function(aesthetic) {
-  function(..., type = getOption(glue("ggplot2.binned.{aesthetic}"))) {
+  function(..., type = getOption("ggplot2.binned.colour")) {
     args <- list2(...)
     args$call <- args$call %||% current_call()
     if (is.function(type)) {
       if (!any(c("...", "call") %in% fn_fmls_names(type))) {
         args$call <- NULL
       }
-      check_scale_type(exec(type, !!!args), glue("scale_{aesthetic}_binned"), aesthetic)
+      check_scale_type(exec(type, !!!args), "scale_colour_binned", aesthetic)
     } else {
-      type_fallback <- getOption(glue("ggplot2.continuous.{aesthetic}"), default = "gradient")
+      type_fallback <- getOption("ggplot2.continuous.colour", default = "gradient")
       # don't use fallback from scale_colour_continuous() if it is
       # a function, since that would change the type of the color
       # scale from binned to continuous
@@ -119,9 +118,9 @@ scale_colour_binned_factory <- function(aesthetic) {
       type <- type %||% type_fallback
 
       if (identical(type, "gradient")) {
-        exec(glue("scale_{aesthetic}_steps"), !!!args)
+        exec("scale_colour_steps", !!!args, aesthetics = aesthetic)
       } else if (identical(type, "viridis")) {
-        exec(glue("scale_{aesthetic}_viridis_b"), !!!args)
+        exec("scale_colour_viridis_b", !!!args, aesthetics = aesthetic)
       } else {
         cli::cli_abort(c(
           "Unknown scale type: {.val {type}}",

--- a/R/scale-grey.R
+++ b/R/scale-grey.R
@@ -1,3 +1,10 @@
+scale_colour_grey_factory <- function(aesthetic) {
+  function(..., start = 0.2, end = 0.8, na.value = "red", aesthetics = aesthetic) {
+    discrete_scale(aesthetics, palette = grey_pal(start, end), na.value = na.value, ...)
+  }
+}
+
+
 #' Sequential grey colour scales
 #'
 #' Based on [gray.colors()]. This is black and white equivalent
@@ -25,13 +32,6 @@
 #' ggplot(mtcars, aes(mpg, wt)) +
 #'   geom_point(aes(colour = miss)) +
 #'   scale_colour_grey(na.value = "green")
-
-scale_colour_grey_factory <- function(aesthetic) {
-  function(..., start = 0.2, end = 0.8, na.value = "red", aesthetics = aesthetic) {
-    discrete_scale(aesthetics, palette = grey_pal(start, end), na.value = na.value, ...)
-  }
-}
-
 #' @rdname scale_grey
 #' @export
 scale_colour_grey <- scale_colour_grey_factory("colour")
@@ -39,3 +39,4 @@ scale_colour_grey <- scale_colour_grey_factory("colour")
 #' @rdname scale_grey
 #' @export
 scale_fill_grey <- scale_colour_grey_factory("fill")
+

--- a/R/scale-grey.R
+++ b/R/scale-grey.R
@@ -9,8 +9,6 @@
 #' @family colour scales
 #' @seealso
 #' The documentation on [colour aesthetics][aes_colour_fill_alpha].
-#' @rdname scale_grey
-#' @export
 #' @examples
 #' p <- ggplot(mtcars, aes(mpg, wt)) + geom_point(aes(colour = factor(cyl)))
 #' p + scale_colour_grey()
@@ -27,14 +25,17 @@
 #' ggplot(mtcars, aes(mpg, wt)) +
 #'   geom_point(aes(colour = miss)) +
 #'   scale_colour_grey(na.value = "green")
-scale_colour_grey <- function(..., start = 0.2, end = 0.8, na.value = "red", aesthetics = "colour") {
-  discrete_scale(aesthetics, palette = grey_pal(start, end),
-    na.value = na.value, ...)
+
+scale_colour_grey_factory <- function(aesthetic) {
+  function(..., start = 0.2, end = 0.8, na.value = "red", aesthetics = aesthetic) {
+    discrete_scale(aesthetics, palette = grey_pal(start, end), na.value = na.value, ...)
+  }
 }
 
 #' @rdname scale_grey
 #' @export
-scale_fill_grey <- function(..., start = 0.2, end = 0.8, na.value = "red", aesthetics = "fill") {
-  discrete_scale(aesthetics, palette = grey_pal(start, end),
-    na.value = na.value, ...)
-}
+scale_colour_grey <- scale_colour_grey_factory("colour")
+
+#' @rdname scale_grey
+#' @export
+scale_fill_grey <- scale_colour_grey_factory("fill")

--- a/R/scale-hue.R
+++ b/R/scale-hue.R
@@ -10,8 +10,6 @@
 #'   example, to apply colour settings to the `colour` and `fill` aesthetics at the
 #'   same time, via `aesthetics = c("colour", "fill")`.
 #' @inheritParams scales::hue_pal
-#' @rdname scale_hue
-#' @export
 #' @family colour scales
 #' @seealso
 #' The documentation on [colour aesthetics][aes_colour_fill_alpha].
@@ -53,19 +51,22 @@
 #'   geom_point(aes(colour = miss)) +
 #'   scale_colour_hue(na.value = "black")
 #' }
-scale_colour_hue <- function(..., h = c(0, 360) + 15, c = 100, l = 65, h.start = 0,
-                             direction = 1, na.value = "grey50", aesthetics = "colour") {
-  discrete_scale(aesthetics, palette = hue_pal(h, c, l, h.start, direction),
-    na.value = na.value, ...)
+scale_colour_hue_factory <- function(aesthetic) {
+  function(..., h = c(0, 360) + 15, c = 100, l = 65, h.start = 0,
+                               direction = 1, na.value = "grey50", aesthetics = aesthetic) {
+    discrete_scale(aesthetics, palette = hue_pal(h, c, l, h.start, direction),
+      na.value = na.value, ...)
+  }
 }
+
 
 #' @rdname scale_hue
 #' @export
-scale_fill_hue <- function(..., h = c(0, 360) + 15, c = 100, l = 65, h.start = 0,
-                           direction = 1, na.value = "grey50", aesthetics = "fill") {
-  discrete_scale(aesthetics, palette = hue_pal(h, c, l, h.start, direction),
-    na.value = na.value, ...)
-}
+scale_colour_hue <- scale_colour_hue_factory("colour")
+
+#' @rdname scale_hue
+#' @export
+scale_fill_hue <- scale_colour_hue_factory("fill")
 
 
 #' Discrete colour scales
@@ -87,7 +88,6 @@ scale_fill_hue <- function(..., h = c(0, 360) + 15, c = 100, l = 65, h.start = 0
 #'   want to change the color palette based on the number of levels.
 #'   * A function that returns a discrete colour/fill scale (e.g., [scale_fill_hue()],
 #'   [scale_fill_brewer()], etc).
-#' @export
 #' @examples
 #' # Template function for creating densities grouped by a variable
 #' cty_by_var <- function(var) {
@@ -123,7 +123,7 @@ scale_fill_hue <- function(..., h = c(0, 360) + 15, c = 100, l = 65, h.start = 0
 #'
 
 scale_colour_discrete_factory <- function(aesthetic) {
-  function(..., type = getOption(glue("ggplot2.discrete.{aesthetic}"))) {
+  function(..., type = getOption("ggplot2.discrete.colour")) {
     # TODO: eventually `type` should default to a set of colour-blind safe color codes (e.g. Okabe-Ito)
     type <- type %||% "hue"
     args <- list2(...)
@@ -135,19 +135,19 @@ scale_colour_discrete_factory <- function(aesthetic) {
       }
       check_scale_type(
         exec(type, !!!args),
-        glue("scale_{aesthetic}_discrete"),
+        "scale_colour_discrete",
         "aesthetic",
         scale_is_discrete = TRUE
       )
     } else {
-      exec(glue("scale_{aesthetic}_qualitative"), !!!args, type = type)
+      exec("scale_colour_qualitative", !!!args, type = type, aesthetics = aesthetic)
     }
   }
 }
 
 scale_colour_qualitative_factory <- function(aesthetic) {
   function(..., type = NULL, h = c(0, 360) + 15, c = 100, l = 65, h.start = 0,
-                                     direction = 1, na.value = "grey50", aesthetics = aesthetic) {
+           direction = 1, na.value = "grey50", aesthetics = aesthetic) {
     discrete_scale(
       aesthetics, palette = qualitative_pal(type, h, c, l, h.start, direction),
       na.value = na.value, ...
@@ -156,6 +156,7 @@ scale_colour_qualitative_factory <- function(aesthetic) {
 }
 
 
+#' @export
 scale_colour_discrete <- scale_colour_discrete_factory("colour")
 
 #' @rdname scale_colour_discrete

--- a/R/scale-hue.R
+++ b/R/scale-hue.R
@@ -1,3 +1,45 @@
+scale_colour_hue_factory <- function(aesthetic) {
+  function(..., h = c(0, 360) + 15, c = 100, l = 65, h.start = 0,
+                               direction = 1, na.value = "grey50", aesthetics = aesthetic) {
+    discrete_scale(aesthetics, palette = hue_pal(h, c, l, h.start, direction),
+      na.value = na.value, ...)
+  }
+}
+
+scale_colour_discrete_factory <- function(aesthetic) {
+  function(..., type = getOption("ggplot2.discrete.colour")) {
+    # TODO: eventually `type` should default to a set of colour-blind safe color codes (e.g. Okabe-Ito)
+    type <- type %||% "hue"
+    args <- list2(...)
+    args$call <- args$call %||% current_call()
+
+    if (is.function(type)) {
+      if (!any(c("...", "call") %in% fn_fmls_names(type))) {
+        args$call <- NULL
+      }
+      check_scale_type(
+        exec(type, !!!args),
+        "scale_colour_discrete",
+        "aesthetic",
+        scale_is_discrete = TRUE
+      )
+    } else {
+      exec("scale_colour_qualitative", !!!args, type = type, aesthetics = aesthetic)
+    }
+  }
+}
+
+scale_colour_qualitative_factory <- function(aesthetic) {
+  function(..., type = NULL, h = c(0, 360) + 15, c = 100, l = 65, h.start = 0,
+           direction = 1, na.value = "grey50", aesthetics = aesthetic) {
+    discrete_scale(
+      aesthetics, palette = qualitative_pal(type, h, c, l, h.start, direction),
+      na.value = na.value, ...
+    )
+  }
+}
+
+
 #' Evenly spaced colours for discrete data
 #'
 #' Maps each level to an evenly spaced hue on the colour wheel.
@@ -51,15 +93,6 @@
 #'   geom_point(aes(colour = miss)) +
 #'   scale_colour_hue(na.value = "black")
 #' }
-scale_colour_hue_factory <- function(aesthetic) {
-  function(..., h = c(0, 360) + 15, c = 100, l = 65, h.start = 0,
-                               direction = 1, na.value = "grey50", aesthetics = aesthetic) {
-    discrete_scale(aesthetics, palette = hue_pal(h, c, l, h.start, direction),
-      na.value = na.value, ...)
-  }
-}
-
-
 #' @rdname scale_hue
 #' @export
 scale_colour_hue <- scale_colour_hue_factory("colour")
@@ -69,11 +102,14 @@ scale_colour_hue <- scale_colour_hue_factory("colour")
 scale_fill_hue <- scale_colour_hue_factory("fill")
 
 
+
 #' Discrete colour scales
 #'
 #' The default discrete colour scale. Defaults to [scale_fill_hue()]/[scale_fill_brewer()]
 #' unless `type` (which defaults to the `ggplot2.discrete.fill`/`ggplot2.discrete.colour` options)
 #' is specified.
+#'
+#'
 #'
 #' @param ... Additional parameters passed on to the scale type,
 #' @param type One of the following:
@@ -121,41 +157,6 @@ scale_fill_hue <- scale_colour_hue_factory("fill")
 #'   print(cty_by_var(fl))
 #' })
 #'
-
-scale_colour_discrete_factory <- function(aesthetic) {
-  function(..., type = getOption("ggplot2.discrete.colour")) {
-    # TODO: eventually `type` should default to a set of colour-blind safe color codes (e.g. Okabe-Ito)
-    type <- type %||% "hue"
-    args <- list2(...)
-    args$call <- args$call %||% current_call()
-
-    if (is.function(type)) {
-      if (!any(c("...", "call") %in% fn_fmls_names(type))) {
-        args$call <- NULL
-      }
-      check_scale_type(
-        exec(type, !!!args),
-        "scale_colour_discrete",
-        "aesthetic",
-        scale_is_discrete = TRUE
-      )
-    } else {
-      exec("scale_colour_qualitative", !!!args, type = type, aesthetics = aesthetic)
-    }
-  }
-}
-
-scale_colour_qualitative_factory <- function(aesthetic) {
-  function(..., type = NULL, h = c(0, 360) + 15, c = 100, l = 65, h.start = 0,
-           direction = 1, na.value = "grey50", aesthetics = aesthetic) {
-    discrete_scale(
-      aesthetics, palette = qualitative_pal(type, h, c, l, h.start, direction),
-      na.value = na.value, ...
-    )
-  }
-}
-
-
 #' @export
 scale_colour_discrete <- scale_colour_discrete_factory("colour")
 
@@ -166,6 +167,7 @@ scale_fill_discrete <- scale_colour_discrete_factory("fill")
 scale_colour_qualitative <- scale_colour_qualitative_factory("colour")
 
 scale_fill_qualitative <- scale_colour_qualitative_factory("fill")
+
 
 #' Given set(s) of colour codes (i.e., type), find the smallest set that can support n levels
 #' @param type a character vector or a list of character vectors

--- a/R/scale-viridis.R
+++ b/R/scale-viridis.R
@@ -18,8 +18,6 @@
 #' @family colour scales
 #' @seealso
 #' The documentation on [colour aesthetics][aes_colour_fill_alpha].
-#' @rdname scale_viridis
-#' @export
 #' @examples
 #' # viridis is the default colour/fill scale for ordered factors
 #' set.seed(596)
@@ -58,98 +56,76 @@
 #' # Use viridis_b to bin continuous data before mapping
 #' v + scale_fill_viridis_b()
 #'
-scale_colour_viridis_d <- function(..., alpha = 1, begin = 0, end = 1,
-                                   direction = 1, option = "D", aesthetics = "colour") {
-  discrete_scale(
-    aesthetics,
-    palette = viridis_pal(alpha, begin, end, direction, option),
-    ...
-  )
+
+scale_colour_viridis_d_factory <- function(aesthetic) {
+  function(..., alpha = 1, begin = 0, end = 1,
+           direction = 1, option = "D", aesthetics = aesthetic) {
+    discrete_scale(
+      aesthetics,
+      palette = viridis_pal(alpha, begin, end, direction, option),
+      ...
+    )
+  }
 }
+
+scale_colour_viridis_c_factory <- function(aesthetic) {
+  function(..., alpha = 1, begin = 0, end = 1,
+           direction = 1, option = "D", values = NULL,
+           space = "Lab", na.value = "grey50",
+           guide = "colourbar", aesthetics = aesthetic) {
+    continuous_scale(
+      aesthetics,
+      palette = gradient_n_pal(
+        viridis_pal(alpha, begin, end, direction, option)(6),
+        values,
+        space
+      ),
+      na.value = na.value,
+      guide = guide,
+      ...
+    )
+  }
+}
+
+scale_colour_viridis_b_factory <- function(aesthetic) {
+  function(..., alpha = 1, begin = 0, end = 1,
+           direction = 1, option = "D", values = NULL,
+           space = "Lab", na.value = "grey50",
+           guide = "coloursteps", aesthetics = aesthetic) {
+    pal <-  binned_pal(
+      viridis_pal(alpha, begin, end, direction, option)
+    )
+
+    binned_scale(
+      aesthetics,
+      palette = pal,
+      na.value = na.value,
+      guide = guide,
+      ...
+    )
+  }
+}
+
+#' @rdname scale_viridis
+#' @export
+scale_colour_viridis_d <- scale_colour_viridis_d_factory("colour")
 
 #' @export
 #' @rdname scale_viridis
-scale_fill_viridis_d <- function(..., alpha = 1, begin = 0, end = 1,
-                                 direction = 1, option = "D", aesthetics = "fill") {
-  discrete_scale(
-    aesthetics,
-    palette = viridis_pal(alpha, begin, end, direction, option),
-    ...
-  )
-}
+scale_fill_viridis_d <- scale_colour_viridis_d_factory("fill")
 
 #' @export
 #' @rdname scale_viridis
-scale_colour_viridis_c <- function(..., alpha = 1, begin = 0, end = 1,
-                                   direction = 1, option = "D", values = NULL,
-                                   space = "Lab", na.value = "grey50",
-                                   guide = "colourbar", aesthetics = "colour") {
-  continuous_scale(
-    aesthetics,
-    palette = gradient_n_pal(
-      viridis_pal(alpha, begin, end, direction, option)(6),
-      values,
-      space
-    ),
-    na.value = na.value,
-    guide = guide,
-    ...
-  )
-}
+scale_colour_viridis_c <- scale_colour_viridis_c_factory("colour")
 
 #' @export
 #' @rdname scale_viridis
-scale_fill_viridis_c <- function(..., alpha = 1, begin = 0, end = 1,
-                                 direction = 1, option = "D", values = NULL,
-                                 space = "Lab", na.value = "grey50",
-                                 guide = "colourbar", aesthetics = "fill") {
-  continuous_scale(
-    aesthetics,
-    palette = gradient_n_pal(
-      viridis_pal(alpha, begin, end, direction, option)(6),
-      values,
-      space
-    ),
-    na.value = na.value,
-    guide = guide,
-    ...
-  )
-}
+scale_fill_viridis_c <- scale_colour_viridis_c_factory("fill")
 
 #' @export
 #' @rdname scale_viridis
-scale_colour_viridis_b <- function(..., alpha = 1, begin = 0, end = 1,
-                                   direction = 1, option = "D", values = NULL,
-                                   space = "Lab", na.value = "grey50",
-                                   guide = "coloursteps", aesthetics = "colour") {
-  pal <-  binned_pal(
-    viridis_pal(alpha, begin, end, direction, option)
-  )
-
-  binned_scale(
-    aesthetics,
-    palette = pal,
-    na.value = na.value,
-    guide = guide,
-    ...
-  )
-}
+scale_colour_viridis_b <- scale_colour_viridis_b_factory("colour")
 
 #' @export
 #' @rdname scale_viridis
-scale_fill_viridis_b <- function(..., alpha = 1, begin = 0, end = 1,
-                                 direction = 1, option = "D", values = NULL,
-                                 space = "Lab", na.value = "grey50",
-                                 guide = "coloursteps", aesthetics = "fill") {
-  pal <-  binned_pal(
-    viridis_pal(alpha, begin, end, direction, option)
-  )
-
-  binned_scale(
-    aesthetics,
-    palette = pal,
-    na.value = na.value,
-    guide = guide,
-    ...
-  )
-}
+scale_fill_viridis_b <- scale_colour_viridis_b_factory("fill")

--- a/R/scale-viridis.R
+++ b/R/scale-viridis.R
@@ -1,3 +1,52 @@
+scale_colour_viridis_d_factory <- function(aesthetic) {
+  function(..., alpha = 1, begin = 0, end = 1,
+           direction = 1, option = "D", aesthetics = aesthetic) {
+    discrete_scale(
+      aesthetics,
+      palette = viridis_pal(alpha, begin, end, direction, option),
+      ...
+    )
+  }
+}
+
+scale_colour_viridis_c_factory <- function(aesthetic) {
+  function(..., alpha = 1, begin = 0, end = 1,
+           direction = 1, option = "D", values = NULL,
+           space = "Lab", na.value = "grey50",
+           guide = "colourbar", aesthetics = aesthetic) {
+    continuous_scale(
+      aesthetics,
+      palette = gradient_n_pal(
+        viridis_pal(alpha, begin, end, direction, option)(6),
+        values,
+        space
+      ),
+      na.value = na.value,
+      guide = guide,
+      ...
+    )
+  }
+}
+
+scale_colour_viridis_b_factory <- function(aesthetic) {
+  function(..., alpha = 1, begin = 0, end = 1,
+           direction = 1, option = "D", values = NULL,
+           space = "Lab", na.value = "grey50",
+           guide = "coloursteps", aesthetics = aesthetic) {
+    pal <-  binned_pal(
+      viridis_pal(alpha, begin, end, direction, option)
+    )
+
+    binned_scale(
+      aesthetics,
+      palette = pal,
+      na.value = na.value,
+      guide = guide,
+      ...
+    )
+  }
+}
+
 #' Viridis colour scales from viridisLite
 #'
 #' The `viridis` scales provide colour maps that are perceptually uniform in both
@@ -56,56 +105,6 @@
 #' # Use viridis_b to bin continuous data before mapping
 #' v + scale_fill_viridis_b()
 #'
-
-scale_colour_viridis_d_factory <- function(aesthetic) {
-  function(..., alpha = 1, begin = 0, end = 1,
-           direction = 1, option = "D", aesthetics = aesthetic) {
-    discrete_scale(
-      aesthetics,
-      palette = viridis_pal(alpha, begin, end, direction, option),
-      ...
-    )
-  }
-}
-
-scale_colour_viridis_c_factory <- function(aesthetic) {
-  function(..., alpha = 1, begin = 0, end = 1,
-           direction = 1, option = "D", values = NULL,
-           space = "Lab", na.value = "grey50",
-           guide = "colourbar", aesthetics = aesthetic) {
-    continuous_scale(
-      aesthetics,
-      palette = gradient_n_pal(
-        viridis_pal(alpha, begin, end, direction, option)(6),
-        values,
-        space
-      ),
-      na.value = na.value,
-      guide = guide,
-      ...
-    )
-  }
-}
-
-scale_colour_viridis_b_factory <- function(aesthetic) {
-  function(..., alpha = 1, begin = 0, end = 1,
-           direction = 1, option = "D", values = NULL,
-           space = "Lab", na.value = "grey50",
-           guide = "coloursteps", aesthetics = aesthetic) {
-    pal <-  binned_pal(
-      viridis_pal(alpha, begin, end, direction, option)
-    )
-
-    binned_scale(
-      aesthetics,
-      palette = pal,
-      na.value = na.value,
-      guide = guide,
-      ...
-    )
-  }
-}
-
 #' @rdname scale_viridis
 #' @export
 scale_colour_viridis_d <- scale_colour_viridis_d_factory("colour")


### PR DESCRIPTION
Currently, each color scale (hue, grey, viridis, etc.) needs a duplicate function for each aesthetic it maps to. Here are the functions in `scale-grey.r`:

```r
scale_colour_grey <- function(..., start = 0.2, end = 0.8, na.value = "red", aesthetics = "colour") {
  discrete_scale(aesthetics, palette = grey_pal(start, end),
    na.value = na.value, ...)
}

scale_fill_grey <- function(..., start = 0.2, end = 0.8, na.value = "red", aesthetics = "fill") {
  discrete_scale(aesthetics, palette = grey_pal(start, end),
    na.value = na.value, ...)
}
```

## Problems with that approach:
1. The argument defaults and internal logic are duplicated, so changing one but forgetting to change the other could cause confusing inconsistent behavior.
2. Adding a new color aesthetic like linecolor or outliercolor requires duplicating the function for each color scale. As a result, adding a new color-based aesthetic is pretty cumbersome.

## Why the `aesthetics` argument isn't a sufficient solution:
A new color aesthetic still needs defaults that behave like the others. If you map a new aesthetic in the same way that you map `fill`,  but fill uses default the color scale, they won't match. So you'll need to duplicate the scale functions for hue, gradient, and viridis just for defaults to match the behavior of color and fill.

## Proposed approach: Create factory methods
Instead of `scale_colour_grey()` and `scale_fill_grey` defined above, create one function takes an aesthetic as a parameter and returns a scale function:

```r
scale_grey_factory <- function(aesthetic) {
  function(..., start = 0.2, end = 0.8, na.value = "red", aesthetics = aesthetic) {
    discrete_scale(aesthetics, palette = grey_pal(start, end),
    na.value = na.value, ...)
  }
}

scale_colour_grey <- scale_grey_factory("colour")
scale_fill_grey <- scale_grey_factory("fill")
```

This approach avoids duplicating the argument defaults. Also, adding another color aesthetic only requires one line of code per color scale:

```r
scale_linecolour_grey <- scale_grey_factory("linecolour")
scale_outliercolor_grey <- scale_grey_factory("outliercolor")
```

## TODOs

* As I'm writing this, I realized I forgot `scale-brewer.R`. Any other scales I missed?
* Test more thoroughly to ensure everything works and looks unchanged for users.
* Roxygen works correctly, but I had to stick the factory functions at the very top of the file. That OK?