### PR TITLE
No partial matching in theme subsetting

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 S3method("$",ggproto)
 S3method("$",ggproto_parent)
+S3method("$",theme)
 S3method("$<-",uneval)
 S3method("+",gg)
 S3method("[",mapped_discrete)

--- a/R/theme.R
+++ b/R/theme.R
@@ -805,7 +805,9 @@ is.subclass <- function(x, y) {
 is.theme <- function(x) inherits(x, "theme")
 
 #' @export
-`$.theme` <- .subset2
+`$.theme` <- function(x, ...) {
+  .subset2(x, ...)
+}
 
 #' @export
 print.theme <- function(x, ...) utils::str(x)

--- a/R/theme.R
+++ b/R/theme.R
@@ -805,4 +805,7 @@ is.subclass <- function(x, y) {
 is.theme <- function(x) inherits(x, "theme")
 
 #' @export
+`$.theme` <- .subset2
+
+#' @export
 print.theme <- function(x, ...) utils::str(x)

--- a/tests/testthat/test-theme.R
+++ b/tests/testthat/test-theme.R
@@ -1,5 +1,11 @@
 skip_on_cran() # This test suite is long-running (on cran) and is skipped
 
+test_that("dollar subsetting the theme does no partial matching", {
+  t <- theme(foobar = 12)
+  expect_null(t$foo)
+  expect_equal(t$foobar, 12)
+})
+
 test_that("modifying theme element properties with + operator works", {
 
   # Changing a "leaf node" works


### PR DESCRIPTION
This PR aims to fix #2724. It supersedes #5335.

Briefly, it implements https://github.com/tidyverse/ggplot2/issues/2724#issuecomment-401388408 by using `.subset2()` as the dollar-subsetting method for themes.

Quick demo:

``` r
library(ggplot2)

# Old problematic behaviour
t <- theme(foobar = 12)
t$foo
#> [1] 12
t$foobar
#> [1] 12

devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

# New correct behaviour
t$foo
#> NULL
t$foobar
#> [1] 12
```

<sup>Created on 2023-11-14 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
