### PR TITLE
fix typo in doc

### DIFF
--- a/R/annotation.R
+++ b/R/annotation.R
@@ -14,7 +14,7 @@
 #' @section Unsupported geoms:
 #' Due to their special nature, reference line geoms [geom_abline()],
 #' [geom_hline()], and [geom_vline()] can't be used with [annotate()].
-#' You can use these geoms directory for annotations.
+#' You can use these geoms directly for annotations.
 #' @param geom name of geom to use for annotation
 #' @param x,y,xmin,ymin,xmax,ymax,xend,yend positioning aesthetics -
 #'   you must specify at least one of these.

--- a/man/annotate.Rd
+++ b/man/annotate.Rd
@@ -49,7 +49,7 @@ affect the legend.
 
 Due to their special nature, reference line geoms \code{\link[=geom_abline]{geom_abline()}},
 \code{\link[=geom_hline]{geom_hline()}}, and \code{\link[=geom_vline]{geom_vline()}} can't be used with \code{\link[=annotate]{annotate()}}.
-You can use these geoms directory for annotations.
+You can use these geoms directly for annotations.
 }
 
 \examples{


### PR DESCRIPTION
In `annotate`'s doc:
"You can use these geoms **directory** for annotations."
 should read 
"You can use these geoms **directly**   for annotations."

