### PR TITLE
Fix colourbar's `ticks.length` argument not working

### DIFF
--- a/R/guide-colorbar.R
+++ b/R/guide-colorbar.R
@@ -439,14 +439,11 @@ GuideColourbar <- ggproto(
       "horizontal" = c("bottom", "top"),
       "vertical"   = c("right", "left")
     )
-    elements$ticks_length <- rep(elements$ticks_length, length.out = 2)
-    elem1 <- elem2 <- elements
-    elem1$ticks_length <- elements$ticks_length[2]
-    elem2$ticks_length <- elements$ticks_length[1]
+    ticks_length <- rep(elements$ticks_length, length.out = 2)
 
     grobTree(
-      Guide$build_ticks(pos, elem1, params, position[1]),
-      Guide$build_ticks(pos, elem2, params, position[2])
+      Guide$build_ticks(pos, elements, params, position[1], ticks_length[1]),
+      Guide$build_ticks(pos, elements, params, position[2], ticks_length[2])
     )
   },
 

--- a/tests/testthat/_snaps/guides/white-to-red-colorbar-long-thick-black-ticks-green-frame.svg
+++ b/tests/testthat/_snaps/guides/white-to-red-colorbar-long-thick-black-ticks-green-frame.svg
@@ -59,21 +59,21 @@
 <text x='679.53' y='241.79' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
 <image width='17.28' height='86.40' x='679.53' y='248.41' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAeUlEQVQ4jcWPSw6AMAhEH2O9/5F1Y2pSARtL4oYA82HggEPsxlWaEM0QmyEkp+uj3WMvFnUTo7vjSRkVOQUEEZDLzBytJ3u/EbrMAHXkYYfzUbxLXyVV1LhMp59UjGhotRrthxhFpim69GVN8OjGR5c4ZKFLYeaEdwL6pgZTBMOKRwAAAABJRU5ErkJggg=='/>
 <rect x='679.53' y='248.41' width='17.28' height='86.40' style='stroke-width: 1.12; stroke: #00FF00;' />
-<polyline points='693.35,334.67 696.81,334.67 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
-<polyline points='693.35,313.14 696.81,313.14 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
-<polyline points='693.35,291.61 696.81,291.61 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
-<polyline points='693.35,270.09 696.81,270.09 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
-<polyline points='693.35,248.56 696.81,248.56 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
-<polyline points='682.98,334.67 679.53,334.67 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
-<polyline points='682.98,313.14 679.53,313.14 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
-<polyline points='682.98,291.61 679.53,291.61 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
-<polyline points='682.98,270.09 679.53,270.09 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
-<polyline points='682.98,248.56 679.53,248.56 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
+<polyline points='689.90,334.67 696.81,334.67 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
+<polyline points='689.90,313.14 696.81,313.14 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
+<polyline points='689.90,291.61 696.81,291.61 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
+<polyline points='689.90,270.09 696.81,270.09 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
+<polyline points='689.90,248.56 696.81,248.56 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
+<polyline points='686.44,334.67 679.53,334.67 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
+<polyline points='686.44,313.14 679.53,313.14 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
+<polyline points='686.44,291.61 679.53,291.61 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
+<polyline points='686.44,270.09 679.53,270.09 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
+<polyline points='686.44,248.56 679.53,248.56 ' style='stroke-width: 1.88; stroke-linecap: butt;' />
 <text x='702.29' y='337.70' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='702.29' y='316.17' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
 <text x='702.29' y='294.64' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
 <text x='702.29' y='273.11' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
 <text x='702.29' y='251.59' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
-<text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='298.62px' lengthAdjust='spacingAndGlyphs'>white-to-red colorbar, thick black ticks, green frame</text>
+<text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='327.25px' lengthAdjust='spacingAndGlyphs'>white-to-red colorbar, long thick black ticks, green frame</text>
 </g>
 </svg>

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -708,14 +708,15 @@ test_that("colorbar can be styled", {
     p + scale_color_gradient(low = 'white', high = 'red')
   )
 
-  expect_doppelganger("white-to-red colorbar, thick black ticks, green frame",
+  expect_doppelganger("white-to-red colorbar, long thick black ticks, green frame",
     p + scale_color_gradient(
           low = 'white', high = 'red',
           guide = guide_colorbar(
             frame = element_rect(colour = "green"),
             frame.linewidth = 1.5 / .pt,
             ticks.colour = "black",
-            ticks.linewidth = 2.5 / .pt
+            ticks.linewidth = 2.5 / .pt,
+            ticks.length = unit(0.4, "npc")
             )
         )
     )


### PR DESCRIPTION
I became aware that the `ticks.length` argument of `guide_colourbar()` wasn't working as intended, so this PR fixes that problem.
I've including this argument in an already existing test so that we might know if this breaks again in the future.

Small demonstration of setting the tick length:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

ggplot(mpg, aes(displ, hwy)) +
  geom_point(aes(colour = cty)) +
  guides(colour = guide_colourbar(ticks.length = unit(0.5, "npc")))
```

![](https://i.imgur.com/HGmD9qR.png)<!-- -->

<sup>Created on 2023-11-20 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
