### PR TITLE
Fix Version 3.4.4 NEWS Typo

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@ This hotfix release adapts to a change in r-devel's `base::is.atomic()` and
 the upcoming retirement of maptools.
 
 * `fortify()` for sp objects (e.g., `SpatialPolygonsDataFrame`) is now deprecated
-  and will be removed soon in support of [the upcoming retirement of rproj, rgeos,
+  and will be removed soon in support of [the upcoming retirement of rgdal, rgeos,
   and maptools](https://r-spatial.org/r/2023/05/15/evolution4.html). In advance
   of the whole removal, `fortify(<SpatialPolygonsDataFrame>, region = ...)`
   no longer works as of this version (@yutannihilation, #5244).


### PR DESCRIPTION
Fixes #5478. Change "the upcoming retirement of rproj, rgeos, and maptools" to "the upcoming retirement of rgdal, rgeos, and maptools"