### PR TITLE
`create.dir` argument for `ggsave()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* `ggsave()` no longer sometimes creates new directories, which is now 
+  controlled by the new `create.dir` argument (#5489).
+
 * Legend titles no longer take up space if they've been removed by setting 
   `legend.title = element_blank()` (@teunbrand, #3587).
 

--- a/R/save.R
+++ b/R/save.R
@@ -43,6 +43,10 @@
 #'   specifying dimensions in pixels.
 #' @param bg Background colour. If `NULL`, uses the `plot.background` fill value
 #'   from the plot theme.
+#' @param create.dir Whether to create new directories if a non-existing
+#'   directory is specified in the `filename` or `path` (`TRUE`) or return an
+#'   error (`FALSE`, default). If `FALSE` and run in an interactive session,
+#'   a prompt will appear asking to create a new directory when necessary.
 #' @param ... Other arguments passed on to the graphics device function,
 #'   as specified by `device`.
 #' @export
@@ -84,27 +88,16 @@
 ggsave <- function(filename, plot = last_plot(),
                    device = NULL, path = NULL, scale = 1,
                    width = NA, height = NA, units = c("in", "cm", "mm", "px"),
-                   dpi = 300, limitsize = TRUE, bg = NULL, ...) {
-  if (length(filename) != 1) {
-    if (length(filename) == 0) {
-      cli::cli_abort("{.arg filename} cannot be empty.")
-    }
-    len <- length(filename)
-    filename <- filename[1]
-    cli::cli_warn(c(
-      "{.arg filename} must have length 1, not length {len}.",
-      "!" = "Only the first, {.file {filename}}, will be used."
-    ))
-  }
+                   dpi = 300, limitsize = TRUE, bg = NULL,
+                   create.dir = FALSE,
+                   ...) {
+  filename <- check_path(path, filename, create.dir)
 
   dpi <- parse_dpi(dpi)
   dev <- plot_dev(device, filename, dpi = dpi)
   dim <- plot_dim(c(width, height), scale = scale, units = units,
     limitsize = limitsize, dpi = dpi)
 
-  if (!is.null(path)) {
-    filename <- file.path(path, filename)
-  }
   if (is_null(bg)) {
     bg <- calc_element("plot.background", plot_theme(plot))$fill %||% "transparent"
   }
@@ -117,6 +110,56 @@ ggsave <- function(filename, plot = last_plot(),
   grid.draw(plot)
 
   invisible(filename)
+}
+
+check_path <- function(path, filename, create.dir,
+                       call = caller_env()) {
+
+  if (length(filename) > 1 && is.character(filename)) {
+    cli::cli_warn(c(
+      "{.arg filename} must have length 1, not {length(filename)}.",
+      "!" = "Only the first, {.file {filename[1]}}, will be used."
+    ), call = call)
+    filename <- filename[1]
+  }
+  check_string(filename, allow_empty = FALSE)
+
+  check_string(path, allow_empty = FALSE, allow_null = TRUE)
+  if (!is.null(path)) {
+    filename <- file.path(path, filename)
+  } else {
+    path <- dirname(filename)
+  }
+
+  # Happy path: target file is in valid directory
+  if (dir.exists(path)) {
+    return(filename)
+  }
+
+  check_bool(create.dir)
+
+  # Try to ask user to create a new directory
+  if (interactive() && !create.dir) {
+    cli::cli_bullets(c(
+      "Cannot find directory {.path {path}}.",
+      "i" = "Would you like to create a new directory?"
+    ))
+    create.dir <- utils::menu(c("Yes", "No")) == 1
+  }
+
+  # Create new directory
+  if (create.dir) {
+    dir.create(path, recursive = TRUE)
+    if (dir.exists(path)) {
+      cli::cli_alert_success("Created directory: {.path {path}}.")
+      return(filename)
+    }
+  }
+
+  cli::cli_abort(c(
+    "Cannot find directory {.path {path}}.",
+    i = "Please supply an existing directory or use {.code create.dir = TRUE}."
+  ), call = call)
 }
 
 #' Parse a DPI input from the user

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -85,7 +85,7 @@ test_that("ggsave warns about empty or multiple filenames", {
 
   expect_error(
     ggsave(character(), plot),
-    "`filename` cannot be empty."
+    "`filename` must be a single string"
   )
 })
 

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -108,7 +108,7 @@ test_that("guesses and informs if dim not specified", {
 })
 
 test_that("uses 7x7 if no graphics device open", {
-  expect_equal(plot_dim(), c(7, 7))
+  suppressMessages(expect_equal(plot_dim(), c(7, 7)))
 })
 
 test_that("warned about large plot unless limitsize = FALSE", {

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -9,6 +9,21 @@ test_that("ggsave creates file", {
   expect_true(file.exists(path))
 })
 
+test_that("ggsave can create directories", {
+  dir <- tempdir()
+  path <- file.path(dir, "foobar", "tmp.pdf")
+  on.exit(unlink(path))
+
+  p <- ggplot(mpg, aes(displ, hwy)) + geom_point()
+
+  expect_error(ggsave(path, p))
+  expect_false(dir.exists(dirname(path)))
+
+  # 2 messages: 1 for saving and 1 informing about directory creation
+  expect_message(expect_message(ggsave(path, p, create.dir = TRUE)))
+  expect_true(dir.exists(dirname(path)))
+})
+
 test_that("ggsave restores previous graphics device", {
   # When multiple devices are open, dev.off() restores the next one in the list,
   # not the previously-active one. (#2363)


### PR DESCRIPTION
This PR aims to fix #5489.

Briefly, it adds a `create.dir` argument to `ggsave()`, which controls whether a new directory can be created.

Example:
``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

p <- ggplot()

ggsave("foobar/test.png", plot = p)
#> Error in `ggsave()`:
#> ! Cannot find directory 'foobar'.
#> ℹ Please supply an existing directory or use `create.dir = TRUE`.

ggsave("foobar/test.png", plot = p, create.dir = TRUE)
#> ✔ Created directory: 'foobar'.
#> Saving 7 x 5 in image
```

<sup>Created on 2023-10-24 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Because the default `create.dir = FALSE` might be pain for interactive use, it prompts a small menu choice in interactive mode (which I don't know how to reprex)

```r
ggsave("foobar/test.png", plot = p)
#> Cannot find directory foobar.
#> ℹ Would you like to create a new directory?
#>
#> 1: Yes
#> 2: No
#>
#> Selection: 1
#> ✔ Created directory: foobar.
#> Saving 7 x 7 in image
```
