### PR TITLE
Gradient as colourbar

### DIFF
--- a/R/backports.R
+++ b/R/backports.R
@@ -22,3 +22,17 @@ if (getRversion() < "3.5") {
   isFALSE <- function(x) is.logical(x) && length(x) == 1L && !is.na(x) && !x
   isTRUE  <- function(x) is.logical(x) && length(x) == 1L && !is.na(x) &&  x
 }
+
+version_unavailable <- function(...) {
+  fun <- as_label(current_call()[[1]])
+  cli::cli_abort("{.fn {fun}} is not available in R version {getRversion()}.")
+}
+
+# Unavailable prior to R 4.1.0
+linearGradient <- version_unavailable
+
+on_load({
+  if ("linearGradient" %in% getNamespaceExports("grid")) {
+    linearGradient <- grid::linearGradient()
+  }
+})

--- a/R/guide-colorbar.R
+++ b/R/guide-colorbar.R
@@ -447,8 +447,7 @@ GuideColourbar <- ggproto(
   },
 
   build_decor = function(decor, grobs, elements, params) {
-
-    if (params$raster) {
+    if (params$display == "raster") {
       image <- switch(
         params$direction,
         "horizontal" = t(decor$colour),
@@ -462,7 +461,7 @@ GuideColourbar <- ggproto(
         gp = gpar(col = NA),
         interpolate = TRUE
       )
-    } else{
+    } else if (params$display == "rectangles") {
       if (params$direction == "horizontal") {
         width  <- elements$key.width / nrow(decor)
         height <- elements$key.height
@@ -481,6 +480,20 @@ GuideColourbar <- ggproto(
         default.units = "cm",
         gp = gpar(col = NA, fill = decor$colour)
       )
+    } else if (params$display == "gradient") {
+      check_device("gradients", call = expr(guide_colourbar()))
+      value <- if (isTRUE(params$reverse)) {
+        rescale(decor$value, to = c(1, 0))
+      } else {
+        rescale(decor$value, to = c(0, 1))
+      }
+      position <- switch(
+        params$direction,
+        horizontal = list(y1 = unit(0.5, "npc"), y2 = unit(0.5, "npc")),
+        vertical   = list(x1 = unit(0.5, "npc"), x2 = unit(0.5, "npc"))
+      )
+      gradient <- inject(linearGradient(decor$colour, value, !!!position))
+      grob <- rectGrob(gp = gpar(fill = gradient, col = NA))
     }
 
     frame <- element_grob(elements$frame, fill = NA)

--- a/R/guide-colorbar.R
+++ b/R/guide-colorbar.R
@@ -133,7 +133,7 @@ guide_colourbar <- function(
   # bar
   barwidth = NULL,
   barheight = NULL,
-  nbin = 300,
+  nbin = NULL,
   display = "raster",
   raster = lifecycle::deprecated(),
 
@@ -165,6 +165,8 @@ guide_colourbar <- function(
     display <- if (raster) "raster" else "rectangles"
   }
   display <- match.arg(display, c("raster", "rectangles", "gradient"))
+  nbin <- nbin %||% switch(display, gradient = 15, 300)
+
   if (!(is.null(barwidth) || is.unit(barwidth))) {
     barwidth <- unit(barwidth, default.unit)
   }

--- a/R/guide-colorbar.R
+++ b/R/guide-colorbar.R
@@ -354,13 +354,13 @@ GuideColourbar <- ggproto(
     params$title <- scale$make_title(
       params$title %|W|% scale$name %|W|% title
     )
-
     limits <- c(params$decor$value[1], params$decor$value[nrow(params$decor)])
-    params$key$.value <- rescale(
-      params$key$.value,
-      c(0.5, params$nbin - 0.5) / params$nbin,
-      limits
+    to <- switch(
+      params$display,
+      gradient = c(0, 1),
+      c(0.5, params$nbin - 0.5) / params$nbin
     )
+    params$key$.value <- rescale(params$key$.value, to = to, from = limits)
     params
   },
 

--- a/R/guide-colorbar.R
+++ b/R/guide-colorbar.R
@@ -134,7 +134,8 @@ guide_colourbar <- function(
   barwidth = NULL,
   barheight = NULL,
   nbin = 300,
-  raster = TRUE,
+  display = "raster",
+  raster = lifecycle::deprecated(),
 
   # frame
   frame = element_blank(),
@@ -158,6 +159,12 @@ guide_colourbar <- function(
   available_aes = c("colour", "color", "fill"),
   ...
 ) {
+  if (lifecycle::is_present(raster)) {
+    deprecate_soft0("3.5.0", "guide_colourbar(raster)", "guide_colourbar(display)")
+    check_bool(raster)
+    display <- if (raster) "raster" else "rectangles"
+  }
+  display <- match.arg(display, c("raster", "rectangles", "gradient"))
   if (!(is.null(barwidth) || is.unit(barwidth))) {
     barwidth <- unit(barwidth, default.unit)
   }
@@ -229,7 +236,7 @@ guide_colourbar <- function(
     keywidth = barwidth,
     keyheight = barheight,
     nbin = nbin,
-    raster = raster,
+    display = display,
 
     # frame
     frame = frame,
@@ -282,7 +289,7 @@ GuideColourbar <- ggproto(
     keywidth  = NULL,
     keyheight = NULL,
     nbin = 300,
-    raster = TRUE,
+    display = "raster",
 
     draw_lim = c(TRUE, TRUE),
 


### PR DESCRIPTION
This PR aims to fix #5547.

Briefly, it adds a new argument to `guide_colourbar()`: `display`, which can be set to `"gradient'` to display the bar as a gradient. 

In some more detail; since the `raster` argument was implemented as a boolean, I'd thought it best to deprecate it and use `display` as an enumeration instead. Possible values for `display` are `"raster"`, which is the same as current `raster = TRUE`, `"rectangles"`, equivalent to `raster = FALSE` and `"gradient"`, the new option. 

When `display = "gradient"`, the `nbins` argument is used for the number of colours set in the gradient, rather than actual bins. As such, we don't need to account for the half bin-size offset for the label placement. The `nbins` number can be a lot less in gradient displays compared to raster/rectangle displays. As such, `nbins` defaults to 15 for gradients.

Prior to R 4.1.0, {grid} hadn't implemented `linearGradient()`, so for older R versions it throws an error saying that `linearGradient` is unavailabe in the R version.

Small demo:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

ggplot(mpg, aes(displ, hwy)) +
  geom_point(aes(colour = cty)) +
  guides(colour = guide_colourbar(display = "gradient"))
```

![](https://i.imgur.com/6E91jPX.png)<!-- -->

<sup>Created on 2023-11-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
