### PR TITLE
Uses OutDec in isolines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* Contour functinos will not fail when `options("OutDec")` is not `.` (@eliocamp, #5555).
+
 * The `legend.key` theme element is set to inherit from the `panel.background`
   theme element. The default themes no longer set the `legend.key` element.
   This causes a visual change with the default `theme_gray()` (#5549).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # ggplot2 (development version)
 
-* Contour functinos will not fail when `options("OutDec")` is not `.` (@eliocamp, #5555).
+* Contour functions will not fail when `options("OutDec")` is not `.` (@eliocamp, #5555).
 
 * The `legend.key` theme element is set to inherit from the `panel.background`
   theme element. The default themes no longer set the `legend.key` element.

--- a/R/stat-contour.R
+++ b/R/stat-contour.R
@@ -107,7 +107,7 @@ StatContour <- ggproto("StatContour", Stat,
 
     breaks <- contour_breaks(z.range, bins, binwidth, breaks)
 
-    isolines <- xyz_to_isolines(data, breaks)
+    isolines <- withr::with_options(list(OutDec = "."), xyz_to_isolines(data, breaks))
     path_df <- iso_to_path(isolines, data$group[1])
 
     path_df$level <- as.numeric(path_df$level)
@@ -140,7 +140,7 @@ StatContourFilled <- ggproto("StatContourFilled", Stat,
   compute_group = function(data, scales, z.range, bins = NULL, binwidth = NULL, breaks = NULL, na.rm = FALSE) {
     breaks <- contour_breaks(z.range, bins, binwidth, breaks)
 
-    isobands <- xyz_to_isobands(data, breaks)
+    isobands <- withr::with_options(list(OutDec = "."), xyz_to_isobands(data, breaks))
     names(isobands) <- pretty_isoband_levels(names(isobands))
     path_df <- iso_to_polygon(isobands, data$group[1])
 


### PR DESCRIPTION
This PR Closes #5555 (Huh, neat issue number!) 

With this PR:

``` r
library(ggplot2)

options(OutDec= ",")
ggplot(faithfuld, aes(waiting, eruptions, z = density)) +
  geom_contour_filled()
```

![](https://i.imgur.com/ZmuROko.png)<!-- -->

``` r

ggplot(faithfuld, aes(waiting, eruptions, z = density)) +
  geom_contour(aes(color = after_stat(factor(level))))
```

![](https://i.imgur.com/6crl1x1.png)<!-- -->

<sup>Created on 2023-12-01 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>