### PR TITLE
Fixes partial matching on guides

### DIFF
--- a/R/guide-axis.R
+++ b/R/guide-axis.R
@@ -377,7 +377,7 @@ GuideAxis <- ggproto(
     spacer <- max(unit(0, "pt"), unit(-1 * diff(range), "cm"))
 
     # Text
-    labels <- unit(measure(grobs$label), "cm")
+    labels <- unit(measure(grobs$labels), "cm")
     title  <- unit(measure(grobs$title), "cm")
 
     sizes <- unit.c(length, spacer, labels, title)


### PR DESCRIPTION
I caught this testing ggnewscale. This is using the latest dev.

``` r
library(ggplot2)
options(warnPartialMatchDollar = TRUE)
ggplot(mpg, aes(displ, hwy)) +
  geom_point(aes(colour = factor(year)), size = 5) 
#> Warning in grobs$label: partial match of 'label' to 'labels'

#> Warning in grobs$label: partial match of 'label' to 'labels'
```

I think this is the correct change.