### PR TITLE
Blank text for `guide_axis_theta()`

### DIFF
--- a/R/guide-axis-theta.R
+++ b/R/guide-axis-theta.R
@@ -148,7 +148,7 @@ GuideAxisTheta <- ggproto(
     }
 
     offset <- max(unit(0, "pt"), elements$major_length, elements$minor_length)
-    elements$offset <- offset + max(elements$text$margin)
+    elements$offset <- offset + max(elements$text$margin %||% unit(0, "pt"))
     elements
   },
 
@@ -160,12 +160,16 @@ GuideAxisTheta <- ggproto(
 
   build_labels = function(key, elements, params) {
 
+    if (inherits(elements$text, "element_blank")) {
+      return(zeroGrob())
+    }
+
     key <- vec_slice(key, !vec_detect_missing(key$.label %||% NA))
 
     # Early exit if drawing no labels
     labels <- key$.label
     if (length(labels) < 1) {
-      return(list(zeroGrob()))
+      return(zeroGrob())
     }
 
     # Resolve text angle


### PR DESCRIPTION
This PR aims to fix #5530.

Briefly, it just early-exits when labels are blank and fills `NULL`s where values are expected.

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

p <- ggplot(mpg, aes(displ, hwy)) +
  geom_point() +
  coord_radial()

p + theme(axis.text = element_blank())
```

![](https://i.imgur.com/RUrWb4H.png)<!-- -->

``` r
p + theme_void()
```

![](https://i.imgur.com/a8LoHeG.png)<!-- -->

<sup>Created on 2023-11-21 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
