### PR TITLE
Put linebreak in example of `scale_brewer`

### DIFF
--- a/R/scale-brewer.R
+++ b/R/scale-brewer.R
@@ -76,7 +76,8 @@
 #' v
 #' v + scale_fill_distiller()
 #' v + scale_fill_distiller(palette = "Spectral")
-#' # the order of colour can be reversed, but with scale_*_distiller(), the default direction = -1, so to reverse, use direction = 1.
+#' # the order of colour can be reversed, but with scale_*_distiller(),
+#' # the default direction = -1, so to reverse, use direction = 1.
 #' v + scale_fill_distiller(palette = "Spectral", direction = 1)
 #'
 #' # or use blender variants to discretise continuous data

--- a/man/scale_brewer.Rd
+++ b/man/scale_brewer.Rd
@@ -169,7 +169,8 @@ v <- ggplot(faithfuld) +
 v
 v + scale_fill_distiller()
 v + scale_fill_distiller(palette = "Spectral")
-# the order of colour can be reversed, but with scale_*_distiller(), the default direction = -1, so to reverse, use direction = 1.
+# the order of colour can be reversed, but with scale_*_distiller(),
+# the default direction = -1, so to reverse, use direction = 1.
 v + scale_fill_distiller(palette = "Spectral", direction = 1)
 
 # or use blender variants to discretise continuous data


### PR DESCRIPTION
This PR fixes a NOTE in the CI:

```
❯ checking Rd line widths ... NOTE
  Rd file 'scale_brewer.Rd':
    \examples lines wider than 100 characters:
       # the order of colour can be reversed, but with scale_*_distiller(), the default direction = -1, so to reverse, use direction = 1.
  
  These lines will be truncated in the PDF manual.
```

This example was last updated in #5381