### PR TITLE
Ignoring `AsIs` objects (again)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # ggplot2 (development version)
 
+* Plot scales now ignore `AsIs` objects constructed with `I(x)`, instead of
+  invoking the identity scale. This allows these columns to co-exist with other
+  layers that need a non-identity scale for the same aesthetic. Also, it makes
+  it easy to specify relative positions (@teunbrand, #5142).
+
 * Legend titles no longer take up space if they've been removed by setting 
   `legend.title = element_blank()` (@teunbrand, #3587).
 

--- a/R/plot-build.R
+++ b/R/plot-build.R
@@ -51,6 +51,7 @@ ggplot_build.ggplot <- function(plot) {
 
   # Compute aesthetics to produce data with generalised variable names
   data <- by_layer(function(l, d) l$compute_aesthetics(d, plot), layers, data, "computing aesthetics")
+  data <- ignore_data(data)
 
   # Transform all scales
   data <- lapply(data, scales$transform_df)
@@ -62,6 +63,7 @@ ggplot_build.ggplot <- function(plot) {
 
   layout$train_position(data, scale_x(), scale_y())
   data <- layout$map_position(data)
+  data <- expose_data(data)
 
   # Apply and map statistics
   data <- by_layer(function(l, d) l$compute_statistic(d, layout), layers, data, "computing stat")
@@ -79,6 +81,7 @@ ggplot_build.ggplot <- function(plot) {
   # Reset position scales, then re-train and map.  This ensures that facets
   # have control over the range of a plot: is it generated from what is
   # displayed, or does it include the range of underlying data
+  data <- ignore_data(data)
   layout$reset_scales()
   layout$train_position(data, scale_x(), scale_y())
   layout$setup_panel_params()
@@ -90,6 +93,7 @@ ggplot_build.ggplot <- function(plot) {
     lapply(data, npscales$train_df)
     data <- lapply(data, npscales$map_df)
   }
+  data <- expose_data(data)
 
   # Fill in defaults etc.
   data <- by_layer(function(l, d) l$compute_geom_2(d), layers, data, "setting up geom aesthetics")

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -598,6 +598,47 @@ is_bang <- function(x) {
   is_call(x, "!", n = 1)
 }
 
+# Puts all columns with 'AsIs' type in a '.ignore' column.
+ignore_data <- function(data) {
+  if (!is_bare_list(data)) {
+    data <- list(data)
+  }
+  lapply(data, function(df) {
+    is_asis <- vapply(df, inherits, logical(1), what = "AsIs")
+    if (!any(is_asis)) {
+      return(df)
+    }
+    df <- unclass(df)
+    # We trust that 'df' is a valid data.frame with equal length columns etc,
+    # so we can use the more performant `new_data_frame()`
+    new_data_frame(c(
+      df[!is_asis],
+      list(.ignored = new_data_frame(df[is_asis]))
+    ))
+  })
+}
+
+# Restores all columns packed into the '.ignored' column.
+expose_data <- function(data) {
+  if (!is_bare_list(data)) {
+    data <- list(data)
+  }
+  lapply(data, function(df) {
+    is_ignored <- which(names(df) == ".ignored")
+    if (length(is_ignored) == 0) {
+      return(df)
+    }
+    df <- unclass(df)
+    new_data_frame(c(df[-is_ignored], df[[is_ignored[1]]]))
+  })
+}
+
+#' @export
+#' @method rescale AsIs
+rescale.AsIs <- function(x, to, from, ...) {
+  x
+}
+
 is_triple_bang <- function(x) {
   if (!is_bang(x)) {
     return(FALSE)

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -177,3 +177,21 @@ test_that("resolution() gives correct answers", {
   # resolution has a tolerance
   expect_equal(resolution(c(1, 1 + 1000 * .Machine$double.eps, 2)), 1)
 })
+
+test_that("expose/ignore_data() can round-trip a data.frame", {
+
+  # Plain data.frame
+  df <- data_frame0(a = 1:3, b = 4:6, c = LETTERS[1:3], d = LETTERS[4:6])
+  expect_equal(list(df), ignore_data(df))
+  expect_equal(list(df), expose_data(df))
+
+  # data.frame with ignored columns
+  df <- data_frame0(a = 1:3, b = I(4:6), c = LETTERS[1:3], d = I(LETTERS[4:6]))
+  test <- ignore_data(df)[[1]]
+  expect_equal(names(test), c("a", "c", ".ignored"))
+  expect_equal(names(test$.ignored), c("b", "d"))
+
+  test <- expose_data(test)[[1]]
+  expect_equal(test, df[, c("a", "c", "b", "d")])
+
+})


### PR DESCRIPTION
This PR attempts to fix #5142 and replaces #5290 and #5418.

Briefly, instead of assigning `scale_*_identity()` to `<AsIs>` objects, it ignores these in scale operations.

Benefits of this are:
  * You can safely do `aes(colour = I(...))` in one layers and do `aes(colour = proper_column)` in another layer, without having a clash of colour scales.
  * Using `x/y = I(...)` effectively makes the position aesthetic in an relative unit (`"npc"` units), which can be very convenient for annotations and such.

The mechanism this PR employs is to hide/unhide `<AsIs>` column at strategic moments during plot building.
'Ignoring' packs `<AsIs>` columns into one `.ignored` data.frame column.
'Exposing' unpacks the `.ignored` data.frame column into separate columns again.

A quick comparison with the other PRs:

Compared to #5290:

* No need for scales to make a formal exemption for `<AsIs>` columns; plot building takes care of this.
* For that reason, this PR has a much smaller footprint and is less invasive.

Compared to #5418:

* Don't need bother with mappings to derive which columns should be ignored.
* Because the `<AsIs>` class is 'infective', the mechanism automatically propagates through reparameterization, which is desirable (e.g. from x/width to xmin/xmax).

A quick benchmark to show that hiding/exposing scales well with dataset size (nrow = 32, 234 and 53.940 for mtcars, mpg and diamonds respectively). All in all, I think this PR wouldn't even add 1ms to plot building in 90% of plots.

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

data <- list(
  transform(mtcars, cyl = I(cyl), disp  = I(disp)),
  transform(mpg,    cyl = I(cyl), displ = I(displ)),
  transform(diamonds, color = I(color), depth = I(depth))
)

bench::mark(
  "mtcars"   = ignore_data(data[[1]]),
  "mpg"      = ignore_data(data[[2]]),
  "diamonds" = ignore_data(data[[3]]),
  "all"      = ignore_data(data), 
  check = FALSE
)
#> # A tibble: 4 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 mtcars       38.7µs   41.3µs    22758.    3.84KB     4.55
#> 2 mpg          38.1µs   40.6µs    23882.        0B     4.78
#> 3 diamonds     39.5µs   42.2µs    23048.        0B     4.61
#> 4 all         107.9µs    114µs     8594.      304B     4.08

ignored <- ignore_data(data)

bench::mark(
  "mtcars"   = expose_data(ignored[[1]]),
  "mpg"      = expose_data(ignored[[2]]),
  "diamonds" = expose_data(ignored[[3]]),
  "all"      = expose_data(ignored),
  check = FALSE
)
#> # A tibble: 4 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 mtcars       11.2µs   12.4µs    77564.        0B     7.76
#> 2 mpg          11.3µs   12.2µs    76183.        0B     0   
#> 3 diamonds     11.2µs   12.4µs    78313.        0B     7.83
#> 4 all          25.6µs   27.9µs    34930.        0B     3.49
```

<sup>Created on 2023-10-12 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

