### PR TITLE
Review error messages

### DIFF
--- a/R/aes.R
+++ b/R/aes.R
@@ -425,7 +425,7 @@ alternative_aes_extract_usage <- function(x) {
   } else if (is_call(x, "$")) {
     as.character(x[[3]])
   } else {
-    cli::cli_abort("Don't know how to get alternative usage for {.var {x}}")
+    cli::cli_abort("Don't know how to get alternative usage for {.var {x}}.")
   }
 }
 

--- a/R/annotation-custom.R
+++ b/R/annotation-custom.R
@@ -71,7 +71,7 @@ GeomCustomAnn <- ggproto("GeomCustomAnn", Geom,
   draw_panel = function(data, panel_params, coord, grob, xmin, xmax,
                         ymin, ymax) {
     if (!inherits(coord, "CoordCartesian")) {
-      cli::cli_abort("{.fn annotation_custom} only works with {.fn coord_cartesian}")
+      cli::cli_abort("{.fn annotation_custom} only works with {.fn coord_cartesian}.")
     }
     corners <- data_frame0(
       x = c(xmin, xmax),

--- a/R/annotation-map.R
+++ b/R/annotation-map.R
@@ -63,7 +63,7 @@ annotation_map <- function(map, ...) {
   if (!is.null(map$long)) map$x <- map$long
   if (!is.null(map$region)) map$id <- map$region
   if (!all(c("x", "y", "id") %in% names(map))) {
-    cli::cli_abort("{.arg map} must have the columns {.col x}, {.col y}, and {.col id}")
+    cli::cli_abort("{.arg map} must have the columns {.col x}, {.col y}, and {.col id}.")
   }
 
   layer(

--- a/R/annotation-raster.R
+++ b/R/annotation-raster.R
@@ -74,7 +74,7 @@ GeomRasterAnn <- ggproto("GeomRasterAnn", Geom,
   draw_panel = function(data, panel_params, coord, raster, xmin, xmax,
                         ymin, ymax, interpolate = FALSE) {
     if (!inherits(coord, "CoordCartesian")) {
-      cli::cli_abort("{.fn annotation_raster} only works with {.fn coord_cartesian}")
+      cli::cli_abort("{.fn annotation_raster} only works with {.fn coord_cartesian}.")
     }
     corners <- data_frame0(
       x = c(xmin, xmax),

--- a/R/annotation.R
+++ b/R/annotation.R
@@ -13,7 +13,7 @@
 #'
 #' @section Unsupported geoms:
 #' Due to their special nature, reference line geoms [geom_abline()],
-#' [geom_hline()], and [geom_vline()] can't be used with [annotate()].
+#' [geom_hline()], and [geom_vline()] can't be used with `annotate()`.
 #' You can use these geoms directly for annotations.
 #' @param geom name of geom to use for annotation
 #' @param x,y,xmin,ymin,xmax,ymax,xend,yend positioning aesthetics -

--- a/R/autolayer.R
+++ b/R/autolayer.R
@@ -15,5 +15,5 @@ autolayer <- function(object, ...) {
 
 #' @export
 autolayer.default <- function(object, ...) {
-  cli::cli_abort("No autolayer method available for {.cls {class(object)[1]}} objects")
+  cli::cli_abort("No autolayer method available for {.cls {class(object)[1]}} objects.")
 }

--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -17,7 +17,7 @@ autoplot <- function(object, ...) {
 autoplot.default <- function(object, ...) {
   cli::cli_abort(c(
     "Objects of class {.cls {class(object)[[1]]}} are not supported by autoplot.",
-    "i" = "have you loaded the required package?"
+    "i" = "Have you loaded the required package?"
   ))
 }
 

--- a/R/axis-secondary.R
+++ b/R/axis-secondary.R
@@ -123,7 +123,7 @@ set_sec_axis <- function(sec.axis, scale) {
   if (!is.waive(sec.axis)) {
     if (is.formula(sec.axis)) sec.axis <- sec_axis(sec.axis)
     if (!is.sec_axis(sec.axis)) {
-      cli::cli_abort("Secondary axes must be specified using {.fn sec_axis}")
+      cli::cli_abort("Secondary axes must be specified using {.fn sec_axis}.")
     }
     scale$secondary.axis <- sec.axis
   }
@@ -165,7 +165,7 @@ AxisSecondary <- ggproto("AxisSecondary", NULL,
       return()
     }
     if (!is.function(self$trans)) {
-      cli::cli_abort("Transformation for secondary axes must be a function")
+      cli::cli_abort("Transformation for secondary axes must be a function.")
     }
     if (is.derived(self$name) && !is.waive(scale$name)) self$name <- scale$name
     if (is.derived(self$breaks)) self$breaks <- scale$breaks
@@ -194,7 +194,7 @@ AxisSecondary <- ggproto("AxisSecondary", NULL,
 
     # Test for monotonicity
     if (!is_unique(sign(diff(full_range))))
-      cli::cli_abort("Transformation for secondary axes must be monotonic")
+      cli::cli_abort("Transformation for secondary axes must be monotonic.")
   },
 
   break_info = function(self, range, scale) {

--- a/R/bin.R
+++ b/R/bin.R
@@ -51,13 +51,11 @@ bin_breaks <- function(breaks, closed = c("right", "left")) {
 bin_breaks_width <- function(x_range, width = NULL, center = NULL,
                              boundary = NULL, closed = c("right", "left")) {
   if (length(x_range) != 2) {
-    cli::cli_abort("{.arg x_range} must have two elements")
+    cli::cli_abort("{.arg x_range} must have two elements.")
   }
 
-  check_number_decimal(width)
-  if (width <= 0) {
-    cli::cli_abort("{.arg binwidth} must be positive")
-  }
+  # binwidth seems to be the argument name supplied to width. (stat-bin and stat-bindot)
+  check_number_decimal(width, min = 0, allow_infinite = FALSE, arg = "binwidth")
 
   if (!is.null(boundary) && !is.null(center)) {
     cli::cli_abort("Only one of {.arg boundary} and {.arg center} may be specified.")
@@ -105,7 +103,7 @@ bin_breaks_width <- function(x_range, width = NULL, center = NULL,
 bin_breaks_bins <- function(x_range, bins = 30, center = NULL,
                             boundary = NULL, closed = c("right", "left")) {
   if (length(x_range) != 2) {
-    cli::cli_abort("{.arg x_range} must have two elements")
+    cli::cli_abort("{.arg x_range} must have two elements.")
   }
 
   check_number_whole(bins, min = 1)

--- a/R/compat-plyr.R
+++ b/R/compat-plyr.R
@@ -19,7 +19,7 @@ unrowname <- function(x) {
   } else if (is.matrix(x)) {
     dimnames(x)[1] <- list(NULL)
   } else {
-    cli::cli_abort("Can only remove rownames from {.cls data.frame} and {.cls matrix} objects")
+    cli::cli_abort("Can only remove rownames from {.cls data.frame} and {.cls matrix} objects.")
   }
   x
 }
@@ -239,7 +239,7 @@ as.quoted <- function(x, env = parent.frame()) {
   } else if (is.call(x)) {
     as.list(x)[-1]
   } else {
-    cli::cli_abort("Must be a character vector, call, or formula")
+    cli::cli_abort("Must be a character vector, call, or formula.")
   }
   attributes(x) <- list(env = env, class = 'quoted')
   x

--- a/R/coord-.R
+++ b/R/coord-.R
@@ -66,27 +66,27 @@ Coord <- ggproto("Coord",
   render_fg = function(panel_params, theme) element_render(theme, "panel.border"),
 
   render_bg = function(self, panel_params, theme) {
-    cli::cli_abort("{.fn {snake_class(self)}} has not implemented a {.fn render_bg} method")
+    cli::cli_abort("{.fn {snake_class(self)}} has not implemented a {.fn render_bg} method.")
   },
 
   render_axis_h = function(self, panel_params, theme) {
-    cli::cli_abort("{.fn {snake_class(self)}} has not implemented a {.fn render_axis_h} method")
+    cli::cli_abort("{.fn {snake_class(self)}} has not implemented a {.fn render_axis_h} method.")
   },
 
   render_axis_v = function(self, panel_params, theme) {
-    cli::cli_abort("{.fn {snake_class(self)}} has not implemented a {.fn render_axis_v} method")
+    cli::cli_abort("{.fn {snake_class(self)}} has not implemented a {.fn render_axis_v} method.")
   },
 
   # transform range given in transformed coordinates
   # back into range in given in (possibly scale-transformed)
   # data coordinates
   backtransform_range = function(self, panel_params) {
-    cli::cli_abort("{.fn {snake_class(self)}} has not implemented a {.fn backtransform_range} method")
+    cli::cli_abort("{.fn {snake_class(self)}} has not implemented a {.fn backtransform_range} method.")
   },
 
   # return range stored in panel_params
   range = function(self, panel_params) {
-    cli::cli_abort("{.fn {snake_class(self)}} has not implemented a {.fn range} method")
+    cli::cli_abort("{.fn {snake_class(self)}} has not implemented a {.fn range} method.")
   },
 
   setup_panel_params = function(scale_x, scale_y, params = list()) {

--- a/R/coord-sf.R
+++ b/R/coord-sf.R
@@ -127,7 +127,7 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
     }
 
     if (length(x_labels) != length(x_breaks)) {
-      cli::cli_abort("Breaks and labels along x direction are different lengths")
+      cli::cli_abort("{.arg breaks} and {.arg labels} along {.code x} direction have different lengths.")
     }
     graticule$degree_label[graticule$type == "E"] <- x_labels
 
@@ -152,7 +152,7 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
     }
 
     if (length(y_labels) != length(y_breaks)) {
-      cli::cli_abort("Breaks and labels along y direction are different lengths")
+      cli::cli_abort("{.arg breaks} and {.arg labels} along {.code y} direction have different lengths.")
     }
     graticule$degree_label[graticule$type == "N"] <- y_labels
 
@@ -203,7 +203,7 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
       if (self$lims_method != "geometry_bbox") {
         cli::cli_warn(c(
                 "Projection of {.field x} or {.field y} limits failed in {.fn coord_sf}.",
-          "i" = "Consider setting {.code lims_method = \"geometry_bbox\"} or {.code default_crs = NULL}."
+          "i" = "Consider setting {.code lims_method = {.val geometry_bbox}} or {.code default_crs = NULL}."
         ))
       }
       coord_bbox <- self$params$bbox
@@ -409,7 +409,7 @@ sf_rescale01 <- function(x, x_range, y_range) {
 calc_limits_bbox <- function(method, xlim, ylim, crs, default_crs) {
   if (any(!is.finite(c(xlim, ylim))) && method != "geometry_bbox") {
     cli::cli_abort(c(
-            "Scale limits cannot be mapped onto spatial coordinates in {.fn coord_sf}",
+            "Scale limits cannot be mapped onto spatial coordinates in {.fn coord_sf}.",
       "i" = "Consider setting {.code lims_method = \"geometry_bbox\"} or {.code default_crs = NULL}."
     ))
   }
@@ -542,14 +542,14 @@ coord_sf <- function(xlim = NULL, ylim = NULL, expand = TRUE,
     label_axes <- parse_axes_labeling(label_axes)
   } else if (!is.list(label_axes)) {
     cli::cli_abort("Panel labeling format not recognized.")
-    label_axes <- list(left = "N", bottom = "E")
+    # label_axes <- list(left = "N", bottom = "E")
   }
 
   if (is.character(label_graticule)) {
     label_graticule <- unlist(strsplit(label_graticule, ""))
   } else {
     cli::cli_abort("Graticule labeling format not recognized.")
-    label_graticule <- ""
+    # label_graticule <- ""
   }
 
   # switch limit method to "orthogonal" if not specified and default_crs indicates projected coords

--- a/R/facet-.R
+++ b/R/facet-.R
@@ -323,13 +323,13 @@ as_facets_list <- function(x) {
 
 validate_facets <- function(x) {
   if (inherits(x, "uneval")) {
-    cli::cli_abort("Please use {.fn vars} to supply facet variables")
+    cli::cli_abort("Please use {.fn vars} to supply facet variables.")
   }
   # Native pipe have higher precedence than + so any type of gg object can be
   # expected here, not just ggplot
   if (inherits(x, "gg")) {
     cli::cli_abort(c(
-      "Please use {.fn vars} to supply facet variables",
+      "Please use {.fn vars} to supply facet variables.",
       "i" = "Did you use {.code %>%} or {.code |>} instead of {.code +}?"
     ))
   }
@@ -500,7 +500,7 @@ check_layout <- function(x) {
     return()
   }
 
-  cli::cli_abort("Facet layout has a bad format. It must contain columns {.col PANEL}, {.col SCALE_X}, and {.col SCALE_Y}")
+  cli::cli_abort("Facet layout has a bad format. It must contain columns {.col PANEL}, {.col SCALE_X}, and {.col SCALE_Y}.")
 }
 
 check_facet_vars <- function(..., name) {
@@ -509,8 +509,8 @@ check_facet_vars <- function(..., name) {
   problems <- intersect(vars_names, reserved_names)
   if (length(problems) != 0) {
     cli::cli_abort(c(
-      "{.val {problems}} {?is/are} not {?an/} allowed name{?/s} for faceting variables",
-      "i" = "Change the name of your data columns to not be {.or {.str {reserved_names}}}"
+      "{.val {problems}} {?is/are} not {?an/} allowed name{?/s} for faceting variables.",
+      "i" = "Change the name of your data columns to not be {.or {.str {reserved_names}}}."
     ), call = call2(name))
   }
 }
@@ -631,7 +631,7 @@ combine_vars <- function(data, env = emptyenv(), vars = NULL, drop = TRUE) {
   }
 
   if (empty(base)) {
-    cli::cli_abort("Faceting variables must have at least one value")
+    cli::cli_abort("Faceting variables must have at least one value.")
   }
 
   base

--- a/R/facet-grid-.R
+++ b/R/facet-grid-.R
@@ -137,8 +137,8 @@ facet_grid <- function(rows = NULL, cols = NULL, scales = "fixed",
     y = any(space %in% c("free_y", "free"))
   )
 
-  if (!is.null(switch) && !switch %in% c("both", "x", "y")) {
-    cli::cli_abort("{.arg switch} must be either {.val both}, {.val x}, or {.val y}")
+  if (!is.null(switch)) {
+    arg_match0(switch, c("both", "x", "y"))
   }
 
   facets_list <- grid_as_facets_list(rows, cols)
@@ -159,7 +159,7 @@ grid_as_facets_list <- function(rows, cols) {
   is_rows_vars <- is.null(rows) || is_quosures(rows)
   if (!is_rows_vars) {
     if (!is.null(cols)) {
-      msg <- "{.arg rows} must be {.val NULL} or a {.fn vars} list if {.arg cols} is a {.fn vars} list"
+      msg <- "{.arg rows} must be {.code NULL} or a {.fn vars} list if {.arg cols} is a {.fn vars} list."
       # Native pipe have higher precedence than + so any type of gg object can be
       # expected here, not just ggplot
       if (inherits(rows, "gg")) {
@@ -173,7 +173,7 @@ grid_as_facets_list <- function(rows, cols) {
     # For backward-compatibility
     facets_list <- as_facets_list(rows)
     if (length(facets_list) > 2L) {
-      cli::cli_abort("A grid facet specification can't have more than two dimensions")
+      cli::cli_abort("A grid facet specification can't have more than two dimensions.")
     }
     # Fill with empty quosures
     facets <- list(rows = quos(), cols = quos())
@@ -206,7 +206,7 @@ FacetGrid <- ggproto("FacetGrid", Facet,
     dups <- intersect(names(rows), names(cols))
     if (length(dups) > 0) {
       cli::cli_abort(c(
-              "Faceting variables can only appear in {.arg rows} or {.arg cols}, not both.\n",
+              "Faceting variables can only appear in {.arg rows} or {.arg cols}, not both.",
         "i" = "Duplicated variables: {.val {dups}}"
       ), call = call2(snake_class(self)))
     }
@@ -303,7 +303,7 @@ FacetGrid <- ggproto("FacetGrid", Facet,
   },
   draw_panels = function(panels, layout, x_scales, y_scales, ranges, coord, data, theme, params) {
     if ((params$free$x || params$free$y) && !coord$is_free()) {
-      cli::cli_abort("{.fn {snake_class(coord)}} doesn't support free scales")
+      cli::cli_abort("{.fn {snake_class(coord)}} doesn't support free scales.")
     }
 
     cols <- which(layout$ROW == 1)
@@ -321,7 +321,7 @@ FacetGrid <- ggproto("FacetGrid", Facet,
 
     aspect_ratio <- theme$aspect.ratio
     if (!is.null(aspect_ratio) && (params$space_free$x || params$space_free$y)) {
-      cli::cli_abort("Free scales cannot be mixed with a fixed aspect ratio")
+      cli::cli_abort("Free scales cannot be mixed with a fixed aspect ratio.")
     }
     if (is.null(aspect_ratio) && !params$free$x && !params$free$y) {
       aspect_ratio <- coord$aspect(ranges[[1]])

--- a/R/facet-wrap.R
+++ b/R/facet-wrap.R
@@ -217,7 +217,7 @@ FacetWrap <- ggproto("FacetWrap", Facet,
   },
   draw_panels = function(self, panels, layout, x_scales, y_scales, ranges, coord, data, theme, params) {
     if ((params$free$x || params$free$y) && !coord$is_free()) {
-      cli::cli_abort("{.fn {snake_class(self)}} can't use free scales with {.fn {snake_class(coord)}}")
+      cli::cli_abort("{.fn {snake_class(self)}} can't use free scales with {.fn {snake_class(coord)}}.")
     }
 
     if (inherits(coord, "CoordFlip")) {
@@ -470,8 +470,8 @@ wrap_dims <- function(n, nrow = NULL, ncol = NULL) {
   }
   if (nrow * ncol < n) {
     cli::cli_abort(c(
-      "Need {n} panels, but together {.arg nrow} and {.arg ncol} only provide {nrow * ncol}",
-      i = "Please increase {.arg ncol} and/or {.arg nrow}"
+      "Need {n} panel{?s}, but together {.arg nrow} and {.arg ncol} only provide {nrow * ncol}.",
+      i = "Please increase {.arg ncol} and/or {.arg nrow}."
     ))
   }
 

--- a/R/fortify.R
+++ b/R/fortify.R
@@ -78,8 +78,8 @@ validate_as_data_frame <- function(data) {
 fortify.default <- function(model, data, ...) {
   msg0 <- paste0(
     "{{.arg data}} must be a {{.cls data.frame}}, ",
-    "or an object coercible by {{.code fortify()}}, or a valid ",
-    "{{.cls data.frame}}-like object coercible by {{.code as.data.frame()}}"
+    "or an object coercible by {{.fn fortify}}, or a valid ",
+    "{{.cls data.frame}}-like object coercible by {{.fn as.data.frame}}"
   )
   if (inherits(model, "uneval")) {
     msg <- c(

--- a/R/geom-.R
+++ b/R/geom-.R
@@ -239,8 +239,8 @@ check_aesthetics <- function(x, n) {
   }
 
   cli::cli_abort(c(
-    "Aesthetics must be either length 1 or the same as the data ({n})",
-    "x" = "Fix the following mappings: {.col {names(which(!good))}}"
+    "Aesthetics must be either length 1 or the same as the data ({n}).",
+    "x" = "Fix the following mappings: {.col {names(which(!good))}}."
   ))
 }
 

--- a/R/geom-boxplot.R
+++ b/R/geom-boxplot.R
@@ -230,7 +230,7 @@ GeomBoxplot <- ggproto("GeomBoxplot", Geom,
     # this may occur when using geom_boxplot(stat = "identity")
     if (nrow(data) != 1) {
       cli::cli_abort(c(
-        "Can only draw one boxplot per group",
+        "Can only draw one boxplot per group.",
         "i"= "Did you forget {.code aes(group = ...)}?"
       ))
     }

--- a/R/geom-jitter.R
+++ b/R/geom-jitter.R
@@ -44,8 +44,8 @@ geom_jitter <- function(mapping = NULL, data = NULL,
   if (!missing(width) || !missing(height)) {
     if (!missing(position)) {
       cli::cli_abort(c(
-        "both {.arg position} and {.arg width}/{.arg height} are supplied",
-        "i" = "Only use one approach to alter the position"
+        "Both {.arg position} and {.arg width}/{.arg height} were supplied.",
+        "i" = "Choose a single approach to alter the position."
       ))
     }
 

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -19,8 +19,8 @@ geom_label <- function(mapping = NULL, data = NULL,
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
       cli::cli_abort(c(
-        "both {.arg position} and {.arg nudge_x}/{.arg nudge_y} are supplied",
-        "i" = "Only use one approach to alter the position"
+        "Both {.arg position} and {.arg nudge_x}/{.arg nudge_y} are supplied.",
+        "i" = "Choose one approach to alter the position."
       ))
     }
 
@@ -122,7 +122,7 @@ labelGrob <- function(label, x = unit(0.5, "npc"), y = unit(0.5, "npc"),
                       text.gp = gpar(), rect.gp = gpar(fill = "white"), vp = NULL) {
 
   if (length(label) != 1) {
-    cli::cli_abort("{.arg label} must be of length 1")
+    cli::cli_abort("{.arg label} must be of length 1.")
   }
 
   if (!is.unit(x))

--- a/R/geom-linerange.R
+++ b/R/geom-linerange.R
@@ -101,7 +101,7 @@ GeomLinerange <- ggproto("GeomLinerange", Geom,
     params$flipped_aes <- has_flipped_aes(data, params, range_is_orthogonal = TRUE)
     # if flipped_aes == TRUE then y, xmin, xmax is present
     if (!(params$flipped_aes || all(c("x", "ymin", "ymax") %in% c(names(data), names(params))))) {
-      cli::cli_abort("Either, {.field x}, {.field ymin}, and {.field ymax} {.emph or} {.field y}, {.field xmin}, and {.field xmax} must be supplied")
+      cli::cli_abort("Either, {.field x}, {.field ymin}, and {.field ymax} {.emph or} {.field y}, {.field xmin}, and {.field xmax} must be supplied.")
     }
     params
   },

--- a/R/geom-map.R
+++ b/R/geom-map.R
@@ -102,7 +102,7 @@ geom_map <- function(mapping = NULL, data = NULL,
   if (!is.null(map$long)) map$x <- map$long
   if (!is.null(map$region)) map$id <- map$region
   if (!all(c("x", "y", "id") %in% names(map))) {
-    cli::cli_abort("{.arg map} must have the columns {.col x}, {.col y}, and {.col id}")
+    cli::cli_abort("{.arg map} must have the columns {.col x}, {.col y}, and {.col id}.")
   }
 
   layer(

--- a/R/geom-path.R
+++ b/R/geom-path.R
@@ -184,7 +184,7 @@ GeomPath <- ggproto("GeomPath", Geom,
     solid_lines <- all(attr$solid)
     constant <- all(attr$constant)
     if (!solid_lines && !constant) {
-      cli::cli_abort("{.fn {snake_class(self)}} can't have varying {.field colour}, {.field linewidth}, and/or {.field alpha} along the line when {.field linetype} isn't solid")
+      cli::cli_abort("{.fn {snake_class(self)}} can't have varying {.field colour}, {.field linewidth}, and/or {.field alpha} along the line when {.field linetype} isn't solid.")
     }
 
     # Work out grouping variables for grobs
@@ -351,11 +351,6 @@ stairstep <- function(data, direction = "hv") {
   } else if (direction == "mid") {
     xs <- rep(1:(n-1), each = 2)
     ys <- rep(1:n, each = 2)
-  } else {
-    cli::cli_abort(c(
-      "{.arg direction} is invalid.",
-      "i" = "Use either {.val vh}, {.val hv}, or {.va mid}"
-    ))
   }
 
   if (direction == "mid") {

--- a/R/geom-point.R
+++ b/R/geom-point.R
@@ -203,14 +203,14 @@ translate_shape_string <- function(shape_string) {
 
   if (any(invalid_strings)) {
     bad_string <- unique0(shape_string[invalid_strings])
-    cli::cli_abort("Shape aesthetic contains invalid value{?s}: {.val {bad_string}}")
+    cli::cli_abort("Shape aesthetic contains invalid value{?s}: {.val {bad_string}}.")
   }
 
   if (any(nonunique_strings)) {
     bad_string <- unique0(shape_string[nonunique_strings])
     cli::cli_abort(c(
-      "shape names must be given unambiguously",
-      "i" = "Fix {.val {bad_string}}"
+      "Shape names must be given unambiguously.",
+      "i" = "Fix {.val {bad_string}}."
     ))
   }
 

--- a/R/geom-polygon.R
+++ b/R/geom-polygon.R
@@ -142,8 +142,8 @@ GeomPolygon <- ggproto("GeomPolygon", Geom,
         )
       )
     } else {
-      if (utils::packageVersion('grid') < "3.6") {
-        cli::cli_abort("Polygons with holes requires R 3.6 or above")
+      if (getRversion() < "3.6") {
+        cli::cli_abort("Polygons with holes requires R 3.6 or above.")
       }
       # Sort by group to make sure that colors, fill, etc. come in same order
       munched <- munched[order(munched$group, munched$subgroup), ]

--- a/R/geom-raster.R
+++ b/R/geom-raster.R
@@ -89,7 +89,7 @@ GeomRaster <- ggproto("GeomRaster", Geom,
                         hjust = 0.5, vjust = 0.5) {
     if (!inherits(coord, "CoordCartesian")) {
       cli::cli_abort(c(
-        "{.fn {snake_class(self)}} only works with {.fn coord_cartesian}"
+        "{.fn {snake_class(self)}} only works with {.fn coord_cartesian}."
       ))
     }
 

--- a/R/geom-ribbon.R
+++ b/R/geom-ribbon.R
@@ -137,7 +137,7 @@ GeomRibbon <- ggproto("GeomRibbon", Geom,
     # Check that aesthetics are constant
     aes <- unique0(data[names(data) %in% c("colour", "fill", "linewidth", "linetype", "alpha")])
     if (nrow(aes) > 1) {
-      cli::cli_abort("Aesthetics can not vary along a ribbon")
+      cli::cli_abort("Aesthetics can not vary along a ribbon.")
     }
     aes <- as.list(aes)
 
@@ -200,14 +200,15 @@ GeomRibbon <- ggproto("GeomRibbon", Geom,
     # Increment the IDs of the lower line so that they will be drawn as separate lines
     munched_lower$id <- munched_lower$id + max(ids, na.rm = TRUE)
 
+    arg_match0(
+      outline.type,
+      c("both", "upper", "lower")
+    )
+
     munched_lines <- switch(outline.type,
       both = vec_rbind0(munched_upper, munched_lower),
       upper = munched_upper,
-      lower = munched_lower,
-      cli::cli_abort(c(
-        "invalid {.arg outline.type}: {.val {outline.type}}",
-        "i" = "use either {.val upper}, {.val lower}, or {.val both}"
-      ))
+      lower = munched_lower
     )
     g_lines <- polylineGrob(
       munched_lines$x, munched_lines$y, id = munched_lines$id,

--- a/R/geom-sf.R
+++ b/R/geom-sf.R
@@ -131,7 +131,7 @@ GeomSf <- ggproto("GeomSf", Geom,
                         lineend = "butt", linejoin = "round", linemitre = 10,
                         arrow = NULL, na.rm = TRUE) {
     if (!inherits(coord, "CoordSf")) {
-      cli::cli_abort("{.fn {snake_class(self)}} can only be used with {.fn coord_sf}")
+      cli::cli_abort("{.fn {snake_class(self)}} can only be used with {.fn coord_sf}.")
     }
 
     # Need to refactor this to generate one grob per geometry type
@@ -267,8 +267,8 @@ geom_sf_label <- function(mapping = aes(), data = NULL,
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
       cli::cli_abort(c(
-        "both {.arg position} and {.arg nudge_x}/{.arg nudge_y} are supplied",
-        "i" = "Only use one approach to alter the position"
+        "Both {.arg position} and {.arg nudge_x}/{.arg nudge_y} are supplied.",
+        "i" = "Only use one approach to alter the position."
       ))
     }
 
@@ -314,8 +314,8 @@ geom_sf_text <- function(mapping = aes(), data = NULL,
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
       cli::cli_abort(c(
-        "both {.arg position} and {.arg nudge_x}/{.arg nudge_y} are supplied",
-        "i" = "Only use one approach to alter the position"
+        "both {.arg position} and {.arg nudge_x}/{.arg nudge_y} are supplied.",
+        "i" = "Only use one approach to alter the position."
       ))
     }
 

--- a/R/geom-text.R
+++ b/R/geom-text.R
@@ -170,8 +170,8 @@ geom_text <- function(mapping = NULL, data = NULL,
   if (!missing(nudge_x) || !missing(nudge_y)) {
     if (!missing(position)) {
       cli::cli_abort(c(
-        "both {.arg position} and {.arg nudge_x}/{.arg nudge_y} are supplied",
-        "i" = "Only use one approach to alter the position"
+        "Both {.arg position} and {.arg nudge_x}/{.arg nudge_y} are supplied.",
+        "i" = "Only use one approach to alter the position."
       ))
     }
 

--- a/R/geom-violin.R
+++ b/R/geom-violin.R
@@ -164,7 +164,7 @@ GeomViolin <- ggproto("GeomViolin", Geom,
     # Draw quantiles if requested, so long as there is non-zero y range
     if (length(draw_quantiles) > 0 & !scales::zero_range(range(data$y))) {
       if (!(all(draw_quantiles >= 0) && all(draw_quantiles <= 1))) {
-        cli::cli_abort("{.arg draw_quantiles} must be between 0 and 1")
+        cli::cli_abort("{.arg draw_quantiles} must be between 0 and 1.")
       }
 
       # Compute the quantile segments and combine with existing aesthetics

--- a/R/ggproto.R
+++ b/R/ggproto.R
@@ -118,7 +118,7 @@ fetch_ggproto <- function(x, name) {
       res <- fetch_ggproto(super(), name)
     } else {
       cli::cli_abort(c(
-        "{.cls {x}} was built with an incompatible version of ggproto.",
+        "{.obj_type_friendly {x}} was built with an incompatible version of ggproto.",
         "i" = "Please reinstall the package that provides this extension."
       ))
     }

--- a/R/ggproto.R
+++ b/R/ggproto.R
@@ -118,9 +118,9 @@ fetch_ggproto <- function(x, name) {
       res <- fetch_ggproto(super(), name)
     } else {
       cli::cli_abort(c(
-              "{class(x)[[1]]} was built with an incompatible version of ggproto.",
-        "i" = "Please reinstall the package that provides this extension.
-      "))
+        "{.cls {x}} was built with an incompatible version of ggproto.",
+        "i" = "Please reinstall the package that provides this extension."
+      ))
     }
   }
 

--- a/R/guide-axis.R
+++ b/R/guide-axis.R
@@ -570,6 +570,10 @@ axis_label_element_overrides <- function(axis_position, angle = NULL) {
 
   check_number_decimal(angle)
   angle <- angle %% 360
+  arg_match0(
+    axis_position,
+    c("bottom", "left", "top", "right")
+  )
 
   if (axis_position == "bottom") {
 
@@ -590,13 +594,6 @@ axis_label_element_overrides <- function(axis_position, angle = NULL) {
 
     hjust = if (angle %in% c(90, 270)) 0.5 else if (angle > 90 & angle < 270) 1 else 0
     vjust = if (angle %in% c(0, 180))  0.5 else if (angle < 180) 1 else 0
-
-  } else {
-
-    cli::cli_abort(c(
-      "Unrecognized {.arg axis_position}: {.val {axis_position}}",
-      "i" = "Use one of {.val top}, {.val bottom}, {.val left} or {.val right}"
-    ))
 
   }
 

--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -395,7 +395,7 @@ GuideLegend <- ggproto(
         params$nrow * params$ncol < n_breaks) {
       cli::cli_abort(paste0(
         "{.arg nrow} * {.arg ncol} needs to be larger than the number of ",
-        "breaks ({n_breaks})"
+        "breaks ({n_breaks})."
       ))
     }
     if (is.null(params$nrow) && is.null(params$ncol)) {

--- a/R/labeller.R
+++ b/R/labeller.R
@@ -241,12 +241,12 @@ is_labeller <- function(x) inherits(x, "labeller")
 
 resolve_labeller <- function(rows, cols, labels) {
   if (is.null(cols) && is.null(rows)) {
-    cli::cli_abort("Supply one of {.arg rows} or {.arg cols}")
+    cli::cli_abort("Supply one of {.arg rows} or {.arg cols}.")
   }
   if (attr(labels, "facet") == "wrap") {
     # Return either rows or cols for facet_wrap()
     if (!is.null(cols) && !is.null(rows)) {
-      cli::cli_abort("Cannot supply both {.arg rows} and {.arg cols} to {.fn facet_wrap}")
+      cli::cli_abort("Cannot supply both {.arg rows} and {.arg cols} to {.fn facet_wrap}.")
     }
     cols %||% rows
   } else {
@@ -441,7 +441,7 @@ labeller <- function(..., .rows = NULL, .cols = NULL,
       # Check that variable-specific labellers do not overlap with
       # margin-wide labeller
       if (any(names(dots) %in% names(labels))) {
-        cli::cli_abort("Conflict between {.var {paste0('.', attr(labels, 'type'))}} and {.var {names(dots)}}")
+        cli::cli_abort("Conflict between {.var {paste0('.', attr(labels, 'type'))}} and {.var {names(dots)}}.")
       }
     }
 

--- a/R/layer.R
+++ b/R/layer.R
@@ -171,7 +171,7 @@ layer <- function(geom = NULL, stat = NULL,
 
 validate_mapping <- function(mapping, call = caller_env()) {
   if (!inherits(mapping, "uneval")) {
-    msg <- paste0("{.arg mapping} must be created by {.fn aes}")
+    msg <- "{.arg mapping} must be created by {.fn aes}."
     # Native pipe have higher precedence than + so any type of gg object can be
     # expected here, not just ggplot
     if (inherits(mapping, "gg")) {
@@ -221,7 +221,7 @@ Layer <- ggproto("Layer", NULL,
     } else if (is.function(self$data)) {
       data <- self$data(plot_data)
       if (!is.data.frame(data)) {
-        cli::cli_abort("{.fn layer_data} must return a {.cls data.frame}")
+        cli::cli_abort("{.fn layer_data} must return a {.cls data.frame}.")
       }
     } else {
       data <- self$data
@@ -445,7 +445,7 @@ check_subclass <- function(x, subclass,
     obj <- find_global(name, env = env)
 
     if (is.null(obj) || !inherits(obj, subclass)) {
-      cli::cli_abort("Can't find {argname} called {.val {x}}", call = call)
+      cli::cli_abort("Can't find {argname} called {.val {x}}.", call = call)
     } else {
       obj
     }

--- a/R/layout.R
+++ b/R/layout.R
@@ -306,8 +306,8 @@ scale_apply <- function(data, vars, method, scale_id, scales) {
   if (length(vars) == 0) return()
   if (nrow(data) == 0) return()
 
-  if (any(is.na(scale_id))) {
-    cli::cli_abort("{.arg scale_id} must not contain any {.val NA}")
+  if (anyNA(scale_id)) {
+    cli::cli_abort("{.arg scale_id} must not contain any {.val NA}.")
   }
 
   scale_index <- split_with_index(seq_along(scale_id), scale_id, length(scales))

--- a/R/limits.R
+++ b/R/limits.R
@@ -80,8 +80,8 @@
 lims <- function(...) {
   args <- list2(...)
 
-  if (any(!has_name(args))) {
-    cli::cli_abort("All arguments must be named")
+  if (!all(has_name(args))) {
+    cli::cli_abort("All arguments must be named.")
   }
   env <- current_env()
   Map(limits, args, names(args), rep(list(env), length(args)))
@@ -114,7 +114,7 @@ limits <- function(lims, var, call = caller_env()) UseMethod("limits")
 #' @export
 limits.numeric <- function(lims, var, call = caller_env()) {
   if (length(lims) != 2) {
-    cli::cli_abort("{.arg {var}} must be a two-element vector", call = call)
+    cli::cli_abort("{.arg {var}} must be a two-element vector.", call = call)
   }
   if (!any(is.na(lims)) && lims[1] > lims[2]) {
     trans <- "reverse"
@@ -144,21 +144,21 @@ limits.factor <- function(lims, var, call = caller_env()) {
 #' @export
 limits.Date <- function(lims, var, call = caller_env()) {
   if (length(lims) != 2) {
-    cli::cli_abort("{.arg {var}} must be a two-element vector", call = call)
+    cli::cli_abort("{.arg {var}} must be a two-element vector.", call = call)
   }
   make_scale("date", var, limits = lims, call = call)
 }
 #' @export
 limits.POSIXct <- function(lims, var, call = caller_env()) {
   if (length(lims) != 2) {
-    cli::cli_abort("{.arg {var}} must be a two-element vector", call = call)
+    cli::cli_abort("{.arg {var}} must be a two-element vector.", call = call)
   }
   make_scale("datetime", var, limits = lims, call = call)
 }
 #' @export
 limits.POSIXlt <- function(lims, var, call = caller_env()) {
   if (length(lims) != 2) {
-    cli::cli_abort("{.arg {var}} must be a two-element vector", call = call)
+    cli::cli_abort("{.arg {var}} must be a two-element vector.", call = call)
   }
   make_scale("datetime", var, limits = as.POSIXct(lims), call = call)
 }

--- a/R/plot-build.R
+++ b/R/plot-build.R
@@ -362,7 +362,8 @@ by_layer <- function(f, layers, data, step = NULL) {
       out[[i]] <- f(l = layers[[i]], d = data[[i]])
     },
     error = function(cnd) {
-      cli::cli_abort(c("Problem while {step}.", "i" = "Error occurred in the {ordinal(i)} layer."), call = layers[[i]]$constructor, parent = cnd)
+      cli::cli_abort(c("Problem while {step}.",
+                       "i" = "Error occurred in the {ordinal(i)} layer."), call = layers[[i]]$constructor, parent = cnd)
     }
   )
   out
@@ -391,14 +392,16 @@ table_add_tag <- function(table, label, theme) {
     if (location == "margin") {
       cli::cli_abort(paste0(
         "A {.cls numeric} {.arg plot.tag.position} cannot be used with ",
-        "{.code \"margin\"} as {.arg plot.tag.location}."
-      ))
+        "`{.val margin}` as {.arg plot.tag.location}."
+      ),
+      call = expr(theme()))
     }
     if (length(position) != 2) {
       cli::cli_abort(paste0(
         "A {.cls numeric} {.arg plot.tag.position} ",
         "theme setting must have length 2."
-      ))
+      ),
+      call = expr(theme()))
     }
     top <- left <- right <- bottom <- FALSE
   } else {
@@ -407,7 +410,8 @@ table_add_tag <- function(table, label, theme) {
       position[1],
       c("topleft", "top", "topright", "left",
         "right", "bottomleft", "bottom", "bottomright"),
-      arg_nm = "plot.tag.position"
+      arg_nm = "plot.tag.position",
+      error_call = expr(theme())
     )
     top    <- position %in% c("topleft",    "top",    "topright")
     left   <- position %in% c("topleft",    "left",   "bottomleft")

--- a/R/plot-build.R
+++ b/R/plot-build.R
@@ -362,8 +362,12 @@ by_layer <- function(f, layers, data, step = NULL) {
       out[[i]] <- f(l = layers[[i]], d = data[[i]])
     },
     error = function(cnd) {
-      cli::cli_abort(c("Problem while {step}.",
-                       "i" = "Error occurred in the {ordinal(i)} layer."), call = layers[[i]]$constructor, parent = cnd)
+      cli::cli_abort(c(
+        "Problem while {step}.",
+        "i" = "Error occurred in the {ordinal(i)} layer."),
+        call = layers[[i]]$constructor,
+        parent = cnd
+      )
     }
   )
   out

--- a/R/plot-construction.R
+++ b/R/plot-construction.R
@@ -42,7 +42,7 @@
 "+.gg" <- function(e1, e2) {
   if (missing(e2)) {
     cli::cli_abort(c(
-            "Cannot use {.code +} with a single argument",
+            "Cannot use {.code +} with a single argument.",
       "i" = "Did you accidentally put {.code +} on a new line?"
     ))
   }
@@ -55,7 +55,7 @@
   else if (is.ggplot(e1)) add_ggplot(e1, e2, e2name)
   else if (is.ggproto(e1)) {
     cli::cli_abort(c(
-      "Cannot add {.cls ggproto} objects together",
+      "Cannot add {.cls ggproto} objects together.",
       "i" = "Did you forget to add this object to a {.cls ggplot} object?"
     ))
   }

--- a/R/plot.R
+++ b/R/plot.R
@@ -18,12 +18,12 @@
 #' The first pattern is recommended if all layers use the same
 #' data and the same set of aesthetics, although this method
 #' can also be used when adding a layer using data from another
-#' data frame. 
+#' data frame.
 #'
 #' The second pattern specifies the default data frame to use
 #' for the plot, but no aesthetics are defined up front. This
 #' is useful when one data frame is used predominantly for the
-#' plot, but the aesthetics vary from one layer to another. 
+#' plot, but the aesthetics vary from one layer to another.
 #'
 #' The third pattern initializes a skeleton `ggplot` object, which
 #' is fleshed out as layers are added. This is useful when
@@ -48,22 +48,22 @@
 #' # Create a data frame with some sample data, then create a data frame
 #' # containing the mean value for each group in the sample data.
 #' set.seed(1)
-#' 
+#'
 #' sample_df <- data.frame(
 #'   group = factor(rep(letters[1:3], each = 10)),
 #'   value = rnorm(30)
 #' )
-#' 
+#'
 #' group_means_df <- setNames(
 #'   aggregate(value ~ group, sample_df, mean),
 #'   c("group", "group_mean")
 #' )
-#' 
+#'
 #' # The following three code blocks create the same graphic, each using one
 #' # of the three patterns specified above. In each graphic, the sample data
 #' # are plotted in the first layer and the group means data frame is used to
 #' # plot larger red points on top of the sample data in the second layer.
-#' 
+#'
 #' # Pattern 1
 #' # Both the `data` and `mapping` arguments are passed into the `ggplot()`
 #' # call. Those arguments are omitted in the first `geom_point()` layer
@@ -76,7 +76,7 @@
 #'     mapping = aes(y = group_mean), data = group_means_df,
 #'     colour = 'red', size = 3
 #'   )
-#' 
+#'
 #' # Pattern 2
 #' # Same plot as above, passing only the `data` argument into the `ggplot()`
 #' # call. The `mapping` arguments are now required in each `geom_point()`
@@ -88,7 +88,7 @@
 #'     mapping = aes(x = group, y = group_mean), data = group_means_df,
 #'     colour = 'red', size = 3
 #'   )
-#' 
+#'
 #' # Pattern 3
 #' # Same plot as above, passing neither the `data` or `mapping` arguments
 #' # into the `ggplot()` call. Both those arguments are now required in
@@ -112,7 +112,7 @@ ggplot.default <- function(data = NULL, mapping = aes(), ...,
   if (!missing(mapping) && !inherits(mapping, "uneval")) {
     cli::cli_abort(c(
       "{.arg mapping} should be created with {.fn aes}.",
-      "x" = "You've supplied a {.cls {class(mapping)[1]}} object"
+      "x" = "You've supplied a {.cls {class(mapping)[1]}} object."
     ))
   }
 

--- a/R/position-collide.R
+++ b/R/position-collide.R
@@ -5,12 +5,12 @@ collide_setup <- function(data, width = NULL, name, strategy,
   # Determine width
   if (!is.null(width)) {
     # Width set manually
-    if (!(all(c("xmin", "xmax") %in% names(data)))) {
+    if (!all(c("xmin", "xmax") %in% names(data))) {
       data$xmin <- data$x - width / 2
       data$xmax <- data$x + width / 2
     }
   } else {
-    if (!(all(c("xmin", "xmax") %in% names(data)))) {
+    if (!all(c("xmin", "xmax") %in% names(data))) {
       data$xmin <- data$x
       data$xmax <- data$x
     }
@@ -49,7 +49,7 @@ collide <- function(data, width = NULL, name, strategy,
   intervals <- intervals[!is.na(intervals)]
 
   if (vec_unique_count(intervals) > 1 & any(diff(scale(intervals)) < -1e-6)) {
-    cli::cli_warn("{.fn {name}} requires non-overlapping {.field x} intervals")
+    cli::cli_warn("{.fn {name}} requires non-overlapping {.field x} intervals.")
     # This is where the algorithm from [L. Wilkinson. Dot plots.
     # The American Statistician, 1999.] should be used
   }
@@ -61,7 +61,7 @@ collide <- function(data, width = NULL, name, strategy,
     data <- dapply(data, "xmin", strategy, ..., width = width)
     data$y <- data$ymax
   } else {
-    cli::cli_abort("Neither {.field y} nor {.field ymax} defined")
+    cli::cli_abort("{.field y} and {.field ymax} are undefined.")
   }
   data[match(seq_along(ord), ord), ]
 }

--- a/R/position-jitterdodge.R
+++ b/R/position-jitterdodge.R
@@ -50,7 +50,8 @@ PositionJitterdodge <- ggproto("PositionJitterdodge", Position,
     # Adjust the x transformation based on the number of 'dodge' variables
     dodgecols <- intersect(c("fill", "colour", "linetype", "shape", "size", "alpha"), colnames(data))
     if (length(dodgecols) == 0) {
-      cli::cli_abort("{.fn position_jitterdodge} requires at least one aesthetic to dodge by")
+      # TODO improve this error message?
+      cli::cli_abort("{.fn position_jitterdodge} requires at least one aesthetic to dodge by.")
     }
     ndodge    <- lapply(data[dodgecols], levels)  # returns NULL for numeric, i.e. non-dodge layers
     ndodge    <- vec_unique_count(unlist(ndodge))

--- a/R/position-stack.R
+++ b/R/position-stack.R
@@ -202,7 +202,7 @@ PositionStack <- ggproto("PositionStack", Position,
         reverse = params$reverse
       )
     }
-    if (any(!negative)) {
+    if (!all(negative)) {
       pos <- collide(pos, NULL, "position_stack", pos_stack,
         vjust = params$vjust,
         fill = params$fill,

--- a/R/save.R
+++ b/R/save.R
@@ -171,14 +171,12 @@ check_path <- function(path, filename, create.dir,
 #' @noRd
 parse_dpi <- function(dpi, call = caller_env()) {
   if (is_scalar_character(dpi)) {
+    arg_match0(dpi, c("screen", "print", "retina"), error_call = call)
+
     switch(dpi,
       screen = 72,
       print = 300,
       retina = 320,
-      cli::cli_abort(c(
-        "Unknown {.arg dpi} string",
-        "i" = "Use either {.val screen}, {.val print}, or {.val retina}"
-      ), call = call)
     )
   } else if (is_scalar_numeric(dpi)) {
     dpi
@@ -290,7 +288,10 @@ plot_dev <- function(device, filename = NULL, dpi = 300, call = caller_env()) {
   if (is.null(device)) {
     device <- to_lower_ascii(tools::file_ext(filename))
     if (identical(device, "")) {
-      cli::cli_abort("{.arg filename} has no file extension and {.arg device} is {.val NULL}.", call = call)
+      cli::cli_abort(c(
+        "Can't save to {filename}.",
+        i = "Either supply {.arg filename} with a file extension or supply {.arg device}."),
+        call = call)
     }
   }
 

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -418,7 +418,7 @@ Scale <- ggproto("Scale", NULL,
   call = NULL,
   aesthetics = aes(),
   palette = function() {
-    cli::cli_abort("Not implemented.")
+    cli::cli_abort("Not implemented")
   },
 
   range = Range$new(),
@@ -434,7 +434,7 @@ Scale <- ggproto("Scale", NULL,
 
 
   is_discrete = function() {
-    cli::cli_abort("Not implemented.")
+    cli::cli_abort("Not implemented")
   },
 
   train_df = function(self, df) {
@@ -448,7 +448,7 @@ Scale <- ggproto("Scale", NULL,
   },
 
   train = function(self, x) {
-    cli::cli_abort("Not implemented.", call = self$call)
+    cli::cli_abort("Not implemented", call = self$call)
   },
 
   reset = function(self) {
@@ -473,7 +473,7 @@ Scale <- ggproto("Scale", NULL,
   },
 
   transform = function(self, x) {
-    cli::cli_abort("Not implemented.", call = self$call)
+    cli::cli_abort("Not implemented", call = self$call)
   },
 
   map_df = function(self, df, i = NULL) {
@@ -495,11 +495,11 @@ Scale <- ggproto("Scale", NULL,
   },
 
   map = function(self, x, limits = self$get_limits()) {
-    cli::cli_abort("Not implemented.", call = self$call)
+    cli::cli_abort("Not implemented", call = self$call)
   },
 
   rescale = function(self, x, limits = self$get_limits(), range = self$dimension()) {
-    cli::cli_abort("Not implemented.", call = self$call)
+    cli::cli_abort("Not implemented", call = self$call)
   },
 
   get_limits = function(self) {
@@ -517,11 +517,11 @@ Scale <- ggproto("Scale", NULL,
   },
 
   dimension = function(self, expand = expansion(0, 0), limits = self$get_limits()) {
-    cli::cli_abort("Not implemented.", call = self$call)
+    cli::cli_abort("Not implemented", call = self$call)
   },
 
   get_breaks = function(self, limits = self$get_limits()) {
-    cli::cli_abort("Not implemented.", call = self$call)
+    cli::cli_abort("Not implemented", call = self$call)
   },
 
   break_positions = function(self, range = self$get_limits()) {
@@ -529,19 +529,19 @@ Scale <- ggproto("Scale", NULL,
   },
 
   get_breaks_minor = function(self, n = 2, b = self$break_positions(), limits = self$get_limits()) {
-    cli::cli_abort("Not implemented.", call = self$call)
+    cli::cli_abort("Not implemented", call = self$call)
   },
 
   get_labels = function(self, breaks = self$get_breaks()) {
-    cli::cli_abort("Not implemented.", call = self$call)
+    cli::cli_abort("Not implemented", call = self$call)
   },
 
   clone = function(self) {
-    cli::cli_abort("Not implemented.", call = self$call)
+    cli::cli_abort("Not implemented", call = self$call)
   },
 
   break_info = function(self, range = NULL) {
-    cli::cli_abort("Not implemented.", call = self$call)
+    cli::cli_abort("Not implemented", call = self$call)
   },
 
   axis_order = function(self) {
@@ -573,7 +573,7 @@ check_breaks_labels <- function(breaks, labels, call = NULL) {
     length(breaks) != length(labels)
   if (bad_labels) {
     cli::cli_abort(
-      "{.arg breaks} and {.arg labels} must have the same length",
+      "{.arg breaks} and {.arg labels} must have the same length.",
       call = call
     )
   }
@@ -614,7 +614,7 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
     # Intercept error here to give examples and mention scale in call
     if (is.factor(x) || !typeof(x) %in% c("integer", "double")) {
       cli::cli_abort(
-        c("Discrete values supplied to continuous scale",
+        c("Discrete values supplied to continuous scale.",
           i = "Example values: {.and {.val {head(x, 5)}}}"),
         call = self$call
       )
@@ -686,7 +686,7 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
 
     if (identical(self$breaks, NA)) {
       cli::cli_abort(
-        "Invalid {.arg breaks} specification. Use {.val NULL}, not {.val NA}.",
+        "Invalid {.arg breaks} specification. Use {.code NULL}, not {.code NA}.",
         call = self$call
       )
     }
@@ -732,7 +732,7 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
 
     if (identical(self$minor_breaks, NA)) {
       cli::cli_abort(
-        "Invalid {.arg minor_breaks} specification. Use {.val NULL}, not {.val NA}.",
+        "Invalid {.arg minor_breaks} specification. Use {.code NULL}, not {.code NA}.",
         call = self$call
       )
     }
@@ -768,7 +768,7 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
 
     if (identical(self$labels, NA)) {
       cli::cli_abort(
-        "Invalid {.arg labels} specification. Use {.val NULL}, not {.val NA}.",
+        "Invalid {.arg labels} specification. Use {.code NULL}, not {.code NA}.",
         call = self$call
       )
     }
@@ -783,7 +783,7 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
 
     if (length(labels) != length(breaks)) {
       cli::cli_abort(
-        "{.arg breaks} and {.arg labels} are different lengths.",
+        "{.arg breaks} and {.arg labels} have different lengths.",
         call = self$call
       )
     }
@@ -874,7 +874,7 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
     # Intercept error here to give examples and mention scale in call
     if (!is.discrete(x)) {
       cli::cli_abort(
-        c("Continuous values supplied to discrete scale",
+        c("Continuous values supplied to discrete scale.",
           i = "Example values: {.and {.val {head(x, 5)}}}"),
         call = self$call
       )
@@ -938,7 +938,7 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
 
     if (identical(self$breaks, NA)) {
       cli::cli_abort(
-        "Invalid {.arg breaks} specification. Use {.val NULL}, not {.val NA}.",
+        "Invalid {.arg breaks} specification. Use {.code NULL}, not {.code NA}.",
         call = self$call
       )
     }
@@ -973,7 +973,7 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
 
     if (identical(self$labels, NA)) {
       cli::cli_abort(
-        "Invalid {.arg labels} specification. Use {.val NULL}, not {.val NA}.",
+        "Invalid {.arg labels} specification. Use {.code NULL}, not {.code NA}.",
         call = self$call
       )
     }
@@ -1133,7 +1133,7 @@ ScaleBinned <- ggproto("ScaleBinned", Scale,
       return(NULL)
     } else if (identical(self$breaks, NA)) {
       cli::cli_abort(
-        "Invalid {.arg breaks} specification. Use {.val NULL}, not {.val NA}.",
+        "Invalid {.arg breaks} specification. Use {.code NULL}, not {.code NA}.",
         call = self$call
       )
     } else if (is.waive(self$breaks)) {
@@ -1222,7 +1222,7 @@ ScaleBinned <- ggproto("ScaleBinned", Scale,
       return(NULL)
     } else if (identical(self$labels, NA)) {
       cli::cli_abort(
-        "Invalid {.arg labels} specification. Use {.val NULL}, not {.val NA}.",
+        "Invalid {.arg labels} specification. Use {.code NULL}, not {.code NA}.",
         call = self$call
       )
     } else if (is.waive(self$labels)) {
@@ -1234,7 +1234,7 @@ ScaleBinned <- ggproto("ScaleBinned", Scale,
     }
     if (length(labels) != length(breaks)) {
       cli::cli_abort(
-        "{.arg breaks} and {.arg labels} are different lengths.",
+        "{.arg breaks} and {.arg labels} have different lengths.",
         call = self$call
       )
     }

--- a/R/scale-colour.R
+++ b/R/scale-colour.R
@@ -93,7 +93,7 @@ scale_colour_continuous <- function(...,
   } else {
     cli::cli_abort(c(
       "Unknown scale type: {.val {type}}",
-      "i" = "Use either {.val gradient} or {.val viridis}"
+      "i" = "Use either {.val gradient} or {.val viridis}."
     ))
   }
 }
@@ -118,7 +118,7 @@ scale_fill_continuous <- function(...,
   } else {
     cli::cli_abort(c(
       "Unknown scale type: {.val {type}}",
-      "i" = "Use either {.val gradient} or {.val viridis}"
+      "i" = "Use either {.val gradient} or {.val viridis}."
     ))
   }
 }
@@ -151,7 +151,7 @@ scale_colour_binned <- function(...,
     } else {
       cli::cli_abort(c(
         "Unknown scale type: {.val {type}}",
-        "i" = "Use either {.val gradient} or {.val viridis}"
+        "i" = "Use either {.val gradient} or {.val viridis}."
       ))
     }
   }
@@ -185,7 +185,7 @@ scale_fill_binned <- function(...,
     } else {
       cli::cli_abort(c(
         "Unknown scale type: {.val {type}}",
-        "i" = "Use either {.val gradient} or {.val viridis}"
+        "i" = "Use either {.val gradient} or {.val viridis}."
       ))
     }
   }
@@ -204,7 +204,7 @@ check_scale_type <- function(scale, name, aesthetic, scale_is_discrete = FALSE, 
   if (!isTRUE(aesthetic %in% scale$aesthetics)) {
     cli::cli_abort(c(
       "The {.arg type} argument must return a continuous scale for the {.field {aesthetic}} aesthetic.",
-      "x" = "The provided scale works with the following aesthetics: {.field {scale$aesthetics}}"
+      "x" = "The provided scale works with the following aesthetics: {.field {scale$aesthetics}}."
     ), call = call)
   }
   if (isTRUE(scale$is_discrete()) != scale_is_discrete) {

--- a/R/scale-expansion.R
+++ b/R/scale-expansion.R
@@ -37,7 +37,7 @@
 #'
 expansion <- function(mult = 0, add = 0) {
   if (!(is.numeric(mult) && (length(mult) %in% 1:2) && is.numeric(add) && (length(add) %in% 1:2))) {
-    cli::cli_abort("{.arg mult} and {.arg add} must be numeric vectors with 1 or 2 elements")
+    cli::cli_abort("{.arg mult} and {.arg add} must be numeric vectors with 1 or 2 elements.")
   }
 
   mult <- rep(mult, length.out = 2)
@@ -66,7 +66,7 @@ expand_scale <- function(mult = 0, add = 0) {
 #'
 expand_range4 <- function(limits, expand) {
   if (!(is.numeric(expand) && length(expand) %in% c(2,4))) {
-    cli::cli_abort("{.arg expand} must be a numeric vector with 2 or 4 elements")
+    cli::cli_abort("{.arg expand} must be a numeric vector with 2 or 4 elements.")
   }
 
   if (all(!is.finite(limits))) {

--- a/R/scale-hue.R
+++ b/R/scale-hue.R
@@ -188,7 +188,7 @@ qualitative_pal <- function(type, h, c, l, h.start, direction) {
   function(n) {
     type_list <- if (!is.list(type)) list(type) else type
     if (!all(vapply(type_list, is.character, logical(1)))) {
-      cli::cli_abort("{.arg type} must be a character vector or a list of character vectors")
+      cli::cli_abort("{.arg type} must be a character vector or a list of character vectors.")
     }
     type_lengths <- lengths(type_list)
     # If there are more levels than color codes default to hue_pal()

--- a/R/scale-linetype.R
+++ b/R/scale-linetype.R
@@ -48,8 +48,8 @@ scale_linetype_binned <- function(..., na.value = "blank") {
 #' @export
 scale_linetype_continuous <- function(...) {
   cli::cli_abort(c(
-    "A continuous variable cannot be mapped to the {.field linetype} aesthetic",
-    "i" = "choose a different aesthetic or use {.fn scale_linetype_binned}"
+    "A continuous variable cannot be mapped to the {.field linetype} aesthetic.",
+    "i" = "Choose a different aesthetic or use {.fn scale_linetype_binned}."
   ))
 }
 #' @rdname scale_linetype

--- a/R/scale-shape.R
+++ b/R/scale-shape.R
@@ -70,7 +70,7 @@ scale_shape_ordinal <- function(...) {
 #' @usage NULL
 scale_shape_continuous <- function(...) {
   cli::cli_abort(c(
-    "A continuous variable cannot be mapped to the {.field shape} aesthetic",
-    "i" = "choose a different aesthetic or use {.fn scale_shape_binned}"
+    "A continuous variable cannot be mapped to the {.field shape} aesthetic.",
+    "i" = "Choose a different aesthetic or use {.fn scale_shape_binned}."
   ))
 }

--- a/R/stat-.R
+++ b/R/stat-.R
@@ -105,7 +105,7 @@ Stat <- ggproto("Stat",
       try_fetch(
         inject(self$compute_panel(data = data, scales = scales, !!!params)),
         error = function(cnd) {
-          cli::cli_warn("Computation failed in {.fn {snake_class(self)}}", parent = cnd)
+          cli::cli_warn("Computation failed in {.fn {snake_class(self)}}.", parent = cnd)
           data_frame0()
         }
       )
@@ -166,7 +166,7 @@ Stat <- ggproto("Stat",
     dropped <- non_constant_columns[!non_constant_columns %in% self$dropped_aes]
     if (length(dropped) > 0) {
       cli::cli_warn(c(
-        "The following aesthetics were dropped during statistical transformation: {.field {glue_collapse(dropped, sep = ', ')}}",
+        "The following aesthetics were dropped during statistical transformation: {.field {dropped}}.",
         "i" = "This can happen when ggplot fails to infer the correct grouping structure in the data.",
         "i" = "Did you forget to specify a {.code group} aesthetic or to convert a numerical variable into a factor?"
       ))

--- a/R/stat-bin.R
+++ b/R/stat-bin.R
@@ -103,7 +103,7 @@ StatBin <- ggproto("StatBin", Stat,
     x <- flipped_names(params$flipped_aes)$x
     if (is_mapped_discrete(data[[x]])) {
       cli::cli_abort(c(
-        "{.fn {snake_class(self)}} requires a continuous {.field {x}} aesthetic",
+        "{.fn {snake_class(self)}} requires a continuous {.field {x}} aesthetic.",
         "x" = "the {.field {x}} aesthetic is discrete.",
         "i" = "Perhaps you want {.code stat=\"count\"}?"
       ))

--- a/R/stat-density-2d.R
+++ b/R/stat-density-2d.R
@@ -146,12 +146,10 @@ StatDensity2d <- ggproto("StatDensity2d", Stat,
 
     # set up data and parameters for contouring
     contour_var <- params$contour_var %||% "density"
-    if (!isTRUE(contour_var %in% c("density", "ndensity", "count"))) {
-      cli::cli_abort(c(
-        "Invalid value of {.arg contour_var} ({.val {contour_var}})",
-        "i" = "Supported values are {.val density}, {.val ndensity}, and {.val count}."
-      ))
-    }
+    arg_match0(
+      contour_var,
+      c("density", "ndensity", "count")
+    )
     data$z <- data[[contour_var]]
     z.range <- range(data$z, na.rm = TRUE, finite = TRUE)
     params <- params[intersect(names(params), c("bins", "binwidth", "breaks"))]
@@ -170,7 +168,7 @@ StatDensity2d <- ggproto("StatDensity2d", Stat,
       try_fetch(
         inject(contour_stat$compute_panel(data = data, scales = scales, !!!params)),
         error = function(cnd) {
-          cli::cli_warn("Computation failed in {.fn {snake_class(self)}}", parent = cnd)
+          cli::cli_warn("Computation failed in {.fn {snake_class(self)}}.", parent = cnd)
           data_frame0()
         }
       )

--- a/R/stat-density.R
+++ b/R/stat-density.R
@@ -167,7 +167,7 @@ compute_density <- function(x, w, from, to, bw = "nrd0", adjust = 1,
 fit_data_to_bounds <- function(bounds, x, w) {
   is_inside_bounds <- (bounds[1] <= x) & (x <= bounds[2])
 
-  if (any(!is_inside_bounds)) {
+  if (!all(is_inside_bounds)) {
     cli::cli_warn("Some data points are outside of `bounds`. Removing them.")
     x <- x[is_inside_bounds]
     w <- w[is_inside_bounds]

--- a/R/stat-qq-line.R
+++ b/R/stat-qq-line.R
@@ -66,7 +66,7 @@ StatQqLine <- ggproto("StatQqLine", Stat,
     if (is.null(quantiles)) {
       quantiles <- stats::ppoints(n)
     } else if (length(quantiles) != n) {
-      cli::cli_abort("{.arg quantiles} must have the same length as the data")
+      cli::cli_abort("{.arg quantiles} must have the same length as the data.")
     }
 
     theoretical <- inject(distribution(p = quantiles, !!!dparams))

--- a/R/stat-qq.R
+++ b/R/stat-qq.R
@@ -95,7 +95,7 @@ StatQq <- ggproto("StatQq", Stat,
     if (is.null(quantiles)) {
       quantiles <- stats::ppoints(n)
     } else if (length(quantiles) != n) {
-      cli::cli_abort("The length of {.arg quantiles} must match the length of the data")
+      cli::cli_abort("The length of {.arg quantiles} must match the length of the data.")
     }
 
     theoretical <- inject(distribution(p = quantiles, !!!dparams))

--- a/R/stat-ydensity.R
+++ b/R/stat-ydensity.R
@@ -155,7 +155,7 @@ StatYdensity <- ggproto("StatYdensity", Stat,
 calc_bw <- function(x, bw) {
   if (is.character(bw)) {
     if (length(x) < 2) {
-      cli::cli_abort("{.arg x} must contain at least 2 elements to select a bandwidth automatically")
+      cli::cli_abort("{.arg x} must contain at least 2 elements to select a bandwidth automatically.")
     }
 
     bw <- switch(
@@ -167,7 +167,7 @@ calc_bw <- function(x, bw) {
       sj = ,
       `sj-ste` = stats::bw.SJ(x, method = "ste"),
       `sj-dpi` = stats::bw.SJ(x, method = "dpi"),
-      cli::cli_abort("{.var {bw}} is not a valid bandwidth rule")
+      cli::cli_abort("{.var {bw}} is not a valid bandwidth rule.")
     )
   }
   bw

--- a/R/theme.R
+++ b/R/theme.R
@@ -545,7 +545,7 @@ add_theme <- function(t1, t2, t2name, call = caller_env()) {
       t1[item] <- list(x)
     },
     error = function(cnd) {
-      cli::cli_abort("Problem merging the {.var {item}} theme element", parent = cnd, call = call)
+      cli::cli_abort("Can't merge the {.var {item}} theme element.", parent = cnd, call = call)
     }
   )
 
@@ -585,7 +585,7 @@ add_theme <- function(t1, t2, t2name, call = caller_env()) {
 #' t$text
 calc_element <- function(element, theme, verbose = FALSE, skip_blank = FALSE,
                          call = caller_env()) {
-  if (verbose) message(element, " --> ", appendLF = FALSE)
+  if (verbose) cli::cli_inform(paste0(element, " --> "))
 
   el_out <- theme[[element]]
 
@@ -595,7 +595,7 @@ calc_element <- function(element, theme, verbose = FALSE, skip_blank = FALSE,
     if (isTRUE(skip_blank)) {
       el_out <- NULL
     } else {
-      if (verbose) message("element_blank (no inheritance)")
+      if (verbose) cli::cli_inform("`element_blank()` (no inheritance)")
       return(el_out)
     }
   }
@@ -607,7 +607,7 @@ calc_element <- function(element, theme, verbose = FALSE, skip_blank = FALSE,
   # it is of the class specified in element_tree
   if (!is.null(el_out) &&
       !inherits(el_out, element_tree[[element]]$class)) {
-    cli::cli_abort("Theme element {.var {element}} must have class {.cls {ggplot_global$element_tree[[element]]$class}}", call = call)
+    cli::cli_abort("Theme element {.var {element}} must have class {.cls {ggplot_global$element_tree[[element]]$class}}.", call = call)
   }
 
   # Get the names of parents from the inheritance tree
@@ -615,7 +615,7 @@ calc_element <- function(element, theme, verbose = FALSE, skip_blank = FALSE,
 
   # If no parents, this is a "root" node. Just return this element.
   if (is.null(pnames)) {
-    if (verbose) message("nothing (top level)")
+    if (verbose) cli::cli_inform("nothing (top level)")
 
     # Check that all the properties of this element are non-NULL
     nullprops <- vapply(el_out, is.null, logical(1))
@@ -630,11 +630,11 @@ calc_element <- function(element, theme, verbose = FALSE, skip_blank = FALSE,
       return(el_out) # no null properties remaining, return element
     }
 
-    cli::cli_abort("Theme element {.var {element}} has {.val NULL} property without default: {.field {names(nullprops)[nullprops]}}", call = call)
+    cli::cli_abort("Theme element {.var {element}} has {.code NULL} property without default: {.field {names(nullprops)[nullprops]}}.", call = call)
   }
 
   # Calculate the parent objects' inheritance
-  if (verbose) message(paste(pnames, collapse = ", "))
+  if (verbose) cli::cli_inform("{pnames}")
   parents <- lapply(
     pnames,
     calc_element,
@@ -686,7 +686,7 @@ merge_element.default <- function(new, old) {
   }
 
   # otherwise we can't merge
-  cli::cli_abort("No method for merging {.cls {class(new)[1]}} into {.cls {class(old)[1]}}")
+  cli::cli_abort("No method for merging {.cls {class(new)[1]}} into {.cls {class(old)[1]}}.")
 }
 
 #' @rdname merge_element
@@ -706,7 +706,7 @@ merge_element.element <- function(new, old) {
 
   # actual merging can only happen if classes match
   if (!inherits(new, class(old)[1])) {
-    cli::cli_abort("Only elements of the same class can be merged")
+    cli::cli_abort("Only elements of the same class can be merged.")
   }
 
   # Override NULL properties of new with the values in old

--- a/R/utilities-break.R
+++ b/R/utilities-break.R
@@ -95,7 +95,7 @@ find_origin <- function(x_range, width, boundary) {
 breaks <- function(x, equal, nbins = NULL, binwidth = NULL) {
   equal <- arg_match0(equal, c("numbers", "width"))
   if ((!is.null(nbins) && !is.null(binwidth)) || (is.null(nbins) && is.null(binwidth))) {
-    cli::cli_abort("Specify exactly one of {.arg n} and {.arg width}")
+    cli::cli_abort("Specify exactly one of {.arg n} and {.arg width}.")
   }
 
   rng <- range(x, na.rm = TRUE, finite = TRUE)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -42,7 +42,7 @@ check_required_aesthetics <- function(required, present, name, call = caller_env
   if (length(missing_aes) > 1) {
     message <- paste0(message, " {.strong or} {.field {missing_aes[[2]]}}")
   }
-  cli::cli_abort(message, call = call)
+  cli::cli_abort(paste0(message, "."), call = call)
 }
 
 # Concatenate a named list for output
@@ -62,7 +62,7 @@ clist <- function(l) {
 # @keyword internal
 uniquecols <- function(df) {
   df <- df[1, sapply(df, is_unique), drop = FALSE]
-  rownames(df) <- 1:nrow(df)
+  rownames(df) <- seq_len(nrow(df))
   df
 }
 
@@ -199,7 +199,7 @@ gg_dep <- function(version, msg) {
   .Deprecated()
   v <- as.package_version(version)
   cv <- utils::packageVersion("ggplot2")
-  text <- "{msg} (Defunct; last used in version {version})"
+  text <- "{msg} (Defunct; last used in version {version})."
 
   # If current major number is greater than last-good major number, or if
   #  current minor number is more than 1 greater than last-good minor number,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -11,11 +11,11 @@ random_tip <- function() {
   tips <- c(
     "RStudio Community is a great place to get help: https://community.rstudio.com/c/tidyverse",
     "Learn more about the underlying theory at https://ggplot2-book.org/",
-    "Keep up to date with changes at https://www.tidyverse.org/blog/",
+    "Keep up to date with changes at https://tidyverse.org/blog/",
     "Use suppressPackageStartupMessages() to eliminate package startup messages",
     "Need help? Try Stackoverflow: https://stackoverflow.com/tags/ggplot2",
     "Need help getting started? Try the R Graphics Cookbook: https://r-graphics.org",
-    "Want to understand how all the pieces fit together? Read R for Data Science: https://r4ds.had.co.nz/"
+    "Want to understand how all the pieces fit together? Read R for Data Science: https://r4ds.hadley.nz/"
   )
 
   sample(tips, 1)

--- a/man/annotate.Rd
+++ b/man/annotate.Rd
@@ -48,7 +48,7 @@ affect the legend.
 \section{Unsupported geoms}{
 
 Due to their special nature, reference line geoms \code{\link[=geom_abline]{geom_abline()}},
-\code{\link[=geom_hline]{geom_hline()}}, and \code{\link[=geom_vline]{geom_vline()}} can't be used with \code{\link[=annotate]{annotate()}}.
+\code{\link[=geom_hline]{geom_hline()}}, and \code{\link[=geom_vline]{geom_vline()}} can't be used with \code{annotate()}.
 You can use these geoms directly for annotations.
 }
 

--- a/tests/testthat/_snaps/aes-calculated.md
+++ b/tests/testthat/_snaps/aes-calculated.md
@@ -1,18 +1,27 @@
 # staged aesthetics warn appropriately for duplicated names
 
-    Duplicated aesthetics after name standardisation: colour
-
----
-
-    Duplicated aesthetics after name standardisation: colour
+    Code
+      p <- ggplot(df, aes(x, y, label = lab)) + geom_label(aes(colour = stage(lab,
+        after_scale = colour), color = after_scale(color))) + guides(colour = "none")
+    Condition
+      Warning:
+      Duplicated aesthetics after name standardisation: colour
 
 # A deprecated warning is issued when stat(var) or ..var.. is used
 
-    `stat(foo)` was deprecated in ggplot2 3.4.0.
-    i Please use `after_stat(foo)` instead.
+    Code
+      out <- ggplot_build(p1)
+    Condition
+      Warning:
+      `stat(foo)` was deprecated in ggplot2 3.4.0.
+      i Please use `after_stat(foo)` instead.
 
 ---
 
-    The dot-dot notation (`..bar..`) was deprecated in ggplot2 3.4.0.
-    i Please use `after_stat(bar)` instead.
+    Code
+      out <- ggplot_build(p2)
+    Condition
+      Warning:
+      The dot-dot notation (`..bar..`) was deprecated in ggplot2 3.4.0.
+      i Please use `after_stat(bar)` instead.
 

--- a/tests/testthat/_snaps/aes.md
+++ b/tests/testthat/_snaps/aes.md
@@ -1,20 +1,37 @@
 # aes evaluation fails with unknown input
 
-    Unknown input: <environment>
-
----
-
-    Unknown input: <environment>
+    Code
+      is_calculated(environment())
+    Condition
+      Error in `is_calculated()`:
+      ! Unknown input: <environment>
+    Code
+      strip_dots(environment())
+    Condition
+      Error in `strip_dots()`:
+      ! Unknown input: <environment>
 
 # aes() supports `!!!` in named arguments (#2675)
 
-    formal argument "y" matched by multiple actual arguments
+    Code
+      aes(y = 1, !!!list(y = 2))
+    Condition
+      Error in `aes()`:
+      ! formal argument "y" matched by multiple actual arguments
 
 # alternative_aes_extract_usage() can inspect the call
 
-    Don't know how to get alternative usage for `foo`
+    Code
+      alternative_aes_extract_usage(x)
+    Condition
+      Error in `alternative_aes_extract_usage()`:
+      ! Don't know how to get alternative usage for `foo`.
 
 # new_aes() checks its inputs
 
-    `x` must be a <list>, not an integer vector.
+    Code
+      new_aes(1:5)
+    Condition
+      Error in `new_aes()`:
+      ! `x` must be a <list>, not an integer vector.
 

--- a/tests/testthat/_snaps/annotate.md
+++ b/tests/testthat/_snaps/annotate.md
@@ -1,36 +1,61 @@
 # annotation_raster() and annotation_custom() requires cartesian coordinates
 
-    Problem while converting geom to grob.
-    i Error occurred in the 1st layer.
-    Caused by error in `draw_panel()`:
-    ! `annotation_raster()` only works with `coord_cartesian()`
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `annotation_raster()`:
+      ! Problem while converting geom to grob.
+      i Error occurred in the 1st layer.
+      Caused by error in `draw_panel()`:
+      ! `annotation_raster()` only works with `coord_cartesian()`.
 
 ---
 
-    Problem while converting geom to grob.
-    i Error occurred in the 1st layer.
-    Caused by error in `draw_panel()`:
-    ! `annotation_custom()` only works with `coord_cartesian()`
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `annotation_custom()`:
+      ! Problem while converting geom to grob.
+      i Error occurred in the 1st layer.
+      Caused by error in `draw_panel()`:
+      ! `annotation_custom()` only works with `coord_cartesian()`.
 
 # annotation_map() checks the input data
 
-    `map` must be a data frame, not a character vector.
-
----
-
-    `map` must have the columns `x`, `y`, and `id`
+    Code
+      annotation_map(letters)
+    Condition
+      Error in `annotation_map()`:
+      ! `map` must be a data frame, not a character vector.
+    Code
+      annotation_map(mtcars)
+    Condition
+      Error in `annotation_map()`:
+      ! `map` must have the columns `x`, `y`, and `id`.
 
 # unsupported geoms signal a warning (#4719)
 
-    `geom` must not be "hline".
-    i Please use `geom_hline()` directly instead.
+    Code
+      out <- annotate("hline", yintercept = 0)
+    Condition
+      Warning:
+      `geom` must not be "hline".
+      i Please use `geom_hline()` directly instead.
 
 # annotate() checks aesthetic lengths match
 
-    Unequal parameter lengths: x (3), y (3), and fill (2)
+    Code
+      annotate("point", 1:3, 1:3, fill = c("red", "black"))
+    Condition
+      Error in `annotate()`:
+      ! Unequal parameter lengths: x (3), y (3), and fill (2)
 
 # annotation_logticks warns about deprecated `size` argument
 
-    Using the `size` aesthetic in this geom was deprecated in ggplot2 3.5.0.
-    i Please use `linewidth` instead.
+    Code
+      out <- annotation_logticks(size = 5)
+    Condition
+      Warning:
+      Using the `size` aesthetic in this geom was deprecated in ggplot2 3.5.0.
+      i Please use `linewidth` instead.
 

--- a/tests/testthat/_snaps/autolayer.md
+++ b/tests/testthat/_snaps/autolayer.md
@@ -1,4 +1,8 @@
 # autolayers default error looks correct
 
-    No autolayer method available for <character> objects
+    Code
+      autolayer(letters)
+    Condition
+      Error in `autolayer()`:
+      ! No autolayer method available for <character> objects.
 

--- a/tests/testthat/_snaps/autoplot.md
+++ b/tests/testthat/_snaps/autoplot.md
@@ -1,5 +1,9 @@
 # autoplot throws helpful error on default
 
-    Objects of class <integer> are not supported by autoplot.
-    i have you loaded the required package?
+    Code
+      autoplot(1:4)
+    Condition
+      Error in `autoplot()`:
+      ! Objects of class <integer> are not supported by autoplot.
+      i Have you loaded the required package?
 

--- a/tests/testthat/_snaps/compat-plyr.md
+++ b/tests/testthat/_snaps/compat-plyr.md
@@ -1,16 +1,32 @@
 # input checks work in compat functions
 
-    Can only remove rownames from <data.frame> and <matrix> objects
+    Code
+      unrowname(1:6)
+    Condition
+      Error in `unrowname()`:
+      ! Can only remove rownames from <data.frame> and <matrix> objects.
 
 ---
 
-    `x` must be a factor or character vector, not an integer vector.
+    Code
+      revalue(1:7, c(`5` = 2))
+    Condition
+      Error in `revalue()`:
+      ! `x` must be a factor or character vector, not an integer vector.
 
 ---
 
-    Must be a character vector, call, or formula
+    Code
+      as.quoted(1:7)
+    Condition
+      Error in `as.quoted()`:
+      ! Must be a character vector, call, or formula.
 
 ---
 
-    `x` must be a <numeric> vector, not a character vector.
+    Code
+      round_any(letters)
+    Condition
+      Error in `round_any()`:
+      ! `x` must be a <numeric> vector, not a character vector.
 

--- a/tests/testthat/_snaps/coord-.md
+++ b/tests/testthat/_snaps/coord-.md
@@ -1,20 +1,28 @@
 # Coord errors on missing methods
 
-    `coord()` has not implemented a `render_bg()` method
-
----
-
-    `coord()` has not implemented a `render_axis_h()` method
-
----
-
-    `coord()` has not implemented a `render_axis_v()` method
-
----
-
-    `coord()` has not implemented a `backtransform_range()` method
-
----
-
-    `coord()` has not implemented a `range()` method
+    Code
+      Coord$render_bg()
+    Condition
+      Error in `render_bg()`:
+      ! `coord()` has not implemented a `render_bg()` method.
+    Code
+      Coord$render_axis_h()
+    Condition
+      Error in `render_axis_h()`:
+      ! `coord()` has not implemented a `render_axis_h()` method.
+    Code
+      Coord$render_axis_v()
+    Condition
+      Error in `render_axis_v()`:
+      ! `coord()` has not implemented a `render_axis_v()` method.
+    Code
+      Coord$backtransform_range()
+    Condition
+      Error in `backtransform_range()`:
+      ! `coord()` has not implemented a `backtransform_range()` method.
+    Code
+      Coord$range()
+    Condition
+      Error in `range()`:
+      ! `coord()` has not implemented a `range()` method.
 

--- a/tests/testthat/_snaps/coord-cartesian.md
+++ b/tests/testthat/_snaps/coord-cartesian.md
@@ -1,8 +1,16 @@
 # cartesian coords throws error when limits are badly specified
 
-    `xlim` must be a vector of length 2, not a <ScaleContinuousPosition/ScaleContinuous/Scale/ggproto/gg> object.
+    Code
+      ggplot() + coord_cartesian(xlim(1, 1))
+    Condition
+      Error in `coord_cartesian()`:
+      ! `xlim` must be a vector of length 2, not a <ScaleContinuousPosition/ScaleContinuous/Scale/ggproto/gg> object.
 
 ---
 
-    `ylim` must be a vector of length 2, not an integer vector of length 3.
+    Code
+      ggplot() + coord_cartesian(ylim = 1:3)
+    Condition
+      Error in `coord_cartesian()`:
+      ! `ylim` must be a vector of length 2, not an integer vector of length 3.
 

--- a/tests/testthat/_snaps/coord-flip.md
+++ b/tests/testthat/_snaps/coord-flip.md
@@ -1,8 +1,16 @@
 # flip coords throws error when limits are badly specified
 
-    `xlim` must be a vector of length 2, not a <ScaleContinuousPosition/ScaleContinuous/Scale/ggproto/gg> object.
+    Code
+      ggplot() + coord_flip(xlim(1, 1))
+    Condition
+      Error in `coord_flip()`:
+      ! `xlim` must be a vector of length 2, not a <ScaleContinuousPosition/ScaleContinuous/Scale/ggproto/gg> object.
 
 ---
 
-    `ylim` must be a vector of length 2, not an integer vector of length 3.
+    Code
+      ggplot() + coord_flip(ylim = 1:3)
+    Condition
+      Error in `coord_flip()`:
+      ! `ylim` must be a vector of length 2, not an integer vector of length 3.
 

--- a/tests/testthat/_snaps/coord-map.md
+++ b/tests/testthat/_snaps/coord-map.md
@@ -1,8 +1,16 @@
 # coord map throws error when limits are badly specified
 
-    `xlim` must be a vector of length 2, not a <ScaleContinuousPosition/ScaleContinuous/Scale/ggproto/gg> object.
+    Code
+      ggplot() + coord_map(xlim = xlim(1, 1))
+    Condition
+      Error in `coord_map()`:
+      ! `xlim` must be a vector of length 2, not a <ScaleContinuousPosition/ScaleContinuous/Scale/ggproto/gg> object.
 
 ---
 
-    `ylim` must be a vector of length 2, not an integer vector of length 3.
+    Code
+      ggplot() + coord_cartesian(ylim = 1:3)
+    Condition
+      Error in `coord_cartesian()`:
+      ! `ylim` must be a vector of length 2, not an integer vector of length 3.
 

--- a/tests/testthat/_snaps/coord-polar.md
+++ b/tests/testthat/_snaps/coord-polar.md
@@ -1,10 +1,16 @@
 # coord_radial warns about axes
 
-    `guide_axis()` cannot be used for theta.
-    i Use one of x, y, or r instead.
-
----
-
-    No appropriate placement found for `r_axis_inside`.
-    i Axis will be placed at panel edge.
+    Code
+      out <- ggplotGrob(p + coord_radial() + guides(theta = "axis"))
+    Condition
+      Warning:
+      `guide_axis()` cannot be used for theta.
+      i Use one of x, y, or r instead.
+    Code
+      out <- ggplotGrob(p + coord_radial(start = 0.1 * pi, end = 0.4 * pi,
+      r_axis_inside = FALSE))
+    Condition
+      Warning:
+      No appropriate placement found for `r_axis_inside`.
+      i Axis will be placed at panel edge.
 

--- a/tests/testthat/_snaps/coord-transform.md
+++ b/tests/testthat/_snaps/coord-transform.md
@@ -1,8 +1,16 @@
 # coord_trans() throws error when limits are badly specified
 
-    `xlim` must be a vector of length 2, not a <ScaleContinuousPosition/ScaleContinuous/Scale/ggproto/gg> object.
+    Code
+      ggplot() + coord_trans(xlim = xlim(1, 1))
+    Condition
+      Error in `coord_trans()`:
+      ! `xlim` must be a vector of length 2, not a <ScaleContinuousPosition/ScaleContinuous/Scale/ggproto/gg> object.
 
 ---
 
-    `ylim` must be a vector of length 2, not an integer vector of length 3.
+    Code
+      ggplot() + coord_trans(ylim = 1:3)
+    Condition
+      Error in `coord_trans()`:
+      ! `ylim` must be a vector of length 2, not an integer vector of length 3.
 

--- a/tests/testthat/_snaps/coord_sf.md
+++ b/tests/testthat/_snaps/coord_sf.md
@@ -1,29 +1,55 @@
 # axis labels can be set manually
 
-    Breaks and labels along x direction are different lengths
+    Code
+      p <- plot + scale_x_continuous(breaks = c(1000, 2000, 3000), labels = function(
+        ...) c("A", "B"))
+      ggplot_build(p)
+    Condition
+      Error in `fixup_graticule_labels()`:
+      ! `breaks` and `labels` along `x` direction have different lengths.
+    Code
+      p <- plot + scale_y_continuous(breaks = c(1000, 2000, 3000), labels = function(
+        ...) c("A", "B"))
+      ggplot_build(p)
+    Condition
+      Error in `fixup_graticule_labels()`:
+      ! `breaks` and `labels` along `y` direction have different lengths.
 
 ---
 
-    Breaks and labels along y direction are different lengths
-
----
-
-    Graticule labeling format not recognized.
-
----
-
-    Panel labeling format not recognized.
+    Code
+      coord_sf(label_graticule = 1:17)
+    Condition
+      Error in `coord_sf()`:
+      ! Graticule labeling format not recognized.
+    Code
+      coord_sf(label_axes = 1:17)
+    Condition
+      Error in `coord_sf()`:
+      ! Panel labeling format not recognized.
 
 # default crs works
 
-    Scale limits cannot be mapped onto spatial coordinates in `coord_sf()`
-    i Consider setting `lims_method = "geometry_bbox"` or `default_crs = NULL`.
+    Code
+      ggplot_build(p + xlim(-Inf, 80))
+    Condition
+      Error in `calc_limits_bbox()`:
+      ! Scale limits cannot be mapped onto spatial coordinates in `coord_sf()`.
+      i Consider setting `lims_method = "geometry_bbox"` or `default_crs = NULL`.
 
 # coord_sf() throws error when limits are badly specified
 
-    `xlim` must be a vector of length 2, not a <ScaleContinuousPosition/ScaleContinuous/Scale/ggproto/gg> object.
+    Code
+      ggplot() + coord_sf(xlim(1, 1))
+    Condition
+      Error in `coord_sf()`:
+      ! `xlim` must be a vector of length 2, not a <ScaleContinuousPosition/ScaleContinuous/Scale/ggproto/gg> object.
 
 ---
 
-    `ylim` must be a vector of length 2, not an integer vector of length 3.
+    Code
+      ggplot() + coord_sf(ylim = 1:3)
+    Condition
+      Error in `coord_sf()`:
+      ! `ylim` must be a vector of length 2, not an integer vector of length 3.
 

--- a/tests/testthat/_snaps/error.md
+++ b/tests/testthat/_snaps/error.md
@@ -1,10 +1,23 @@
 # various misuses of +.gg (#2638)
 
-    Cannot use `+` with a single argument
-    i Did you accidentally put `+` on a new line?
-
----
-
-    Cannot add <ggproto> objects together
-    i Did you forget to add this object to a <ggplot> object?
+    Code
+      ggplot(mtcars, aes(hwy, displ))
+    Condition
+      Error in `geom_blank()`:
+      ! Problem while computing aesthetics.
+      i Error occurred in the 1st layer.
+      Caused by error:
+      ! object 'hwy' not found
+    Code
+      +geom_point()
+    Condition
+      Error:
+      ! Cannot use `+` with a single argument.
+      i Did you accidentally put `+` on a new line?
+    Code
+      geom_point() + geom_point()
+    Condition
+      Error:
+      ! Cannot add <ggproto> objects together.
+      i Did you forget to add this object to a <ggplot> object?
 

--- a/tests/testthat/_snaps/facet-.md
+++ b/tests/testthat/_snaps/facet-.md
@@ -1,55 +1,105 @@
 # facet_grid() fails if passed both a formula and a vars()
 
-    `rows` must be "NULL" or a `vars()` list if `cols` is a `vars()` list
+    Code
+      facet_grid(~foo, vars())
+    Condition
+      Error in `grid_as_facets_list()`:
+      ! `rows` must be `NULL` or a `vars()` list if `cols` is a `vars()` list.
 
 # can't pass formulas to `cols`
 
-    `cols` must be a `vars()` specification or `NULL`, not a <formula> object.
+    Code
+      facet_grid(NULL, ~foo)
+    Condition
+      Error in `grid_as_facets_list()`:
+      ! `cols` must be a `vars()` specification or `NULL`, not a <formula> object.
 
 # facet gives clear error if 
 
-    Faceting variables can only appear in `rows` or `cols`, not both.
-    i Duplicated variables: "x"
+    Code
+      print(ggplot(df, aes(x)) + facet_grid(x ~ x))
+    Condition
+      Error in `facet_grid()`:
+      ! Faceting variables can only appear in `rows` or `cols`, not both.
+      i Duplicated variables: "x"
 
 ---
 
-    `rows` must be "NULL" or a `vars()` list if `cols` is a `vars()` list
-    i Did you use `%>%` or `|>` instead of `+`?
+    Code
+      print(ggplot(df, aes(x)) %>% facet_grid(. ~ x))
+    Condition
+      Error in `grid_as_facets_list()`:
+      ! `rows` must be `NULL` or a `vars()` list if `cols` is a `vars()` list.
+      i Did you use `%>%` or `|>` instead of `+`?
 
 ---
 
-    A grid facet specification can't have more than two dimensions
+    Code
+      print(ggplot(df, aes(x)) + facet_grid(list(1, 2, 3)))
+    Condition
+      Error in `grid_as_facets_list()`:
+      ! A grid facet specification can't have more than two dimensions.
 
 ---
 
-    `cols` must be a `vars()` specification or `NULL`, not the string "free".
+    Code
+      print(ggplot(df, aes(x)) + facet_grid(vars(x), "free"))
+    Condition
+      Error in `grid_as_facets_list()`:
+      ! `cols` must be a `vars()` specification or `NULL`, not the string "free".
 
 # at least one layer must contain all facet variables in combine_vars()
 
-    At least one layer must contain all faceting variables: `letter`
-    x Plot is missing `letter`
-    Layer is missing `letter`
+    Code
+      combine_vars(list(df), vars = vars(letter = number))
+    Condition
+      Error in `combine_vars()`:
+      ! At least one layer must contain all faceting variables: `letter`
+      x Plot is missing `letter`
+      Layer is missing `letter`
 
 # combine_vars() generates the correct combinations
 
-    At least one layer must contain all faceting variables: `b` and `c`
-    x Plot is missing `c`
-    x Layer 1 is missing `b`
+    Code
+      combine_vars(list(data.frame(a = 1:2, b = 2:3), data.frame(a = 1:2, c = 2:3)),
+      vars = vars(b = b, c = c))
+    Condition
+      Error in `combine_vars()`:
+      ! At least one layer must contain all faceting variables: `b` and `c`
+      x Plot is missing `c`
+      x Layer 1 is missing `b`
 
 ---
 
-    Faceting variables must have at least one value
+    Code
+      combine_vars(list(data.frame(a = 1:2), data.frame(b = numeric())), vars = vars(
+        b = b))
+    Condition
+      Error in `combine_vars()`:
+      ! Faceting variables must have at least one value.
 
 # validate_facets() provide meaningful errors
 
-    Please use `vars()` to supply facet variables
+    Code
+      validate_facets(aes(var))
+    Condition
+      Error in `validate_facets()`:
+      ! Please use `vars()` to supply facet variables.
 
 ---
 
-    Please use `vars()` to supply facet variables
-    i Did you use `%>%` or `|>` instead of `+`?
+    Code
+      validate_facets(ggplot())
+    Condition
+      Error in `validate_facets()`:
+      ! Please use `vars()` to supply facet variables.
+      i Did you use `%>%` or `|>` instead of `+`?
 
 # check_layout() throws meaningful errors
 
-    Facet layout has a bad format. It must contain columns `PANEL`, `SCALE_X`, and `SCALE_Y`
+    Code
+      check_layout(mtcars)
+    Condition
+      Error in `check_layout()`:
+      ! Facet layout has a bad format. It must contain columns `PANEL`, `SCALE_X`, and `SCALE_Y`.
 

--- a/tests/testthat/_snaps/facet-layout.md
+++ b/tests/testthat/_snaps/facet-layout.md
@@ -1,56 +1,108 @@
 # facet_wrap throws errors at bad layout specs
 
-    `ncol` must be a whole number or `NULL`, not an integer vector.
+    Code
+      facet_wrap(~test, ncol = 1:4)
+    Condition
+      Error in `facet_wrap()`:
+      ! `ncol` must be a whole number or `NULL`, not an integer vector.
 
 ---
 
-    `ncol` must be a whole number larger than or equal to 1 or `NULL`, not the number -1.
+    Code
+      facet_wrap(~test, ncol = -1)
+    Condition
+      Error in `facet_wrap()`:
+      ! `ncol` must be a whole number larger than or equal to 1 or `NULL`, not the number -1.
 
 ---
 
-    `ncol` must be a whole number or `NULL`, not the number 1.5.
+    Code
+      facet_wrap(~test, ncol = 1.5)
+    Condition
+      Error in `facet_wrap()`:
+      ! `ncol` must be a whole number or `NULL`, not the number 1.5.
 
 ---
 
-    `nrow` must be a whole number or `NULL`, not an integer vector.
+    Code
+      facet_wrap(~test, nrow = 1:4)
+    Condition
+      Error in `facet_wrap()`:
+      ! `nrow` must be a whole number or `NULL`, not an integer vector.
 
 ---
 
-    `nrow` must be a whole number larger than or equal to 1 or `NULL`, not the number -1.
+    Code
+      facet_wrap(~test, nrow = -1)
+    Condition
+      Error in `facet_wrap()`:
+      ! `nrow` must be a whole number larger than or equal to 1 or `NULL`, not the number -1.
 
 ---
 
-    `nrow` must be a whole number or `NULL`, not the number 1.5.
+    Code
+      facet_wrap(~test, nrow = 1.5)
+    Condition
+      Error in `facet_wrap()`:
+      ! `nrow` must be a whole number or `NULL`, not the number 1.5.
 
 ---
 
-    Need 3 panels, but together `nrow` and `ncol` only provide 1
-    i Please increase `ncol` and/or `nrow`
+    Code
+      ggplot_build(p)
+    Condition
+      Error in `wrap_dims()`:
+      ! Need 3 panels, but together `nrow` and `ncol` only provide 1.
+      i Please increase `ncol` and/or `nrow`.
 
 ---
 
-    `facet_wrap()` can't use free scales with `coord_fixed()`
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `draw_panels()`:
+      ! `facet_wrap()` can't use free scales with `coord_fixed()`.
 
 # facet_grid throws errors at bad layout specs
 
-    `coord_fixed()` doesn't support free scales
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `draw_panels()`:
+      ! `coord_fixed()` doesn't support free scales.
 
 ---
 
-    Free scales cannot be mixed with a fixed aspect ratio
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `draw_panels()`:
+      ! Free scales cannot be mixed with a fixed aspect ratio.
 
 # facet_wrap and facet_grid throws errors when using reserved words
 
-    "ROW" is not an allowed name for faceting variables
-    i Change the name of your data columns to not be "PANEL", "ROW", "COL", "SCALE_X", or "SCALE_Y"
+    Code
+      ggplotGrob(p + facet_grid(ROW ~ gear))
+    Condition
+      Error in `facet_grid()`:
+      ! "ROW" is not an allowed name for faceting variables.
+      i Change the name of your data columns to not be "PANEL", "ROW", "COL", "SCALE_X", or "SCALE_Y".
 
 ---
 
-    "ROW" and "PANEL" are not allowed names for faceting variables
-    i Change the name of your data columns to not be "PANEL", "ROW", "COL", "SCALE_X", or "SCALE_Y"
+    Code
+      ggplotGrob(p + facet_grid(ROW ~ PANEL))
+    Condition
+      Error in `facet_grid()`:
+      ! "ROW" and "PANEL" are not allowed names for faceting variables.
+      i Change the name of your data columns to not be "PANEL", "ROW", "COL", "SCALE_X", or "SCALE_Y".
 
 ---
 
-    "ROW" is not an allowed name for faceting variables
-    i Change the name of your data columns to not be "PANEL", "ROW", "COL", "SCALE_X", or "SCALE_Y"
+    Code
+      ggplotGrob(p + facet_wrap(~ROW))
+    Condition
+      Error in `facet_wrap()`:
+      ! "ROW" is not an allowed name for faceting variables.
+      i Change the name of your data columns to not be "PANEL", "ROW", "COL", "SCALE_X", or "SCALE_Y".
 

--- a/tests/testthat/_snaps/facet-strips.md
+++ b/tests/testthat/_snaps/facet-strips.md
@@ -1,4 +1,8 @@
 # facet_grid() warns about bad switch input
 
-    `switch` must be either "both", "x", or "y"
+    Code
+      facet_grid(am ~ cyl, switch = "z")
+    Condition
+      Error in `facet_grid()`:
+      ! `switch` must be one of "both", "x", or "y", not "z".
 

--- a/tests/testthat/_snaps/fortify.md
+++ b/tests/testthat/_snaps/fortify.md
@@ -1,5 +1,9 @@
 # fortify.default proves a helpful error with class uneval
 
-    `data` must be a <data.frame>, or an object coercible by `fortify()`, or a valid <data.frame>-like object coercible by `as.data.frame()`, not a <uneval> object.
-    i Did you accidentally pass `aes()` to the `data` argument?
+    Code
+      ggplot(aes(x = x))
+    Condition
+      Error in `fortify()`:
+      ! `data` must be a <data.frame>, or an object coercible by `fortify()`, or a valid <data.frame>-like object coercible by `as.data.frame()`, not a <uneval> object.
+      i Did you accidentally pass `aes()` to the `data` argument?
 

--- a/tests/testthat/_snaps/geom-.md
+++ b/tests/testthat/_snaps/geom-.md
@@ -1,15 +1,23 @@
 # aesthetic checking in geom throws correct errors
 
-    Problem while setting up geom aesthetics.
-    i Error occurred in the 1st layer.
-    Caused by error in `use_defaults()`:
-    ! Aesthetic modifiers returned invalid values
-    x The following mappings are invalid
-    x `colour = after_scale(data)`
-    i Did you map the modifier in the wrong layer?
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `geom_point()`:
+      ! Problem while setting up geom aesthetics.
+      i Error occurred in the 1st layer.
+      Caused by error in `use_defaults()`:
+      ! Aesthetic modifiers returned invalid values
+      x The following mappings are invalid
+      x `colour = after_scale(data)`
+      i Did you map the modifier in the wrong layer?
 
 ---
 
-    Aesthetics must be either length 1 or the same as the data (4)
-    x Fix the following mappings: `d` and `e`
+    Code
+      check_aesthetics(aes, 4)
+    Condition
+      Error in `check_aesthetics()`:
+      ! Aesthetics must be either length 1 or the same as the data (4).
+      x Fix the following mappings: `d` and `e`.
 

--- a/tests/testthat/_snaps/geom-boxplot.md
+++ b/tests/testthat/_snaps/geom-boxplot.md
@@ -1,5 +1,9 @@
 # boxplots with a group size >1 error
 
-    Can only draw one boxplot per group
-    i Did you forget `aes(group = ...)`?
+    Code
+      layer_grob(p, 1)
+    Condition
+      Error in `draw_group()`:
+      ! Can only draw one boxplot per group.
+      i Did you forget `aes(group = ...)`?
 

--- a/tests/testthat/_snaps/geom-dotplot.md
+++ b/tests/testthat/_snaps/geom-dotplot.md
@@ -1,16 +1,31 @@
 # NA's result in warning from stat_bindot
 
-    Removed 2 rows containing missing values or values outside the scale range (`stat_bindot()`).
+    Code
+      out <- ggplot_build(ggplot(dat, aes(x)) + geom_dotplot(binwidth = 0.2))
+    Condition
+      Warning:
+      Removed 2 rows containing missing values or values outside the scale range (`stat_bindot()`).
 
 # weight aesthetic is checked
 
-    Computation failed in `stat_bindot()`
-    Caused by error in `compute_group()`:
-    ! `weight` must be nonnegative integers, not a double vector.
-
----
-
-    Computation failed in `stat_bindot()`
-    Caused by error in `compute_group()`:
-    ! `weight` must be nonnegative integers, not a double vector.
+    Code
+      p <- ggplot(mtcars, aes(x = mpg, weight = gear / 3)) + geom_dotplot()
+      e <- ggplot_build(p)
+    Message
+      Bin width defaults to 1/30 of the range of the data. Pick better value with `binwidth`.
+    Condition
+      Warning:
+      Computation failed in `stat_bindot()`.
+      Caused by error in `compute_group()`:
+      ! `weight` must be nonnegative integers, not a double vector.
+    Code
+      p <- ggplot(mtcars, aes(x = mpg, weight = -gear)) + geom_dotplot()
+      e <- ggplot_build(p)
+    Message
+      Bin width defaults to 1/30 of the range of the data. Pick better value with `binwidth`.
+    Condition
+      Warning:
+      Computation failed in `stat_bindot()`.
+      Caused by error in `compute_group()`:
+      ! `weight` must be nonnegative integers, not a double vector.
 

--- a/tests/testthat/_snaps/geom-hline-vline-abline.md
+++ b/tests/testthat/_snaps/geom-hline-vline-abline.md
@@ -1,32 +1,43 @@
 # warnings are thrown when parameters cause mapping and data to be ignored
 
-    `geom_vline()`: Ignoring `mapping` because `xintercept` was provided.
-
----
-
-    `geom_vline()`: Ignoring `data` because `xintercept` was provided.
-
----
-
-    `geom_hline()`: Ignoring `mapping` because `yintercept` was provided.
-
----
-
-    `geom_hline()`: Ignoring `data` because `yintercept` was provided.
-
----
-
-    `geom_abline()`: Ignoring `mapping` because `slope` and/or `intercept` were provided.
-
----
-
-    `geom_abline()`: Ignoring `mapping` because `slope` and/or `intercept` were provided.
-
----
-
-    `geom_abline()`: Ignoring `data` because `slope` and/or `intercept` were provided.
-
----
-
-    `geom_abline()`: Ignoring `data` because `slope` and/or `intercept` were provided.
+    Code
+      out <- geom_vline(aes(), xintercept = 2)
+    Condition
+      Warning:
+      `geom_vline()`: Ignoring `mapping` because `xintercept` was provided.
+    Code
+      out <- geom_vline(data = mtcars, xintercept = 2)
+    Condition
+      Warning:
+      `geom_vline()`: Ignoring `data` because `xintercept` was provided.
+    Code
+      out <- geom_hline(aes(), yintercept = 2)
+    Condition
+      Warning:
+      `geom_hline()`: Ignoring `mapping` because `yintercept` was provided.
+    Code
+      out <- geom_hline(data = mtcars, yintercept = 2)
+    Condition
+      Warning:
+      `geom_hline()`: Ignoring `data` because `yintercept` was provided.
+    Code
+      out <- geom_abline(aes(), slope = 2)
+    Condition
+      Warning:
+      `geom_abline()`: Ignoring `mapping` because `slope` and/or `intercept` were provided.
+    Code
+      out <- geom_abline(aes(), intercept = 2)
+    Condition
+      Warning:
+      `geom_abline()`: Ignoring `mapping` because `slope` and/or `intercept` were provided.
+    Code
+      out <- geom_abline(data = mtcars, slope = 2)
+    Condition
+      Warning:
+      `geom_abline()`: Ignoring `data` because `slope` and/or `intercept` were provided.
+    Code
+      out <- geom_abline(data = mtcars, intercept = 2)
+    Condition
+      Warning:
+      `geom_abline()`: Ignoring `data` because `slope` and/or `intercept` were provided.
 

--- a/tests/testthat/_snaps/geom-jitter.md
+++ b/tests/testthat/_snaps/geom-jitter.md
@@ -1,5 +1,9 @@
 # geom_jitter() throws relevant errors
 
-    both `position` and `width`/`height` are supplied
-    i Only use one approach to alter the position
+    Code
+      geom_jitter(position = "jitter", width = 4)
+    Condition
+      Error in `geom_jitter()`:
+      ! Both `position` and `width`/`height` were supplied.
+      i Choose a single approach to alter the position.
 

--- a/tests/testthat/_snaps/geom-label.md
+++ b/tests/testthat/_snaps/geom-label.md
@@ -1,9 +1,17 @@
 # geom_label() throws meaningful errors
 
-    both `position` and `nudge_x`/`nudge_y` are supplied
-    i Only use one approach to alter the position
+    Code
+      geom_label(position = "jitter", nudge_x = 0.5)
+    Condition
+      Error in `geom_label()`:
+      ! Both `position` and `nudge_x`/`nudge_y` are supplied.
+      i Choose one approach to alter the position.
 
 ---
 
-    `label` must be of length 1
+    Code
+      labelGrob(label = 1:3)
+    Condition
+      Error in `labelGrob()`:
+      ! `label` must be of length 1.
 

--- a/tests/testthat/_snaps/geom-linerange.md
+++ b/tests/testthat/_snaps/geom-linerange.md
@@ -1,7 +1,11 @@
 # geom_linerange request the right aesthetics
 
-    Problem while setting up geom.
-    i Error occurred in the 1st layer.
-    Caused by error in `compute_geom_1()`:
-    ! `geom_linerange()` requires the following missing aesthetics: ymax or xmin and xmax
+    Code
+      ggplot_build(p)
+    Condition
+      Error in `geom_linerange()`:
+      ! Problem while setting up geom.
+      i Error occurred in the 1st layer.
+      Caused by error in `compute_geom_1()`:
+      ! `geom_linerange()` requires the following missing aesthetics: ymax or xmin and xmax.
 

--- a/tests/testthat/_snaps/geom-map.md
+++ b/tests/testthat/_snaps/geom-map.md
@@ -1,8 +1,16 @@
 # geom_map() checks its input
 
-    `map` must be a data frame, not a character vector.
+    Code
+      geom_map(map = letters)
+    Condition
+      Error in `geom_map()`:
+      ! `map` must be a data frame, not a character vector.
 
 ---
 
-    `map` must have the columns `x`, `y`, and `id`
+    Code
+      geom_map(map = mtcars)
+    Condition
+      Error in `geom_map()`:
+      ! `map` must have the columns `x`, `y`, and `id`.
 

--- a/tests/testthat/_snaps/geom-path.md
+++ b/tests/testthat/_snaps/geom-path.md
@@ -1,7 +1,11 @@
 # geom_path() throws meaningful error on bad combination of varying aesthetics
 
-    Problem while converting geom to grob.
-    i Error occurred in the 1st layer.
-    Caused by error in `draw_panel()`:
-    ! `geom_path()` can't have varying colour, linewidth, and/or alpha along the line when linetype isn't solid
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `geom_path()`:
+      ! Problem while converting geom to grob.
+      i Error occurred in the 1st layer.
+      Caused by error in `draw_panel()`:
+      ! `geom_path()` can't have varying colour, linewidth, and/or alpha along the line when linetype isn't solid.
 

--- a/tests/testthat/_snaps/geom-point.md
+++ b/tests/testthat/_snaps/geom-point.md
@@ -1,9 +1,17 @@
 # invalid shape names raise an error
 
-    Shape aesthetic contains invalid value: "void"
+    Code
+      translate_shape_string("void")
+    Condition
+      Error in `translate_shape_string()`:
+      ! Shape aesthetic contains invalid value: "void".
 
 ---
 
-    shape names must be given unambiguously
-    i Fix "tri"
+    Code
+      translate_shape_string("tri")
+    Condition
+      Error in `translate_shape_string()`:
+      ! Shape names must be given unambiguously.
+      i Fix "tri".
 

--- a/tests/testthat/_snaps/geom-raster.md
+++ b/tests/testthat/_snaps/geom-raster.md
@@ -1,23 +1,43 @@
 # geom_raster() checks input and coordinate system
 
-    `hjust` must be a number, not a double vector.
+    Code
+      geom_raster(hjust = c(2.5, 1.3))
+    Condition
+      Error in `geom_raster()`:
+      ! `hjust` must be a number, not a double vector.
 
 ---
 
-    `hjust` must be a number, not the string "a".
+    Code
+      geom_raster(hjust = "a")
+    Condition
+      Error in `geom_raster()`:
+      ! `hjust` must be a number, not the string "a".
 
 ---
 
-    `vjust` must be a number, not a double vector.
+    Code
+      geom_raster(vjust = c(2.5, 1.3))
+    Condition
+      Error in `geom_raster()`:
+      ! `vjust` must be a number, not a double vector.
 
 ---
 
-    `vjust` must be a number, not the string "a".
+    Code
+      geom_raster(vjust = "a")
+    Condition
+      Error in `geom_raster()`:
+      ! `vjust` must be a number, not the string "a".
 
 ---
 
-    Problem while converting geom to grob.
-    i Error occurred in the 1st layer.
-    Caused by error in `draw_panel()`:
-    ! `geom_raster()` only works with `coord_cartesian()`
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `geom_raster()`:
+      ! Problem while converting geom to grob.
+      i Error occurred in the 1st layer.
+      Caused by error in `draw_panel()`:
+      ! `geom_raster()` only works with `coord_cartesian()`.
 

--- a/tests/testthat/_snaps/geom-ribbon.md
+++ b/tests/testthat/_snaps/geom-ribbon.md
@@ -1,25 +1,41 @@
 # geom_ribbon() checks the aesthetics
 
-    Problem while setting up geom.
-    i Error occurred in the 1st layer.
-    Caused by error in `setup_data()`:
-    ! Either xmin or xmax must be given as an aesthetic.
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `geom_ribbon()`:
+      ! Problem while setting up geom.
+      i Error occurred in the 1st layer.
+      Caused by error in `setup_data()`:
+      ! Either xmin or xmax must be given as an aesthetic.
 
 ---
 
-    Problem while setting up geom.
-    i Error occurred in the 1st layer.
-    Caused by error in `setup_data()`:
-    ! Either ymin or ymax must be given as an aesthetic.
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `geom_ribbon()`:
+      ! Problem while setting up geom.
+      i Error occurred in the 1st layer.
+      Caused by error in `setup_data()`:
+      ! Either ymin or ymax must be given as an aesthetic.
 
 ---
 
-    Problem while converting geom to grob.
-    i Error occurred in the 1st layer.
-    Caused by error in `draw_group()`:
-    ! Aesthetics can not vary along a ribbon
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `geom_ribbon()`:
+      ! Problem while converting geom to grob.
+      i Error occurred in the 1st layer.
+      Caused by error in `draw_group()`:
+      ! Aesthetics can not vary along a ribbon.
 
 ---
 
-    `outline.type` must be one of "both", "upper", "lower", or "full", not "test".
+    Code
+      geom_ribbon(aes(year, ymin = level - 5, ymax = level + 5), outline.type = "test")
+    Condition
+      Error in `geom_ribbon()`:
+      ! `outline.type` must be one of "both", "upper", "lower", or "full", not "test".
 

--- a/tests/testthat/_snaps/geom-rug.md
+++ b/tests/testthat/_snaps/geom-rug.md
@@ -1,7 +1,11 @@
 # Rug length needs unit object
 
-    Problem while converting geom to grob.
-    i Error occurred in the 1st layer.
-    Caused by error in `draw_panel()`:
-    ! `length` must be a <unit> object, not the number 0.01.
+    Code
+      print(p + geom_rug(length = 0.01))
+    Condition
+      Error in `geom_rug()`:
+      ! Problem while converting geom to grob.
+      i Error occurred in the 1st layer.
+      Caused by error in `draw_panel()`:
+      ! `length` must be a <unit> object, not the number 0.01.
 

--- a/tests/testthat/_snaps/geom-sf.md
+++ b/tests/testthat/_snaps/geom-sf.md
@@ -1,17 +1,39 @@
 # errors are correctly triggered
 
-    Problem while converting geom to grob.
-    i Error occurred in the 1st layer.
-    Caused by error in `draw_panel()`:
-    ! `geom_sf()` can only be used with `coord_sf()`
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `geom_sf()`:
+      ! Problem while converting geom to grob.
+      i Error occurred in the 1st layer.
+      Caused by error in `draw_panel()`:
+      ! `geom_sf()` can only be used with `coord_sf()`.
 
 ---
 
-    both `position` and `nudge_x`/`nudge_y` are supplied
-    i Only use one approach to alter the position
+    Code
+      geom_sf_label(position = "jitter", nudge_x = 0.5)
+    Condition
+      Error in `geom_sf_label()`:
+      ! Both `position` and `nudge_x`/`nudge_y` are supplied.
+      i Only use one approach to alter the position.
 
 ---
 
-    both `position` and `nudge_x`/`nudge_y` are supplied
-    i Only use one approach to alter the position
+    Code
+      geom_sf_text(position = "jitter", nudge_x = 0.5)
+    Condition
+      Error in `geom_sf_text()`:
+      ! both `position` and `nudge_x`/`nudge_y` are supplied.
+      i Only use one approach to alter the position.
+
+---
+
+    Code
+      sf_grob(pts, na.rm = FALSE)
+    Condition
+      Warning:
+      Removed 1 row containing missing values or values outside the scale range (`geom_sf()`).
+    Output
+      polyline[GRID.polyline.8434] 
 

--- a/tests/testthat/_snaps/geom-text.md
+++ b/tests/testthat/_snaps/geom-text.md
@@ -1,5 +1,9 @@
 # geom_text() checks input
 
-    both `position` and `nudge_x`/`nudge_y` are supplied
-    i Only use one approach to alter the position
+    Code
+      geom_text(position = "jitter", nudge_x = 0.5)
+    Condition
+      Error in `geom_text()`:
+      ! Both `position` and `nudge_x`/`nudge_y` are supplied.
+      i Only use one approach to alter the position.
 

--- a/tests/testthat/_snaps/geom-violin.md
+++ b/tests/testthat/_snaps/geom-violin.md
@@ -1,14 +1,22 @@
 # quantiles fails outside 0-1 bound
 
-    Problem while converting geom to grob.
-    i Error occurred in the 1st layer.
-    Caused by error in `draw_group()`:
-    ! `draw_quantiles` must be between 0 and 1
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `geom_violin()`:
+      ! Problem while converting geom to grob.
+      i Error occurred in the 1st layer.
+      Caused by error in `draw_group()`:
+      ! `draw_quantiles` must be between 0 and 1.
 
 ---
 
-    Problem while converting geom to grob.
-    i Error occurred in the 1st layer.
-    Caused by error in `draw_group()`:
-    ! `draw_quantiles` must be between 0 and 1
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `geom_violin()`:
+      ! Problem while converting geom to grob.
+      i Error occurred in the 1st layer.
+      Caused by error in `draw_group()`:
+      ! `draw_quantiles` must be between 0 and 1.
 

--- a/tests/testthat/_snaps/ggproto.md
+++ b/tests/testthat/_snaps/ggproto.md
@@ -1,12 +1,24 @@
 # construction checks input
 
-    All members of a <ggproto> object must be named.
+    Code
+      ggproto("Test", NULL, function(self, a) a)
+    Condition
+      Error in `ggproto()`:
+      ! All members of a <ggproto> object must be named.
 
 ---
 
-    All members of a <ggproto> object must be named.
+    Code
+      ggproto("Test", NULL, a <- (function(self, a) a))
+    Condition
+      Error in `ggproto()`:
+      ! All members of a <ggproto> object must be named.
 
 ---
 
-    `_inherit` must be a <ggproto> object, not a <data.frame> object.
+    Code
+      ggproto("Test", mtcars, a = function(self, a) a)
+    Condition
+      Error in `ggproto()`:
+      ! `_inherit` must be a <ggproto> object, not a <data.frame> object.
 

--- a/tests/testthat/_snaps/ggsave.md
+++ b/tests/testthat/_snaps/ggsave.md
@@ -1,25 +1,39 @@
 # unknown device triggers error
 
-    `device` must be a string, function or `NULL`, not the number 1.
+    Code
+      plot_dev(1)
+    Condition
+      Error:
+      ! `device` must be a string, function or `NULL`, not the number 1.
 
 # invalid single-string DPI values throw an error
 
-    Unknown `dpi` string
-    i Use either "screen", "print", or "retina"
+    Code
+      parse_dpi("abc")
+    Condition
+      Error:
+      ! `dpi` must be one of "screen", "print", or "retina", not "abc".
 
 # invalid non-single-string DPI values throw an error
 
-    `dpi` must be a single number or string, not a <factor> object.
-
----
-
-    `dpi` must be a single number or string, not a character vector.
-
----
-
-    `dpi` must be a single number or string, not a double vector.
-
----
-
-    `dpi` must be a single number or string, not a list.
+    Code
+      parse_dpi(factor(100))
+    Condition
+      Error:
+      ! `dpi` must be a single number or string, not a <factor> object.
+    Code
+      parse_dpi(c("print", "screen"))
+    Condition
+      Error:
+      ! `dpi` must be a single number or string, not a character vector.
+    Code
+      parse_dpi(c(150, 300))
+    Condition
+      Error:
+      ! `dpi` must be a single number or string, not a double vector.
+    Code
+      parse_dpi(list(150))
+    Condition
+      Error:
+      ! `dpi` must be a single number or string, not a list.
 

--- a/tests/testthat/_snaps/guides.md
+++ b/tests/testthat/_snaps/guides.md
@@ -1,78 +1,149 @@
 # Using non-position guides for position scales results in an informative error
 
-    `guide_legend()` cannot be used for x, xmin, xmax, or xend.
-    i Use any non position aesthetic instead.
+    Code
+      p <- ggplot(mpg, aes(cty, hwy)) + geom_point() + scale_x_continuous(guide = guide_legend())
+      e <- ggplot_build(p)
+    Condition
+      Warning:
+      `guide_legend()` cannot be used for x, xmin, xmax, or xend.
+      i Use any non position aesthetic instead.
 
 # guide specifications are properly checked
 
-    Unknown guide: test
+    Code
+      validate_guide("test")
+    Condition
+      Error in `validate_guide()`:
+      ! Unknown guide: test
+    Code
+      validate_guide(1)
+    Condition
+      Error in `validate_guide()`:
+      ! Unknown guide: 1
 
 ---
 
-    Unknown guide: 1
+    Code
+      p <- ggplot(mtcars) + geom_point(aes(mpg, disp, shape = factor(gear))) + guides(
+        shape = "colourbar")
+      e <- ggplotGrob(p)
+    Condition
+      Warning:
+      `guide_colourbar()` cannot be used for shape.
+      i Use one of colour, color, or fill instead.
 
 ---
 
-    `guide_colourbar()` cannot be used for shape.
-    i Use one of colour, color, or fill instead.
+    Code
+      guide_legend(title.position = "leftish")
+    Condition
+      Error in `guide_legend()`:
+      ! `title.position` must be one of "top", "right", "bottom", or "left", not "leftish".
+    Code
+      guide_legend(label.position = "test")
+    Condition
+      Error in `guide_legend()`:
+      ! `label.position` must be one of "top", "right", "bottom", or "left", not "test".
+      i Did you mean "left"?
+    Code
+      guide_colourbar()$transform()
+    Condition
+      Error in `transform()`:
+      ! `guide_colourbar()` does not implement a `transform()` method.
+      i Did you mean to use `guide_axis()`?
 
 ---
 
-    `title.position` must be one of "top", "right", "bottom", or "left", not "leftish".
+    Code
+      p <- ggplot(mtcars) + geom_point(aes(mpg, disp, colour = gear)) + guides(
+        colour = guide_colourbar(label.position = "top"))
+      ggplotGrob(p)
+    Condition
+      Error in `setup_params()`:
+      ! When `direction` is "vertical", `label.position` must be one of "right" or "left", not "top".
 
 ---
 
-    `guide_colourbar()` does not implement a `transform()` method.
-    i Did you mean to use `guide_axis()`?
+    Code
+      p <- ggplot(mtcars) + geom_point(aes(mpg, disp, colour = gear)) + guides(
+        colour = guide_colourbar(direction = "horizontal", label.position = "left"))
+      ggplotGrob(p)
+    Condition
+      Error in `setup_params()`:
+      ! When `direction` is "horizontal", `label.position` must be one of "bottom" or "top", not "left".
 
 ---
 
-    When `direction` is "vertical", `label.position` must be one of "right" or "left", not "top".
-
----
-
-    When `direction` is "horizontal", `label.position` must be one of "bottom" or "top", not "left".
-
----
-
-    `label.position` must be one of "top", "right", "bottom", or "left", not "test".
-    i Did you mean "left"?
-
----
-
-    `nrow` * `ncol` needs to be larger than the number of breaks (5)
+    Code
+      p <- ggplot(mtcars) + geom_point(aes(mpg, disp, colour = gear)) + guides(
+        colour = guide_legend(nrow = 2, ncol = 2))
+      ggplotGrob(p)
+    Condition
+      Error in `setup_params()`:
+      ! `nrow` * `ncol` needs to be larger than the number of breaks (5).
 
 # colorsteps and bins checks the breaks format
 
-    Breaks are not formatted correctly for a bin legend.
-    i Use `(<lower>, <upper>]` format to indicate bins.
-
----
-
-    Breaks are not formatted correctly for a bin legend.
-    i Use `(<lower>, <upper>]` format to indicate bins.
+    Code
+      p <- ggplot(mtcars) + geom_point(aes(mpg, disp, colour = paste("A", gear))) +
+        guides(colour = "colorsteps")
+      suppressWarnings(ggplotGrob(p))
+    Condition
+      Error in `parse_binned_breaks()`:
+      ! Breaks are not formatted correctly for a bin legend.
+      i Use `(<lower>, <upper>]` format to indicate bins.
+    Code
+      p <- ggplot(mtcars) + geom_point(aes(mpg, disp, colour = paste("A", gear))) +
+        guides(colour = "bins")
+      suppressWarnings(ggplotGrob(p))
+    Condition
+      Error in `parse_binned_breaks()`:
+      ! Breaks are not formatted correctly for a bin legend.
+      i Use `(<lower>, <upper>]` format to indicate bins.
 
 # guide_axis_logticks calculates appropriate ticks
 
-    The `prescale_base` argument will override the scale's log-10 transformation in log-tick positioning.
+    Code
+      res <- train_guide(guide, scale)$logkey
+    Condition
+      Warning:
+      The `prescale_base` argument will override the scale's log-10 transformation in log-tick positioning.
 
 # binning scales understand the different combinations of limits, breaks, labels, and show.limits
 
-    `show.limits` is ignored when `labels` are given as a character vector.
-    i Either add the limits to `breaks` or provide a function for `labels`.
+    Code
+      res <- ggplotGrob(p + scale_color_binned(labels = 1:4, show.limits = TRUE,
+      guide = "bins"))
+    Condition
+      Warning:
+      `show.limits` is ignored when `labels` are given as a character vector.
+      i Either add the limits to `breaks` or provide a function for `labels`.
 
 ---
 
-    `show.limits` is ignored when `labels` are given as a character vector.
-    i Either add the limits to `breaks` or provide a function for `labels`.
+    Code
+      res <- ggplotGrob(p + scale_color_binned(labels = 1:4, show.limits = TRUE))
+    Condition
+      Warning:
+      `show.limits` is ignored when `labels` are given as a character vector.
+      i Either add the limits to `breaks` or provide a function for `labels`.
 
 # a warning is generated when guides(<scale> = FALSE) is specified
 
-    The `guide` argument in `scale_*()` cannot be `FALSE`. This was deprecated in ggplot2 3.3.4.
-    i Please use "none" instead.
+    Code
+      e <- ggplot_build(p)
+    Condition
+      Warning:
+      The `guide` argument in `scale_*()` cannot be `FALSE`. This was deprecated in ggplot2 3.3.4.
+      i Please use "none" instead.
 
 # old S3 guides can be implemented
 
-    The S3 guide system was deprecated in ggplot2 3.5.0.
-    i It has been replaced by a ggproto system that can be extended.
+    Code
+      expect_doppelganger("old S3 guide drawing a circle", ggplot(mtcars, aes(disp,
+        mpg)) + geom_point() + guides(x = "circle"))
+    Condition
+      Warning:
+      The S3 guide system was deprecated in ggplot2 3.5.0.
+      i It has been replaced by a ggproto system that can be extended.
 

--- a/tests/testthat/_snaps/labellers.md
+++ b/tests/testthat/_snaps/labellers.md
@@ -1,12 +1,24 @@
 # resolve_labeller() provide meaningful errors
 
-    Supply one of `rows` or `cols`
+    Code
+      resolve_labeller(NULL, NULL)
+    Condition
+      Error in `resolve_labeller()`:
+      ! Supply one of `rows` or `cols`.
 
 ---
 
-    Cannot supply both `rows` and `cols` to `facet_wrap()`
+    Code
+      resolve_labeller(prod, sum, structure(1:4, facet = "wrap"))
+    Condition
+      Error in `resolve_labeller()`:
+      ! Cannot supply both `rows` and `cols` to `facet_wrap()`.
 
 # labeller function catches overlap in names
 
-    Conflict between `.rows` and `vs`
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `labeller()`:
+      ! Conflict between `.rows` and `vs`.
 

--- a/tests/testthat/_snaps/labels.md
+++ b/tests/testthat/_snaps/labels.md
@@ -1,8 +1,16 @@
 # plot.tag.position rejects invalid input
 
-    The `plot.tag.position` theme element must be a <character/numeric/integer> object.
+    Code
+      ggplotGrob(p + theme(plot.tag.position = TRUE))
+    Condition
+      Error in `mapply()`:
+      ! The `plot.tag.position` theme element must be a <character/numeric/integer> object.
 
 ---
 
-    `plot.tag.position` must be one of "topleft", "top", "topright", "left", "right", "bottomleft", "bottom", or "bottomright", not "foobar".
+    Code
+      ggplotGrob(p + theme(plot.tag.position = "foobar"))
+    Condition
+      Error in `theme()`:
+      ! `plot.tag.position` must be one of "topleft", "top", "topright", "left", "right", "bottomleft", "bottom", or "bottomright", not "foobar".
 

--- a/tests/testthat/_snaps/layer.md
+++ b/tests/testthat/_snaps/layer.md
@@ -1,95 +1,167 @@
 # layer() checks its input
 
-    Can't create layer without a geom.
+    Code
+      layer(stat = "identity", position = "identity")
+    Condition
+      Error:
+      ! Can't create layer without a geom.
+    Code
+      layer(geom = "point", position = "identity")
+    Condition
+      Error:
+      ! Can't create layer without a stat.
+    Code
+      layer(geom = "point", stat = "identity")
+    Condition
+      Error:
+      ! Can't create layer without a position.
+    Code
+      layer("point", "identity", mapping = 1:4, position = "identity")
+    Condition
+      Error:
+      ! `mapping` must be created by `aes()`.
+    Code
+      layer("point", "identity", mapping = ggplot(), position = "identity")
+    Condition
+      Error:
+      ! `mapping` must be created by `aes()`.
+      i Did you use `%>%` or `|>` instead of `+`?
 
 ---
 
-    Can't create layer without a stat.
-
----
-
-    Can't create layer without a position.
-
----
-
-    `mapping` must be created by `aes()`
-
----
-
-    `mapping` must be created by `aes()`
-    i Did you use `%>%` or `|>` instead of `+`?
-
----
-
-    Can't find geom called "test"
-
----
-
-    `x` must be either a string or a <geom> object, not an environment.
+    Code
+      check_subclass("test", "geom")
+    Condition
+      Error:
+      ! Can't find geom called "test".
+    Code
+      check_subclass(environment(), "geom")
+    Condition
+      Error in `check_subclass()`:
+      ! `x` must be either a string or a <geom> object, not an environment.
 
 # invalid aesthetics throws errors
 
-    Problem while computing aesthetics.
-    i Error occurred in the 1st layer.
-    Caused by error in `compute_aesthetics()`:
-    ! Aesthetics are not valid data columns.
-    x The following aesthetics are invalid:
-    x `fill = data`
-    i Did you mistype the name of a data column or forget to add `after_stat()`?
+    Code
+      ggplot_build(p)
+    Message
+      Don't know how to automatically pick scale for object of type <function>. Defaulting to continuous.
+    Condition
+      Error in `geom_point()`:
+      ! Problem while computing aesthetics.
+      i Error occurred in the 1st layer.
+      Caused by error in `compute_aesthetics()`:
+      ! Aesthetics are not valid data columns.
+      x The following aesthetics are invalid:
+      x `fill = data`
+      i Did you mistype the name of a data column or forget to add `after_stat()`?
 
 ---
 
-    Problem while mapping stat to aesthetics.
-    i Error occurred in the 1st layer.
-    Caused by error in `map_statistic()`:
-    ! Aesthetics must be valid computed stats.
-    x The following aesthetics are invalid:
-    x `fill = after_stat(data)`
-    i Did you map your stat in the wrong layer?
+    Code
+      ggplot_build(p)
+    Condition
+      Error in `geom_point()`:
+      ! Problem while mapping stat to aesthetics.
+      i Error occurred in the 1st layer.
+      Caused by error in `map_statistic()`:
+      ! Aesthetics must be valid computed stats.
+      x The following aesthetics are invalid:
+      x `fill = after_stat(data)`
+      i Did you map your stat in the wrong layer?
+
+# missing aesthetics trigger informative error
+
+    Code
+      p <- ggplot(df) + geom_line()
+      ggplot_build(p)
+    Condition
+      Error in `geom_line()`:
+      ! Problem while setting up geom.
+      i Error occurred in the 1st layer.
+      Caused by error in `compute_geom_1()`:
+      ! `geom_line()` requires the following missing aesthetics: x and y.
+    Code
+      p <- ggplot(df) + geom_col()
+      ggplot_build(p)
+    Condition
+      Error in `geom_col()`:
+      ! Problem while setting up geom.
+      i Error occurred in the 1st layer.
+      Caused by error in `compute_geom_1()`:
+      ! `geom_col()` requires the following missing aesthetics: x and y.
 
 # function aesthetics are wrapped with after_stat()
 
-    Problem while computing aesthetics.
-    i Error occurred in the 1st layer.
-    Caused by error in `compute_aesthetics()`:
-    ! Aesthetics are not valid data columns.
-    x The following aesthetics are invalid:
-    x `colour = NULL`
-    x `fill = NULL`
-    i Did you mistype the name of a data column or forget to add `after_stat()`?
+    Code
+      ggplot_build(ggplot(df, aes(colour = density, fill = density)) + geom_point())
+    Message
+      Don't know how to automatically pick scale for object of type <function>. Defaulting to continuous.
+      Don't know how to automatically pick scale for object of type <function>. Defaulting to continuous.
+    Condition
+      Error in `geom_point()`:
+      ! Problem while computing aesthetics.
+      i Error occurred in the 1st layer.
+      Caused by error in `compute_aesthetics()`:
+      ! Aesthetics are not valid data columns.
+      x The following aesthetics are invalid:
+      x `colour = NULL`
+      x `fill = NULL`
+      i Did you mistype the name of a data column or forget to add `after_stat()`?
 
 # computed stats are in appropriate layer
 
-    Problem while mapping stat to aesthetics.
-    i Error occurred in the 1st layer.
-    Caused by error in `map_statistic()`:
-    ! Aesthetics must be valid computed stats.
-    x The following aesthetics are invalid:
-    x `colour = NULL`
-    x `fill = NULL`
-    i Did you map your stat in the wrong layer?
+    Code
+      ggplot_build(ggplot(df, aes(colour = after_stat(density), fill = after_stat(
+        density))) + geom_point())
+    Condition
+      Error in `geom_point()`:
+      ! Problem while mapping stat to aesthetics.
+      i Error occurred in the 1st layer.
+      Caused by error in `map_statistic()`:
+      ! Aesthetics must be valid computed stats.
+      x The following aesthetics are invalid:
+      x `colour = NULL`
+      x `fill = NULL`
+      i Did you map your stat in the wrong layer?
 
 # layer reports the error with correct index etc
 
-    Problem while setting up geom.
-    i Error occurred in the 1st layer.
-    Caused by error in `compute_geom_1()`:
-    ! `geom_linerange()` requires the following missing aesthetics: ymax or xmin and xmax
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `geom_linerange()`:
+      ! Problem while setting up geom.
+      i Error occurred in the 1st layer.
+      Caused by error in `compute_geom_1()`:
+      ! `geom_linerange()` requires the following missing aesthetics: ymax or xmin and xmax.
 
 ---
 
-    Problem while converting geom to grob.
-    i Error occurred in the 2nd layer.
-    Caused by error in `draw_group()`:
-    ! Can only draw one boxplot per group
-    i Did you forget `aes(group = ...)`?
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `geom_boxplot()`:
+      ! Problem while converting geom to grob.
+      i Error occurred in the 2nd layer.
+      Caused by error in `draw_group()`:
+      ! Can only draw one boxplot per group.
+      i Did you forget `aes(group = ...)`?
 
 # layer warns for constant aesthetics
 
-    All aesthetics have length 1, but the data has 32 rows.
-    i Did you mean to use `annotate()`?
+    Code
+      e <- ggplot_build(p)
+    Condition
+      Warning in `geom_point()`:
+      All aesthetics have length 1, but the data has 32 rows.
+      i Did you mean to use `annotate()`?
 
 # layer_data returns a data.frame
 
-    `layer_data()` must return a <data.frame>
+    Code
+      l$layer_data(mtcars)
+    Condition
+      Error in `layer_data()`:
+      ! `layer_data()` must return a <data.frame>.
 

--- a/tests/testthat/_snaps/limits.md
+++ b/tests/testthat/_snaps/limits.md
@@ -1,8 +1,16 @@
 # limits() throw meaningful errors
 
-    All arguments must be named
+    Code
+      lims(1:2)
+    Condition
+      Error in `lims()`:
+      ! All arguments must be named.
 
 ---
 
-    `linewidth` must be a two-element vector
+    Code
+      lims(linewidth = 1)
+    Condition
+      Error in `lims()`:
+      ! `linewidth` must be a two-element vector.
 

--- a/tests/testthat/_snaps/margins.md
+++ b/tests/testthat/_snaps/margins.md
@@ -1,4 +1,8 @@
 # justify_grobs() checks input
 
-    `grobs` must be an individual <grob> or list of <grob> objects, not the number 1.
+    Code
+      justify_grobs(1)
+    Condition
+      Error in `justify_grobs()`:
+      ! `grobs` must be an individual <grob> or list of <grob> objects, not the number 1.
 

--- a/tests/testthat/_snaps/plot.md
+++ b/tests/testthat/_snaps/plot.md
@@ -1,29 +1,53 @@
 # ggplot() throws informative errors
 
-    `mapping` should be created with `aes()`.
-    x You've supplied a <character> object
+    Code
+      ggplot(mapping = letters)
+    Condition
+      Error in `ggplot()`:
+      ! `mapping` should be created with `aes()`.
+      x You've supplied a <character> object.
 
 ---
 
-    `data` cannot be a function.
-    i Have you misspelled the `data` argument in `ggplot()`
+    Code
+      ggplot(data)
+    Condition
+      Error in `ggplot()`:
+      ! `data` cannot be a function.
+      i Have you misspelled the `data` argument in `ggplot()`
 
 # construction have user friendly errors
 
-    Cannot use `+` with a single argument
-    i Did you accidentally put `+` on a new line?
+    Code
+      +geom_point()
+    Condition
+      Error:
+      ! Cannot use `+` with a single argument.
+      i Did you accidentally put `+` on a new line?
 
 ---
 
-    Cannot add <ggproto> objects together
-    i Did you forget to add this object to a <ggplot> object?
+    Code
+      geom_point() + geom_bar()
+    Condition
+      Error:
+      ! Cannot add <ggproto> objects together.
+      i Did you forget to add this object to a <ggplot> object?
 
 ---
 
-    Can't add `1` to a <ggplot> object.
+    Code
+      ggplot() + 1
+    Condition
+      Error in `ggplot_add()`:
+      ! Can't add `1` to a <ggplot> object.
 
 ---
 
-    Can't add `geom_point` to a <ggplot> object
-    i Did you forget to add parentheses, as in `geom_point()`?
+    Code
+      ggplot() + geom_point
+    Condition
+      Error in `ggplot_add()`:
+      ! Can't add `geom_point` to a <ggplot> object
+      i Did you forget to add parentheses, as in `geom_point()`?
 

--- a/tests/testthat/_snaps/position-collide.md
+++ b/tests/testthat/_snaps/position-collide.md
@@ -1,8 +1,14 @@
 # collide() checks the input data
 
-    Neither y nor ymax defined
-
----
-
-    `test()` requires non-overlapping x intervals
+    Code
+      collide(data, width = 1, "test", pos_stack)
+    Condition
+      Error in `collide()`:
+      ! y and ymax are undefined.
+    Code
+      data$y <- 1
+      out <- collide(data, width = 2, "test", pos_stack)
+    Condition
+      Warning:
+      `test()` requires non-overlapping x intervals.
 

--- a/tests/testthat/_snaps/position-jitterdodge.md
+++ b/tests/testthat/_snaps/position-jitterdodge.md
@@ -1,7 +1,11 @@
 # position_jitterdodge() fails with meaningful error
 
-    Problem while computing position.
-    i Error occurred in the 1st layer.
-    Caused by error in `setup_params()`:
-    ! `position_jitterdodge()` requires at least one aesthetic to dodge by
+    Code
+      ggplot_build(p)
+    Condition
+      Error in `geom_point()`:
+      ! Problem while computing position.
+      i Error occurred in the 1st layer.
+      Caused by error in `setup_params()`:
+      ! `position_jitterdodge()` requires at least one aesthetic to dodge by.
 

--- a/tests/testthat/_snaps/qplot.md
+++ b/tests/testthat/_snaps/qplot.md
@@ -1,4 +1,10 @@
 # qplot() only work with character geom
 
-    `geom` must be a character vector, not a <GeomLinerange/Geom/ggproto/gg> object.
+    Code
+      qplot(geom = GeomLinerange)
+    Condition
+      Warning:
+      `qplot()` was deprecated in ggplot2 3.4.0.
+      Error in `qplot()`:
+      ! `geom` must be a character vector, not a <GeomLinerange/Geom/ggproto/gg> object.
 

--- a/tests/testthat/_snaps/scale-binned.md
+++ b/tests/testthat/_snaps/scale-binned.md
@@ -1,8 +1,16 @@
 # binned scales only support continuous data
 
-    Binned scales only support continuous data.
+    Code
+      ggplot_build(p)
+    Condition
+      Error in `scale_x_binned()`:
+      ! Binned scales only support continuous data.
 
 ---
 
-    Binned scales only support continuous data.
+    Code
+      ggplot_build(p)
+    Condition
+      Error in `scale_color_binned()`:
+      ! Binned scales only support continuous data.
 

--- a/tests/testthat/_snaps/scale-colour-continuous.md
+++ b/tests/testthat/_snaps/scale-colour-continuous.md
@@ -1,30 +1,55 @@
 # type argument is checked for proper input
 
-    The `type` argument must return a continuous scale for the colour aesthetic.
-    x The provided object is not a scale function.
+    Code
+      scale_colour_continuous(type = function() "abc")
+    Condition
+      Error in `scale_colour_continuous()`:
+      ! The `type` argument must return a continuous scale for the colour aesthetic.
+      x The provided object is not a scale function.
 
 ---
 
-    The `type` argument must return a continuous scale for the fill aesthetic.
-    x The provided object is not a scale function.
+    Code
+      suppressWarnings(scale_fill_continuous(type = geom_point))
+    Condition
+      Error in `scale_fill_continuous()`:
+      ! The `type` argument must return a continuous scale for the fill aesthetic.
+      x The provided object is not a scale function.
 
 ---
 
-    The `type` argument must return a continuous scale for the colour aesthetic.
-    x The provided scale works with the following aesthetics: fill and point_colour
+    Code
+      scale_colour_binned(type = function(...) scale_colour_binned(aesthetics = c(
+        "fill", "point_colour")))
+    Condition
+      Error in `scale_colour_binned()`:
+      ! The `type` argument must return a continuous scale for the colour aesthetic.
+      x The provided scale works with the following aesthetics: fill and point_colour.
 
 ---
 
-    The `type` argument must return a continuous scale for the fill aesthetic.
-    x The provided scale is discrete.
+    Code
+      scale_fill_binned(type = scale_fill_brewer)
+    Condition
+      Error in `scale_fill_binned()`:
+      ! The `type` argument must return a continuous scale for the fill aesthetic.
+      x The provided scale is discrete.
 
 ---
 
-    Unknown scale type: "abc"
-    i Use either "gradient" or "viridis"
+    Code
+      scale_fill_continuous(type = "abc")
+    Condition
+      Error in `scale_fill_continuous()`:
+      ! Unknown scale type: "abc"
+      i Use either "gradient" or "viridis".
 
 ---
 
-    Unknown scale type: "abc"
-    i Use either "gradient" or "viridis"
+    Code
+      scale_colour_continuous(type = "abc")
+    Condition
+      Error in `scale_colour_continuous()`:
+      ! Unknown scale type: "abc"
+      i Use either "gradient" or "viridis".
 

--- a/tests/testthat/_snaps/scale-discrete.md
+++ b/tests/testthat/_snaps/scale-discrete.md
@@ -1,10 +1,18 @@
 # Aesthetics with no continuous interpretation fails when called
 
-    A continuous variable cannot be mapped to the linetype aesthetic
-    i choose a different aesthetic or use `scale_linetype_binned()`
+    Code
+      scale_linetype_continuous()
+    Condition
+      Error in `scale_linetype_continuous()`:
+      ! A continuous variable cannot be mapped to the linetype aesthetic.
+      i Choose a different aesthetic or use `scale_linetype_binned()`.
 
 ---
 
-    A continuous variable cannot be mapped to the shape aesthetic
-    i choose a different aesthetic or use `scale_shape_binned()`
+    Code
+      scale_shape_continuous()
+    Condition
+      Error in `scale_shape_continuous()`:
+      ! A continuous variable cannot be mapped to the shape aesthetic.
+      i Choose a different aesthetic or use `scale_shape_binned()`.
 

--- a/tests/testthat/_snaps/scale-expansion.md
+++ b/tests/testthat/_snaps/scale-expansion.md
@@ -1,8 +1,16 @@
 # expansion() checks input
 
-    `mult` and `add` must be numeric vectors with 1 or 2 elements
+    Code
+      expansion(mult = 2:4)
+    Condition
+      Error in `expansion()`:
+      ! `mult` and `add` must be numeric vectors with 1 or 2 elements.
 
 ---
 
-    `mult` and `add` must be numeric vectors with 1 or 2 elements
+    Code
+      expansion(add = 2:4)
+    Condition
+      Error in `expansion()`:
+      ! `mult` and `add` must be numeric vectors with 1 or 2 elements.
 

--- a/tests/testthat/_snaps/scale-hue.md
+++ b/tests/testthat/_snaps/scale-hue.md
@@ -1,4 +1,8 @@
 # scale_hue() checks the type input
 
-    `type` must be a character vector or a list of character vectors
+    Code
+      pal(4)
+    Condition
+      Error in `pal()`:
+      ! `type` must be a character vector or a list of character vectors.
 

--- a/tests/testthat/_snaps/scale-manual.md
+++ b/tests/testthat/_snaps/scale-manual.md
@@ -1,4 +1,8 @@
 # names of values used in manual scales
 
-    No shared levels found between `names(values)` of the manual scale and the data's colour values.
+    Code
+      out <- s$get_limits()
+    Condition
+      Warning:
+      No shared levels found between `names(values)` of the manual scale and the data's colour values.
 

--- a/tests/testthat/_snaps/scales.md
+++ b/tests/testthat/_snaps/scales.md
@@ -1,46 +1,90 @@
 # scale_apply preserves class and attributes
 
-    `scale_id` must not contain any "NA"
+    Code
+      scale_apply(df, "x", "transform", c(NA, 1), plot$layout$panel_scales_x)
+    Condition
+      Error in `scale_apply()`:
+      ! `scale_id` must not contain any "NA".
 
 # breaks and labels are correctly checked
 
-    `breaks` and `labels` must have the same length
+    Code
+      check_breaks_labels(1:10, letters)
+    Condition
+      Error:
+      ! `breaks` and `labels` must have the same length.
 
 ---
 
-    Invalid `breaks` specification. Use "NULL", not "NA".
+    Code
+      ggplot_build(p)
+    Condition
+      Error in `scale_x_continuous()`:
+      ! Invalid `breaks` specification. Use `NULL`, not `NA`.
 
 ---
 
-    Invalid `minor_breaks` specification. Use "NULL", not "NA".
+    Code
+      ggplot_build(p)
+    Condition
+      Error in `scale_x_continuous()`:
+      ! Invalid `minor_breaks` specification. Use `NULL`, not `NA`.
 
 ---
 
-    Invalid `labels` specification. Use "NULL", not "NA".
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `scale_x_continuous()`:
+      ! Invalid `labels` specification. Use `NULL`, not `NA`.
 
 ---
 
-    `breaks` and `labels` are different lengths.
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `scale_x_continuous()`:
+      ! `breaks` and `labels` have different lengths.
 
 ---
 
-    Invalid `breaks` specification. Use "NULL", not "NA".
+    Code
+      ggplot_build(p)
+    Condition
+      Error in `scale_x_discrete()`:
+      ! Invalid `breaks` specification. Use `NULL`, not `NA`.
 
 ---
 
-    Invalid `labels` specification. Use "NULL", not "NA".
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `scale_x_discrete()`:
+      ! Invalid `labels` specification. Use `NULL`, not `NA`.
 
 ---
 
-    Invalid `breaks` specification. Use "NULL", not "NA".
+    Code
+      ggplot_build(p)
+    Condition
+      Error in `scale_x_binned()`:
+      ! Invalid `breaks` specification. Use `NULL`, not `NA`.
 
 ---
 
-    Invalid `labels` specification. Use "NULL", not "NA".
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `scale_x_binned()`:
+      ! Invalid `labels` specification. Use `NULL`, not `NA`.
 
 ---
 
-    `breaks` and `labels` are different lengths.
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `scale_x_binned()`:
+      ! `breaks` and `labels` have different lengths.
 
 # numeric scale transforms can produce breaks
 
@@ -51,23 +95,37 @@
 
 # training incorrectly appropriately communicates the offenders
 
-    Continuous values supplied to discrete scale
-    i Example values: 1, 2, 3, 4, and 5
+    Code
+      sc$train(1:5)
+    Condition
+      Error in `scale_colour_viridis_d()`:
+      ! Continuous values supplied to discrete scale.
+      i Example values: 1, 2, 3, 4, and 5
 
 ---
 
-    Discrete values supplied to continuous scale
-    i Example values: "A", "B", "C", "D", and "E"
+    Code
+      sc$train(LETTERS[1:5])
+    Condition
+      Error in `scale_colour_viridis_c()`:
+      ! Discrete values supplied to continuous scale.
+      i Example values: "A", "B", "C", "D", and "E"
 
 # Using `scale_name` prompts deprecation message
 
-    The `scale_name` argument of `continuous_scale()` is deprecated as of ggplot2 3.5.0.
-
----
-
-    The `scale_name` argument of `discrete_scale()` is deprecated as of ggplot2 3.5.0.
-
----
-
-    The `scale_name` argument of `binned_scale()` is deprecated as of ggplot2 3.5.0.
+    Code
+      res <- continuous_scale("x", "foobar", identity_pal())
+    Condition
+      Warning:
+      The `scale_name` argument of `continuous_scale()` is deprecated as of ggplot2 3.5.0.
+    Code
+      res <- discrete_scale("x", "foobar", identity_pal())
+    Condition
+      Warning:
+      The `scale_name` argument of `discrete_scale()` is deprecated as of ggplot2 3.5.0.
+    Code
+      res <- binned_scale("x", "foobar", identity_pal())
+    Condition
+      Warning:
+      The `scale_name` argument of `binned_scale()` is deprecated as of ggplot2 3.5.0.
 

--- a/tests/testthat/_snaps/sec-axis.md
+++ b/tests/testthat/_snaps/sec-axis.md
@@ -1,12 +1,24 @@
 # sec_axis checks the user input
 
-    Secondary axes must be specified using `sec_axis()`
+    Code
+      set_sec_axis(16, scale)
+    Condition
+      Error in `set_sec_axis()`:
+      ! Secondary axes must be specified using `sec_axis()`.
 
 ---
 
-    Transformation for secondary axes must be a function
+    Code
+      secondary$init(scale)
+    Condition
+      Error in `init()`:
+      ! Transformation for secondary axes must be a function.
 
 ---
 
-    Transformation for secondary axes must be monotonic
+    Code
+      ggplot_build(p)
+    Condition
+      Error in `mono_test()`:
+      ! Transformation for secondary axes must be monotonic.
 

--- a/tests/testthat/_snaps/stat-bin.md
+++ b/tests/testthat/_snaps/stat-bin.md
@@ -1,62 +1,85 @@
 # stat_bin throws error when wrong combination of aesthetic is present
 
-    Problem while computing stat.
-    i Error occurred in the 1st layer.
-    Caused by error in `setup_params()`:
-    ! `stat_bin()` requires an x or y aesthetic.
+    Code
+      ggplot_build(ggplot(dat) + stat_bin())
+    Condition
+      Error in `stat_bin()`:
+      ! Problem while computing stat.
+      i Error occurred in the 1st layer.
+      Caused by error in `setup_params()`:
+      ! `stat_bin()` requires an x or y aesthetic.
 
 ---
 
-    Problem while computing stat.
-    i Error occurred in the 1st layer.
-    Caused by error in `setup_params()`:
-    ! `stat_bin()` must only have an x or y aesthetic.
+    Code
+      ggplot_build(ggplot(dat, aes(x, y)) + stat_bin())
+    Condition
+      Error in `stat_bin()`:
+      ! Problem while computing stat.
+      i Error occurred in the 1st layer.
+      Caused by error in `setup_params()`:
+      ! `stat_bin()` must only have an x or y aesthetic.
 
 ---
 
-    Problem while computing stat.
-    i Error occurred in the 1st layer.
-    Caused by error in `setup_params()`:
-    ! `stat_bin()` requires a continuous x aesthetic
-    x the x aesthetic is discrete.
-    i Perhaps you want `stat="count"`?
+    Code
+      ggplot_build(ggplot(dat, aes(x)) + stat_bin(y = 5))
+    Condition
+      Error in `stat_bin()`:
+      ! Problem while computing stat.
+      i Error occurred in the 1st layer.
+      Caused by error in `setup_params()`:
+      ! `stat_bin()` requires a continuous x aesthetic.
+      x the x aesthetic is discrete.
+      i Perhaps you want `stat="count"`?
 
 # inputs to binning are checked
 
-    Computation failed in `stat_bin()`
-    Caused by error in `bins()`:
-    ! `breaks` must be a <numeric> vector, not a character vector.
+    Code
+      r <- comp_bin(dat, breaks = letters)
+    Condition
+      Warning:
+      Computation failed in `stat_bin()`.
+      Caused by error in `bins()`:
+      ! `breaks` must be a <numeric> vector, not a character vector.
+    Code
+      r <- comp_bin(dat, binwidth = letters)
+    Condition
+      Warning:
+      Computation failed in `stat_bin()`.
+      Caused by error in `bin_breaks_width()`:
+      ! `binwidth` must be a number, not a character vector.
+    Code
+      r <- comp_bin(dat, binwidth = -4)
+    Condition
+      Warning:
+      Computation failed in `stat_bin()`.
+      Caused by error in `bin_breaks_width()`:
+      ! `binwidth` must be a number larger than or equal to 0, not the number -4.
+    Code
+      r <- comp_bin(dat, bins = -4)
+    Condition
+      Warning:
+      Computation failed in `stat_bin()`.
+      Caused by error in `bin_breaks_bins()`:
+      ! `bins` must be a whole number larger than or equal to 1, not the number -4.
 
 ---
 
-    `x_range` must have two elements
-
----
-
-    Computation failed in `stat_bin()`
-    Caused by error in `bin_breaks_width()`:
-    ! `width` must be a number, not a character vector.
-
----
-
-    Computation failed in `stat_bin()`
-    Caused by error in `bin_breaks_width()`:
-    ! `binwidth` must be positive
-
----
-
-    `x_range` must have two elements
-
----
-
-    Computation failed in `stat_bin()`
-    Caused by error in `bin_breaks_bins()`:
-    ! `bins` must be a whole number larger than or equal to 1, not the number -4.
+    Code
+      bin_breaks_bins(3)
+    Condition
+      Error in `bin_breaks_bins()`:
+      ! `x_range` must have two elements.
 
 # stat_count throws error when both x and y aesthetic present
 
-    Problem while computing stat.
-    i Error occurred in the 1st layer.
-    Caused by error in `setup_params()`:
-    ! `stat_count()` must only have an x or y aesthetic.
+    Code
+      ggplot_build(ggplot(dat, aes(x, y)) + stat_count())
+    Condition
+      Error in `stat_count()`:
+      ! Problem while computing stat.
+      i Error occurred in the 1st layer.
+      Caused by error in `setup_params()`:
+      ! `stat_count()` must only have an x or y aesthetic.
 

--- a/tests/testthat/_snaps/stat-bin2d.md
+++ b/tests/testthat/_snaps/stat-bin2d.md
@@ -1,12 +1,20 @@
 # binwidth is respected
 
-    Computation failed in `stat_bin2d()`
-    Caused by error in `bin2d_breaks()`:
-    ! `binwidth` must be a number, not a double vector.
+    Code
+      res <- ggplot_build(p)
+    Condition
+      Warning:
+      Computation failed in `stat_bin2d()`.
+      Caused by error in `bin2d_breaks()`:
+      ! `binwidth` must be a number, not a double vector.
 
 ---
 
-    Computation failed in `stat_bin2d()`
-    Caused by error in `bin2d_breaks()`:
-    ! `origin` must be a number, not a double vector.
+    Code
+      res <- ggplot_build(p)
+    Condition
+      Warning:
+      Computation failed in `stat_bin2d()`.
+      Caused by error in `bin2d_breaks()`:
+      ! `origin` must be a number, not a double vector.
 

--- a/tests/testthat/_snaps/stat-boxplot.md
+++ b/tests/testthat/_snaps/stat-boxplot.md
@@ -1,15 +1,24 @@
 # stat_boxplot drops missing rows with a warning
 
-    Removed 10 rows containing missing values or values outside the scale range (`stat_boxplot()`).
-
----
-
-    Removed 10 rows containing missing values or values outside the scale range (`stat_boxplot()`).
+    Code
+      res <- ggplot_build(p1)
+    Condition
+      Warning:
+      Removed 10 rows containing missing values or values outside the scale range (`stat_boxplot()`).
+    Code
+      res <- ggplot_build(p2)
+    Condition
+      Warning:
+      Removed 10 rows containing missing values or values outside the scale range (`stat_boxplot()`).
 
 # stat_boxplot errors with missing x/y aesthetics
 
-    Problem while computing stat.
-    i Error occurred in the 1st layer.
-    Caused by error in `setup_params()`:
-    ! `stat_boxplot()` requires an x or y aesthetic.
+    Code
+      ggplot_build(p)
+    Condition
+      Error in `geom_boxplot()`:
+      ! Problem while computing stat.
+      i Error occurred in the 1st layer.
+      Caused by error in `setup_params()`:
+      ! `stat_boxplot()` requires an x or y aesthetic.
 

--- a/tests/testthat/_snaps/stat-count.md
+++ b/tests/testthat/_snaps/stat-count.md
@@ -1,14 +1,22 @@
 # stat_count() checks the aesthetics
 
-    Problem while computing stat.
-    i Error occurred in the 1st layer.
-    Caused by error in `setup_params()`:
-    ! `stat_count()` requires an x or y aesthetic.
+    Code
+      ggplot_build(p)
+    Condition
+      Error in `stat_count()`:
+      ! Problem while computing stat.
+      i Error occurred in the 1st layer.
+      Caused by error in `setup_params()`:
+      ! `stat_count()` requires an x or y aesthetic.
 
 ---
 
-    Problem while computing stat.
-    i Error occurred in the 1st layer.
-    Caused by error in `setup_params()`:
-    ! `stat_count()` must only have an x or y aesthetic.
+    Code
+      ggplot_build(p)
+    Condition
+      Error in `stat_count()`:
+      ! Problem while computing stat.
+      i Error occurred in the 1st layer.
+      Caused by error in `setup_params()`:
+      ! `stat_count()` must only have an x or y aesthetic.
 

--- a/tests/testthat/_snaps/stat-density.md
+++ b/tests/testthat/_snaps/stat-density.md
@@ -1,15 +1,27 @@
 # stat_density works in both directions
 
-    Problem while computing stat.
-    i Error occurred in the 1st layer.
-    Caused by error in `setup_params()`:
-    ! `stat_density()` requires an x or y aesthetic.
+    Code
+      ggplot_build(p)
+    Condition
+      Error in `stat_density()`:
+      ! Problem while computing stat.
+      i Error occurred in the 1st layer.
+      Caused by error in `setup_params()`:
+      ! `stat_density()` requires an x or y aesthetic.
 
 # precompute_bandwidth() errors appropriately
 
-    `bw` must be one of "nrd0", "nrd", "ucv", "bcv", "sj", "sj-ste", or "sj-dpi", not "foobar".
+    Code
+      precompute_bw(1:10, bw = "foobar")
+    Condition
+      Error in `precompute_bw()`:
+      ! `bw` must be one of "nrd0", "nrd", "ucv", "bcv", "sj", "sj-ste", or "sj-dpi", not "foobar".
 
 ---
 
-    `bw` must be a finite, positive number, not `Inf`.
+    Code
+      precompute_bw(1:10, bw = Inf)
+    Condition
+      Error in `precompute_bw()`:
+      ! `bw` must be a finite, positive number, not `Inf`.
 

--- a/tests/testthat/_snaps/stat-density2d.md
+++ b/tests/testthat/_snaps/stat-density2d.md
@@ -1,8 +1,11 @@
 # stat_density2d can produce contour and raster data
 
-    Problem while computing stat.
-    i Error occurred in the 1st layer.
-    Caused by error in `compute_layer()`:
-    ! Invalid value of `contour_var` ("abcd")
-    i Supported values are "density", "ndensity", and "count".
+    Code
+      ggplot_build(p + stat_density_2d(contour_var = "abcd"))
+    Condition
+      Error in `stat_density_2d()`:
+      ! Problem while computing stat.
+      i Error occurred in the 1st layer.
+      Caused by error in `compute_layer()`:
+      ! `contour_var` must be one of "density", "ndensity", or "count", not "abcd".
 

--- a/tests/testthat/_snaps/stat-ecdf.md
+++ b/tests/testthat/_snaps/stat-ecdf.md
@@ -1,7 +1,11 @@
 # stat_ecdf works in both directions
 
-    Problem while computing stat.
-    i Error occurred in the 1st layer.
-    Caused by error in `setup_params()`:
-    ! `stat_ecdf()` requires an x or y aesthetic.
+    Code
+      ggplot_build(p)
+    Condition
+      Error in `stat_ecdf()`:
+      ! Problem while computing stat.
+      i Error occurred in the 1st layer.
+      Caused by error in `setup_params()`:
+      ! `stat_ecdf()` requires an x or y aesthetic.
 

--- a/tests/testthat/_snaps/stat-qq.md
+++ b/tests/testthat/_snaps/stat-qq.md
@@ -1,18 +1,27 @@
 # error is thrown with wrong quantile input
 
-    Computation failed in `stat_qq()`
-    Caused by error in `compute_group()`:
-    ! The length of `quantiles` must match the length of the data
-
----
-
-    Computation failed in `stat_qq_line()`
-    Caused by error in `compute_group()`:
-    ! `quantiles` must have the same length as the data
-
----
-
-    Computation failed in `stat_qq_line()`
-    Caused by error in `compute_group()`:
-    ! Cannot fit line quantiles 0.15. `line.p` must have length 2.
+    Code
+      p <- ggplot(mtcars, aes(sample = mpg)) + stat_qq(quantiles = 1:5)
+      res <- ggplot_build(p)
+    Condition
+      Warning:
+      Computation failed in `stat_qq()`.
+      Caused by error in `compute_group()`:
+      ! The length of `quantiles` must match the length of the data.
+    Code
+      p <- ggplot(mtcars, aes(sample = mpg)) + geom_qq_line(quantiles = 1:5)
+      res <- ggplot_build(p)
+    Condition
+      Warning:
+      Computation failed in `stat_qq_line()`.
+      Caused by error in `compute_group()`:
+      ! `quantiles` must have the same length as the data.
+    Code
+      p <- ggplot(mtcars, aes(sample = mpg)) + geom_qq_line(line.p = 0.15)
+      res <- ggplot_build(p)
+    Condition
+      Warning:
+      Computation failed in `stat_qq_line()`.
+      Caused by error in `compute_group()`:
+      ! Cannot fit line quantiles 0.15. `line.p` must have length 2.
 

--- a/tests/testthat/_snaps/stat-ydensity.md
+++ b/tests/testthat/_snaps/stat-ydensity.md
@@ -1,8 +1,16 @@
 # calc_bw() requires at least two values and correct method
 
-    `x` must contain at least 2 elements to select a bandwidth automatically
+    Code
+      calc_bw(1, "nrd0")
+    Condition
+      Error in `calc_bw()`:
+      ! `x` must contain at least 2 elements to select a bandwidth automatically.
 
 ---
 
-    `test` is not a valid bandwidth rule
+    Code
+      calc_bw(1:5, "test")
+    Condition
+      Error in `calc_bw()`:
+      ! `test` is not a valid bandwidth rule.
 

--- a/tests/testthat/_snaps/stats.md
+++ b/tests/testthat/_snaps/stats.md
@@ -1,0 +1,10 @@
+# erroneously dropped aesthetics are found and issue a warning
+
+    Code
+      b2 <- ggplot_build(p2)
+    Condition
+      Warning:
+      The following aesthetics were dropped during statistical transformation: colour and fill.
+      i This can happen when ggplot fails to infer the correct grouping structure in the data.
+      i Did you forget to specify a `group` aesthetic or to convert a numerical variable into a factor?
+

--- a/tests/testthat/_snaps/summarise-plot.md
+++ b/tests/testthat/_snaps/summarise-plot.md
@@ -1,12 +1,24 @@
 # summarise_*() throws appropriate errors
 
-    `p` must be a <ggplot_built> object, not the number 10.
+    Code
+      summarise_layout(10)
+    Condition
+      Error in `summarise_layout()`:
+      ! `p` must be a <ggplot_built> object, not the number 10.
 
 ---
 
-    `p` must be a <ggplot_built> object, not the string "A".
+    Code
+      summarise_coord("A")
+    Condition
+      Error in `summarise_coord()`:
+      ! `p` must be a <ggplot_built> object, not the string "A".
 
 ---
 
-    `p` must be a <ggplot_built> object, not `TRUE`.
+    Code
+      summarise_layers(TRUE)
+    Condition
+      Error in `summarise_layers()`:
+      ! `p` must be a <ggplot_built> object, not `TRUE`.
 

--- a/tests/testthat/_snaps/theme.md
+++ b/tests/testthat/_snaps/theme.md
@@ -1,59 +1,115 @@
 # theme validation happens at build stage
 
-    The `text` theme element must be a <element_text> object.
+    Code
+      print(p)
+    Condition
+      Error in `mapply()`:
+      ! The `text` theme element must be a <element_text> object.
 
 ---
 
-    Theme element `text` must have class <element_text>
+    Code
+      print(p)
+    Condition
+      Error in `element_render()`:
+      ! Theme element `text` must have class <element_text>.
 
 # incorrect theme specifications throw meaningful errors
 
-    Problem merging the `line` theme element
-    Caused by error in `merge_element()`:
-    ! Only elements of the same class can be merged
+    Code
+      add_theme(theme_grey(), theme(line = element_rect()))
+    Condition
+      Error:
+      ! Can't merge the `line` theme element.
+      Caused by error in `merge_element()`:
+      ! Only elements of the same class can be merged.
 
 ---
 
-    Theme element `line` must have class <element_line>
+    Code
+      calc_element("line", theme(line = element_rect()))
+    Condition
+      Error:
+      ! Theme element `line` must have class <element_line>.
 
 ---
 
-    Theme element `test` has "NULL" property without default: fill, colour, linewidth, and linetype
+    Code
+      calc_element("test", theme_gray() + theme(test = element_rect()))
+    Condition
+      Error:
+      ! Theme element `test` has `NULL` property without default: fill, colour, linewidth, and linetype.
 
 ---
 
-    `new` must be a <theme> object, not the string "foo".
+    Code
+      theme_set("foo")
+    Condition
+      Error in `theme_set()`:
+      ! `new` must be a <theme> object, not the string "foo".
 
 # element tree can be modified
 
-    The `blablabla` theme element is not defined in the element hierarchy.
+    Code
+      print(p)
+    Condition
+      Error in `mapply()`:
+      ! The `blablabla` theme element is not defined in the element hierarchy.
 
 ---
 
-    The `blablabla` theme element must be a <character> object.
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `mapply()`:
+      ! The `blablabla` theme element must be a <character> object.
 
 ---
 
-    The `blablabla` theme element must be a <unit> object.
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `mapply()`:
+      ! The `blablabla` theme element must be a <unit> object.
 
 ---
 
-    The `blablabla` theme element must be a <element_text> object.
+    Code
+      ggplotGrob(p1)
+    Condition
+      Error in `mapply()`:
+      ! The `blablabla` theme element must be a <element_text> object.
 
 # Theme elements are checked during build
 
-    `plot.title.position` must be one of "panel" or "plot", not "test".
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `theme()`:
+      ! `plot.title.position` must be one of "panel" or "plot", not "test".
 
 ---
 
-    `plot.caption.position` must be one of "panel" or "plot", not "test".
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `theme()`:
+      ! `plot.caption.position` must be one of "panel" or "plot", not "test".
 
 ---
 
-    `plot.tag.position` must be one of "topleft", "top", "topright", "left", "right", "bottomleft", "bottom", or "bottomright", not "test".
-    i Did you mean "left"?
+    Code
+      ggplotGrob(p)
+    Condition
+      Error in `theme()`:
+      ! `plot.tag.position` must be one of "topleft", "top", "topright", "left", "right", "bottomleft", "bottom", or "bottomright", not "test".
+      i Did you mean "left"?
 
 # Theme validation behaves as expected
 
-    The `aspect.ratio` theme element must be a <numeric/integer> object.
+    Code
+      validate_element("A", "aspect.ratio", tree)
+    Condition
+      Error:
+      ! The `aspect.ratio` theme element must be a <numeric/integer> object.
 

--- a/tests/testthat/_snaps/utilities.md
+++ b/tests/testthat/_snaps/utilities.md
@@ -1,56 +1,112 @@
 # check_required_aesthetics() errors on missing
 
-    `test()` requires the following missing aesthetics: y
+    Code
+      check_required_aesthetics(required_single, present = "x", name = "test")
+    Condition
+      Error:
+      ! `test()` requires the following missing aesthetics: y.
 
 ---
 
-    `test()` requires the following missing aesthetics: x and y
+    Code
+      check_required_aesthetics(required_single, present = "shape", name = "test")
+    Condition
+      Error:
+      ! `test()` requires the following missing aesthetics: x and y.
 
 ---
 
-    `test()` requires the following missing aesthetics: x or y
+    Code
+      check_required_aesthetics(required_bidirectional, present = "fill", name = "test")
+    Condition
+      Error:
+      ! `test()` requires the following missing aesthetics: x or y.
 
 ---
 
-    `test()` requires the following missing aesthetics: x and fill or y and fill
+    Code
+      check_required_aesthetics(required_bidirectional, present = "shape", name = "test")
+    Condition
+      Error:
+      ! `test()` requires the following missing aesthetics: x and fill or y and fill.
 
 # remove_missing checks input
 
-    `na.rm` must be `TRUE` or `FALSE`, not an integer vector.
+    Code
+      remove_missing(na.rm = 1:5)
+    Condition
+      Error in `remove_missing()`:
+      ! `na.rm` must be `TRUE` or `FALSE`, not an integer vector.
 
 # tolower() and toupper() has been masked
 
-    Please use `to_lower_ascii()`, which works fine in all locales.
+    Code
+      tolower()
+    Condition
+      Error in `tolower()`:
+      ! Please use `to_lower_ascii()`, which works fine in all locales.
 
 ---
 
-    Please use `to_upper_ascii()`, which works fine in all locales.
+    Code
+      toupper()
+    Condition
+      Error in `toupper()`:
+      ! Please use `to_upper_ascii()`, which works fine in all locales.
 
 # parse_safe() checks input
 
-    `text` must be a character vector, not an integer vector.
+    Code
+      parse_safe(1:5)
+    Condition
+      Error in `parse_safe()`:
+      ! `text` must be a character vector, not an integer vector.
 
 # width_cm() and height_cm() checks input
 
-    Don't know how to get width of <character> object
+    Code
+      width_cm(letters)
+    Condition
+      Error in `width_cm()`:
+      ! Don't know how to get width of <character> object
 
 ---
 
-    Don't know how to get height of <character> object
+    Code
+      height_cm(letters)
+    Condition
+      Error in `height_cm()`:
+      ! Don't know how to get height of <character> object
 
 # cut_*() checks its input and output
 
-    Insufficient data values to produce 10 bins.
+    Code
+      cut_number(1, 10)
+    Condition
+      Error in `cut_number()`:
+      ! Insufficient data values to produce 10 bins.
 
 ---
 
-    Specify exactly one of `n` and `width`
+    Code
+      breaks(1:10, "numbers", nbins = 2, binwidth = 5)
+    Condition
+      Error in `breaks()`:
+      ! Specify exactly one of `n` and `width`.
 
 ---
 
-    Only one of `boundary` and `center` may be specified.
+    Code
+      cut_width(1:10, 1, center = 0, boundary = 0.5)
+    Condition
+      Error in `cut_width()`:
+      ! Only one of `boundary` and `center` may be specified.
 
 # interleave() checks the vector lengths
 
-    Can't recycle `..1` (size 4) to match `..2` (size 0).
+    Code
+      interleave(1:4, numeric())
+    Condition
+      Error in `vec_interleave()`:
+      ! Can't recycle `..1` (size 4) to match `..2` (size 0).
 

--- a/tests/testthat/test-aes-calculated.R
+++ b/tests/testthat/test-aes-calculated.R
@@ -55,7 +55,8 @@ test_that("staged aesthetics warn appropriately for duplicated names", {
   df <- data.frame(x = 1, y = 1, lab = "test")
 
   # One warning in plot code due to evaluation of `aes()`
-  expect_snapshot_warning(
+  expect_snapshot({
+
     p <- ggplot(df, aes(x, y, label = lab)) +
       geom_label(
         aes(colour = stage(lab, after_scale = colour),
@@ -65,15 +66,13 @@ test_that("staged aesthetics warn appropriately for duplicated names", {
       # `guide_geom.legend` also using `Geom$use_defaults` method, which we
       # test next
       guides(colour = "none")
-  )
-  # One warning in building due to `stage()`/`after_scale()`
-  expect_snapshot_warning(ggplot_build(p))
+  })
 })
 
 test_that("A deprecated warning is issued when stat(var) or ..var.. is used", {
   p1 <- ggplot(NULL, aes(stat(foo)))
-  expect_snapshot_warning(b1 <- ggplot_build(p1))
+  expect_snapshot(out <- ggplot_build(p1))
 
   p2 <- ggplot(NULL, aes(..bar..))
-  expect_snapshot_warning(b2 <- ggplot_build(p2))
+  expect_snapshot(out <- ggplot_build(p2))
 })

--- a/tests/testthat/test-aes-setting.R
+++ b/tests/testthat/test-aes-setting.R
@@ -31,7 +31,7 @@ test_that("legend filters out aesthetics not of length 1", {
 
   # Ideally would test something in the legend data structure, but
   # that's not easily accessible currently.
-  expect_error(ggplot_gtable(ggplot_build(p)), NA)
+  expect_no_error(ggplot_gtable(ggplot_build(p)))
 })
 
 test_that("alpha affects only fill colour of solid geoms", {

--- a/tests/testthat/test-aes.R
+++ b/tests/testthat/test-aes.R
@@ -165,8 +165,10 @@ test_that("Warnings are issued when plots use discouraged extract usage within a
 })
 
 test_that("aes evaluation fails with unknown input", {
-  expect_snapshot_error(is_calculated(environment()))
-  expect_snapshot_error(strip_dots(environment()))
+  expect_snapshot(error = TRUE, {
+    is_calculated(environment())
+    strip_dots(environment())
+  })
 })
 
 test_that("aes() supports `!!!` in named arguments (#2675)", {
@@ -182,7 +184,7 @@ test_that("aes() supports `!!!` in named arguments (#2675)", {
     aes(, , !!!list(y = 1)),
     aes(y = 1)
   )
-  expect_snapshot_error(aes(y = 1, !!!list(y = 2)))
+  expect_snapshot(error = TRUE, aes(y = 1, !!!list(y = 2)))
 })
 
 test_that("alternative_aes_extract_usage() can inspect the call", {
@@ -191,11 +193,11 @@ test_that("alternative_aes_extract_usage() can inspect the call", {
   x <- quote(test$var)
   expect_identical(alternative_aes_extract_usage(x), "var")
   x <- quote(foo())
-  expect_snapshot_error(alternative_aes_extract_usage(x))
+  expect_snapshot(error = TRUE, alternative_aes_extract_usage(x))
 })
 
 test_that("new_aes() checks its inputs", {
-  expect_snapshot_error(new_aes(1:5))
+  expect_snapshot(error = TRUE, new_aes(1:5))
 })
 
 # Visual tests ------------------------------------------------------------

--- a/tests/testthat/test-annotate.R
+++ b/tests/testthat/test-annotate.R
@@ -30,7 +30,7 @@ test_that("segment annotations transform with scales", {
 
 test_that("annotation_* has dummy data assigned and don't inherit aes", {
   skip_if_not_installed("maps")
-  skip_if(packageVersion("base") < "3.5.0")
+  skip_if(getRversion() < "3.5.0")
   custom <- annotation_custom(zeroGrob())
   logtick <- annotation_logticks()
   usamap <- map_data("state")
@@ -54,29 +54,31 @@ test_that("annotation_raster() and annotation_custom() requires cartesian coordi
   p <- ggplot() +
     annotation_raster(rainbow, 15, 20, 3, 4) +
     coord_polar()
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
   p <- ggplot() +
     annotation_custom(
       grob = grid::roundrectGrob(),
       xmin = -Inf, xmax = Inf, ymin = -Inf, ymax = Inf
     ) +
     coord_polar()
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
 })
 
 test_that("annotation_map() checks the input data", {
-  expect_snapshot_error(annotation_map(letters))
-  expect_snapshot_error(annotation_map(mtcars))
+  expect_snapshot(error = TRUE, {
+    annotation_map(letters)
+    annotation_map(mtcars)
+  })
 })
 
 test_that("unsupported geoms signal a warning (#4719)", {
-  expect_snapshot_warning(annotate("hline", yintercept = 0))
+  expect_snapshot(out <- annotate("hline", yintercept = 0))
 })
 
 test_that("annotate() checks aesthetic lengths match", {
-  expect_snapshot_error(annotate("point", 1:3, 1:3, fill = c('red', 'black')))
+  expect_snapshot(error = TRUE, annotate("point", 1:3, 1:3, fill = c('red', 'black')))
 })
 
 test_that("annotation_logticks warns about deprecated `size` argument", {
-  expect_snapshot_warning(annotation_logticks(size = 5))
+  expect_snapshot(out <- annotation_logticks(size = 5))
 })

--- a/tests/testthat/test-autolayer.R
+++ b/tests/testthat/test-autolayer.R
@@ -1,3 +1,3 @@
 test_that("autolayers default error looks correct", {
-  expect_snapshot_error(autolayer(letters))
+  expect_snapshot(error = TRUE, autolayer(letters))
 })

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -1,3 +1,3 @@
 test_that("autoplot throws helpful error on default", {
-  expect_snapshot_error(autoplot(1:4))
+  expect_snapshot(error = TRUE, autoplot(1:4))
 })

--- a/tests/testthat/test-compat-plyr.R
+++ b/tests/testthat/test-compat-plyr.R
@@ -1,6 +1,6 @@
 test_that("input checks work in compat functions", {
-  expect_snapshot_error(unrowname(1:6))
-  expect_snapshot_error(revalue(1:7, c("5" = 2)))
-  expect_snapshot_error(as.quoted(1:7))
-  expect_snapshot_error(round_any(letters))
+  expect_snapshot(error = TRUE, unrowname(1:6))
+  expect_snapshot(error = TRUE, revalue(1:7, c("5" = 2)))
+  expect_snapshot(error = TRUE, as.quoted(1:7))
+  expect_snapshot(error = TRUE, round_any(letters))
 })

--- a/tests/testthat/test-coord-.R
+++ b/tests/testthat/test-coord-.R
@@ -1,9 +1,11 @@
 test_that("Coord errors on missing methods", {
-  expect_snapshot_error(Coord$render_bg())
-  expect_snapshot_error(Coord$render_axis_h())
-  expect_snapshot_error(Coord$render_axis_v())
-  expect_snapshot_error(Coord$backtransform_range())
-  expect_snapshot_error(Coord$range())
+  expect_snapshot(error = TRUE, {
+    Coord$render_bg()
+    Coord$render_axis_h()
+    Coord$render_axis_v()
+    Coord$backtransform_range()
+    Coord$range()
+  })
 })
 
 test_that("clipping is on by default", {
@@ -17,7 +19,7 @@ test_that("message when replacing non-default coordinate system", {
   df <- data_frame(x = 1, y = 2)
   gg <- ggplot(df, aes(x, y))
 
-  expect_message(gg + coord_cartesian(), NA)
+  expect_no_message(gg + coord_cartesian())
   expect_message(
     gg + coord_cartesian() + coord_cartesian(),
     "Adding new coordinate system"
@@ -37,7 +39,7 @@ test_that("guide names are not removed by `train_panel_guides()`", {
   layout$setup_panel_guides(guides_list(NULL), plot$layers)
 
   # Line showing change in outcome
-  expect_equal(names(layout$panel_params[[1]]$guides$aesthetics),
+  expect_named(layout$panel_params[[1]]$guides$aesthetics,
                c("x", "y", "x.sec", "y.sec"))
 })
 

--- a/tests/testthat/test-coord-cartesian.R
+++ b/tests/testthat/test-coord-cartesian.R
@@ -16,10 +16,10 @@ test_that("clipping can be turned off and on", {
 
 test_that("cartesian coords throws error when limits are badly specified", {
   # throws error when limit is a Scale object instead of vector
-  expect_snapshot_error(ggplot() + coord_cartesian(xlim(1,1)))
+  expect_snapshot(error = TRUE, ggplot() + coord_cartesian(xlim(1,1)))
 
   # throws error when limit's length is different than two
-  expect_snapshot_error(ggplot() + coord_cartesian(ylim=1:3))
+  expect_snapshot(error = TRUE, ggplot() + coord_cartesian(ylim=1:3))
 })
 
 

--- a/tests/testthat/test-coord-flip.R
+++ b/tests/testthat/test-coord-flip.R
@@ -10,8 +10,8 @@ test_that("secondary labels are correctly turned off", {
 
 test_that("flip coords throws error when limits are badly specified", {
   # throws error when limit is a Scale object instead of vector
-  expect_snapshot_error(ggplot() + coord_flip(xlim(1,1)))
+  expect_snapshot(error = TRUE, ggplot() + coord_flip(xlim(1,1)))
 
   # throws error when limit's length is different than two
-  expect_snapshot_error(ggplot() + coord_flip(ylim=1:3))
+  expect_snapshot(error = TRUE, ggplot() + coord_flip(ylim=1:3))
 })

--- a/tests/testthat/test-coord-map.R
+++ b/tests/testthat/test-coord-map.R
@@ -45,8 +45,8 @@ test_that("Inf is squished to range", {
 
 test_that("coord map throws error when limits are badly specified", {
   # throws error when limit is a Scale object instead of vector
-  expect_snapshot_error(ggplot() + coord_map(xlim=xlim(1,1)))
+  expect_snapshot(error = TRUE, ggplot() + coord_map(xlim=xlim(1,1)))
 
   # throws error when limit's length is different than two
-  expect_snapshot_error(ggplot() + coord_cartesian(ylim=1:3))
+  expect_snapshot(error = TRUE, ggplot() + coord_cartesian(ylim=1:3))
 })

--- a/tests/testthat/test-coord-polar.R
+++ b/tests/testthat/test-coord-polar.R
@@ -83,7 +83,8 @@ test_that("coord_radial warns about axes", {
 
   p <- ggplot(mtcars, aes(disp, mpg)) +
     geom_point()
-  # use out to avoid showin g output in snapshot (mostly interested in the warning)
+
+  # use out to capture warning only
   expect_snapshot({
     # Cannot use regular axis for theta position
     out <- ggplotGrob(

--- a/tests/testthat/test-coord-polar.R
+++ b/tests/testthat/test-coord-polar.R
@@ -83,18 +83,18 @@ test_that("coord_radial warns about axes", {
 
   p <- ggplot(mtcars, aes(disp, mpg)) +
     geom_point()
-
-  # Cannot use regular axis for theta position
-  expect_snapshot_warning(ggplotGrob(
-    p + coord_radial() + guides(theta = "axis")
-  ))
-
-  # If arc doesn't contain the top/bottom/left/right of a circle,
-  # axis placement cannot be outside panel
-  expect_snapshot_warning(ggplotGrob(
-    p + coord_radial(start = 0.1 * pi, end = 0.4 * pi, r_axis_inside = FALSE)
-  ))
-
+  # use out to avoid showin g output in snapshot (mostly interested in the warning)
+  expect_snapshot({
+    # Cannot use regular axis for theta position
+    out <- ggplotGrob(
+      p + coord_radial() + guides(theta = "axis")
+    )
+    # If arc doesn't contain the top/bottom/left/right of a circle,
+    # axis placement cannot be outside panel
+    out <- ggplotGrob(
+      p + coord_radial(start = 0.1 * pi, end = 0.4 * pi, r_axis_inside = FALSE)
+    )
+  })
 })
 
 test_that("bounding box calculations are sensible", {

--- a/tests/testthat/test-coord-transform.R
+++ b/tests/testthat/test-coord-transform.R
@@ -126,8 +126,8 @@ test_that("second axes display in coord_trans()", {
 
 test_that("coord_trans() throws error when limits are badly specified", {
   # throws error when limit is a Scale object instead of vector
-  expect_snapshot_error(ggplot() + coord_trans(xlim=xlim(1,1)))
+  expect_snapshot(error = TRUE, ggplot() + coord_trans(xlim=xlim(1,1)))
 
   # throws error when limit's length is different than two
-  expect_snapshot_error(ggplot() + coord_trans(ylim=1:3))
+  expect_snapshot(error = TRUE, ggplot() + coord_trans(ylim=1:3))
 })

--- a/tests/testthat/test-coord_sf.R
+++ b/tests/testthat/test-coord_sf.R
@@ -80,21 +80,26 @@ test_that("axis labels can be set manually", {
     graticule[graticule$type == "N", ]$degree_label,
     c("D", "E", "F")
   )
-  p <- plot +
-    scale_x_continuous(
-      breaks = c(1000, 2000, 3000),
-      labels = function(...) c("A", "B")
-    )
-  expect_snapshot_error(ggplot_build(p))
-  p <- plot +
-    scale_y_continuous(
-      breaks = c(1000, 2000, 3000),
-      labels = function(...) c("A", "B")
-    )
-  expect_snapshot_error(ggplot_build(p))
 
-  expect_snapshot_error(coord_sf(label_graticule = 1:17))
-  expect_snapshot_error(coord_sf(label_axes = 1:17))
+  expect_snapshot(error = TRUE, {
+    p <- plot +
+      scale_x_continuous(
+        breaks = c(1000, 2000, 3000),
+        labels = function(...) c("A", "B")
+      )
+    ggplot_build(p)
+    p <- plot +
+      scale_y_continuous(
+        breaks = c(1000, 2000, 3000),
+        labels = function(...) c("A", "B")
+      )
+    ggplot_build(p)
+  })
+
+  expect_snapshot(error = TRUE, {
+    coord_sf(label_graticule = 1:17)
+    coord_sf(label_axes = 1:17)
+  })
 })
 
 test_that("factors are treated like character labels and are not parsed", {
@@ -234,7 +239,7 @@ test_that("default crs works", {
 
   p <- ggplot(polygon) + geom_sf(fill = NA)
 
-  expect_snapshot_error(ggplot_build(p + xlim(-Inf, 80)))
+  expect_snapshot(error = TRUE, ggplot_build(p + xlim(-Inf, 80)))
 
   # by default, regular geoms are interpreted to use projected data
   points_trans <- sf_transform_xy(points, 3347, 4326)
@@ -325,8 +330,8 @@ test_that("coord_sf() uses the guide system", {
 
 test_that("coord_sf() throws error when limits are badly specified", {
   # throws error when limit is a Scale object instead of vector
-  expect_snapshot_error(ggplot() + coord_sf(xlim(1,1)))
+  expect_snapshot(error = TRUE, ggplot() + coord_sf(xlim(1,1)))
 
   # throws error when limit's length is different than two
-  expect_snapshot_error(ggplot() + coord_sf(ylim=1:3))
+  expect_snapshot(error = TRUE, ggplot() + coord_sf(ylim=1:3))
 })

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -1,12 +1,8 @@
 test_that("various misuses of +.gg (#2638)", {
-  expect_snapshot_error(
-    {
-      ggplot(mtcars, aes(hwy, displ))
+  expect_snapshot(error = TRUE, {
+    ggplot(mtcars, aes(hwy, displ))
       + geom_point()
-    }
-  )
 
-  expect_snapshot_error(
     geom_point() + geom_point()
-  )
+  })
 })

--- a/tests/testthat/test-facet-.R
+++ b/tests/testthat/test-facet-.R
@@ -142,11 +142,11 @@ test_that("facet_grid() accepts vars()", {
 })
 
 test_that("facet_grid() fails if passed both a formula and a vars()", {
-  expect_snapshot_error(facet_grid(~foo, vars()))
+  expect_snapshot(error = TRUE, facet_grid(~foo, vars()))
 })
 
 test_that("can't pass formulas to `cols`", {
-  expect_snapshot_error(facet_grid(NULL, ~foo))
+  expect_snapshot(error = TRUE, facet_grid(NULL, ~foo))
 })
 
 test_that("can still pass `margins` as second argument", {
@@ -229,10 +229,10 @@ test_that("facet variables", {
 
 test_that("facet gives clear error if ", {
   df <- data_frame(x = 1)
-  expect_snapshot_error(print(ggplot(df, aes(x)) + facet_grid(x ~ x)))
-  expect_snapshot_error(print(ggplot(df, aes(x)) %>% facet_grid(. ~ x)))
-  expect_snapshot_error(print(ggplot(df, aes(x)) + facet_grid(list(1, 2, 3))))
-  expect_snapshot_error(print(ggplot(df, aes(x)) + facet_grid(vars(x), "free")))
+  expect_snapshot(error = TRUE, print(ggplot(df, aes(x)) + facet_grid(x ~ x)))
+  expect_snapshot(error = TRUE, print(ggplot(df, aes(x)) %>% facet_grid(. ~ x)))
+  expect_snapshot(error = TRUE, print(ggplot(df, aes(x)) + facet_grid(list(1, 2, 3))))
+  expect_snapshot(error = TRUE, print(ggplot(df, aes(x)) + facet_grid(vars(x), "free")))
 })
 
 # Variable combinations ---------------------------------------------------
@@ -246,7 +246,7 @@ test_that("zero-length vars in combine_vars() generates zero combinations", {
 test_that("at least one layer must contain all facet variables in combine_vars()", {
   df <- data_frame(letter = c("a", "b"))
   expect_silent(combine_vars(list(df), vars = vars(letter = letter)))
-  expect_snapshot_error(combine_vars(list(df), vars = vars(letter = number)))
+  expect_snapshot(error = TRUE, combine_vars(list(df), vars = vars(letter = number)))
 })
 
 test_that("at least one combination must exist in combine_vars()", {
@@ -297,14 +297,14 @@ test_that("combine_vars() generates the correct combinations", {
     ignore_attr = TRUE   # do not compare `row.names`
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE, 
     combine_vars(
       list(data.frame(a = 1:2, b = 2:3), data.frame(a = 1:2, c = 2:3)),
       vars = vars(b=b, c=c)
     )
   )
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE, 
     combine_vars(
       list(data.frame(a = 1:2), data.frame(b = numeric())),
       vars = vars(b=b)
@@ -368,12 +368,12 @@ test_that("eval_facet() is tolerant for missing columns (#2963)", {
 })
 
 test_that("validate_facets() provide meaningful errors", {
-  expect_snapshot_error(validate_facets(aes(var)))
-  expect_snapshot_error(validate_facets(ggplot()))
+  expect_snapshot(error = TRUE, validate_facets(aes(var)))
+  expect_snapshot(error = TRUE, validate_facets(ggplot()))
 })
 
 test_that("check_layout() throws meaningful errors", {
-  expect_snapshot_error(check_layout(mtcars))
+  expect_snapshot(error = TRUE, check_layout(mtcars))
 })
 
 # Visual tests ------------------------------------------------------------

--- a/tests/testthat/test-facet-layout.R
+++ b/tests/testthat/test-facet-layout.R
@@ -155,24 +155,24 @@ test_that("missing values get a panel", {
 # Input checking ----------------------------------------------------------
 
 test_that("facet_wrap throws errors at bad layout specs", {
-  expect_snapshot_error(facet_wrap(~test, ncol = 1:4))
-  expect_snapshot_error(facet_wrap(~test, ncol = -1))
-  expect_snapshot_error(facet_wrap(~test, ncol = 1.5))
+  expect_snapshot(error = TRUE, facet_wrap(~test, ncol = 1:4))
+  expect_snapshot(error = TRUE, facet_wrap(~test, ncol = -1))
+  expect_snapshot(error = TRUE, facet_wrap(~test, ncol = 1.5))
 
-  expect_snapshot_error(facet_wrap(~test, nrow = 1:4))
-  expect_snapshot_error(facet_wrap(~test, nrow = -1))
-  expect_snapshot_error(facet_wrap(~test, nrow = 1.5))
+  expect_snapshot(error = TRUE, facet_wrap(~test, nrow = 1:4))
+  expect_snapshot(error = TRUE, facet_wrap(~test, nrow = -1))
+  expect_snapshot(error = TRUE, facet_wrap(~test, nrow = 1.5))
 
   p <- ggplot(mtcars) +
     geom_point(aes(mpg, disp)) +
     facet_wrap(~gear, ncol = 1, nrow = 1)
-  expect_snapshot_error(ggplot_build(p))
+  expect_snapshot(error = TRUE, ggplot_build(p))
 
   p <- ggplot(mtcars) +
     geom_point(aes(mpg, disp)) +
     facet_wrap(~gear, scales = "free") +
     coord_fixed()
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
 })
 
 test_that("facet_grid throws errors at bad layout specs", {
@@ -180,12 +180,12 @@ test_that("facet_grid throws errors at bad layout specs", {
     geom_point(aes(mpg, disp)) +
     facet_grid(.~gear, scales = "free") +
     coord_fixed()
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
   p <- ggplot(mtcars) +
     geom_point(aes(mpg, disp)) +
     facet_grid(.~gear, space = "free") +
     theme(aspect.ratio = 1)
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
 })
 
 test_that("facet_wrap and facet_grid throws errors when using reserved words", {
@@ -195,7 +195,7 @@ test_that("facet_wrap and facet_grid throws errors when using reserved words", {
 
   p <- ggplot(mtcars2) +
     geom_point(aes(mpg, disp))
-  expect_snapshot_error(ggplotGrob(p + facet_grid(ROW ~ gear)))
-  expect_snapshot_error(ggplotGrob(p + facet_grid(ROW ~ PANEL)))
-  expect_snapshot_error(ggplotGrob(p + facet_wrap(~ROW)))
+  expect_snapshot(error = TRUE, ggplotGrob(p + facet_grid(ROW ~ gear)))
+  expect_snapshot(error = TRUE, ggplotGrob(p + facet_grid(ROW ~ PANEL)))
+  expect_snapshot(error = TRUE, ggplotGrob(p + facet_wrap(~ROW)))
 })

--- a/tests/testthat/test-facet-strips.R
+++ b/tests/testthat/test-facet-strips.R
@@ -121,7 +121,7 @@ test_that("facet_grid() switches to both 'x' and 'y'", {
 })
 
 test_that("facet_grid() warns about bad switch input", {
-  expect_snapshot_error(facet_grid(am ~ cyl, switch = "z"))
+  expect_snapshot(error = TRUE, facet_grid(am ~ cyl, switch = "z"))
 })
 
 test_that("strips can be removed", {

--- a/tests/testthat/test-fortify.R
+++ b/tests/testthat/test-fortify.R
@@ -52,7 +52,7 @@ test_that("spatial polygons have correct ordering", {
 })
 
 test_that("fortify.default proves a helpful error with class uneval", {
-  expect_snapshot_error(ggplot(aes(x = x)))
+  expect_snapshot(error = TRUE, ggplot(aes(x = x)))
 })
 
 test_that("fortify.default can handle healthy data-frame-like objects", {

--- a/tests/testthat/test-geom-.R
+++ b/tests/testthat/test-geom-.R
@@ -1,9 +1,9 @@
 test_that("aesthetic checking in geom throws correct errors", {
   p <- ggplot(mtcars) + geom_point(aes(disp, mpg, colour = after_scale(data)))
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
 
   aes <- list(a = 1:4, b = letters[1:4], c = TRUE, d = 1:2, e = 1:5)
-  expect_snapshot_error(check_aesthetics(aes, 4))
+  expect_snapshot(error = TRUE, check_aesthetics(aes, 4))
 })
 
 

--- a/tests/testthat/test-geom-boxplot.R
+++ b/tests/testthat/test-geom-boxplot.R
@@ -84,7 +84,7 @@ test_that("boxplots with a group size >1 error", {
     geom_boxplot(stat = "identity")
 
   expect_equal(nrow(layer_data(p, 1)), 3)
-  expect_snapshot_error(layer_grob(p, 1))
+  expect_snapshot(error = TRUE, layer_grob(p, 1))
 })
 
 # Visual tests ------------------------------------------------------------

--- a/tests/testthat/test-geom-dotplot.R
+++ b/tests/testthat/test-geom-dotplot.R
@@ -58,7 +58,7 @@ test_that("NA's result in warning from stat_bindot", {
   dat$x[c(2,10)] <- NA
 
   # Need to assign it to a var here so that it doesn't automatically print
-  expect_snapshot_warning(ggplot_build(ggplot(dat, aes(x)) + geom_dotplot(binwidth = .2)))
+  expect_snapshot(out <- ggplot_build(ggplot(dat, aes(x)) + geom_dotplot(binwidth = .2)))
 })
 
 test_that("when binning on y-axis, limits depend on the panel", {
@@ -76,12 +76,16 @@ test_that("when binning on y-axis, limits depend on the panel", {
 })
 
 test_that("weight aesthetic is checked", {
-  p <- ggplot(mtcars, aes(x = mpg, weight = gear/3)) +
-    geom_dotplot()
-  expect_snapshot_warning(ggplot_build(p))
-  p <- ggplot(mtcars, aes(x = mpg, weight = -gear)) +
-    geom_dotplot()
-  expect_snapshot_warning(ggplot_build(p))
+  expect_snapshot({
+    p <- ggplot(mtcars, aes(x = mpg, weight = gear/3)) +
+      geom_dotplot()
+    # avoid printing the empty plot
+    e <- ggplot_build(p)
+    p <- ggplot(mtcars, aes(x = mpg, weight = -gear)) +
+      geom_dotplot()
+    # avoid printing the empty plot
+    e <- ggplot_build(p)
+  })
 })
 
 # Visual tests ------------------------------------------------------------

--- a/tests/testthat/test-geom-hline-vline-abline.R
+++ b/tests/testthat/test-geom-hline-vline-abline.R
@@ -48,12 +48,15 @@ test_that("curved lines in map projections", {
 # Warning tests ------------------------------------------------------------
 
 test_that("warnings are thrown when parameters cause mapping and data to be ignored", {
-  expect_snapshot_warning(geom_vline(aes(), xintercept = 2))
-  expect_snapshot_warning(geom_vline(data = mtcars, xintercept = 2))
-  expect_snapshot_warning(geom_hline(aes(), yintercept = 2))
-  expect_snapshot_warning(geom_hline(data = mtcars, yintercept = 2))
-  expect_snapshot_warning(geom_abline(aes(), slope = 2))
-  expect_snapshot_warning(geom_abline(aes(), intercept = 2))
-  expect_snapshot_warning(geom_abline(data = mtcars, slope = 2))
-  expect_snapshot_warning(geom_abline(data = mtcars, intercept = 2))
+  # using out <- to capture the warnings
+  expect_snapshot({
+    out <- geom_vline(aes(), xintercept = 2)
+    out <- geom_vline(data = mtcars, xintercept = 2)
+    out <- geom_hline(aes(), yintercept = 2)
+    out <- geom_hline(data = mtcars, yintercept = 2)
+    out <- geom_abline(aes(), slope = 2)
+    out <- geom_abline(aes(), intercept = 2)
+    out <- geom_abline(data = mtcars, slope = 2)
+    out <- geom_abline(data = mtcars, intercept = 2)
+  })
 })

--- a/tests/testthat/test-geom-jitter.R
+++ b/tests/testthat/test-geom-jitter.R
@@ -1,3 +1,3 @@
 test_that("geom_jitter() throws relevant errors", {
-  expect_snapshot_error(geom_jitter(position = "jitter", width = 4))
+  expect_snapshot(error = TRUE, geom_jitter(position = "jitter", width = 4))
 })

--- a/tests/testthat/test-geom-label.R
+++ b/tests/testthat/test-geom-label.R
@@ -1,6 +1,6 @@
 test_that("geom_label() throws meaningful errors", {
-  expect_snapshot_error(geom_label(position = "jitter", nudge_x = 0.5))
-  expect_snapshot_error(labelGrob(label = 1:3))
+  expect_snapshot(error = TRUE, geom_label(position = "jitter", nudge_x = 0.5))
+  expect_snapshot(error = TRUE, labelGrob(label = 1:3))
 })
 
 test_that("geom_label() rotates labels", {

--- a/tests/testthat/test-geom-linerange.R
+++ b/tests/testthat/test-geom-linerange.R
@@ -1,4 +1,4 @@
 test_that("geom_linerange request the right aesthetics", {
   p <- ggplot(mtcars) + geom_linerange(aes(disp, mpg), ymin = 2)
-  expect_snapshot_error(ggplot_build(p))
+  expect_snapshot(error = TRUE, ggplot_build(p))
 })

--- a/tests/testthat/test-geom-map.R
+++ b/tests/testthat/test-geom-map.R
@@ -1,4 +1,4 @@
 test_that("geom_map() checks its input", {
-  expect_snapshot_error(geom_map(map = letters))
-  expect_snapshot_error(geom_map(map = mtcars))
+  expect_snapshot(error = TRUE, geom_map(map = letters))
+  expect_snapshot(error = TRUE, geom_map(map = mtcars))
 })

--- a/tests/testthat/test-geom-path.R
+++ b/tests/testthat/test-geom-path.R
@@ -7,7 +7,7 @@ test_that("keep_mid_true drops leading/trailing FALSE", {
 
 test_that("geom_path() throws meaningful error on bad combination of varying aesthetics", {
   p <- ggplot(economics, aes(unemploy/pop, psavert, colour = pop)) + geom_path(linetype = 2)
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
 })
 
 test_that("repair_segment_arrow() repairs sensibly", {

--- a/tests/testthat/test-geom-point.R
+++ b/tests/testthat/test-geom-point.R
@@ -19,6 +19,6 @@ test_that("single characters are not translated to integers", {
 })
 
 test_that("invalid shape names raise an error", {
-  expect_snapshot_error(translate_shape_string("void"))
-  expect_snapshot_error(translate_shape_string("tri"))
+  expect_snapshot(error = TRUE, translate_shape_string("void"))
+  expect_snapshot(error = TRUE, translate_shape_string("tri"))
 })

--- a/tests/testthat/test-geom-raster.R
+++ b/tests/testthat/test-geom-raster.R
@@ -1,12 +1,12 @@
 test_that("geom_raster() checks input and coordinate system", {
-  expect_snapshot_error(geom_raster(hjust = c(2.5, 1.3)))
-  expect_snapshot_error(geom_raster(hjust = "a"))
-  expect_snapshot_error(geom_raster(vjust = c(2.5, 1.3)))
-  expect_snapshot_error(geom_raster(vjust = "a"))
+  expect_snapshot(error = TRUE, geom_raster(hjust = c(2.5, 1.3)))
+  expect_snapshot(error = TRUE, geom_raster(hjust = "a"))
+  expect_snapshot(error = TRUE, geom_raster(vjust = c(2.5, 1.3)))
+  expect_snapshot(error = TRUE, geom_raster(vjust = "a"))
 
   df <- data_frame(x = rep(c(-1, 1), each = 3), y = rep(-1:1, 2), z = 1:6)
   p <- ggplot(df, aes(x, y, fill = z)) + geom_raster() + coord_polar()
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
 })
 
 # Visual tests ------------------------------------------------------------

--- a/tests/testthat/test-geom-ribbon.R
+++ b/tests/testthat/test-geom-ribbon.R
@@ -2,15 +2,15 @@ test_that("geom_ribbon() checks the aesthetics", {
   huron <- data.frame(year = 1875:1972, level = as.vector(LakeHuron))
   p <- ggplot(huron) +
     geom_ribbon(aes(year, ymin = level - 5, ymax = level + 5), orientation = "y")
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
   p <- ggplot(huron) +
     geom_ribbon(aes(y = year, xmin = level - 5, xmax = level + 5), orientation = "x")
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
   p <- ggplot(huron) +
     geom_ribbon(aes(year, ymin = level - 5, ymax = level + 5, fill = year))
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
 
-  expect_snapshot_error(geom_ribbon(aes(year, ymin = level - 5, ymax = level + 5), outline.type = "test"))
+  expect_snapshot(error = TRUE, geom_ribbon(aes(year, ymin = level - 5, ymax = level + 5), outline.type = "test"))
 })
 
 test_that("NAs are not dropped from the data", {

--- a/tests/testthat/test-geom-rug.R
+++ b/tests/testthat/test-geom-rug.R
@@ -21,7 +21,7 @@ test_that("coord_flip flips the rugs", {
 
 test_that("Rug length needs unit object", {
   p <- ggplot(df, aes(x,y))
-  expect_snapshot_error(print(p + geom_rug(length = 0.01)))
+  expect_snapshot(error = TRUE, print(p + geom_rug(length = 0.01)))
 })
 
 test_that("Rug lengths are correct", {

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -146,9 +146,9 @@ test_that("errors are correctly triggered", {
     colour = c("red", NA)
   )
   p <- ggplot(pts) + geom_sf() + coord_cartesian()
-  expect_snapshot_error(ggplotGrob(p))
-  expect_snapshot_error(geom_sf_label(position = "jitter", nudge_x = 0.5))
-  expect_snapshot_error(geom_sf_text(position = "jitter", nudge_x = 0.5))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
+  expect_snapshot(error = TRUE, geom_sf_label(position = "jitter", nudge_x = 0.5))
+  expect_snapshot(error = TRUE, geom_sf_text(position = "jitter", nudge_x = 0.5))
 
   # #5204: missing linewidth should be dropped
   pts <- sf::st_sf(
@@ -158,7 +158,7 @@ test_that("errors are correctly triggered", {
     ),
     linewidth = c(1, NA)
   )
-  expect_snapshot_warning(sf_grob(pts, na.rm = FALSE))
+  expect_snapshot(sf_grob(pts, na.rm = FALSE))
 })
 
 # Visual tests ------------------------------------------------------------

--- a/tests/testthat/test-geom-text.R
+++ b/tests/testthat/test-geom-text.R
@@ -1,5 +1,5 @@
 test_that("geom_text() checks input", {
-  expect_snapshot_error(geom_text(position = "jitter", nudge_x = 0.5))
+  expect_snapshot(error = TRUE, geom_text(position = "jitter", nudge_x = 0.5))
 })
 
 test_that("geom_text() drops missing angles", {

--- a/tests/testthat/test-geom-violin.R
+++ b/tests/testthat/test-geom-violin.R
@@ -49,10 +49,10 @@ test_that("quantiles do not fail on zero-range data", {
 test_that("quantiles fails outside 0-1 bound", {
   p <- ggplot(mtcars) +
     geom_violin(aes(as.factor(gear), mpg), draw_quantiles = c(-1, 0.5))
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
   p <- ggplot(mtcars) +
     geom_violin(aes(as.factor(gear), mpg), draw_quantiles = c(0.5, 2))
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
 })
 
 test_that("quantiles are at expected positions at zero width", {
@@ -72,7 +72,7 @@ test_that("quantiles do not issue warning", {
   p <- ggplot(data, aes(x = x, y = y)) +
     geom_violin(draw_quantiles = 0.5)
 
-  expect_warning(plot(p), regexp = NA)
+  expect_no_warning(plot(p))
 })
 
 

--- a/tests/testthat/test-ggproto.R
+++ b/tests/testthat/test-ggproto.R
@@ -6,7 +6,7 @@ test_that(".DollarNames retrieves inherited methods", {
 })
 
 test_that("construction checks input", {
-  expect_snapshot_error(ggproto("Test", NULL, function(self, a) a))
-  expect_snapshot_error(ggproto("Test", NULL, a <- function(self, a) a))
-  expect_snapshot_error(ggproto("Test", mtcars, a = function(self, a) a))
+  expect_snapshot(error = TRUE, ggproto("Test", NULL, function(self, a) a))
+  expect_snapshot(error = TRUE, ggproto("Test", NULL, a <- function(self, a) a))
+  expect_snapshot(error = TRUE, ggproto("Test", mtcars, a = function(self, a) a))
 })

--- a/tests/testthat/test-ggsave.R
+++ b/tests/testthat/test-ggsave.R
@@ -93,7 +93,7 @@ test_that("ggsave fails informatively for no-extension filenames", {
   plot <- ggplot(mtcars, aes(disp, mpg)) + geom_point()
   expect_error(
     ggsave(tempfile(), plot),
-    '`filename` has no file extension and `device` is "NULL"'
+    "Can't save"
   )
 })
 
@@ -125,7 +125,7 @@ test_that("scale multiplies height & width", {
 # plot_dev ---------------------------------------------------------------------
 
 test_that("unknown device triggers error", {
-  expect_snapshot_error(plot_dev(1))
+  expect_snapshot(error = TRUE, plot_dev(1))
   expect_error(plot_dev("xyz"), "Unknown graphics device")
   expect_error(plot_dev(NULL, "test.xyz"), "Unknown graphics device")
 })
@@ -151,12 +151,14 @@ test_that("DPI string values are parsed correctly", {
 })
 
 test_that("invalid single-string DPI values throw an error", {
-  expect_snapshot_error(parse_dpi("abc"))
+  expect_snapshot(error = TRUE, parse_dpi("abc"))
 })
 
 test_that("invalid non-single-string DPI values throw an error", {
-  expect_snapshot_error(parse_dpi(factor(100)))
-  expect_snapshot_error(parse_dpi(c("print", "screen")))
-  expect_snapshot_error(parse_dpi(c(150, 300)))
-  expect_snapshot_error(parse_dpi(list(150)))
+  expect_snapshot(error = TRUE,  {
+    parse_dpi(factor(100))
+    parse_dpi(c("print", "screen"))
+    parse_dpi(c(150, 300))
+    parse_dpi(list(150))
+  })
 })

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -151,10 +151,14 @@ test_that("guide_none() can be used in non-position scales", {
 })
 
 test_that("Using non-position guides for position scales results in an informative error", {
-  p <- ggplot(mpg, aes(cty, hwy)) +
-    geom_point() +
-    scale_x_continuous(guide = guide_legend())
-  expect_snapshot_warning(ggplot_build(p))
+
+  expect_snapshot({
+    p <- ggplot(mpg, aes(cty, hwy)) +
+      geom_point() +
+      scale_x_continuous(guide = guide_legend())
+    # avoid printing the plot
+    e <- ggplot_build(p)
+  })
 })
 
 test_that("guide merging for guide_legend() works as expected", {
@@ -225,44 +229,60 @@ test_that("size = NA doesn't throw rendering errors", {
 })
 
 test_that("guide specifications are properly checked", {
-  expect_snapshot_error(validate_guide("test"))
-  expect_snapshot_error(validate_guide(1))
+  expect_snapshot(error = TRUE, {
+    validate_guide("test")
+    validate_guide(1)
+  })
 
-  p <- ggplot(mtcars) +
-    geom_point(aes(mpg, disp, shape = factor(gear))) +
-    guides(shape = "colourbar")
+  # Capture warning
+  expect_snapshot({
+    p <- ggplot(mtcars) +
+      geom_point(aes(mpg, disp, shape = factor(gear))) +
+      guides(shape = "colourbar")
+    # Avoid printing to console
+    e <- ggplotGrob(p)
+  })
 
-  expect_snapshot_warning(ggplotGrob(p))
+  expect_snapshot(error = TRUE, {
+    guide_legend(title.position = "leftish")
+    guide_legend(label.position = "test")
+    guide_colourbar()$transform()
+  })
 
-  expect_snapshot_error(guide_legend(title.position = "leftish"))
+  expect_snapshot(error = TRUE, {
+    p <- ggplot(mtcars) +
+      geom_point(aes(mpg, disp, colour = gear)) +
+      guides(colour = guide_colourbar(label.position = "top"))
+    ggplotGrob(p)
+  })
 
-  expect_snapshot_error(guide_colourbar()$transform())
+  expect_snapshot(error = TRUE, {
+    p <- ggplot(mtcars) +
+      geom_point(aes(mpg, disp, colour = gear)) +
+      guides(colour = guide_colourbar(direction = "horizontal", label.position = "left"))
+    ggplotGrob(p)
+  })
 
-  p <- ggplot(mtcars) +
-    geom_point(aes(mpg, disp, colour = gear)) +
-    guides(colour = guide_colourbar(label.position = "top"))
-  expect_snapshot_error(ggplotGrob(p))
-  p <- ggplot(mtcars) +
-    geom_point(aes(mpg, disp, colour = gear)) +
-    guides(colour = guide_colourbar(direction = "horizontal", label.position = "left"))
-  expect_snapshot_error(ggplotGrob(p))
-
-  expect_snapshot_error(guide_legend(label.position = "test"))
-  p <- ggplot(mtcars) +
-    geom_point(aes(mpg, disp, colour = gear)) +
-    guides(colour = guide_legend(nrow = 2, ncol = 2))
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, {
+    p <- ggplot(mtcars) +
+      geom_point(aes(mpg, disp, colour = gear)) +
+      guides(colour = guide_legend(nrow = 2, ncol = 2))
+    ggplotGrob(p)
+  })
 })
 
 test_that("colorsteps and bins checks the breaks format", {
-  p <- ggplot(mtcars) +
-    geom_point(aes(mpg, disp, colour = paste("A", gear))) +
-    guides(colour = "colorsteps")
-  expect_snapshot_error(suppressWarnings(ggplotGrob(p)))
-  p <- ggplot(mtcars) +
-    geom_point(aes(mpg, disp, colour = paste("A", gear))) +
-    guides(colour = "bins")
-  expect_snapshot_error(suppressWarnings(ggplotGrob(p)))
+
+  expect_snapshot(error = TRUE, {
+    p <- ggplot(mtcars) +
+      geom_point(aes(mpg, disp, colour = paste("A", gear))) +
+      guides(colour = "colorsteps")
+    suppressWarnings(ggplotGrob(p))
+    p <- ggplot(mtcars) +
+      geom_point(aes(mpg, disp, colour = paste("A", gear))) +
+      guides(colour = "bins")
+    suppressWarnings(ggplotGrob(p))
+  })
 })
 
 test_that("legend reverse argument reverses the key", {
@@ -301,7 +321,7 @@ test_that("guide_coloursteps and guide_bins return ordered breaks", {
 
 
 test_that("guide_colourbar merging preserves both aesthetics", {
-  # See issue 5324
+  # See issue #5324
 
   scale1 <- scale_colour_viridis_c()
   scale1$train(c(0, 2))
@@ -317,7 +337,7 @@ test_that("guide_colourbar merging preserves both aesthetics", {
 
   merged <- g$merge(p1, g, p2)
 
-  expect_true(all(c("colour", "fill") %in% names(merged$params$key)))
+  expect_contains(names(merged$params$key), c("colour", "fill"))
 })
 
 test_that("guide_colourbar warns about discrete scales", {
@@ -409,7 +429,8 @@ test_that("guide_axis_logticks calculates appropriate ticks", {
 
   # Should warn when scale also has transformation
   scale <- test_scale(log10_trans(), limits = c(10, 1000))
-  expect_snapshot_warning(train_guide(guide, scale)$logkey)
+  # avoid printing output
+  expect_snapshot(res <- train_guide(guide, scale)$logkey)
 })
 
 test_that("guide_legend uses key.spacing correctly", {
@@ -923,7 +944,10 @@ test_that("binning scales understand the different combinations of limits, break
                            breaks = c(1999, 2000, 2002, 2004, 2006),
                            labels = 1:5, guide = 'bins')
   )
-  expect_snapshot_warning(ggplotGrob(p + scale_color_binned(labels = 1:4, show.limits = TRUE, guide = "bins")))
+  expect_snapshot(
+    res <- ggplotGrob(
+      p + scale_color_binned(labels = 1:4, show.limits = TRUE, guide = "bins"))
+  )
 
   expect_doppelganger("guide_colorsteps understands coinciding limits and bins",
     p + scale_color_binned(limits = c(1999, 2008),
@@ -943,7 +967,9 @@ test_that("binning scales understand the different combinations of limits, break
                            breaks = c(1999, 2000, 2002, 2004, 2006),
                            labels = 1:5)
   )
-  expect_snapshot_warning(ggplotGrob(p + scale_color_binned(labels = 1:4, show.limits = TRUE)))
+  # Capture warning only
+  expect_snapshot(
+    res <- ggplotGrob(p + scale_color_binned(labels = 1:4, show.limits = TRUE)))
 })
 
 test_that("guide_axis_theta sets relative angle", {
@@ -987,7 +1013,7 @@ test_that("a warning is generated when guides(<scale> = FALSE) is specified", {
 
   # warn on scale_*(guide = FALSE)
   p <- ggplot(df, aes(x, y, colour = x)) + scale_colour_continuous(guide = FALSE)
-  expect_snapshot_warning(ggplot_build(p))
+  expect_snapshot(e <- ggplot_build(p))
 })
 
 test_that("guides() warns if unnamed guides are provided", {
@@ -1045,12 +1071,9 @@ test_that("old S3 guides can be implemented", {
 
   withr::local_environment(my_env)
 
-  expect_snapshot_warning(
-    expect_doppelganger(
-      "old S3 guide drawing a circle",
-      ggplot(mtcars, aes(disp, mpg)) +
-        geom_point() +
-        guides(x = "circle")
-    )
-  )
+  expect_snapshot(expect_doppelganger(
+    "old S3 guide drawing a circle",
+    ggplot(mtcars, aes(disp, mpg)) +geom_point() + guides(x = "circle")
+
+  ))
 })

--- a/tests/testthat/test-labellers.R
+++ b/tests/testthat/test-labellers.R
@@ -7,8 +7,8 @@ test_that("label_bquote has access to functions in the calling environment", {
 })
 
 test_that("resolve_labeller() provide meaningful errors", {
-  expect_snapshot_error(resolve_labeller(NULL, NULL))
-  expect_snapshot_error(resolve_labeller(prod, sum, structure(1:4, facet = "wrap")))
+  expect_snapshot(error = TRUE, resolve_labeller(NULL, NULL))
+  expect_snapshot(error = TRUE, resolve_labeller(prod, sum, structure(1:4, facet = "wrap")))
 })
 
 test_that("labeller function catches overlap in names", {
@@ -18,7 +18,7 @@ test_that("labeller function catches overlap in names", {
       vs + am ~ gear,
       labeller = labeller(.rows = label_both, vs = label_value)
     )
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
 })
 
 test_that("labeller handles badly specified labels from lookup tables", {

--- a/tests/testthat/test-labels.R
+++ b/tests/testthat/test-labels.R
@@ -73,10 +73,10 @@ test_that("alt text is returned", {
 test_that("plot.tag.position rejects invalid input", {
   p <- ggplot(mtcars, aes(mpg, disp)) + geom_point() + labs(tag = "Fig. A)")
 
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE, 
     ggplotGrob(p + theme(plot.tag.position = TRUE))
   )
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE, 
     ggplotGrob(p + theme(plot.tag.position = "foobar"))
   )
   expect_error(

--- a/tests/testthat/test-layer.R
+++ b/tests/testthat/test-layer.R
@@ -1,15 +1,18 @@
 # Parameters --------------------------------------------------------------
 
 test_that("layer() checks its input", {
-  expect_snapshot_error(layer(stat = "identity", position = "identity"))
-  expect_snapshot_error(layer(geom = "point", position = "identity"))
-  expect_snapshot_error(layer(geom = "point", stat = "identity"))
+  expect_snapshot(error = TRUE, {
+    layer(stat = "identity", position = "identity")
+    layer(geom = "point", position = "identity")
+    layer(geom = "point", stat = "identity")
+    layer("point", "identity", mapping = 1:4, position = "identity")
+    layer("point", "identity", mapping = ggplot(), position = "identity")
+  })
 
-  expect_snapshot_error(layer("point", "identity", mapping = 1:4, position = "identity"))
-  expect_snapshot_error(layer("point", "identity", mapping = ggplot(), position = "identity"))
-
-  expect_snapshot_error(check_subclass("test", "geom"))
-  expect_snapshot_error(check_subclass(environment(), "geom"))
+  expect_snapshot(error = TRUE, {
+    check_subclass("test", "geom")
+    check_subclass(environment(), "geom")
+  })
 })
 
 test_that("aesthetics go in aes_params", {
@@ -27,13 +30,13 @@ test_that("unknown aesthetics create warning", {
 
 test_that("invalid aesthetics throws errors", {
   p <- ggplot(mtcars) + geom_point(aes(disp, mpg, fill = data))
-  expect_snapshot_error(ggplot_build(p))
+  expect_snapshot(error = TRUE, ggplot_build(p))
   p <- ggplot(mtcars) + geom_point(aes(disp, mpg, fill = after_stat(data)))
-  expect_snapshot_error(ggplot_build(p))
+  expect_snapshot(error = TRUE, ggplot_build(p))
 })
 
 test_that("unknown NULL aesthetic doesn't create warning (#1909)", {
-  expect_warning(geom_point(aes(blah = NULL)), NA)
+  expect_no_warning(geom_point(aes(blah = NULL)))
 })
 
 test_that("column vectors are allowed (#2609)", {
@@ -45,26 +48,25 @@ test_that("column vectors are allowed (#2609)", {
 
 test_that("missing aesthetics trigger informative error", {
   df <- data_frame(x = 1:10)
-  expect_error(
-    ggplot_build(ggplot(df) + geom_line()),
-    "requires the following missing aesthetics:"
-  )
-  expect_error(
-    ggplot_build(ggplot(df) + geom_col()),
-    "requires the following missing aesthetics:"
-  )
+  expect_snapshot(error = TRUE, {
+    p <- ggplot(df) + geom_line()
+    ggplot_build(p)
+    p <- ggplot(df) + geom_col()
+    ggplot_build(p)
+
+  })
 })
 
 test_that("function aesthetics are wrapped with after_stat()", {
   df <- data_frame(x = 1:10)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     ggplot_build(ggplot(df, aes(colour = density, fill = density)) + geom_point())
   )
 })
 
 test_that("computed stats are in appropriate layer", {
   df <- data_frame(x = 1:10)
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     ggplot_build(ggplot(df, aes(colour = after_stat(density), fill = after_stat(density))) + geom_point())
   )
 })
@@ -73,7 +75,7 @@ test_that("if an aes is mapped to a function that returns NULL, it is removed", 
   df <- data_frame(x = 1:10)
   null <- function(...) NULL
   p <- cdata(ggplot(df, aes(x, null())))
-  expect_identical(names(p[[1]]), c("x", "PANEL", "group"))
+  expect_named(p[[1]], c("x", "PANEL", "group"))
 })
 
 test_that("layers are stateless except for the computed params", {
@@ -111,7 +113,7 @@ test_that("retransform works on computed aesthetics in `map_statistic`", {
 test_that("layer reports the error with correct index etc", {
   p <- ggplot(mtcars) + geom_linerange(aes(disp, mpg), ymin = 2)
 
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
 
   p <- ggplot(
     data_frame(x = "one value", y = 3, value = 4:6),
@@ -120,7 +122,7 @@ test_that("layer reports the error with correct index etc", {
     geom_point(aes(x = x, y = y), inherit.aes = FALSE) +
     geom_boxplot(stat = "identity")
 
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
 })
 
 test_that("layer warns for constant aesthetics", {
@@ -128,7 +130,8 @@ test_that("layer warns for constant aesthetics", {
   expect_silent(ggplot_build(p))
 
   p <- ggplot(mtcars, aes(x = 1)) + geom_point(aes(y = 2))
-  expect_snapshot_warning(ggplot_build(p))
+  # Capture warning
+  expect_snapshot(e <- ggplot_build(p))
 })
 
 # Data extraction ---------------------------------------------------------
@@ -143,5 +146,5 @@ test_that("layer_data returns a data.frame", {
   l <- geom_point(data = ~ head(., 10))
   expect_equal(l$layer_data(mtcars), head(unrowname(mtcars), 10))
   l <- geom_point(data = nrow)
-  expect_snapshot_error(l$layer_data(mtcars))
+  expect_snapshot(error = TRUE, l$layer_data(mtcars))
 })

--- a/tests/testthat/test-limits.R
+++ b/tests/testthat/test-limits.R
@@ -1,4 +1,4 @@
 test_that("limits() throw meaningful errors", {
-  expect_snapshot_error(lims(1:2))
-  expect_snapshot_error(lims(linewidth = 1))
+  expect_snapshot(error = TRUE, lims(1:2))
+  expect_snapshot(error = TRUE, lims(linewidth = 1))
 })

--- a/tests/testthat/test-margins.R
+++ b/tests/testthat/test-margins.R
@@ -1,3 +1,3 @@
 test_that("justify_grobs() checks input", {
-  expect_snapshot_error(justify_grobs(1))
+  expect_snapshot(error = TRUE, justify_grobs(1))
 })

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -1,11 +1,11 @@
 test_that("ggplot() throws informative errors", {
-  expect_snapshot_error(ggplot(mapping = letters))
-  expect_snapshot_error(ggplot(data))
+  expect_snapshot(error = TRUE, ggplot(mapping = letters))
+  expect_snapshot(error = TRUE, ggplot(data))
 })
 
 test_that("construction have user friendly errors", {
-  expect_snapshot_error(+ geom_point())
-  expect_snapshot_error(geom_point() + geom_bar())
-  expect_snapshot_error(ggplot() + 1)
-  expect_snapshot_error(ggplot() + geom_point)
+  expect_snapshot(error = TRUE, + geom_point())
+  expect_snapshot(error = TRUE, geom_point() + geom_bar())
+  expect_snapshot(error = TRUE, ggplot() + 1)
+  expect_snapshot(error = TRUE, ggplot() + geom_point)
 })

--- a/tests/testthat/test-position-collide.R
+++ b/tests/testthat/test-position-collide.R
@@ -1,6 +1,9 @@
 test_that("collide() checks the input data", {
   data <- data.frame(x = 1:4, group = 1L)
-  expect_snapshot_error(collide(data, width = 1, 'test', pos_stack))
-  data$y <- 1
-  expect_snapshot_warning(collide(data, width = 2, 'test', pos_stack))
+
+  expect_snapshot(error = TRUE, {
+    collide(data, width = 1, 'test', pos_stack)
+    data$y <- 1
+    out <- collide(data, width = 2, 'test', pos_stack)
+  })
 })

--- a/tests/testthat/test-position-jitterdodge.R
+++ b/tests/testthat/test-position-jitterdodge.R
@@ -1,4 +1,4 @@
 test_that("position_jitterdodge() fails with meaningful error", {
   p <- ggplot(mtcars) + geom_point(aes(disp, mpg), position = 'jitterdodge')
-  expect_snapshot_error(ggplot_build(p))
+  expect_snapshot(error = TRUE, ggplot_build(p))
 })

--- a/tests/testthat/test-qplot.R
+++ b/tests/testthat/test-qplot.R
@@ -51,7 +51,7 @@ test_that("qplot() evaluates layers in package environment", {
 })
 
 test_that("qplot() only work with character geom", {
-  lifecycle::expect_deprecated(
-    expect_snapshot_error(qplot(geom = GeomLinerange))
-  )
+    expect_snapshot(error = TRUE, {
+      qplot(geom = GeomLinerange)
+  })
 })

--- a/tests/testthat/test-scale-binned.R
+++ b/tests/testthat/test-scale-binned.R
@@ -1,8 +1,8 @@
 test_that("binned scales only support continuous data", {
   p <- ggplot(mtcars) + geom_bar(aes(as.character(gear))) + scale_x_binned()
-  expect_snapshot_error(ggplot_build(p))
+  expect_snapshot(error = TRUE, ggplot_build(p))
   p <- ggplot(mtcars) + geom_point(aes(disp, mpg, colour = as.character(gear))) + scale_color_binned()
-  expect_snapshot_error(ggplot_build(p))
+  expect_snapshot(error = TRUE, ggplot_build(p))
 })
 
 test_that("binned scales limits can expand to fit breaks", {

--- a/tests/testthat/test-scale-colour-continuous.R
+++ b/tests/testthat/test-scale-colour-continuous.R
@@ -1,20 +1,20 @@
 test_that("type argument is checked for proper input", {
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE, 
     scale_colour_continuous(type = function() "abc")
   )
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE, 
     suppressWarnings(scale_fill_continuous(type = geom_point))
   )
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE, 
     scale_colour_binned(type = function(...) scale_colour_binned(aesthetics = c("fill", "point_colour")))
   )
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE, 
     scale_fill_binned(type = scale_fill_brewer)
   )
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE, 
     scale_fill_continuous(type = "abc")
   )
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE, 
     scale_colour_continuous(type = "abc")
   )
 })

--- a/tests/testthat/test-scale-discrete.R
+++ b/tests/testthat/test-scale-discrete.R
@@ -144,8 +144,8 @@ test_that("Scale is checked in default colour scale", {
 })
 
 test_that("Aesthetics with no continuous interpretation fails when called", {
-  expect_snapshot_error(scale_linetype_continuous())
-  expect_snapshot_error(scale_shape_continuous())
+  expect_snapshot(error = TRUE, scale_linetype_continuous())
+  expect_snapshot(error = TRUE, scale_shape_continuous())
 })
 
 # mapped_discrete ---------------------------------------------------------

--- a/tests/testthat/test-scale-expansion.R
+++ b/tests/testthat/test-scale-expansion.R
@@ -4,8 +4,8 @@ test_that("expand_scale() produces a deprecation warning", {
 })
 
 test_that("expansion() checks input", {
-  expect_snapshot_error(expansion(mult = 2:4))
-  expect_snapshot_error(expansion(add = 2:4))
+  expect_snapshot(error = TRUE, expansion(mult = 2:4))
+  expect_snapshot(error = TRUE, expansion(add = 2:4))
 })
 
 # Expanding continuous scales -----------------------------------------

--- a/tests/testthat/test-scale-hue.R
+++ b/tests/testthat/test-scale-hue.R
@@ -1,6 +1,6 @@
 test_that("scale_hue() checks the type input", {
   pal <- qualitative_pal(type = 1:4)
-  expect_snapshot_error(pal(4))
+  expect_snapshot(error = TRUE, pal(4))
   pal <- qualitative_pal(type = colors())
   expect_silent(pal(4))
   pal <- qualitative_pal(type = list(colors()[1:10], colors()[11:30]))

--- a/tests/testthat/test-scale-manual.R
+++ b/tests/testthat/test-scale-manual.R
@@ -16,9 +16,8 @@ test_that("names of values used in manual scales", {
    # Names do not match data
    s <- scale_colour_manual(values = c("foo" = "x", "bar" = "y"))
    s$train(c("A", "B"))
-   expect_snapshot_warning(
-     expect_equal(s$get_limits(), character())
-   )
+   expect_snapshot(out <- s$get_limits())
+   expect_equal(out, character())
 })
 
 

--- a/tests/testthat/test-scales.R
+++ b/tests/testthat/test-scales.R
@@ -223,8 +223,8 @@ test_that("size and alpha scales throw appropriate warnings for factors", {
     "Using linewidth for a discrete variable is not advised."
   )
   # There should be no warnings for ordered factors
-  expect_warning(ggplot_build(p + geom_point(aes(size = o))), NA)
-  expect_warning(ggplot_build(p + geom_point(aes(alpha = o))), NA)
+  expect_no_warning(ggplot_build(p + geom_point(aes(size = o))))
+  expect_no_warning(ggplot_build(p + geom_point(aes(alpha = o))))
 })
 
 test_that("shape scale throws appropriate warnings for factors", {
@@ -237,7 +237,7 @@ test_that("shape scale throws appropriate warnings for factors", {
   p <- ggplot(df, aes(x, y))
 
   # There should be no warnings when unordered factors are mapped to shape
-  expect_warning(ggplot_build(p + geom_point(aes(shape = d))), NA)
+  expect_no_warning(ggplot_build(p + geom_point(aes(shape = d))))
 
   # There should be warnings for ordered factors
   expect_warning(
@@ -345,7 +345,7 @@ test_that("scale_apply preserves class and attributes", {
   )[[1]], `c.baz` = `c.baz`, `[.baz` = `[.baz`, .env = global_env())
 
   # Check that it errors on bad scale ids
-  expect_snapshot_error(scale_apply(
+  expect_snapshot(error = TRUE, scale_apply(
     df, "x", "transform", c(NA, 1), plot$layout$panel_scales_x
   ))
 
@@ -427,26 +427,26 @@ test_that("scales accept lambda notation for function input", {
 })
 
 test_that("breaks and labels are correctly checked", {
-  expect_snapshot_error(check_breaks_labels(1:10, letters))
+  expect_snapshot(error = TRUE, check_breaks_labels(1:10, letters))
   p <- ggplot(mtcars) + geom_point(aes(mpg, disp)) + scale_x_continuous(breaks = NA)
-  expect_snapshot_error(ggplot_build(p))
+  expect_snapshot(error = TRUE, ggplot_build(p))
   p <- ggplot(mtcars) + geom_point(aes(mpg, disp)) + scale_x_continuous(minor_breaks = NA)
-  expect_snapshot_error(ggplot_build(p))
+  expect_snapshot(error = TRUE, ggplot_build(p))
   p <- ggplot(mtcars) + geom_point(aes(mpg, disp)) + scale_x_continuous(labels = NA)
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
   p <- ggplot(mtcars) + geom_point(aes(mpg, disp)) + scale_x_continuous(labels = function(x) 1:2)
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
   p <- ggplot(mtcars) + geom_bar(aes(factor(gear))) + scale_x_discrete(breaks = NA)
-  expect_snapshot_error(ggplot_build(p))
+  expect_snapshot(error = TRUE, ggplot_build(p))
   p <- ggplot(mtcars) + geom_bar(aes(factor(gear))) + scale_x_discrete(labels = NA)
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
 
   p <- ggplot(mtcars) + geom_bar(aes(mpg)) + scale_x_binned(breaks = NA)
-  expect_snapshot_error(ggplot_build(p))
+  expect_snapshot(error = TRUE, ggplot_build(p))
   p <- ggplot(mtcars) + geom_bar(aes(mpg)) + scale_x_binned(labels = NA)
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
   p <- ggplot(mtcars) + geom_bar(aes(mpg)) + scale_x_binned(labels = function(x) 1:2)
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
 })
 
 test_that("staged aesthetics are backtransformed properly (#4155)", {
@@ -681,12 +681,12 @@ test_that("scale call is found accurately", {
 test_that("training incorrectly appropriately communicates the offenders", {
 
   sc <- scale_colour_viridis_d()
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     sc$train(1:5)
   )
 
   sc <- scale_colour_viridis_c()
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE,
     sc$train(LETTERS[1:5])
   )
 })
@@ -706,9 +706,11 @@ test_that("find_scale appends appropriate calls", {
 })
 
 test_that("Using `scale_name` prompts deprecation message", {
-
-  expect_snapshot_warning(continuous_scale("x", "foobar", identity_pal()))
-  expect_snapshot_warning(discrete_scale("x",   "foobar", identity_pal()))
-  expect_snapshot_warning(binned_scale("x",     "foobar", identity_pal()))
+  # Interested in message
+  expect_snapshot({
+    res <- continuous_scale("x", "foobar", identity_pal())
+    res <- discrete_scale("x",   "foobar", identity_pal())
+    res <- binned_scale("x",     "foobar", identity_pal())
+  })
 
 })

--- a/tests/testthat/test-sec-axis.R
+++ b/tests/testthat/test-sec-axis.R
@@ -6,13 +6,13 @@ foo <- data_frame(
 
 test_that("sec_axis checks the user input", {
   scale <- scale_x_continuous()
-  expect_snapshot_error(set_sec_axis(16, scale))
+  expect_snapshot(error = TRUE, set_sec_axis(16, scale))
   expect_silent(set_sec_axis(~ .^2, scale))
   secondary <- ggproto(NULL, AxisSecondary, trans = 1:10)
-  expect_snapshot_error(secondary$init(scale))
+  expect_snapshot(error = TRUE, secondary$init(scale))
 
   p <- ggplot(mtcars) + geom_point(aes(disp, mpg)) + scale_y_continuous(sec.axis = ~sin(.))
-  expect_snapshot_error(ggplot_build(p))
+  expect_snapshot(error = TRUE, ggplot_build(p))
 
   p <- ggplot(mtcars) + geom_point(aes(disp, mpg)) + scale_y_continuous(sec.axis = ~sin(./100))
   expect_silent(ggplot_build(p))

--- a/tests/testthat/test-stat-bin.R
+++ b/tests/testthat/test-stat-bin.R
@@ -1,11 +1,11 @@
 test_that("stat_bin throws error when wrong combination of aesthetic is present", {
   dat <- data_frame(x = c("a", "b", "c"), y = c(1, 5, 10))
 
-  expect_snapshot_error(ggplot_build(ggplot(dat) + stat_bin()))
+  expect_snapshot(error = TRUE, ggplot_build(ggplot(dat) + stat_bin()))
 
-  expect_snapshot_error(ggplot_build(ggplot(dat, aes(x, y)) + stat_bin()))
+  expect_snapshot(error = TRUE, ggplot_build(ggplot(dat, aes(x, y)) + stat_bin()))
 
-  expect_snapshot_error(ggplot_build(ggplot(dat, aes(x)) + stat_bin(y = 5)))
+  expect_snapshot(error = TRUE, ggplot_build(ggplot(dat, aes(x)) + stat_bin(y = 5)))
 })
 
 test_that("stat_bin works in both directions", {
@@ -119,13 +119,18 @@ comp_bin <- function(df, ...) {
 
 test_that("inputs to binning are checked", {
   dat <- data_frame(x = c(0, 10))
-  expect_snapshot_error(comp_bin(dat, breaks = letters))
-  expect_snapshot_error(bin_breaks_width(3))
-  expect_snapshot_error(comp_bin(dat, binwidth = letters))
-  expect_snapshot_error(comp_bin(dat, binwidth = -4))
+  expect_snapshot({
+    # Only capture condition
+    r <- comp_bin(dat, breaks = letters)
+    r <- comp_bin(dat, binwidth = letters)
+    r <- comp_bin(dat, binwidth = -4)
+    r <- comp_bin(dat, bins = -4)
+  })
 
-  expect_snapshot_error(bin_breaks_bins(3))
-  expect_snapshot_error(comp_bin(dat, bins = -4))
+  expect_snapshot(error = TRUE, {
+    bin_breaks_bins(3)
+  })
+
 })
 
 test_that("closed left or right", {
@@ -185,7 +190,7 @@ test_that("bin errors at high bin counts", {
 test_that("stat_count throws error when both x and y aesthetic present", {
   dat <- data_frame(x = c("a", "b", "c"), y = c(1, 5, 10))
 
-  expect_snapshot_error(ggplot_build(ggplot(dat, aes(x, y)) + stat_count()))
+  expect_snapshot(error = TRUE, ggplot_build(ggplot(dat, aes(x, y)) + stat_count()))
 })
 
 test_that("stat_count preserves x order for continuous and discrete", {

--- a/tests/testthat/test-stat-bin2d.R
+++ b/tests/testthat/test-stat-bin2d.R
@@ -11,11 +11,13 @@ test_that("binwidth is respected", {
 
   p <- ggplot(df, aes(x, y)) +
     stat_bin_2d(geom = "tile", binwidth = c(0.25, 0.5, 0.75))
-  expect_snapshot_warning(ggplot_build(p))
+  # Capture warning
+  expect_snapshot(res <- ggplot_build(p))
 
   p <- ggplot(df, aes(x, y)) +
     stat_bin_2d(geom = "tile", origin = c(0.25, 0.5, 0.75))
-  expect_snapshot_warning(ggplot_build(p))
+  # Capture warning
+  expect_snapshot(res <- ggplot_build(p))
 })
 
 test_that("breaks override binwidth", {

--- a/tests/testthat/test-stat-boxplot.R
+++ b/tests/testthat/test-stat-boxplot.R
@@ -8,8 +8,11 @@ test_that("stat_boxplot drops missing rows with a warning", {
     geom_boxplot(position = "dodge2") +
     scale_x_discrete(limits = c("trt1", "ctrl"))
 
-  expect_snapshot_warning(ggplot_build(p1))
-  expect_snapshot_warning(ggplot_build(p2))
+  # Capture warnings
+  expect_snapshot({
+    res <- ggplot_build(p1)
+    res <- ggplot_build(p2)
+  })
 })
 
 test_that("stat_boxplot can suppress warning about missing rows", {
@@ -23,5 +26,5 @@ test_that("stat_boxplot can suppress warning about missing rows", {
 test_that("stat_boxplot errors with missing x/y aesthetics", {
   p <- ggplot(PlantGrowth) +
     geom_boxplot()
-  expect_snapshot_error(ggplot_build(p))
+  expect_snapshot(error = TRUE, ggplot_build(p))
 })

--- a/tests/testthat/test-stat-count.R
+++ b/tests/testthat/test-stat-count.R
@@ -1,6 +1,6 @@
 test_that("stat_count() checks the aesthetics", {
   p <- ggplot(mtcars) + stat_count()
-  expect_snapshot_error(ggplot_build(p))
+  expect_snapshot(error = TRUE, ggplot_build(p))
   p <- ggplot(mtcars) + stat_count(aes(factor(gear), mpg))
-  expect_snapshot_error(ggplot_build(p))
+  expect_snapshot(error = TRUE, ggplot_build(p))
 })

--- a/tests/testthat/test-stat-density.R
+++ b/tests/testthat/test-stat-density.R
@@ -108,7 +108,7 @@ test_that("stat_density works in both directions", {
   expect_identical(x, flip_data(y, TRUE)[,names(x)])
 
   p <- ggplot(mpg) + stat_density()
-  expect_snapshot_error(ggplot_build(p))
+  expect_snapshot(error = TRUE, ggplot_build(p))
 })
 
 test_that("compute_density returns useful df and throws warning when <2 values", {
@@ -122,6 +122,6 @@ test_that("compute_density returns useful df and throws warning when <2 values",
 test_that("precompute_bandwidth() errors appropriately", {
   expect_silent(precompute_bw(1:10))
   expect_equal(precompute_bw(1:10, 5), 5)
-  expect_snapshot_error(precompute_bw(1:10, bw = "foobar"))
-  expect_snapshot_error(precompute_bw(1:10, bw = Inf))
+  expect_snapshot(error = TRUE, precompute_bw(1:10, bw = "foobar"))
+  expect_snapshot(error = TRUE, precompute_bw(1:10, bw = Inf))
 })

--- a/tests/testthat/test-stat-density2d.R
+++ b/tests/testthat/test-stat-density2d.R
@@ -91,5 +91,5 @@ test_that("stat_density2d can produce contour and raster data", {
   expect_identical(d_bands$level_mid, d_bands2$level_mid)
 
   # error on incorrect contouring variable
-  expect_snapshot_error(ggplot_build(p + stat_density_2d(contour_var = "abcd")))
+  expect_snapshot(error = TRUE, ggplot_build(p + stat_density_2d(contour_var = "abcd")))
 })

--- a/tests/testthat/test-stat-ecdf.R
+++ b/tests/testthat/test-stat-ecdf.R
@@ -12,7 +12,7 @@ test_that("stat_ecdf works in both directions", {
   expect_identical(x, flip_data(y, TRUE)[,names(x)])
 
   p <- ggplot(mpg) + stat_ecdf()
-  expect_snapshot_error(ggplot_build(p))
+  expect_snapshot(error = TRUE, ggplot_build(p))
 })
 
 # See #5113 and #5112

--- a/tests/testthat/test-stat-qq.R
+++ b/tests/testthat/test-stat-qq.R
@@ -1,11 +1,11 @@
 test_that("error is thrown with wrong quantile input", {
   # Stat errors are converted to warnings
-  p <- ggplot(mtcars, aes(sample = mpg)) + stat_qq(quantiles = 1:5)
-  expect_snapshot_warning(ggplot_build(p))
-
-  p <- ggplot(mtcars, aes(sample = mpg)) + geom_qq_line(quantiles = 1:5)
-  expect_snapshot_warning(ggplot_build(p))
-
-  p <- ggplot(mtcars, aes(sample = mpg)) + geom_qq_line(line.p = 0.15)
-  expect_snapshot_warning(ggplot_build(p))
+  expect_snapshot({
+    p <- ggplot(mtcars, aes(sample = mpg)) + stat_qq(quantiles = 1:5)
+    res <- ggplot_build(p)
+    p <- ggplot(mtcars, aes(sample = mpg)) + geom_qq_line(quantiles = 1:5)
+    res <- ggplot_build(p)
+    p <- ggplot(mtcars, aes(sample = mpg)) + geom_qq_line(line.p = 0.15)
+    res <- ggplot_build(p)
+  })
 })

--- a/tests/testthat/test-stat-ydensity.R
+++ b/tests/testthat/test-stat-ydensity.R
@@ -1,7 +1,7 @@
 test_that("calc_bw() requires at least two values and correct method", {
-  expect_snapshot_error(calc_bw(1, "nrd0"))
+  expect_snapshot(error = TRUE, calc_bw(1, "nrd0"))
   expect_silent(calc_bw(1:5, "nrd0"))
-  expect_snapshot_error(calc_bw(1:5, "test"))
+  expect_snapshot(error = TRUE, calc_bw(1:5, "test"))
 })
 
 test_that("`drop = FALSE` preserves groups with 1 observations", {

--- a/tests/testthat/test-stats.R
+++ b/tests/testthat/test-stats.R
@@ -3,17 +3,17 @@ test_that("plot succeeds even if some computation fails", {
   p1 <- ggplot(df, aes(x, y)) + geom_point()
 
   b1 <- ggplot_build(p1)
-  expect_equal(length(b1$data), 1)
+  expect_length(b1$data, 1)
 
   p2 <- p1 + stat_summary(fun = function(x) stop("Failed computation"))
 
   expect_warning(b2 <- ggplot_build(p2), "Computation failed")
-  expect_equal(length(b2$data), 2)
+  expect_length(b2$data, 2)
 })
 
 test_that("error message is thrown when aesthetics are missing", {
   p <- ggplot(mtcars) + stat_sum()
-  expect_error(ggplot_build(p), "x and y$")
+  expect_error(ggplot_build(p), "x and y.$")
 })
 
 test_that("erroneously dropped aesthetics are found and issue a warning", {
@@ -40,9 +40,9 @@ test_that("erroneously dropped aesthetics are found and issue a warning", {
   )
 
   p2 <- ggplot(df2, aes(id, colour = colour, fill = fill)) + geom_bar()
-  expect_warning(
-    b2 <- ggplot_build(p2),
-    "The following aesthetics were dropped during statistical transformation: .*colour.*, .*fill.*"
+  # Capture warning aesthetics dropping
+  expect_snapshot(
+    b2 <- ggplot_build(p2)
   )
 
   # colour is dropped because group a's colour is not constant (GeomBar$default_aes$colour is NA)

--- a/tests/testthat/test-summarise-plot.R
+++ b/tests/testthat/test-summarise-plot.R
@@ -1,7 +1,7 @@
 test_that("summarise_*() throws appropriate errors", {
 
-  expect_snapshot_error(summarise_layout(10))
-  expect_snapshot_error(summarise_coord("A"))
-  expect_snapshot_error(summarise_layers(TRUE))
+  expect_snapshot(error = TRUE, summarise_layout(10))
+  expect_snapshot(error = TRUE, summarise_coord("A"))
+  expect_snapshot(error = TRUE, summarise_layers(TRUE))
 
 })

--- a/tests/testthat/test-theme.R
+++ b/tests/testthat/test-theme.R
@@ -268,35 +268,35 @@ test_that("theme validation happens at build stage", {
 
   # the error occurs when we try to render the plot
   p <- ggplot() + theme(text = 0)
-  expect_snapshot_error(print(p))
+  expect_snapshot(error = TRUE, print(p))
 
   # without validation, the error occurs when the element is accessed
   p <- ggplot() + theme(text = 0, validate = FALSE)
-  expect_snapshot_error(print(p))
+  expect_snapshot(error = TRUE, print(p))
 })
 
 test_that("incorrect theme specifications throw meaningful errors", {
-  expect_snapshot_error(add_theme(theme_grey(), theme(line = element_rect())))
-  expect_snapshot_error(calc_element("line", theme(line = element_rect())))
+  expect_snapshot(error = TRUE, add_theme(theme_grey(), theme(line = element_rect())))
+  expect_snapshot(error = TRUE, calc_element("line", theme(line = element_rect())))
   register_theme_elements(element_tree = list(test = el_def("element_rect")))
-  expect_snapshot_error(calc_element("test", theme_gray() + theme(test = element_rect())))
-  expect_snapshot_error(theme_set("foo"))
+  expect_snapshot(error = TRUE, calc_element("test", theme_gray() + theme(test = element_rect())))
+  expect_snapshot(error = TRUE, theme_set("foo"))
 })
 
 test_that("element tree can be modified", {
   # we cannot add a new theme element without modifying the element tree
   p <- ggplot() + theme(blablabla = element_text(colour = "red"))
-  expect_snapshot_error(print(p))
+  expect_snapshot(error = TRUE, print(p))
 
   register_theme_elements(
     element_tree = list(blablabla = el_def("character", "text"))
   )
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
 
   register_theme_elements(
     element_tree = list(blablabla = el_def("unit", "text"))
   )
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
 
   # things work once we add a new element to the element tree
   register_theme_elements(
@@ -305,7 +305,7 @@ test_that("element tree can be modified", {
   expect_silent(ggplotGrob(p))
 
   p1 <- ggplot() + theme(blablabla = element_line())
-  expect_snapshot_error(ggplotGrob(p1))
+  expect_snapshot(error = TRUE, ggplotGrob(p1))
 
   # inheritance and final calculation of novel element works
   final_theme <- ggplot2:::plot_theme(p, theme_gray())
@@ -498,21 +498,21 @@ test_that("provided themes explicitly define all elements", {
 
 test_that("Theme elements are checked during build", {
   p <- ggplot(mtcars) + geom_point(aes(disp, mpg)) + theme(plot.title.position = "test")
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
 
   p <- ggplot(mtcars) + geom_point(aes(disp, mpg)) + theme(plot.caption.position = "test")
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
 
   p <- ggplot(mtcars) + geom_point(aes(disp, mpg)) +
     theme(plot.tag.position = "test") + labs(tag = "test")
-  expect_snapshot_error(ggplotGrob(p))
+  expect_snapshot(error = TRUE, ggplotGrob(p))
 })
 
 test_that("Theme validation behaves as expected", {
   tree <- get_element_tree()
   expect_silent(validate_element(1,  "aspect.ratio", tree))
   expect_silent(validate_element(1L, "aspect.ratio", tree))
-  expect_snapshot_error(validate_element("A", "aspect.ratio", tree))
+  expect_snapshot(error = TRUE, validate_element("A", "aspect.ratio", tree))
 })
 
 test_that("Element subclasses are inherited", {

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -93,15 +93,15 @@ test_that("x and y aesthetics have the same length", {
 test_that("check_required_aesthetics() errors on missing", {
   required_single <- c("x", "y")
   required_bidirectional <- c("x|y", "fill")
-  expect_snapshot_error(check_required_aesthetics(required_single, present = "x", name = "test"))
-  expect_snapshot_error(check_required_aesthetics(required_single, present = "shape", name = "test"))
+  expect_snapshot(error = TRUE, check_required_aesthetics(required_single, present = "x", name = "test"))
+  expect_snapshot(error = TRUE, check_required_aesthetics(required_single, present = "shape", name = "test"))
 
-  expect_snapshot_error(check_required_aesthetics(required_bidirectional, present = "fill", name = "test"))
-  expect_snapshot_error(check_required_aesthetics(required_bidirectional, present = "shape", name = "test"))
+  expect_snapshot(error = TRUE, check_required_aesthetics(required_bidirectional, present = "fill", name = "test"))
+  expect_snapshot(error = TRUE, check_required_aesthetics(required_bidirectional, present = "shape", name = "test"))
 })
 
 test_that("remove_missing checks input", {
-  expect_snapshot_error(remove_missing(na.rm = 1:5))
+  expect_snapshot(error = TRUE, remove_missing(na.rm = 1:5))
 })
 
 test_that("characters survive remove_missing", {
@@ -113,27 +113,27 @@ test_that("characters survive remove_missing", {
 })
 
 test_that("tolower() and toupper() has been masked", {
-  expect_snapshot_error(tolower())
-  expect_snapshot_error(toupper())
+  expect_snapshot(error = TRUE, tolower())
+  expect_snapshot(error = TRUE, toupper())
 })
 
 test_that("parse_safe() checks input", {
-  expect_snapshot_error(parse_safe(1:5))
+  expect_snapshot(error = TRUE, parse_safe(1:5))
 })
 
 test_that("width_cm() and height_cm() checks input", {
-  expect_snapshot_error(width_cm(letters))
-  expect_snapshot_error(height_cm(letters))
+  expect_snapshot(error = TRUE, width_cm(letters))
+  expect_snapshot(error = TRUE, height_cm(letters))
 })
 
 test_that("cut_*() checks its input and output", {
-  expect_snapshot_error(cut_number(1, 10))
-  expect_snapshot_error(breaks(1:10, "numbers", nbins = 2, binwidth = 05))
-  expect_snapshot_error(cut_width(1:10, 1, center = 0, boundary = 0.5))
+  expect_snapshot(error = TRUE, cut_number(1, 10))
+  expect_snapshot(error = TRUE, breaks(1:10, "numbers", nbins = 2, binwidth = 05))
+  expect_snapshot(error = TRUE, cut_width(1:10, 1, center = 0, boundary = 0.5))
 })
 
 test_that("interleave() checks the vector lengths", {
-  expect_snapshot_error(interleave(1:4, numeric()))
+  expect_snapshot(error = TRUE, interleave(1:4, numeric()))
 })
 
 test_that("vec_rbind0 can combined ordered factors", {


### PR DESCRIPTION
Add full stops to error messages + other tweaks. (to adhere to tidyverse style guide)

Also use `expect_snapshot()` over `expect_snapshot_warning()` and `error_snapshot_error()` for consistency. (they are superseded in testthat. It allows to see more clearly what error message the user sees.

