### PR TITLE
Use new {scales} syntax

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
     MASS,
     mgcv,
     rlang (>= 1.1.0),
-    scales (>= 1.2.0),
+    scales (>= 1.3.0),
     stats,
     tibble,
     vctrs (>= 0.5.0),

--- a/R/axis-secondary.R
+++ b/R/axis-secondary.R
@@ -280,7 +280,7 @@ AxisSecondary <- ggproto("AxisSecondary", NULL,
   },
 
   # Temporary scale for the purpose of calling break_info()
-  create_scale = function(self, range, trans = identity_trans()) {
+  create_scale = function(self, range, trans = transform_identity()) {
     scale <- ggproto(NULL, ScaleContinuousPosition,
                      name = self$name,
                      breaks = self$breaks,

--- a/R/coord-transform.R
+++ b/R/coord-transform.R
@@ -5,7 +5,7 @@
 #' no guarantee that straight lines will continue to be straight.
 #'
 #' Transformations only work with continuous values: see
-#' [scales::trans_new()] for list of transformations, and instructions
+#' [scales::new_transform()] for list of transformations, and instructions
 #' on how to create your own.
 #'
 #' @inheritParams coord_cartesian
@@ -60,7 +60,7 @@
 #'   geom_smooth(method = "lm") +
 #'   scale_x_log10() +
 #'   scale_y_log10() +
-#'   coord_trans(x = scales::exp_trans(10), y = scales::exp_trans(10))
+#'   coord_trans(x = scales::transform_exp(10), y = scales::transform_exp(10))
 #'
 #' # cf.
 #' ggplot(diamonds, aes(carat, price)) +
@@ -90,8 +90,8 @@ coord_trans <- function(x = "identity", y = "identity", xlim = NULL, ylim = NULL
   check_coord_limits(ylim)
 
   # resolve transformers
-  if (is.character(x)) x <- as.trans(x)
-  if (is.character(y)) y <- as.trans(y)
+  if (is.character(x)) x <- as.transform(x)
+  if (is.character(y)) y <- as.transform(y)
 
   ggproto(NULL, CoordTrans,
     trans = list(x = x, y = y),
@@ -190,7 +190,7 @@ transform_value <- function(trans, value, range) {
 # TODO: can we merge this with view_scales_from_scale()?
 view_scales_from_scale_with_coord_trans <- function(scale, coord_limits, trans, expand = TRUE) {
   expansion <- default_expansion(scale, expand = expand)
-  scale_trans <- scale$trans %||% identity_trans()
+  scale_trans <- scale$trans %||% transform_identity()
   coord_limits <- coord_limits %||% scale_trans$inverse(c(NA, NA))
   scale_limits <- scale$get_limits()
 

--- a/R/guide-axis-logticks.R
+++ b/R/guide-axis-logticks.R
@@ -154,7 +154,7 @@ GuideAxisLogticks <- ggproto(
           "{.field {trans_name}} transformation in log-tick positioning."
         ))
       }
-      trans <- log_trans(base = params$prescale_base)
+      trans <- transform_log(base = params$prescale_base)
     } else {
       trans <- scale$scale$trans
     }

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -7,7 +7,7 @@
 #'   that should be used for error messages associated with this scale.
 #' @param palette A palette function that when called with a numeric vector with
 #'   values between 0 and 1 returns the corresponding output values
-#'   (e.g., [scales::area_pal()]).
+#'   (e.g., [scales::pal_area()]).
 #' @param name The name of the scale. Used as the axis or legend title. If
 #'   `waiver()`, the default, the name of the scale is taken from the first
 #'   mapping used for that aesthetic. If `NULL`, the legend title will be
@@ -157,7 +157,7 @@ continuous_scale <- function(aesthetics, scale_name = deprecated(), palette, nam
 #' @inheritParams continuous_scale
 #' @param palette A palette function that when called with a single integer
 #'   argument (the number of levels in the scale) returns the values that
-#'   they should take (e.g., [scales::hue_pal()]).
+#'   they should take (e.g., [scales::pal_hue()]).
 #' @param breaks One of:
 #'   - `NULL` for no breaks
 #'   - `waiver()` for the default breaks (the scale limits)

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -15,7 +15,7 @@
 #' @param breaks One of:
 #'   - `NULL` for no breaks
 #'   - `waiver()` for the default breaks computed by the
-#'     [transformation object][scales::trans_new()]
+#'     [transformation object][scales::new_transform()]
 #'   - A numeric vector of positions
 #'   - A function that takes the limits as input and returns breaks
 #'     as output (e.g., a function returned by [scales::extended_breaks()]).
@@ -75,8 +75,8 @@
 #'   and methods for generating breaks and labels. Transformation objects
 #'   are defined in the scales package, and are called `<name>_trans`. If
 #'   transformations require arguments, you can call them from the scales
-#'   package, e.g. [`scales::boxcox_trans(p = 2)`][scales::boxcox_trans].
-#'   You can create your own transformation with [scales::trans_new()].
+#'   package, e.g. [`scales::transform_boxcox(p = 2)`][scales::transform_boxcox].
+#'   You can create your own transformation with [scales::new_transform()].
 #' @param guide A function used to create a guide or its name. See
 #'   [guides()] for more information.
 #' @param expand For position scales, a vector of range expansion constants used to add some
@@ -113,7 +113,7 @@ continuous_scale <- function(aesthetics, scale_name = deprecated(), palette, nam
     guide <- "none"
   }
 
-  trans <- as.trans(trans)
+  trans <- as.transform(trans)
   if (!is.null(limits) && !is.function(limits)) {
     limits <- trans$transform(limits)
   }
@@ -278,7 +278,7 @@ binned_scale <- function(aesthetics, scale_name = deprecated(), palette, name = 
     guide <- "none"
   }
 
-  trans <- as.trans(trans)
+  trans <- as.transform(trans)
   if (!is.null(limits)) {
     limits <- trans$transform(limits)
   }
@@ -603,7 +603,7 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
   oob = censor,
   minor_breaks = waiver(),
   n.breaks = NULL,
-  trans = identity_trans(),
+  trans = transform_identity(),
 
   is_discrete = function() FALSE,
 

--- a/R/scale-alpha.R
+++ b/R/scale-alpha.R
@@ -24,7 +24,7 @@
 #' p + scale_alpha("cylinders")
 #' p + scale_alpha(range = c(0.4, 0.8))
 scale_alpha <- function(..., range = c(0.1, 1)) {
-  continuous_scale("alpha", palette = rescale_pal(range), ...)
+  continuous_scale("alpha", palette = pal_rescale(range), ...)
 }
 
 #' @rdname scale_alpha
@@ -34,7 +34,7 @@ scale_alpha_continuous <- scale_alpha
 #' @rdname scale_alpha
 #' @export
 scale_alpha_binned <- function(..., range = c(0.1, 1)) {
-  binned_scale("alpha", palette = rescale_pal(range), ...)
+  binned_scale("alpha", palette = pal_rescale(range), ...)
 }
 
 #' @rdname scale_alpha
@@ -60,12 +60,12 @@ scale_alpha_ordinal <- function(..., range = c(0.1, 1)) {
 #' @export
 #' @usage NULL
 scale_alpha_datetime <- function(..., range = c(0.1, 1)) {
-  datetime_scale("alpha", "time", palette = rescale_pal(range), ...)
+  datetime_scale("alpha", "time", palette = pal_rescale(range), ...)
 }
 
 #' @rdname scale_alpha
 #' @export
 #' @usage NULL
 scale_alpha_date <- function(..., range = c(0.1, 1)){
-  datetime_scale("alpha", "date", palette = rescale_pal(range), ...)
+  datetime_scale("alpha", "date", palette = pal_rescale(range), ...)
 }

--- a/R/scale-brewer.R
+++ b/R/scale-brewer.R
@@ -8,7 +8,7 @@
 #'
 #' @note
 #' The `distiller` scales extend `brewer` scales by smoothly
-#' interpolating 7 colours from any palette to a continuous scale. 
+#' interpolating 7 colours from any palette to a continuous scale.
 #' The `distiller` scales have a default direction = -1. To reverse, use direction = 1.
 #' The `fermenter` scales provide binned versions of the `brewer` scales.
 #'
@@ -27,10 +27,10 @@
 #' }
 #' Modify the palette through the `palette` argument.
 #'
-#' @inheritParams scales::brewer_pal
+#' @inheritParams scales::pal_brewer
 #' @inheritParams scale_colour_hue
 #' @inheritParams scale_colour_gradient
-#' @inheritParams scales::gradient_n_pal
+#' @inheritParams scales::pal_gradient_n
 #' @param palette If a string, will use that named palette. If a number, will index into
 #'   the list of palettes of appropriate `type`. The list of available palettes can found
 #'   in the Palettes section.
@@ -52,7 +52,7 @@
 #' # Change scale label
 #' d + scale_colour_brewer("Diamond\nclarity")
 #'
-#' # Select brewer palette to use, see ?scales::brewer_pal for more details
+#' # Select brewer palette to use, see ?scales::pal_brewer for more details
 #' d + scale_colour_brewer(palette = "Greens")
 #' d + scale_colour_brewer(palette = "Set1")
 #'
@@ -84,13 +84,13 @@
 #' v + scale_fill_fermenter()
 #'
 scale_colour_brewer <- function(..., type = "seq", palette = 1, direction = 1, aesthetics = "colour") {
-  discrete_scale(aesthetics, palette = brewer_pal(type, palette, direction), ...)
+  discrete_scale(aesthetics, palette = pal_brewer(type, palette, direction), ...)
 }
 
 #' @export
 #' @rdname scale_brewer
 scale_fill_brewer <- function(..., type = "seq", palette = 1, direction = 1, aesthetics = "fill") {
-  discrete_scale(aesthetics, palette = brewer_pal(type, palette, direction), ...)
+  discrete_scale(aesthetics, palette = pal_brewer(type, palette, direction), ...)
 }
 
 #' @export
@@ -106,7 +106,7 @@ scale_colour_distiller <- function(..., type = "seq", palette = 1, direction = -
   }
   continuous_scale(
     aesthetics,
-    palette = gradient_n_pal(brewer_pal(type, palette, direction)(7), values, space),
+    palette = pal_gradient_n(pal_brewer(type, palette, direction)(7), values, space),
     na.value = na.value, guide = guide, ...
   )
   # NB: 6-7 colours per palette gives nice gradients; more results in more saturated colours which do not look as good
@@ -125,7 +125,7 @@ scale_fill_distiller <- function(..., type = "seq", palette = 1, direction = -1,
   }
   continuous_scale(
     aesthetics,
-    palette = gradient_n_pal(brewer_pal(type, palette, direction)(7), values, space),
+    palette = pal_gradient_n(pal_brewer(type, palette, direction)(7), values, space),
     na.value = na.value, guide = guide, ...
   )
 }
@@ -141,7 +141,7 @@ scale_colour_fermenter <- function(..., type = "seq", palette = 1, direction = -
       "i" = "Consider using {.code type = \"seq\"} or {.code type = \"div\"} instead"
     ))
   }
-  binned_scale(aesthetics, palette = binned_pal(brewer_pal(type, palette, direction)), na.value = na.value, guide = guide, ...)
+  binned_scale(aesthetics, palette = pal_binned(pal_brewer(type, palette, direction)), na.value = na.value, guide = guide, ...)
 }
 
 #' @export
@@ -154,5 +154,5 @@ scale_fill_fermenter <- function(..., type = "seq", palette = 1, direction = -1,
       "i" = "Consider using {.code type = \"seq\"} or {.code type = \"div\"} instead"
     ))
   }
