### PR TITLE
Enable horizontal margins on (sub)title/caption

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* The plot's title, subtitle and caption now obey horizontal text margins
+  (#5533).
+
 * Lines where `linewidth = NA` are now dropped in `geom_sf()` (#5204).
 
 * New `guide_axis_logticks()` can be used to draw logarithmic tick marks as

--- a/R/plot-build.R
+++ b/R/plot-build.R
@@ -265,15 +265,24 @@ ggplot_gtable.ggplot_built <- function(data) {
   }
 
   # Title
-  title <- element_render(theme, "plot.title", plot$labels$title, margin_y = TRUE)
+  title <- element_render(
+    theme, "plot.title", plot$labels$title,
+    margin_y = TRUE, margin_x = TRUE
+  )
   title_height <- grobHeight(title)
 
   # Subtitle
-  subtitle <- element_render(theme, "plot.subtitle", plot$labels$subtitle, margin_y = TRUE)
+  subtitle <- element_render(
+    theme, "plot.subtitle", plot$labels$subtitle,
+    margin_y = TRUE, margin_x = TRUE
+  )
   subtitle_height <- grobHeight(subtitle)
 
   # whole plot annotation
-  caption <- element_render(theme, "plot.caption", plot$labels$caption, margin_y = TRUE)
+  caption <- element_render(
+    theme, "plot.caption", plot$labels$caption,
+    margin_y = TRUE, margin_x = TRUE
+  )
   caption_height <- grobHeight(caption)
 
   # positioning of title and subtitle is governed by plot.title.position


### PR DESCRIPTION
This PR aims to fix #5533.

As far as I could tell, the (sub)title/captions were the only places where margins were ignored that didn't need to be ignored, so only needed to enable the margins at those places.

Example that margins can be set:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

ggplot(mpg, aes(displ, hwy)) +
  geom_point() +
  labs(
    title    = "Plot of the mpg dataset",
    subtitle = "Engine displacement versus highway miles per gallon",
    caption  = "EPA fuel economy data"
  ) +
  theme(
    plot.title    = element_text(margin = margin(l = 20, b = 5.5)),
    plot.subtitle = element_text(margin = margin(l = 40, b = 5.5)),
    plot.caption  = element_text(margin = margin(r = 40)) 
  )
```

![](https://i.imgur.com/pVAYW2m.png)<!-- -->

<sup>Created on 2023-11-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
