### PR TITLE
Key background inherits panel background

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # ggplot2 (development version)
 
+* The `legend.key` theme element is set to inherit from the `panel.background`
+  theme element. The default themes no longer set the `legend.key` element.
+  This causes a visual change with the default `theme_gray()` (#5549).
+
 * Lines where `linewidth = NA` are now dropped in `geom_sf()` (#5204).
 
 * New `guide_axis_logticks()` can be used to draw logarithmic tick marks as

--- a/R/theme-defaults.R
+++ b/R/theme-defaults.R
@@ -172,7 +172,7 @@ theme_grey <- function(base_size = 11, base_family = "",
     legend.spacing.x =    NULL,
     legend.spacing.y =    NULL,
     legend.margin =      margin(half_line, half_line, half_line, half_line),
-    legend.key =         element_rect(fill = "grey95", colour = NA),
+    legend.key =         NULL,
     legend.key.size =    unit(1.2, "lines"),
     legend.key.height =  NULL,
     legend.key.width =   NULL,
@@ -266,8 +266,6 @@ theme_bw <- function(base_size = 11, base_family = "",
       panel.grid.minor = element_line(linewidth = rel(0.5)),
       # contour strips to match panel contour
       strip.background = element_rect(fill = "grey85", colour = "grey20"),
-      # match legend key to background
-      legend.key       = element_rect(fill = "white", colour = NA),
 
       complete = TRUE
     )
@@ -340,9 +338,6 @@ theme_light <- function(base_size = 11, base_family = "",
       # match axes ticks thickness to gridlines and colour to panel border
       axis.ticks       = element_line(colour = "grey70", linewidth = rel(0.5)),
 
-      # match legend key to panel.background
-      legend.key       = element_rect(fill = "white", colour = NA),
-
       # dark strips with light text (inverse contrast compared to theme_grey)
       strip.background = element_rect(fill = "grey70", colour = NA),
       strip.text       = element_text(
@@ -381,9 +376,6 @@ theme_dark <- function(base_size = 11, base_family = "",
 
       # match axes ticks thickness to gridlines
       axis.ticks       = element_line(colour = "grey20", linewidth = rel(0.5)),
-
-      # match legend key to panel.background
-      legend.key       = element_rect(fill = "grey50", colour = NA),
 
       # dark strips with light text (inverse contrast compared to theme_grey)
       strip.background = element_rect(fill = "grey15", colour = NA),
@@ -441,9 +433,6 @@ theme_classic <- function(base_size = 11, base_family = "",
 
       # show axes
       axis.line      = element_line(colour = "black", linewidth = rel(1)),
-
-      # match legend key to panel.background
-      legend.key       = element_blank(),
 
       # simple, black and white strips
       strip.background = element_rect(fill = "white", colour = "black", linewidth = rel(2)),
@@ -586,7 +575,7 @@ theme_test <- function(base_size = 11, base_family = "",
     legend.spacing.x =   NULL,
     legend.spacing.y =   NULL,
     legend.margin =      margin(0, 0, 0, 0, "cm"),
-    legend.key =         element_rect(fill = "white", colour=NA),
+    legend.key =         NULL,
     legend.key.size =    unit(1.2, "lines"),
     legend.key.height =  NULL,
     legend.key.width =   NULL,

--- a/R/theme-elements.R
+++ b/R/theme-elements.R
@@ -497,7 +497,7 @@ el_def <- function(class = NULL, inherit = NULL, description = NULL) {
   legend.spacing      = el_def("unit"),
   legend.spacing.x     = el_def(c("unit", "rel"), "legend.spacing"),
   legend.spacing.y     = el_def(c("unit", "rel"), "legend.spacing"),
-  legend.key          = el_def("element_rect", "rect"),
+  legend.key          = el_def("element_rect", "panel.background"),
   legend.key.height   = el_def(c("unit", "rel"), "legend.key.size"),
   legend.key.width    = el_def(c("unit", "rel"), "legend.key.size"),
   legend.text         = el_def("element_text", "text"),

--- a/tests/testthat/_snaps/guides/left-aligned-legend-key.svg
+++ b/tests/testthat/_snaps/guides/left-aligned-legend-key.svg
@@ -105,11 +105,11 @@
 <text x='373.66' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='20.18px' lengthAdjust='spacingAndGlyphs'>disp</text>
 <text transform='translate(13.05,298.07) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='21.40px' lengthAdjust='spacingAndGlyphs'>mpg</text>
 <rect x='32.79' y='22.78' width='88.44' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='32.79' y='22.78' width='17.28' height='17.28' style='stroke-width: 1.07; fill: #F2F2F2;' />
+<rect x='32.79' y='22.78' width='17.28' height='17.28' style='stroke-width: 1.07; fill: #EBEBEB;' />
 <circle cx='41.43' cy='31.42' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<rect x='63.74' y='22.78' width='17.28' height='17.28' style='stroke-width: 1.07; fill: #F2F2F2;' />
+<rect x='63.74' y='22.78' width='17.28' height='17.28' style='stroke-width: 1.07; fill: #EBEBEB;' />
 <circle cx='72.38' cy='31.42' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
-<rect x='94.68' y='22.78' width='17.28' height='17.28' style='stroke-width: 1.07; fill: #F2F2F2;' />
+<rect x='94.68' y='22.78' width='17.28' height='17.28' style='stroke-width: 1.07; fill: #EBEBEB;' />
 <circle cx='103.32' cy='31.42' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
 <text x='54.46' y='34.45' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
 <text x='85.40' y='34.45' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>

--- a/tests/testthat/_snaps/theme/caption-aligned-to-entire-plot.svg
+++ b/tests/testthat/_snaps/theme/caption-aligned-to-entire-plot.svg
@@ -183,11 +183,11 @@
 <text transform='translate(13.05,293.26) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
 <rect x='675.91' y='254.19' width='38.61' height='78.13' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='681.39' y='268.38' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>z</text>
-<rect x='681.39' y='275.01' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<rect x='681.39' y='275.01' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
 <circle cx='690.03' cy='283.65' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<rect x='681.39' y='292.29' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<rect x='681.39' y='292.29' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
 <circle cx='690.03' cy='300.93' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
-<rect x='681.39' y='309.57' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<rect x='681.39' y='309.57' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
 <circle cx='690.03' cy='318.21' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
 <text x='704.15' y='286.67' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>a</text>
 <text x='704.15' y='303.95' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text>

--- a/tests/testthat/_snaps/theme/theme-classic-large.svg
+++ b/tests/testthat/_snaps/theme/theme-classic-large.svg
@@ -69,7 +69,9 @@
 <text transform='translate(39.15,300.82) rotate(-90)' text-anchor='middle' style='font-size: 33.00px; font-family: sans;' textLength='16.51px' lengthAdjust='spacingAndGlyphs'>y</text>
 <rect x='622.28' y='237.73' width='81.28' height='126.17' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' />
 <text x='638.72' y='280.31' style='font-size: 33.00px; font-family: sans;' textLength='16.51px' lengthAdjust='spacingAndGlyphs'>z</text>
+<rect x='638.72' y='300.17' width='17.28' height='23.65' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' />
 <circle cx='647.36' cy='311.99' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<rect x='638.72' y='323.82' width='17.28' height='23.65' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' />
 <circle cx='647.36' cy='335.64' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
 <text x='672.44' y='321.08' style='font-size: 26.40px; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>a</text>
 <text x='672.44' y='344.73' style='font-size: 26.40px; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>b</text>

--- a/tests/testthat/_snaps/theme/theme-classic.svg
+++ b/tests/testthat/_snaps/theme/theme-classic.svg
@@ -69,7 +69,9 @@
 <text transform='translate(13.05,292.27) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
 <rect x='675.91' y='261.85' width='38.61' height='60.85' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='681.39' y='276.04' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>z</text>
+<rect x='681.39' y='282.66' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <circle cx='690.03' cy='291.30' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<rect x='681.39' y='299.94' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <circle cx='690.03' cy='308.58' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
 <text x='704.15' y='294.33' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>a</text>
 <text x='704.15' y='311.61' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text>

--- a/tests/testthat/_snaps/theme/theme-gray-large.svg
+++ b/tests/testthat/_snaps/theme/theme-gray-large.svg
@@ -85,9 +85,9 @@
 <text transform='translate(39.15,300.82) rotate(-90)' text-anchor='middle' style='font-size: 33.00px; font-family: sans;' textLength='16.51px' lengthAdjust='spacingAndGlyphs'>y</text>
 <rect x='622.28' y='237.73' width='81.28' height='126.17' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' />
 <text x='638.72' y='280.31' style='font-size: 33.00px; font-family: sans;' textLength='16.51px' lengthAdjust='spacingAndGlyphs'>z</text>
-<rect x='638.72' y='300.17' width='17.28' height='23.65' style='stroke-width: 3.20; stroke: none; fill: #F2F2F2;' />
+<rect x='638.72' y='300.17' width='17.28' height='23.65' style='stroke-width: 3.20; stroke: none; fill: #EBEBEB;' />
 <circle cx='647.36' cy='311.99' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<rect x='638.72' y='323.82' width='17.28' height='23.65' style='stroke-width: 3.20; stroke: none; fill: #F2F2F2;' />
+<rect x='638.72' y='323.82' width='17.28' height='23.65' style='stroke-width: 3.20; stroke: none; fill: #EBEBEB;' />
 <circle cx='647.36' cy='335.64' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
 <text x='672.44' y='321.08' style='font-size: 26.40px; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>a</text>
 <text x='672.44' y='344.73' style='font-size: 26.40px; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>b</text>

--- a/tests/testthat/_snaps/theme/theme-gray.svg
+++ b/tests/testthat/_snaps/theme/theme-gray.svg
@@ -85,9 +85,9 @@
 <text transform='translate(13.05,292.27) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
 <rect x='675.91' y='261.85' width='38.61' height='60.85' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='681.39' y='276.04' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>z</text>
-<rect x='681.39' y='282.66' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<rect x='681.39' y='282.66' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
 <circle cx='690.03' cy='291.30' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<rect x='681.39' y='299.94' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<rect x='681.39' y='299.94' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
 <circle cx='690.03' cy='308.58' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
 <text x='704.15' y='294.33' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>a</text>
 <text x='704.15' y='311.61' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text>

--- a/tests/testthat/_snaps/theme/titles-aligned-to-entire-plot.svg
+++ b/tests/testthat/_snaps/theme/titles-aligned-to-entire-plot.svg
@@ -183,11 +183,11 @@
 <text transform='translate(13.05,293.26) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
 <rect x='675.91' y='254.19' width='38.61' height='78.13' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='681.39' y='268.38' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>z</text>
-<rect x='681.39' y='275.01' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<rect x='681.39' y='275.01' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
 <circle cx='690.03' cy='283.65' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<rect x='681.39' y='292.29' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<rect x='681.39' y='292.29' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
 <circle cx='690.03' cy='300.93' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
-<rect x='681.39' y='309.57' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<rect x='681.39' y='309.57' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
 <circle cx='690.03' cy='318.21' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
 <text x='704.15' y='286.67' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>a</text>
 <text x='704.15' y='303.95' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text>


### PR DESCRIPTION
This PR aims to fix #5549.

Briefly, it sets `legend.key` to inherit from `panel.background` and eliminates the `legend.key` element from the built-in themes.
This causes the key backgrounds to automatically adhere to the panel background style.

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

ggplot(mpg, aes(displ, hwy)) +
  geom_point(aes(shape = factor(cyl))) +
  theme(
    panel.background = element_rect(fill = "cornsilk")
  )
```

![](https://i.imgur.com/VuuCaCb.png)<!-- -->

<sup>Created on 2023-11-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

For many built-in themes, this was already achieved by encoding the `legend.key` element and `panel.background` seperately in the same style. With this PR, this doesn't need to happen seperately anymore.

However, because the default `theme_gray()` had a slightly lighter `legend.key` than `panel.background`, there is a noticible (but not very obvious) visual change in this theme. See attached example where the left part is the current default and the right part is the default with this PR:

![image](https://github.com/tidyverse/ggplot2/assets/49372158/149b3cb2-7078-455b-b617-9dc58ffbafe3)
