### PR TITLE
Fix `guide_axis_theta()` expression label bug

### DIFF
--- a/R/guide-axis-theta.R
+++ b/R/guide-axis-theta.R
@@ -185,7 +185,7 @@ GuideAxisTheta <- ggproto(
     key <- vec_slice(key, !vec_detect_missing(key$.label %||% NA))
 
     # Early exit if drawing no labels
-    labels <- key$.label
+    labels <- validate_labels(key$.label)
     if (length(labels) < 1) {
       return(zeroGrob())
     }
@@ -255,7 +255,7 @@ GuideAxisTheta <- ggproto(
 
     key <- params$key
     key <- vec_slice(key, !is.na(key$.label) & nzchar(key$.label))
-    labels <- key$.label
+    labels <- validate_labels(key$.label)
     if (length(labels) == 0 || inherits(elements$text, "element_blank")) {
       return(list(offset = offset))
     }


### PR DESCRIPTION
I apologise for not filing an issue first, but I ran into the following bug.
On the main branch, expressions aren't rendered properly with `guide_axis_theta()`. You can see in the example below, the subscript and superscript aren't drawn appropriately.

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

ggplot(data.frame(x = 1:2), aes(x, x)) +
  geom_point() +
  coord_radial() +
  scale_x_continuous(
    breaks = c(1.2, 1.8),
    labels = expression(A^2, B[2])
  )
```

![](https://i.imgur.com/ikJQ8Nt.png)<!-- -->

<sup>Created on 2023-12-12 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

The same reprex with this PR draws them appropriately:

![](https://i.imgur.com/Iype45P.png)<!-- -->

The implemented fix is easy: instead of taking the native labels as extracted from the scale, we use the `validate_labels()` function that handles expressions correctly.