-  binned_scale(aesthetics, palette = binned_pal(brewer_pal(type, palette, direction)), na.value = na.value, guide = guide, ...)
+  binned_scale(aesthetics, palette = pal_binned(pal_brewer(type, palette, direction)), na.value = na.value, guide = guide, ...)
 }

--- a/R/scale-continuous.R
+++ b/R/scale-continuous.R
@@ -64,9 +64,9 @@
 #' p1 + scale_y_reverse()
 #'
 #' # Or you can supply a transformation in the `trans` argument:
-#' p1 + scale_y_continuous(trans = scales::reciprocal_trans())
+#' p1 + scale_y_continuous(trans = scales::transform_reciprocal())
 #'
-#' # You can also create your own. See ?scales::trans_new
+#' # You can also create your own. See ?scales::new_transform
 #'
 #' @name scale_continuous
 #' @aliases NULL
@@ -169,30 +169,30 @@ ScaleContinuousPosition <- ggproto("ScaleContinuousPosition", ScaleContinuous,
 #' @rdname scale_continuous
 #' @export
 scale_x_log10 <- function(...) {
-  scale_x_continuous(..., trans = log10_trans())
+  scale_x_continuous(..., trans = transform_log10())
 }
 #' @rdname scale_continuous
 #' @export
 scale_y_log10 <- function(...) {
-  scale_y_continuous(..., trans = log10_trans())
+  scale_y_continuous(..., trans = transform_log10())
 }
 #' @rdname scale_continuous
 #' @export
 scale_x_reverse <- function(...) {
-  scale_x_continuous(..., trans = reverse_trans())
+  scale_x_continuous(..., trans = transform_reverse())
 }
 #' @rdname scale_continuous
 #' @export
 scale_y_reverse <- function(...) {
-  scale_y_continuous(..., trans = reverse_trans())
+  scale_y_continuous(..., trans = transform_reverse())
 }
 #' @rdname scale_continuous
 #' @export
 scale_x_sqrt <- function(...) {
-  scale_x_continuous(..., trans = sqrt_trans())
+  scale_x_continuous(..., trans = transform_sqrt())
 }
 #' @rdname scale_continuous
 #' @export
 scale_y_sqrt <- function(...) {
-  scale_y_continuous(..., trans = sqrt_trans())
+  scale_y_continuous(..., trans = transform_sqrt())
 }

--- a/R/scale-date.R
+++ b/R/scale-date.R
@@ -242,7 +242,7 @@ scale_x_time <- function(name = waiver(),
     na.value = na.value,
     guide = guide,
     position = position,
-    trans = scales::hms_trans(),
+    trans = scales::transform_hms(),
     sec.axis = sec.axis
   )
 }
@@ -273,7 +273,7 @@ scale_y_time <- function(name = waiver(),
     na.value = na.value,
     guide = guide,
     position = position,
-    trans = scales::hms_trans(),
+    trans = scales::transform_hms(),
     sec.axis = sec.axis
   )
 }
