### PR TITLE
`theme()` supports splicing arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* `theme()` now supports splicing a list of arguments (#5542).
+
 * Lines where `linewidth = NA` are now dropped in `geom_sf()` (#5204).
 
 * New `guide_axis_logticks()` can be used to draw logarithmic tick marks as

--- a/R/theme.R
+++ b/R/theme.R
@@ -281,7 +281,8 @@
 #' p3 + theme(strip.text.x.top = element_text(colour = "white", face = "bold"))
 #' p3 + theme(panel.spacing = unit(1, "lines"))
 #' }
-theme <- function(line,
+theme <- function(...,
+                  line,
                   rect,
                   text,
                   title,
@@ -388,7 +389,6 @@ theme <- function(line,
                   strip.text.y.right,
                   strip.switch.pad.grid,
                   strip.switch.pad.wrap,
-                  ...,
                   complete = FALSE,
                   validate = TRUE) {
   elements <- find_args(..., complete = NULL, validate = NULL)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -320,7 +320,7 @@ find_args <- function(...) {
   vals <- mget(args, envir = env)
   vals <- vals[!vapply(vals, is_missing_arg, logical(1))]
 
-  modify_list(vals, list(..., `...` = NULL))
+  modify_list(vals, list2(..., `...` = NULL))
 }
 
 # Used in annotations to ensure printed even when no

--- a/man/theme.Rd
+++ b/man/theme.Rd
@@ -5,6 +5,7 @@
 \title{Modify components of a theme}
 \usage{
 theme(
+  ...,
   line,
   rect,
   text,
@@ -112,12 +113,14 @@ theme(
   strip.text.y.right,
   strip.switch.pad.grid,
   strip.switch.pad.wrap,
-  ...,
   complete = FALSE,
   validate = TRUE
 )
 }
 \arguments{
+\item{...}{additional element specifications not part of base ggplot2. In general,
+these should also be defined in the \verb{element tree} argument.}
+
 \item{line}{all line elements (\code{\link[=element_line]{element_line()}})}
 
 \item{rect}{all rectangular elements (\code{\link[=element_rect]{element_rect()}})}
@@ -297,9 +300,6 @@ switched (\code{unit})}
 
 \item{strip.switch.pad.wrap}{space between strips and axes when strips are
 switched (\code{unit})}
-
-\item{...}{additional element specifications not part of base ggplot2. In general,
-these should also be defined in the \verb{element tree} argument.}
 
 \item{complete}{set this to \code{TRUE} if this is a complete theme, such as
 the one returned by \code{\link[=theme_grey]{theme_grey()}}. Complete themes behave

--- a/tests/testthat/test-theme.R
+++ b/tests/testthat/test-theme.R
@@ -6,6 +6,13 @@ test_that("dollar subsetting the theme does no partial matching", {
   expect_equal(t$foobar, 12)
 })
 
+test_that("theme argument splicing works", {
+  l <- list(a = 10, b = "c", d = c("foo", "bar"))
+  test <- theme(!!!l)
+  ref  <- theme(a = 10, b = "c", d = c("foo", "bar"))
+  expect_equal(test, ref)
+})
+
 test_that("modifying theme element properties with + operator works", {
 
   # Changing a "leaf node" works


### PR DESCRIPTION
This PR aims to fix #5542.

Briefly, `...` is moved to the first argument of the theme (which is technically a breaking change, I suppose), so that it can catch splicing operators. Then `find_args()`, which does the argument collection, just uses `list2()` to support the splicing.

Reprex from #5542:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

red_axis <- list(
  axis.line = element_line(colour = "red"),
  axis.text = element_text(colour = "red"),
  axis.ticks = element_line(colour = "red"),
  axis.title = element_text(colour = "red")
)

ggplot(mpg, aes(displ, hwy)) +
  geom_point() +
  theme(!!!red_axis)
```

![](https://i.imgur.com/jcRLJUd.png)<!-- -->

<sup>Created on 2023-11-28 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
