### PR TITLE
Remove `shape` as non-missing aes in `geom_segment()`

### DIFF
--- a/R/geom-segment.R
+++ b/R/geom-segment.R
@@ -103,7 +103,7 @@ geom_segment <- function(mapping = NULL, data = NULL,
 #' @export
 GeomSegment <- ggproto("GeomSegment", Geom,
   required_aes = c("x", "y", "xend|yend"),
-  non_missing_aes = c("linetype", "linewidth", "shape"),
+  non_missing_aes = c("linetype", "linewidth"),
   default_aes = aes(colour = "black", linewidth = 0.5, linetype = 1, alpha = NA),
   draw_panel = function(self, data, panel_params, coord, arrow = NULL, arrow.fill = NULL,
                         lineend = "butt", linejoin = "round", na.rm = FALSE) {
@@ -111,7 +111,7 @@ GeomSegment <- ggproto("GeomSegment", Geom,
     data$yend <- data$yend %||% data$y
     data <- check_linewidth(data, snake_class(self))
     data <- remove_missing(data, na.rm = na.rm,
-      c("x", "y", "xend", "yend", "linetype", "linewidth", "shape"),
+      c("x", "y", "xend", "yend", "linetype", "linewidth"),
       name = "geom_segment"
     )
 


### PR DESCRIPTION
This PR aims to fix #5517.

`geom_segment()` no longer drops rows with missing `shape` aesthetic, as `shape` doesn't actually correspond to a property of the line that is being drawn.

Reprex from #5517:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

df <- data.frame(
  x = 0, 
  xend = 1, 
  y = c(0, 1), 
  yend = c(1, 0), 
  shape = c("A", NA)
)

ggplot(df, aes(x, y, xend = xend, yend = yend)) +
  geom_segment(aes(shape = shape))
#> Warning in geom_segment(aes(shape = shape)): Ignoring unknown aesthetics: shape
```

![](https://i.imgur.com/ArhucWO.png)<!-- -->

<sup>Created on 2023-11-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