@@ -326,8 +326,8 @@ datetime_scale <- function(aesthetics, trans, palette,
   }
 
   trans <- switch(trans,
-    date = date_trans(),
-    time = time_trans(timezone)
+    date = transform_date(),
+    time = transform_time(timezone)
   )
 
   sc <- continuous_scale(
@@ -357,7 +357,7 @@ ScaleContinuousDatetime <- ggproto("ScaleContinuousDatetime", ScaleContinuous,
     tz <- attr(x, "tzone")
     if (is.null(self$timezone) && !is.null(tz)) {
       self$timezone <- tz
-      self$trans <- time_trans(self$timezone)
+      self$trans <- transform_time(self$timezone)
     }
     ggproto_parent(ScaleContinuous, self)$transform(x)
   },

--- a/R/scale-expansion.R
+++ b/R/scale-expansion.R
@@ -168,7 +168,7 @@ expand_limits_discrete <- function(limits, expand = expansion(0, 0), coord_limit
 }
 
 expand_limits_continuous_trans <- function(limits, expand = expansion(0, 0),
-                                           coord_limits = c(NA, NA), trans = identity_trans()) {
+                                           coord_limits = c(NA, NA), trans = transform_identity()) {
 
   # let non-NA coord_limits override the scale limits
   limits <- ifelse(is.na(coord_limits), limits, coord_limits)
@@ -198,7 +198,7 @@ expand_limits_continuous_trans <- function(limits, expand = expansion(0, 0),
 }
 
 expand_limits_discrete_trans <- function(limits, expand = expansion(0, 0),
-                                         coord_limits = c(NA, NA), trans = identity_trans(),
+                                         coord_limits = c(NA, NA), trans = transform_identity(),
                                          range_continuous = NULL) {
   if (is.discrete(limits)) {
     n_discrete_limits <- length(limits)

--- a/R/scale-gradient.R
+++ b/R/scale-gradient.R
@@ -11,13 +11,13 @@
 #' luminance. The \pkg{munsell} package makes this easy to do using the
 #' Munsell colour system.
 #'
-#' @inheritParams scales::seq_gradient_pal
+#' @inheritParams scales::pal_seq_gradient
 #' @inheritParams scale_colour_hue
 #' @param low,high Colours for low and high ends of the gradient.
 #' @param guide Type of legend. Use `"colourbar"` for continuous
 #'   colour bar, or `"legend"` for discrete colour legend.
 #' @inheritDotParams continuous_scale -na.value -guide -aesthetics
-#' @seealso [scales::seq_gradient_pal()] for details on underlying
+#' @seealso [scales::pal_seq_gradient()] for details on underlying
 #'   palette, [scale_colour_steps()] for binned variants of these scales.
 #'
 #'   The documentation on [colour aesthetics][aes_colour_fill_alpha].
@@ -77,7 +77,7 @@
 #'
 scale_colour_gradient <- function(..., low = "#132B43", high = "#56B1F7", space = "Lab",
                                   na.value = "grey50", guide = "colourbar", aesthetics = "colour") {
-  continuous_scale(aesthetics, palette = seq_gradient_pal(low, high, space),
+  continuous_scale(aesthetics, palette = pal_seq_gradient(low, high, space),
     na.value = na.value, guide = guide, ...)
 }
 
@@ -85,11 +85,11 @@ scale_colour_gradient <- function(..., low = "#132B43", high = "#56B1F7", space 
 #' @export
 scale_fill_gradient <- function(..., low = "#132B43", high = "#56B1F7", space = "Lab",
                                 na.value = "grey50", guide = "colourbar", aesthetics = "fill") {
-  continuous_scale(aesthetics, palette = seq_gradient_pal(low, high, space),
+  continuous_scale(aesthetics, palette = pal_seq_gradient(low, high, space),
     na.value = na.value, guide = guide, ...)
 }
 
-#' @inheritParams scales::div_gradient_pal
+#' @inheritParams scales::pal_div_gradient
 #' @param midpoint The midpoint (in data value) of the diverging scale.
 #'   Defaults to 0.
 #' @rdname scale_gradient
@@ -99,7 +99,7 @@ scale_colour_gradient2 <- function(..., low = muted("red"), mid = "white", high 
                                    aesthetics = "colour") {
   continuous_scale(
     aesthetics,
-    palette = div_gradient_pal(low, mid, high, space),
+    palette = pal_div_gradient(low, mid, high, space),
     na.value = na.value, guide = guide, ...,
     rescaler = mid_rescaler(mid = midpoint)
   )
@@ -112,7 +112,7 @@ scale_fill_gradient2 <- function(..., low = muted("red"), mid = "white", high = 
                                  aesthetics = "fill") {
   continuous_scale(
     aesthetics,
-    palette = div_gradient_pal(low, mid, high, space),
+    palette = pal_div_gradient(low, mid, high, space),
     na.value = na.value, guide = guide, ...,
     rescaler = mid_rescaler(mid = midpoint)
   )
@@ -124,7 +124,7 @@ mid_rescaler <- function(mid) {
   }
 }
 
-#' @inheritParams scales::gradient_n_pal
+#' @inheritParams scales::pal_gradient_n
 #' @param colours,colors Vector of colours to use for n-colour gradient.
 #' @rdname scale_gradient
 #' @export
@@ -134,7 +134,7 @@ scale_colour_gradientn <- function(..., colours, values = NULL, space = "Lab", n
 
   continuous_scale(
     aesthetics,
-    palette = gradient_n_pal(colours, values, space),
+    palette = pal_gradient_n(colours, values, space),
     na.value = na.value, guide = guide, ...
   )
 }
@@ -146,7 +146,7 @@ scale_fill_gradientn <- function(..., colours, values = NULL, space = "Lab", na.
 
   continuous_scale(
     aesthetics,
-    palette = gradient_n_pal(colours, values, space),
+    palette = pal_gradient_n(colours, values, space),
     na.value = na.value, guide = guide, ...
   )
 }

--- a/R/scale-grey.R
+++ b/R/scale-grey.R
@@ -3,7 +3,7 @@
 #' Based on [gray.colors()]. This is black and white equivalent
 #' of [scale_colour_gradient()].
 #'
-#' @inheritParams scales::grey_pal
+#' @inheritParams scales::pal_grey
 #' @inheritParams scale_colour_hue
 #' @inheritDotParams discrete_scale
 #' @family colour scales
@@ -28,13 +28,13 @@
 #'   geom_point(aes(colour = miss)) +
 #'   scale_colour_grey(na.value = "green")
 scale_colour_grey <- function(..., start = 0.2, end = 0.8, na.value = "red", aesthetics = "colour") {
-  discrete_scale(aesthetics, palette = grey_pal(start, end),
+  discrete_scale(aesthetics, palette = pal_grey(start, end),
     na.value = na.value, ...)
 }
 
 #' @rdname scale_grey
 #' @export
 scale_fill_grey <- function(..., start = 0.2, end = 0.8, na.value = "red", aesthetics = "fill") {
-  discrete_scale(aesthetics, palette = grey_pal(start, end),
+  discrete_scale(aesthetics, palette = pal_grey(start, end),
     na.value = na.value, ...)
 }

--- a/R/scale-hue.R
+++ b/R/scale-hue.R
@@ -9,7 +9,7 @@
 #'   name(s) of the aesthetic(s) that this scale works with. This can be useful, for
 #'   example, to apply colour settings to the `colour` and `fill` aesthetics at the
 #'   same time, via `aesthetics = c("colour", "fill")`.
-#' @inheritParams scales::hue_pal
+#' @inheritParams scales::pal_hue
 #' @rdname scale_hue
 #' @export
 #' @family colour scales
@@ -55,7 +55,7 @@
 #' }
 scale_colour_hue <- function(..., h = c(0, 360) + 15, c = 100, l = 65, h.start = 0,
                              direction = 1, na.value = "grey50", aesthetics = "colour") {
-  discrete_scale(aesthetics, palette = hue_pal(h, c, l, h.start, direction),
+  discrete_scale(aesthetics, palette = pal_hue(h, c, l, h.start, direction),
     na.value = na.value, ...)
 }
 
@@ -63,7 +63,7 @@ scale_colour_hue <- function(..., h = c(0, 360) + 15, c = 100, l = 65, h.start =
 #' @export
 scale_fill_hue <- function(..., h = c(0, 360) + 15, c = 100, l = 65, h.start = 0,
                            direction = 1, na.value = "grey50", aesthetics = "fill") {
-  discrete_scale(aesthetics, palette = hue_pal(h, c, l, h.start, direction),
+  discrete_scale(aesthetics, palette = pal_hue(h, c, l, h.start, direction),
     na.value = na.value, ...)
 }
 
@@ -168,7 +168,7 @@ scale_fill_discrete <- function(..., type = getOption("ggplot2.discrete.fill")) 
 scale_colour_qualitative <- function(..., type = NULL, h = c(0, 360) + 15, c = 100, l = 65, h.start = 0,
                                      direction = 1, na.value = "grey50", aesthetics = "colour") {
   discrete_scale(
-    aesthetics, palette = qualitative_pal(type, h, c, l, h.start, direction),
+    aesthetics, palette = pal_qualitative(type, h, c, l, h.start, direction),
     na.value = na.value, ...
   )
 }
@@ -176,7 +176,7 @@ scale_colour_qualitative <- function(..., type = NULL, h = c(0, 360) + 15, c = 1
 scale_fill_qualitative <- function(..., type = NULL, h = c(0, 360) + 15, c = 100, l = 65, h.start = 0,
                                    direction = 1, na.value = "grey50", aesthetics = "fill") {
   discrete_scale(
-    aesthetics, palette = qualitative_pal(type, h, c, l, h.start, direction),
+    aesthetics, palette = pal_qualitative(type, h, c, l, h.start, direction),
     na.value = na.value, ...
   )
 }
@@ -184,16 +184,16 @@ scale_fill_qualitative <- function(..., type = NULL, h = c(0, 360) + 15, c = 100
 #' Given set(s) of colour codes (i.e., type), find the smallest set that can support n levels
 #' @param type a character vector or a list of character vectors
 #' @noRd
-qualitative_pal <- function(type, h, c, l, h.start, direction) {
+pal_qualitative <- function(type, h, c, l, h.start, direction) {
   function(n) {
     type_list <- if (!is.list(type)) list(type) else type
     if (!all(vapply(type_list, is.character, logical(1)))) {
       cli::cli_abort("{.arg type} must be a character vector or a list of character vectors")
     }
     type_lengths <- lengths(type_list)
-    # If there are more levels than color codes default to hue_pal()
+    # If there are more levels than color codes default to pal_hue()
     if (max(type_lengths) < n) {
-      return(scales::hue_pal(h, c, l, h.start, direction)(n))
+      return(scales::pal_hue(h, c, l, h.start, direction)(n))
     }
     # Use the minimum length vector that exceeds the number of levels (n)
     type_list <- type_list[order(type_lengths)]

--- a/R/scale-identity.R
+++ b/R/scale-identity.R
@@ -63,7 +63,7 @@ NULL
 #' @rdname scale_identity
 #' @export
 scale_colour_identity <- function(..., guide = "none", aesthetics = "colour") {
-  sc <- discrete_scale(aesthetics, palette = identity_pal(), ..., guide = guide,
+  sc <- discrete_scale(aesthetics, palette = pal_identity(), ..., guide = guide,
     super = ScaleDiscreteIdentity)
 
   sc
@@ -72,7 +72,7 @@ scale_colour_identity <- function(..., guide = "none", aesthetics = "colour") {
 #' @rdname scale_identity
 #' @export
 scale_fill_identity <- function(..., guide = "none", aesthetics = "fill") {
-  sc <- discrete_scale(aesthetics, palette = identity_pal(), ..., guide = guide,
+  sc <- discrete_scale(aesthetics, palette = pal_identity(), ..., guide = guide,
     super = ScaleDiscreteIdentity)
 
   sc
@@ -83,7 +83,7 @@ scale_fill_identity <- function(..., guide = "none", aesthetics = "fill") {
 #' Other shape scales: [scale_shape()], [scale_shape_manual()].
 #' @export
 scale_shape_identity <- function(..., guide = "none") {
-  sc <- continuous_scale("shape", palette = identity_pal(), ..., guide = guide,
+  sc <- continuous_scale("shape", palette = pal_identity(), ..., guide = guide,
     super = ScaleContinuousIdentity)
 
   sc
@@ -94,7 +94,7 @@ scale_shape_identity <- function(..., guide = "none") {
 #' Other linetype scales: [scale_linetype()], [scale_linetype_manual()].
 #' @export
 scale_linetype_identity <- function(..., guide = "none") {
-  sc <- discrete_scale("linetype", palette = identity_pal(), ..., guide = guide,
+  sc <- discrete_scale("linetype", palette = pal_identity(), ..., guide = guide,
     super = ScaleDiscreteIdentity)
 
   sc
@@ -105,7 +105,7 @@ scale_linetype_identity <- function(..., guide = "none") {
 #' Other alpha scales: [scale_alpha()], [scale_alpha_manual()].
 #' @export
 scale_linewidth_identity <- function(..., guide = "none") {
-  sc <- continuous_scale("linewidth", palette = identity_pal(), ...,
+  sc <- continuous_scale("linewidth", palette = pal_identity(), ...,
                          guide = guide, super = ScaleContinuousIdentity)
 
   sc
@@ -114,7 +114,7 @@ scale_linewidth_identity <- function(..., guide = "none") {
 #' @rdname scale_identity
 #' @export
 scale_alpha_identity <- function(..., guide = "none") {
-  sc <- continuous_scale("alpha", palette = identity_pal(), ..., guide = guide,
+  sc <- continuous_scale("alpha", palette = pal_identity(), ..., guide = guide,
     super = ScaleContinuousIdentity)
 
   sc
@@ -125,7 +125,7 @@ scale_alpha_identity <- function(..., guide = "none") {
 #' Other size scales: [scale_size()], [scale_size_manual()].
 #' @export
 scale_size_identity <- function(..., guide = "none") {
-  sc <- continuous_scale("size", palette = identity_pal(), ..., guide = guide,
+  sc <- continuous_scale("size", palette = pal_identity(), ..., guide = guide,
     super = ScaleContinuousIdentity)
 
   sc
@@ -134,7 +134,7 @@ scale_size_identity <- function(..., guide = "none") {
 #' @rdname scale_identity
 #' @export
 scale_discrete_identity <- function(aesthetics, ..., guide = "none") {
-  sc <- discrete_scale(aesthetics, palette = identity_pal(), ..., guide = guide,
+  sc <- discrete_scale(aesthetics, palette = pal_identity(), ..., guide = guide,
                        super = ScaleDiscreteIdentity)
 
   sc
@@ -143,7 +143,7 @@ scale_discrete_identity <- function(aesthetics, ..., guide = "none") {
 #' @rdname scale_identity
 #' @export
 scale_continuous_identity <- function(aesthetics, ..., guide = "none") {
-  sc <- continuous_scale(aesthetics, palette = identity_pal(), ..., guide = guide,
+  sc <- continuous_scale(aesthetics, palette = pal_identity(), ..., guide = guide,
                          super = ScaleContinuousIdentity)
 
   sc

--- a/R/scale-linetype.R
+++ b/R/scale-linetype.R
@@ -34,14 +34,14 @@
 #'   facet_grid(linetype ~ .) +
 #'   theme_void(20)
 scale_linetype <- function(..., na.value = "blank") {
-  discrete_scale("linetype", palette = linetype_pal(),
+  discrete_scale("linetype", palette = pal_linetype(),
     na.value = na.value, ...)
 }
 
 #' @rdname scale_linetype
 #' @export
 scale_linetype_binned <- function(..., na.value = "blank") {
-  binned_scale("linetype", palette = binned_pal(linetype_pal()), ...)
+  binned_scale("linetype", palette = pal_binned(pal_linetype()), ...)
 }
 
 #' @rdname scale_linetype

--- a/R/scale-linewidth.R
+++ b/R/scale-linewidth.R
@@ -31,7 +31,7 @@ scale_linewidth_continuous <- function(name = waiver(), breaks = waiver(),
                                        labels = waiver(), limits = NULL,
                                        range = c(1, 6), trans = "identity",
                                        guide = "legend") {
-  continuous_scale("linewidth", palette = rescale_pal(range), name = name,
+  continuous_scale("linewidth", palette = pal_rescale(range), name = name,
                    breaks = breaks, labels = labels, limits = limits, trans = trans,
                    guide = guide)
 }
@@ -45,7 +45,7 @@ scale_linewidth <- scale_linewidth_continuous
 scale_linewidth_binned <- function(name = waiver(), breaks = waiver(), labels = waiver(),
                               limits = NULL, range = c(1, 6), n.breaks = NULL,
                               nice.breaks = TRUE, trans = "identity", guide = "bins") {
-  binned_scale("linewidth", palette = rescale_pal(range), name = name,
+  binned_scale("linewidth", palette = pal_rescale(range), name = name,
                breaks = breaks, labels = labels, limits = limits, trans = trans,
                n.breaks = n.breaks, nice.breaks = nice.breaks, guide = guide)
 }
@@ -77,12 +77,12 @@ scale_linewidth_ordinal <- function(..., range = c(2, 6)) {
 #' @export
 #' @usage NULL
 scale_linewidth_datetime <- function(..., range = c(1, 6)) {
-  datetime_scale("linewidth", "time", palette = rescale_pal(range), ...)
+  datetime_scale("linewidth", "time", palette = pal_rescale(range), ...)
 }
 
 #' @rdname scale_linewidth
 #' @export
 #' @usage NULL
 scale_linewidth_date <- function(..., range = c(1, 6)) {
-  datetime_scale("linewidth", "date", palette = rescale_pal(range), ...)
+  datetime_scale("linewidth", "date", palette = pal_rescale(range), ...)
 }

--- a/R/scale-shape.R
+++ b/R/scale-shape.R
@@ -41,13 +41,13 @@
 #'   facet_wrap(~shape) +
 #'   theme_void()
 scale_shape <- function(..., solid = TRUE) {
-  discrete_scale("shape", palette = shape_pal(solid), ...)
+  discrete_scale("shape", palette = pal_shape(solid), ...)
 }
 
 #' @rdname scale_shape
 #' @export
 scale_shape_binned <- function(..., solid = TRUE) {
-  binned_scale("shape", palette = binned_pal(shape_pal(solid)), ...)
+  binned_scale("shape", palette = pal_binned(pal_shape(solid)), ...)
 }
 
 #' @rdname scale_shape

--- a/R/scale-size.R
+++ b/R/scale-size.R
@@ -52,7 +52,7 @@ NULL
 scale_size_continuous <- function(name = waiver(), breaks = waiver(), labels = waiver(),
                                   limits = NULL, range = c(1, 6),
                                   trans = "identity", guide = "legend") {
-  continuous_scale("size", palette = area_pal(range), name = name,
+  continuous_scale("size", palette = pal_area(range), name = name,
     breaks = breaks, labels = labels, limits = limits, trans = trans,
     guide = guide)
 }
@@ -66,7 +66,7 @@ scale_size <- scale_size_continuous
 scale_radius <- function(name = waiver(), breaks = waiver(), labels = waiver(),
                          limits = NULL, range = c(1, 6),
                          trans = "identity", guide = "legend") {
-  continuous_scale("size", palette = rescale_pal(range), name = name,
+  continuous_scale("size", palette = pal_rescale(range), name = name,
     breaks = breaks, labels = labels, limits = limits, trans = trans,
     guide = guide)
 }
@@ -76,7 +76,7 @@ scale_radius <- function(name = waiver(), breaks = waiver(), labels = waiver(),
 scale_size_binned <- function(name = waiver(), breaks = waiver(), labels = waiver(),
                               limits = NULL, range = c(1, 6), n.breaks = NULL,
                               nice.breaks = TRUE, trans = "identity", guide = "bins") {
-  binned_scale("size", palette = area_pal(range), name = name,
+  binned_scale("size", palette = pal_area(range), name = name,
                breaks = breaks, labels = labels, limits = limits, trans = trans,
                n.breaks = n.breaks, nice.breaks = nice.breaks, guide = guide)
 }
@@ -129,12 +129,12 @@ scale_size_binned_area <- function(..., max_size = 6) {
 #' @export
 #' @usage NULL
 scale_size_datetime <- function(..., range = c(1, 6)) {
-  datetime_scale("size", "time", palette = area_pal(range), ...)
+  datetime_scale("size", "time", palette = pal_area(range), ...)
 }
 
 #' @rdname scale_size
 #' @export
 #' @usage NULL
 scale_size_date <- function(..., range = c(1, 6)) {
-  datetime_scale("size", "date", palette = area_pal(range), ...)
+  datetime_scale("size", "date", palette = pal_area(range), ...)
 }

--- a/R/scale-steps.R
+++ b/R/scale-steps.R
@@ -15,7 +15,7 @@
 #' @inheritParams scale_colour_gradient
 #' @inheritDotParams binned_scale -aesthetics -scale_name -palette -na.value -guide -rescaler
 #'
-#' @seealso [scales::seq_gradient_pal()] for details on underlying
+#' @seealso [scales::pal_seq_gradient()] for details on underlying
 #'   palette, [scale_colour_gradient()] for continuous scales without binning.
 #'
 #'   The documentation on [colour aesthetics][aes_colour_fill_alpha].
@@ -46,7 +46,7 @@
 #' @rdname scale_steps
 scale_colour_steps <- function(..., low = "#132B43", high = "#56B1F7", space = "Lab",
                                na.value = "grey50", guide = "coloursteps", aesthetics = "colour") {
-  binned_scale(aesthetics, palette = seq_gradient_pal(low, high, space),
+  binned_scale(aesthetics, palette = pal_seq_gradient(low, high, space),
                na.value = na.value, guide = guide, ...)
 }
 #' @rdname scale_steps
@@ -54,7 +54,7 @@ scale_colour_steps <- function(..., low = "#132B43", high = "#56B1F7", space = "
 scale_colour_steps2 <- function(..., low = muted("red"), mid = "white", high = muted("blue"),
                                 midpoint = 0, space = "Lab", na.value = "grey50", guide = "coloursteps",
                                 aesthetics = "colour") {
-  binned_scale(aesthetics, palette = div_gradient_pal(low, mid, high, space),
+  binned_scale(aesthetics, palette = pal_div_gradient(low, mid, high, space),
                na.value = na.value, guide = guide, rescaler = mid_rescaler(mid = midpoint), ...)
 }
 #' @rdname scale_steps
@@ -62,14 +62,14 @@ scale_colour_steps2 <- function(..., low = muted("red"), mid = "white", high = m
 scale_colour_stepsn <- function(..., colours, values = NULL, space = "Lab", na.value = "grey50",
                                 guide = "coloursteps", aesthetics = "colour", colors) {
   colours <- if (missing(colours)) colors else colours
-  binned_scale(aesthetics, palette = gradient_n_pal(colours, values, space),
+  binned_scale(aesthetics, palette = pal_gradient_n(colours, values, space),
                na.value = na.value, guide = guide, ...)
 }
 #' @rdname scale_steps
 #' @export
 scale_fill_steps <- function(..., low = "#132B43", high = "#56B1F7", space = "Lab",
                              na.value = "grey50", guide = "coloursteps", aesthetics = "fill") {
-  binned_scale(aesthetics, palette = seq_gradient_pal(low, high, space),
+  binned_scale(aesthetics, palette = pal_seq_gradient(low, high, space),
                na.value = na.value, guide = guide, ...)
 }
 #' @rdname scale_steps
@@ -77,7 +77,7 @@ scale_fill_steps <- function(..., low = "#132B43", high = "#56B1F7", space = "La
 scale_fill_steps2 <- function(..., low = muted("red"), mid = "white", high = muted("blue"),
                               midpoint = 0, space = "Lab", na.value = "grey50", guide = "coloursteps",
                               aesthetics = "fill") {
-  binned_scale(aesthetics, palette = div_gradient_pal(low, mid, high, space),
+  binned_scale(aesthetics, palette = pal_div_gradient(low, mid, high, space),
                na.value = na.value, guide = guide, rescaler = mid_rescaler(mid = midpoint), ...)
 }
 #' @rdname scale_steps
@@ -85,6 +85,6 @@ scale_fill_steps2 <- function(..., low = muted("red"), mid = "white", high = mut
 scale_fill_stepsn <- function(..., colours, values = NULL, space = "Lab", na.value = "grey50",
                                 guide = "coloursteps", aesthetics = "fill", colors) {
   colours <- if (missing(colours)) colors else colours
-  binned_scale(aesthetics, palette = gradient_n_pal(colours, values, space),
+  binned_scale(aesthetics, palette = pal_gradient_n(colours, values, space),
                na.value = na.value, guide = guide, ...)
 }

--- a/R/scale-viridis.R
+++ b/R/scale-viridis.R
@@ -5,8 +5,8 @@
 #' with common forms of colour blindness. See also
 #' <https://bids.github.io/colormap/>.
 #'
-#' @inheritParams scales::viridis_pal
-#' @inheritParams scales::gradient_n_pal
+#' @inheritParams scales::pal_viridis
+#' @inheritParams scales::pal_gradient_n
 #' @inheritParams continuous_scale
 #' @param ... Other arguments passed on to [discrete_scale()],
 #' [continuous_scale()], or [binned_scale()] to control name, limits, breaks,
@@ -37,7 +37,7 @@
 #' # Change scale label
 #' d + scale_colour_viridis_d("City\nCenter")
 #'
-#' # Select palette to use, see ?scales::viridis_pal for more details
+#' # Select palette to use, see ?scales::pal_viridis for more details
 #' d + scale_colour_viridis_d(option = "plasma")
 #' d + scale_colour_viridis_d(option = "inferno")
 #'
@@ -62,7 +62,7 @@ scale_colour_viridis_d <- function(..., alpha = 1, begin = 0, end = 1,
                                    direction = 1, option = "D", aesthetics = "colour") {
   discrete_scale(
     aesthetics,
-    palette = viridis_pal(alpha, begin, end, direction, option),
+    palette = pal_viridis(alpha, begin, end, direction, option),
     ...
   )
 }
@@ -73,7 +73,7 @@ scale_fill_viridis_d <- function(..., alpha = 1, begin = 0, end = 1,
                                  direction = 1, option = "D", aesthetics = "fill") {
   discrete_scale(
     aesthetics,
-    palette = viridis_pal(alpha, begin, end, direction, option),
+    palette = pal_viridis(alpha, begin, end, direction, option),
     ...
   )
 }
@@ -86,8 +86,8 @@ scale_colour_viridis_c <- function(..., alpha = 1, begin = 0, end = 1,
                                    guide = "colourbar", aesthetics = "colour") {
   continuous_scale(
     aesthetics,
-    palette = gradient_n_pal(
-      viridis_pal(alpha, begin, end, direction, option)(6),
+    palette = pal_gradient_n(
+      pal_viridis(alpha, begin, end, direction, option)(6),
       values,
       space
     ),
@@ -105,8 +105,8 @@ scale_fill_viridis_c <- function(..., alpha = 1, begin = 0, end = 1,
                                  guide = "colourbar", aesthetics = "fill") {
   continuous_scale(
     aesthetics,
-    palette = gradient_n_pal(
-      viridis_pal(alpha, begin, end, direction, option)(6),
+    palette = pal_gradient_n(
+      pal_viridis(alpha, begin, end, direction, option)(6),
       values,
       space
     ),
@@ -122,8 +122,8 @@ scale_colour_viridis_b <- function(..., alpha = 1, begin = 0, end = 1,
                                    direction = 1, option = "D", values = NULL,
                                    space = "Lab", na.value = "grey50",
                                    guide = "coloursteps", aesthetics = "colour") {
-  pal <-  binned_pal(
-    viridis_pal(alpha, begin, end, direction, option)
+  pal <-  pal_binned(
+    pal_viridis(alpha, begin, end, direction, option)
   )
 
   binned_scale(
@@ -141,8 +141,8 @@ scale_fill_viridis_b <- function(..., alpha = 1, begin = 0, end = 1,
                                  direction = 1, option = "D", values = NULL,
                                  space = "Lab", na.value = "grey50",
                                  guide = "coloursteps", aesthetics = "fill") {
-  pal <-  binned_pal(
-    viridis_pal(alpha, begin, end, direction, option)
+  pal <-  pal_binned(
+    pal_viridis(alpha, begin, end, direction, option)
   )
 
   binned_scale(

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -178,7 +178,7 @@ rescale01 <- function(x) {
   (x - rng[1]) / (rng[2] - rng[1])
 }
 
-binned_pal <- function(palette) {
+pal_binned <- function(palette) {
   function(x) {
     palette(length(x))
   }

--- a/R/zxx.R
+++ b/R/zxx.R
@@ -16,7 +16,7 @@ scale_colour_ordinal <- function(..., type = getOption("ggplot2.ordinal.colour",
     exec(
       discrete_scale,
       aesthetics = "colour",
-      palette = ordinal_pal(type),
+      palette = pal_ordinal(type),
       !!!args
     )
   }
@@ -40,7 +40,7 @@ scale_colour_datetime <- function(...,
   datetime_scale(
     "colour",
     "time",
-    palette = seq_gradient_pal(low, high, space),
+    palette = pal_seq_gradient(low, high, space),
     na.value = na.value,
     guide = guide,
     ...
@@ -64,7 +64,7 @@ scale_colour_date <- function(...,
   datetime_scale(
     "colour",
     "date",
-    palette = seq_gradient_pal(low, high, space),
+    palette = pal_seq_gradient(low, high, space),
     na.value = na.value,
     guide = guide,
     ...
@@ -94,13 +94,13 @@ scale_fill_ordinal <- function(..., type = getOption("ggplot2.ordinal.fill", get
     exec(
       discrete_scale,
       aesthetics = "fill",
-      palette = ordinal_pal(type),
+      palette = pal_ordinal(type),
       !!!args
     )
   }
 }
 
-ordinal_pal <- function(colours, na.color = "grey50", alpha = TRUE) {
+pal_ordinal <- function(colours, na.color = "grey50", alpha = TRUE) {
   pal <- scales::colour_ramp(colours, na.color = na.color, alpha = alpha)
   function(n) {
     pal(seq(0, 1, length.out = n))
@@ -119,7 +119,7 @@ scale_fill_datetime <- function(...,
   datetime_scale(
     "fill",
     "time",
-    palette = seq_gradient_pal(low, high, space),
+    palette = pal_seq_gradient(low, high, space),
     na.value = na.value,
     guide = guide,
     ...
@@ -138,7 +138,7 @@ scale_fill_date <- function(...,
   datetime_scale(
     "fill",
     "date",
-    palette = seq_gradient_pal(low, high, space),
+    palette = pal_seq_gradient(low, high, space),
     na.value = na.value,
     guide = guide,
     ...

--- a/icons/icons.R
+++ b/icons/icons.R
@@ -139,7 +139,7 @@ write_icon("geom_bin2d", {
   out <- expand.grid(x = x, y = x)
   fill <- sqrt((out$x - 0.5) ^ 2 + (out$y - 0.5) ^ 2)
 
-  pal <- scales::seq_gradient_pal("#56B1F7", "#132B43")
+  pal <- scales::pal_seq_gradient("#56B1F7", "#132B43")
   rectGrob(
     out$x + 1/n/2,
     out$y + 1/n/2,

--- a/man/binned_scale.Rd
+++ b/man/binned_scale.Rd
@@ -35,7 +35,7 @@ that should be used for error messages associated with this scale.}
 
 \item{palette}{A palette function that when called with a numeric vector with
 values between 0 and 1 returns the corresponding output values
-(e.g., \code{\link[scales:area_pal]{scales::area_pal()}}).}
+(e.g., \code{\link[scales:pal_area]{scales::pal_area()}}).}
 
 \item{name}{The name of the scale. Used as the axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
@@ -46,7 +46,7 @@ omitted.}
 \itemize{
 \item \code{NULL} for no breaks
 \item \code{waiver()} for the default breaks computed by the
-\link[scales:trans_new]{transformation object}
+\link[scales:new_transform]{transformation object}
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
 as output (e.g., a function returned by \code{\link[scales:breaks_extended]{scales::extended_breaks()}}).
@@ -130,8 +130,8 @@ A transformation object bundles together a transform, its inverse,
 and methods for generating breaks and labels. Transformation objects
 are defined in the scales package, and are called \verb{<name>_trans}. If
 transformations require arguments, you can call them from the scales
-package, e.g. \code{\link[scales:boxcox_trans]{scales::boxcox_trans(p = 2)}}.
-You can create your own transformation with \code{\link[scales:trans_new]{scales::trans_new()}}.}
+package, e.g. \code{\link[scales:transform_boxcox]{scales::transform_boxcox(p = 2)}}.
+You can create your own transformation with \code{\link[scales:new_transform]{scales::new_transform()}}.}
 
 \item{show.limits}{should the limits of the scale appear as ticks}
 

--- a/man/continuous_scale.Rd
+++ b/man/continuous_scale.Rd
@@ -33,7 +33,7 @@ that should be used for error messages associated with this scale.}
 
 \item{palette}{A palette function that when called with a numeric vector with
 values between 0 and 1 returns the corresponding output values
-(e.g., \code{\link[scales:area_pal]{scales::area_pal()}}).}
+(e.g., \code{\link[scales:pal_area]{scales::pal_area()}}).}
 
 \item{name}{The name of the scale. Used as the axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
@@ -44,7 +44,7 @@ omitted.}
 \itemize{
 \item \code{NULL} for no breaks
 \item \code{waiver()} for the default breaks computed by the
-\link[scales:trans_new]{transformation object}
+\link[scales:new_transform]{transformation object}
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
 as output (e.g., a function returned by \code{\link[scales:breaks_extended]{scales::extended_breaks()}}).
@@ -128,8 +128,8 @@ A transformation object bundles together a transform, its inverse,
 and methods for generating breaks and labels. Transformation objects
 are defined in the scales package, and are called \verb{<name>_trans}. If
 transformations require arguments, you can call them from the scales
-package, e.g. \code{\link[scales:boxcox_trans]{scales::boxcox_trans(p = 2)}}.
-You can create your own transformation with \code{\link[scales:trans_new]{scales::trans_new()}}.}
+package, e.g. \code{\link[scales:transform_boxcox]{scales::transform_boxcox(p = 2)}}.
+You can create your own transformation with \code{\link[scales:new_transform]{scales::new_transform()}}.}
 
 \item{guide}{A function used to create a guide or its name. See
 \code{\link[=guides]{guides()}} for more information.}

--- a/man/coord_trans.Rd
+++ b/man/coord_trans.Rd
@@ -42,7 +42,7 @@ no guarantee that straight lines will continue to be straight.
 }
 \details{
 Transformations only work with continuous values: see
-\code{\link[scales:trans_new]{scales::trans_new()}} for list of transformations, and instructions
+\code{\link[scales:new_transform]{scales::new_transform()}} for list of transformations, and instructions
 on how to create your own.
 }
 \examples{
@@ -93,7 +93,7 @@ ggplot(diamonds, aes(carat, price)) +
   geom_smooth(method = "lm") +
   scale_x_log10() +
   scale_y_log10() +
-  coord_trans(x = scales::exp_trans(10), y = scales::exp_trans(10))
+  coord_trans(x = scales::transform_exp(10), y = scales::transform_exp(10))
 
 # cf.
 ggplot(diamonds, aes(carat, price)) +

--- a/man/datetime_scale.Rd
+++ b/man/datetime_scale.Rd
@@ -28,7 +28,7 @@ the object itself. Built-in transformations include "hms", "date" and "time".}
 
 \item{palette}{A palette function that when called with a numeric vector with
 values between 0 and 1 returns the corresponding output values
-(e.g., \code{\link[scales:area_pal]{scales::area_pal()}}).}
+(e.g., \code{\link[scales:pal_area]{scales::pal_area()}}).}
 
 \item{breaks}{One of:
 \itemize{

--- a/man/discrete_scale.Rd
+++ b/man/discrete_scale.Rd
@@ -30,7 +30,7 @@ that should be used for error messages associated with this scale.}
 
 \item{palette}{A palette function that when called with a single integer
 argument (the number of levels in the scale) returns the values that
-they should take (e.g., \code{\link[scales:hue_pal]{scales::hue_pal()}}).}
+they should take (e.g., \code{\link[scales:pal_hue]{scales::pal_hue()}}).}
 
 \item{name}{The name of the scale. Used as the axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first

--- a/man/hmisc.Rd
+++ b/man/hmisc.Rd
@@ -29,10 +29,10 @@ These are wrappers around functions from \pkg{Hmisc} designed to make them
 easier to use with \code{\link[=stat_summary]{stat_summary()}}. See the Hmisc documentation
 for more details:
 \itemize{
-\item \code{\link[Hmisc:smean.cl.boot]{Hmisc::smean.cl.boot()}}
-\item \code{\link[Hmisc:smean.cl.normal]{Hmisc::smean.cl.normal()}}
-\item \code{\link[Hmisc:smean.sdl]{Hmisc::smean.sdl()}}
-\item \code{\link[Hmisc:smedian.hilow]{Hmisc::smedian.hilow()}}
+\item \code{\link[Hmisc:smean.sd]{Hmisc::smean.cl.boot()}}
+\item \code{\link[Hmisc:smean.sd]{Hmisc::smean.cl.normal()}}
+\item \code{\link[Hmisc:smean.sd]{Hmisc::smean.sdl()}}
+\item \code{\link[Hmisc:smean.sd]{Hmisc::smedian.hilow()}}
 }
 }
 \examples{

--- a/man/scale_binned.Rd
+++ b/man/scale_binned.Rd
@@ -58,7 +58,7 @@ breaks are given explicitly.}
 \itemize{
 \item \code{NULL} for no breaks
 \item \code{waiver()} for the default breaks computed by the
-\link[scales:trans_new]{transformation object}
+\link[scales:new_transform]{transformation object}
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
 as output (e.g., a function returned by \code{\link[scales:breaks_extended]{scales::extended_breaks()}}).
@@ -128,8 +128,8 @@ A transformation object bundles together a transform, its inverse,
 and methods for generating breaks and labels. Transformation objects
 are defined in the scales package, and are called \verb{<name>_trans}. If
 transformations require arguments, you can call them from the scales
-package, e.g. \code{\link[scales:boxcox_trans]{scales::boxcox_trans(p = 2)}}.
-You can create your own transformation with \code{\link[scales:trans_new]{scales::trans_new()}}.}
+package, e.g. \code{\link[scales:transform_boxcox]{scales::transform_boxcox(p = 2)}}.
+You can create your own transformation with \code{\link[scales:new_transform]{scales::new_transform()}}.}
 
 \item{guide}{A function used to create a guide or its name. See
 \code{\link[=guides]{guides()}} for more information.}

--- a/man/scale_brewer.Rd
+++ b/man/scale_brewer.Rd
@@ -145,7 +145,7 @@ d + scale_colour_brewer()
 # Change scale label
 d + scale_colour_brewer("Diamond\nclarity")
 
-# Select brewer palette to use, see ?scales::brewer_pal for more details
+# Select brewer palette to use, see ?scales::pal_brewer for more details
 d + scale_colour_brewer(palette = "Greens")
 d + scale_colour_brewer(palette = "Set1")
 

--- a/man/scale_continuous.Rd
+++ b/man/scale_continuous.Rd
@@ -65,7 +65,7 @@ omitted.}
 \itemize{
 \item \code{NULL} for no breaks
 \item \code{waiver()} for the default breaks computed by the
-\link[scales:trans_new]{transformation object}
+\link[scales:new_transform]{transformation object}
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
 as output (e.g., a function returned by \code{\link[scales:breaks_extended]{scales::extended_breaks()}}).
@@ -142,8 +142,8 @@ A transformation object bundles together a transform, its inverse,
 and methods for generating breaks and labels. Transformation objects
 are defined in the scales package, and are called \verb{<name>_trans}. If
 transformations require arguments, you can call them from the scales
-package, e.g. \code{\link[scales:boxcox_trans]{scales::boxcox_trans(p = 2)}}.
-You can create your own transformation with \code{\link[scales:trans_new]{scales::trans_new()}}.}
+package, e.g. \code{\link[scales:transform_boxcox]{scales::transform_boxcox(p = 2)}}.
+You can create your own transformation with \code{\link[scales:new_transform]{scales::new_transform()}}.}
 
 \item{guide}{A function used to create a guide or its name. See
 \code{\link[=guides]{guides()}} for more information.}
@@ -215,9 +215,9 @@ p1 + scale_y_sqrt()
 p1 + scale_y_reverse()
 
 # Or you can supply a transformation in the `trans` argument:
-p1 + scale_y_continuous(trans = scales::reciprocal_trans())
+p1 + scale_y_continuous(trans = scales::transform_reciprocal())
 
-# You can also create your own. See ?scales::trans_new
+# You can also create your own. See ?scales::new_transform
 
 }
 \seealso{

--- a/man/scale_discrete.Rd
+++ b/man/scale_discrete.Rd
@@ -15,7 +15,7 @@ scale_y_discrete(..., expand = waiver(), guide = waiver(), position = "left")
   \describe{
     \item{\code{palette}}{A palette function that when called with a single integer
 argument (the number of levels in the scale) returns the values that
-they should take (e.g., \code{\link[scales:hue_pal]{scales::hue_pal()}}).}
+they should take (e.g., \code{\link[scales:pal_hue]{scales::pal_hue()}}).}
     \item{\code{breaks}}{One of:
 \itemize{
 \item \code{NULL} for no breaks

--- a/man/scale_gradient.Rd
+++ b/man/scale_gradient.Rd
@@ -92,7 +92,7 @@ scale_fill_gradientn(
 that should be used for error messages associated with this scale.}
     \item{\code{palette}}{A palette function that when called with a numeric vector with
 values between 0 and 1 returns the corresponding output values
-(e.g., \code{\link[scales:area_pal]{scales::area_pal()}}).}
+(e.g., \code{\link[scales:pal_area]{scales::pal_area()}}).}
     \item{\code{name}}{The name of the scale. Used as the axis or legend title. If
 \code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic. If \code{NULL}, the legend title will be
@@ -101,7 +101,7 @@ omitted.}
 \itemize{
 \item \code{NULL} for no breaks
 \item \code{waiver()} for the default breaks computed by the
-\link[scales:trans_new]{transformation object}
+\link[scales:new_transform]{transformation object}
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
 as output (e.g., a function returned by \code{\link[scales:breaks_extended]{scales::extended_breaks()}}).
@@ -169,8 +169,8 @@ A transformation object bundles together a transform, its inverse,
 and methods for generating breaks and labels. Transformation objects
 are defined in the scales package, and are called \verb{<name>_trans}. If
 transformations require arguments, you can call them from the scales
-package, e.g. \code{\link[scales:boxcox_trans]{scales::boxcox_trans(p = 2)}}.
-You can create your own transformation with \code{\link[scales:trans_new]{scales::trans_new()}}.}
+package, e.g. \code{\link[scales:transform_boxcox]{scales::transform_boxcox(p = 2)}}.
+You can create your own transformation with \code{\link[scales:new_transform]{scales::new_transform()}}.}
     \item{\code{expand}}{For position scales, a vector of range expansion constants used to add some
 padding around the data to ensure that they are placed some distance
 away from the axes. Use the convenience function \code{\link[=expansion]{expansion()}}
@@ -276,7 +276,7 @@ ggplot(df_na, aes(x = value, y)) +
 
 }
 \seealso{
-\code{\link[scales:seq_gradient_pal]{scales::seq_gradient_pal()}} for details on underlying
+\code{\link[scales:pal_seq_gradient]{scales::pal_seq_gradient()}} for details on underlying
 palette, \code{\link[=scale_colour_steps]{scale_colour_steps()}} for binned variants of these scales.
 
 The documentation on \link[=aes_colour_fill_alpha]{colour aesthetics}.

--- a/man/scale_grey.Rd
+++ b/man/scale_grey.Rd
@@ -28,7 +28,7 @@ scale_fill_grey(
   \describe{
     \item{\code{palette}}{A palette function that when called with a single integer
 argument (the number of levels in the scale) returns the values that
-they should take (e.g., \code{\link[scales:hue_pal]{scales::hue_pal()}}).}
+they should take (e.g., \code{\link[scales:pal_hue]{scales::pal_hue()}}).}
     \item{\code{breaks}}{One of:
 \itemize{
 \item \code{NULL} for no breaks

--- a/man/scale_hue.Rd
+++ b/man/scale_hue.Rd
@@ -34,7 +34,7 @@ scale_fill_hue(
   \describe{
     \item{\code{palette}}{A palette function that when called with a single integer
 argument (the number of levels in the scale) returns the values that
-they should take (e.g., \code{\link[scales:hue_pal]{scales::hue_pal()}}).}
+they should take (e.g., \code{\link[scales:pal_hue]{scales::pal_hue()}}).}
     \item{\code{breaks}}{One of:
 \itemize{
 \item \code{NULL} for no breaks

--- a/man/scale_linetype.Rd
+++ b/man/scale_linetype.Rd
@@ -21,7 +21,7 @@ scale_linetype_discrete(..., na.value = "blank")
   \describe{
     \item{\code{palette}}{A palette function that when called with a single integer
 argument (the number of levels in the scale) returns the values that
-they should take (e.g., \code{\link[scales:hue_pal]{scales::hue_pal()}}).}
+they should take (e.g., \code{\link[scales:pal_hue]{scales::pal_hue()}}).}
     \item{\code{breaks}}{One of:
 \itemize{
 \item \code{NULL} for no breaks

--- a/man/scale_linewidth.Rd
+++ b/man/scale_linewidth.Rd
@@ -42,7 +42,7 @@ omitted.}
 \itemize{
 \item \code{NULL} for no breaks
 \item \code{waiver()} for the default breaks computed by the
-\link[scales:trans_new]{transformation object}
+\link[scales:new_transform]{transformation object}
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
 as output (e.g., a function returned by \code{\link[scales:breaks_extended]{scales::extended_breaks()}}).
@@ -87,8 +87,8 @@ A transformation object bundles together a transform, its inverse,
 and methods for generating breaks and labels. Transformation objects
 are defined in the scales package, and are called \verb{<name>_trans}. If
 transformations require arguments, you can call them from the scales
-package, e.g. \code{\link[scales:boxcox_trans]{scales::boxcox_trans(p = 2)}}.
-You can create your own transformation with \code{\link[scales:trans_new]{scales::trans_new()}}.}
+package, e.g. \code{\link[scales:transform_boxcox]{scales::transform_boxcox(p = 2)}}.
+You can create your own transformation with \code{\link[scales:new_transform]{scales::new_transform()}}.}
 
 \item{guide}{A function used to create a guide or its name. See
 \code{\link[=guides]{guides()}} for more information.}

--- a/man/scale_manual.Rd
+++ b/man/scale_manual.Rd
@@ -46,7 +46,7 @@ scale_discrete_manual(aesthetics, ..., values, breaks = waiver())
   \describe{
     \item{\code{palette}}{A palette function that when called with a single integer
 argument (the number of levels in the scale) returns the values that
-they should take (e.g., \code{\link[scales:hue_pal]{scales::hue_pal()}}).}
+they should take (e.g., \code{\link[scales:pal_hue]{scales::pal_hue()}}).}
     \item{\code{limits}}{One of:
 \itemize{
 \item \code{NULL} to use the default scale values

--- a/man/scale_shape.Rd
+++ b/man/scale_shape.Rd
@@ -18,7 +18,7 @@ scale_shape_binned(..., solid = TRUE)
   \describe{
     \item{\code{palette}}{A palette function that when called with a single integer
 argument (the number of levels in the scale) returns the values that
-they should take (e.g., \code{\link[scales:hue_pal]{scales::hue_pal()}}).}
+they should take (e.g., \code{\link[scales:pal_hue]{scales::pal_hue()}}).}
     \item{\code{breaks}}{One of:
 \itemize{
 \item \code{NULL} for no breaks

--- a/man/scale_size.Rd
+++ b/man/scale_size.Rd
@@ -59,7 +59,7 @@ omitted.}
 \itemize{
 \item \code{NULL} for no breaks
 \item \code{waiver()} for the default breaks computed by the
-\link[scales:trans_new]{transformation object}
+\link[scales:new_transform]{transformation object}
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
 as output (e.g., a function returned by \code{\link[scales:breaks_extended]{scales::extended_breaks()}}).
@@ -104,8 +104,8 @@ A transformation object bundles together a transform, its inverse,
 and methods for generating breaks and labels. Transformation objects
 are defined in the scales package, and are called \verb{<name>_trans}. If
 transformations require arguments, you can call them from the scales
-package, e.g. \code{\link[scales:boxcox_trans]{scales::boxcox_trans(p = 2)}}.
-You can create your own transformation with \code{\link[scales:trans_new]{scales::trans_new()}}.}
+package, e.g. \code{\link[scales:transform_boxcox]{scales::transform_boxcox(p = 2)}}.
+You can create your own transformation with \code{\link[scales:new_transform]{scales::new_transform()}}.}
 
 \item{guide}{A function used to create a guide or its name. See
 \code{\link[=guides]{guides()}} for more information.}

--- a/man/scale_steps.Rd
+++ b/man/scale_steps.Rd
@@ -103,7 +103,7 @@ omitted.}
 \itemize{
 \item \code{NULL} for no breaks
 \item \code{waiver()} for the default breaks computed by the
-\link[scales:trans_new]{transformation object}
+\link[scales:new_transform]{transformation object}
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
 as output (e.g., a function returned by \code{\link[scales:breaks_extended]{scales::extended_breaks()}}).
@@ -152,8 +152,8 @@ A transformation object bundles together a transform, its inverse,
 and methods for generating breaks and labels. Transformation objects
 are defined in the scales package, and are called \verb{<name>_trans}. If
 transformations require arguments, you can call them from the scales
-package, e.g. \code{\link[scales:boxcox_trans]{scales::boxcox_trans(p = 2)}}.
-You can create your own transformation with \code{\link[scales:trans_new]{scales::trans_new()}}.}
+package, e.g. \code{\link[scales:transform_boxcox]{scales::transform_boxcox(p = 2)}}.
+You can create your own transformation with \code{\link[scales:new_transform]{scales::new_transform()}}.}
     \item{\code{expand}}{For position scales, a vector of range expansion constants used to add some
 padding around the data to ensure that they are placed some distance
 away from the axes. Use the convenience function \code{\link[=expansion]{expansion()}}
@@ -231,7 +231,7 @@ ggplot(df, aes(x, y)) +
   scale_colour_stepsn(colours = terrain.colors(10))
 }
 \seealso{
-\code{\link[scales:seq_gradient_pal]{scales::seq_gradient_pal()}} for details on underlying
+\code{\link[scales:pal_seq_gradient]{scales::pal_seq_gradient()}} for details on underlying
 palette, \code{\link[=scale_colour_gradient]{scale_colour_gradient()}} for continuous scales without binning.
 
 The documentation on \link[=aes_colour_fill_alpha]{colour aesthetics}.

--- a/man/scale_viridis.Rd
+++ b/man/scale_viridis.Rd
@@ -109,14 +109,14 @@ reversed.}
 \item{option}{A character string indicating the color map option to use.
 Eight options are available:
 \itemize{
- \item "magma" (or "A")
- \item "inferno" (or "B")
- \item "plasma" (or "C")
- \item "viridis" (or "D")
- \item "cividis" (or "E")
- \item "rocket" (or "F")
- \item "mako" (or "G")
- \item "turbo" (or "H")
+\item \code{"magma"} (or \code{"A"})
+\item \code{"inferno"} (or \code{"B"})
+\item \code{"plasma"} (or \code{"C"})
+\item \code{"viridis"} (or \code{"D"})
+\item \code{"cividis"} (or \code{"E"})
+\item \code{"rocket"} (or \code{"F"})
+\item \code{"mako"} (or \code{"G"})
+\item \code{"turbo"} (or \code{"H"})
 }}
 
 \item{aesthetics}{Character string or vector of character strings listing the
@@ -160,7 +160,7 @@ d + scale_colour_viridis_d()
 # Change scale label
 d + scale_colour_viridis_d("City\nCenter")
 
-# Select palette to use, see ?scales::viridis_pal for more details
+# Select palette to use, see ?scales::pal_viridis for more details
 d + scale_colour_viridis_d(option = "plasma")
 d + scale_colour_viridis_d(option = "inferno")
 

--- a/tests/testthat/test-coord-transform.R
+++ b/tests/testthat/test-coord-transform.R
@@ -1,4 +1,4 @@
-test_that("warnings are generated when cord_trans() results in new infinite values", {
+test_that("warnings are generated when coord_trans() results in new infinite values", {
   p  <- ggplot(head(diamonds, 20)) +
     geom_bar(aes(x = cut)) +
     coord_trans(y = "log10")
@@ -59,7 +59,7 @@ test_that("coord_trans(y = 'log10') expands the x axis identically to scale_y_lo
 })
 
 test_that("coord_trans() expands axes outside the domain of the axis trans", {
-  # sqrt_trans() has a lower limit of 0
+  # transform_sqrt() has a lower limit of 0
   df <- data_frame(x = 1, y = c(0, 1, 2))
   p <- ggplot(df, aes(x, y)) + geom_point()
   built_cartesian <- ggplot_build(p + scale_y_sqrt())

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -350,7 +350,7 @@ test_that("legend directions are set correctly", {
 
 test_that("guide_axis_logticks calculates appropriate ticks", {
 
-  test_scale <- function(trans = identity_trans(), limits = c(NA, NA)) {
+  test_scale <- function(trans = transform_identity(), limits = c(NA, NA)) {
     scale <- scale_x_continuous(trans = trans)
     scale$train(scale$transform(limits))
     view_scale_primary(scale)
@@ -366,28 +366,28 @@ test_that("guide_axis_logticks calculates appropriate ticks", {
   outcome <- c((1:10)*10, (2:10)*100)
 
   # Test the classic log10 transformation
-  scale <- test_scale(log10_trans(), c(10, 1000))
+  scale <- test_scale(transform_log10(), c(10, 1000))
   key <- train_guide(guide, scale)$logkey
 
   expect_equal(sort(key$x), log10(outcome))
   expect_equal(key$.type, rep(c(1,2,3), c(3, 2, 14)))
 
   # Test compound transformation
-  scale <- test_scale(compose_trans(log10_trans(), reverse_trans()), c(10, 1000))
+  scale <- test_scale(transform_compose(transform_log10(), transform_reverse()), c(10, 1000))
   key   <- train_guide(guide, scale)$logkey
 
   expect_equal(sort(key$x), -log10(rev(outcome)))
 
   # Test transformation with negatives
-  scale <- test_scale(pseudo_log_trans(), c(-1000, 1000))
+  scale <- test_scale(transform_pseudo_log(), c(-1000, 1000))
   key   <- train_guide(guide, scale)$logkey
 
-  unlog <- sort(pseudo_log_trans()$inverse(key$x))
+  unlog <- sort(transform_pseudo_log()$inverse(key$x))
   expect_equal(unlog, c(-rev(outcome), 0, outcome))
   expect_equal(key$.type, rep(c(1,2,3), c(7, 4, 28)))
 
   # Test expanded argument
-  scale <- test_scale(log10_trans(), c(20, 900))
+  scale <- test_scale(transform_log10(), c(20, 900))
   scale$continuous_range <- c(1, 3)
 
   guide <- guide_axis_logticks(expanded = TRUE)
@@ -408,7 +408,7 @@ test_that("guide_axis_logticks calculates appropriate ticks", {
   expect_equal(sort(key$x), log2(outcome))
 
   # Should warn when scale also has transformation
-  scale <- test_scale(log10_trans(), limits = c(10, 1000))
+  scale <- test_scale(transform_log10(), limits = c(10, 1000))
   expect_snapshot_warning(train_guide(guide, scale)$logkey)
 })
 
@@ -631,12 +631,12 @@ test_that("logticks look as they should", {
 
   p <- ggplot(data.frame(x = c(-100, 100), y = c(10, 1000)), aes(x, y)) +
     geom_point() +
-    scale_y_continuous(trans = compose_trans(log10_trans(), reverse_trans()),
+    scale_y_continuous(trans = transform_compose(transform_log10(), transform_reverse()),
                        expand = expansion(add = 0.5)) +
     scale_x_continuous(
       breaks = c(-100, -10, -1, 0, 1, 10, 100)
     ) +
-    coord_trans(x = pseudo_log_trans()) +
+    coord_trans(x = transform_pseudo_log()) +
     theme_test() +
     theme(axis.line = element_line(colour = "black"),
           panel.border = element_blank(),

--- a/tests/testthat/test-scale-expansion.R
+++ b/tests/testthat/test-scale-expansion.R
@@ -31,7 +31,7 @@ test_that("expand_limits_continuous_trans() expands limits in coordinate space",
   limit_info <- expand_limits_continuous_trans(
     c(1, 2),
     expand = expansion(add = 0.5),
-    trans = log10_trans()
+    trans = transform_log10()
   )
 
   expect_identical(
@@ -49,7 +49,7 @@ test_that("introduced non-finite values fall back on scale limits", {
   limit_info <- expand_limits_continuous_trans(
     c(1, 100),
     expand = expansion(add = 2),
-    trans = sqrt_trans()
+    trans = transform_sqrt()
   )
 
   expect_identical(limit_info$continuous_range, c(1, (sqrt(100) + 2)^2))
@@ -102,7 +102,7 @@ test_that("expand_limits_continuous_trans() works with inverted transformations"
   limit_info <- expand_limits_continuous_trans(
     c(1, 2),
     expand = expansion(add = 1),
-    trans = reverse_trans()
+    trans = transform_reverse()
   )
 
   expect_identical(limit_info$continuous_range, c(0, 3))

--- a/tests/testthat/test-scale-hue.R
+++ b/tests/testthat/test-scale-hue.R
@@ -1,8 +1,8 @@
 test_that("scale_hue() checks the type input", {
-  pal <- qualitative_pal(type = 1:4)
+  pal <- pal_qualitative(type = 1:4)
   expect_snapshot_error(pal(4))
-  pal <- qualitative_pal(type = colors())
+  pal <- pal_qualitative(type = colors())
   expect_silent(pal(4))
-  pal <- qualitative_pal(type = list(colors()[1:10], colors()[11:30]))
+  pal <- pal_qualitative(type = list(colors()[1:10], colors()[11:30]))
   expect_silent(pal(4))
 })

--- a/tests/testthat/test-scales-breaks-labels.R
+++ b/tests/testthat/test-scales-breaks-labels.R
@@ -115,7 +115,7 @@ test_that("discrete labels match breaks", {
 })
 
 test_that("scale breaks work with numeric log transformation", {
-  sc <- scale_x_continuous(limits = c(1, 1e5), trans = log10_trans())
+  sc <- scale_x_continuous(limits = c(1, 1e5), trans = transform_log10())
   expect_equal(sc$get_breaks(), c(0, 2, 4)) # 1, 100, 10000
   expect_equal(sc$get_breaks_minor(), c(0, 1, 2, 3, 4, 5))
 })
@@ -297,15 +297,15 @@ test_that("minor breaks draw correctly", {
 
   expect_doppelganger("numeric-log",
     ggplot(df, aes(x_log, x_log)) +
-      scale_x_continuous(trans = log2_trans()) +
+      scale_x_continuous(trans = transform_log2()) +
       scale_y_log10() +
       labs(x = NULL, y = NULL) +
       theme
   )
   expect_doppelganger("numeric-exp",
     ggplot(df, aes(x_num, x_num)) +
-      scale_x_continuous(trans = exp_trans(2)) +
-      scale_y_continuous(trans = exp_trans(2)) +
+      scale_x_continuous(trans = transform_exp(2)) +
+      scale_y_continuous(trans = transform_exp(2)) +
       labs(x = NULL, y = NULL) +
       theme
   )

--- a/tests/testthat/test-scales.R
+++ b/tests/testthat/test-scales.R
@@ -707,8 +707,8 @@ test_that("find_scale appends appropriate calls", {
 
 test_that("Using `scale_name` prompts deprecation message", {
 
-  expect_snapshot_warning(continuous_scale("x", "foobar", identity_pal()))
-  expect_snapshot_warning(discrete_scale("x",   "foobar", identity_pal()))
-  expect_snapshot_warning(binned_scale("x",     "foobar", identity_pal()))
+  expect_snapshot_warning(continuous_scale("x", "foobar", pal_identity()))
+  expect_snapshot_warning(discrete_scale("x",   "foobar", pal_identity()))
+  expect_snapshot_warning(binned_scale("x",     "foobar", pal_identity()))
 
 })

--- a/tests/testthat/test-scales.R
+++ b/tests/testthat/test-scales.R
@@ -476,13 +476,13 @@ test_that("numeric scale transforms can produce breaks", {
   expect_equal(test_breaks("atanh", limits = c(-0.9, 0.9)),
                c(NA, -0.5, 0, 0.5, NA))
 
-  # Broken, should fix on {scale}'s side
-  # expect_equal(test_breaks(boxcox_trans(0), limits = c(0, 10)), ...)
+  expect_equal(test_breaks(transform_boxcox(0), limits = c(1, 10)),
+               c(NA, 2.5, 5.0, 7.5, 10))
 
-  expect_equal(test_breaks(modulus_trans(0), c(-10, 10)),
+  expect_equal(test_breaks(transform_modulus(0), c(-10, 10)),
                seq(-10, 10, by = 5))
 
-  expect_equal(test_breaks(yj_trans(0), c(-10, 10)),
+  expect_equal(test_breaks(transform_yj(0), c(-10, 10)),
                seq(-10, 10, by = 5))
 
   expect_equal(test_breaks("exp", c(-10, 10)),

--- a/tests/testthat/test-sec-axis.R
+++ b/tests/testthat/test-sec-axis.R
@@ -231,7 +231,7 @@ test_that("sec_axis() respects custom transformations", {
       }
     })
 
-    trans_new(name = "customlog", transform = trans, inverse = inv, domain = c(1e-16, Inf))
+    new_transform(name = "customlog", transform = trans, inverse = inv, domain = c(1e-16, Inf))
   }
 
   # Create data
@@ -335,7 +335,7 @@ test_that("sec.axis allows independent trans btwn primary and secondary axes", {
     "sec_axis, independent transformations",
     ggplot(data = data, aes(Probability, Value)) + geom_point() +
       scale_x_continuous(
-        trans = scales::probability_trans(distribution = "norm", lower.tail = FALSE),
+        trans = scales::transform_probability(distribution = "norm", lower.tail = FALSE),
         sec.axis = sec_axis(trans = ~ 1 / ., name = "Return Period")
       ) + theme_linedraw()
   )

--- a/vignettes/extending-ggplot2.Rmd
+++ b/vignettes/extending-ggplot2.Rmd
@@ -834,7 +834,7 @@ facet_trans <- function(trans, horizontal = TRUE, shrink = TRUE) {
   ggproto(NULL, FacetTrans,
     shrink = shrink,
     params = list(
-      trans = scales::as.trans(trans),
+      trans = scales::as.transform(trans),
       horizontal = horizontal
     )
   )


### PR DESCRIPTION
Briefly, {scales} went from `_pal` and `_trans` suffixed functions to `pal_` and `transform_` prefixed functions in version 1.3.0. This PR propagates the prefixed versions throughout ggplot2.