### PR TITLE
Scale name first

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* The `name` argument in most scales is now explicitly the first argument 
+  (#5535)
+
 * (breaking) In the `scale_{colour/fill}_gradient2()` and 
   `scale_{colour/fill}_steps2()` functions, the `midpoint` argument is 
   transformed by the scale transformation (#3198).

--- a/R/scale-alpha.R
+++ b/R/scale-alpha.R
@@ -23,8 +23,8 @@
 #' p
 #' p + scale_alpha("cylinders")
 #' p + scale_alpha(range = c(0.4, 0.8))
-scale_alpha <- function(..., range = c(0.1, 1)) {
-  continuous_scale("alpha", palette = pal_rescale(range), ...)
+scale_alpha <- function(name = waiver(), ..., range = c(0.1, 1)) {
+  continuous_scale("alpha", name = name, palette = pal_rescale(range), ...)
 }
 
 #' @rdname scale_alpha
@@ -33,8 +33,8 @@ scale_alpha_continuous <- scale_alpha
 
 #' @rdname scale_alpha
 #' @export
-scale_alpha_binned <- function(..., range = c(0.1, 1)) {
-  binned_scale("alpha", palette = pal_rescale(range), ...)
+scale_alpha_binned <- function(name = waiver(), ..., range = c(0.1, 1)) {
+  binned_scale("alpha", name = name, palette = pal_rescale(range), ...)
 }
 
 #' @rdname scale_alpha
@@ -48,9 +48,9 @@ scale_alpha_discrete <- function(...) {
 
 #' @rdname scale_alpha
 #' @export
-scale_alpha_ordinal <- function(..., range = c(0.1, 1)) {
+scale_alpha_ordinal <- function(name = waiver(), ..., range = c(0.1, 1)) {
   discrete_scale(
-    "alpha",
+    "alpha", name = name,
     palette = function(n) seq(range[1], range[2], length.out = n),
     ...
   )
@@ -59,13 +59,21 @@ scale_alpha_ordinal <- function(..., range = c(0.1, 1)) {
 #' @rdname scale_alpha
 #' @export
 #' @usage NULL
-scale_alpha_datetime <- function(..., range = c(0.1, 1)) {
-  datetime_scale("alpha", "time", palette = pal_rescale(range), ...)
+scale_alpha_datetime <- function(name = waiver(), ..., range = c(0.1, 1)) {
+  datetime_scale(
+    aesthetics = "alpha", transform = "time", name = name,
+    palette = pal_rescale(range),
+    ...
+  )
 }
 
 #' @rdname scale_alpha
 #' @export
 #' @usage NULL
-scale_alpha_date <- function(..., range = c(0.1, 1)){
-  datetime_scale("alpha", "date", palette = pal_rescale(range), ...)
+scale_alpha_date <- function(name = waiver(), ..., range = c(0.1, 1)){
+  datetime_scale(
+    aesthetics = "alpha", transform = "date", name = name,
+    palette = pal_rescale(range),
+    ...
+  )
 }

--- a/R/scale-alpha.R
+++ b/R/scale-alpha.R
@@ -9,6 +9,7 @@
 #'   or [discrete_scale()] as appropriate, to control name, limits,
 #'   breaks, labels and so forth.
 #' @param range Output range of alpha values. Must lie between 0 and 1.
+#' @inheritParams continuous_scale
 #' @family colour scales
 #' @family alpha scales
 #' @seealso

--- a/R/scale-brewer.R
+++ b/R/scale-brewer.R
@@ -83,19 +83,32 @@
 #' # or use blender variants to discretise continuous data
 #' v + scale_fill_fermenter()
 #'
-scale_colour_brewer <- function(..., type = "seq", palette = 1, direction = 1, aesthetics = "colour") {
-  discrete_scale(aesthetics, palette = pal_brewer(type, palette, direction), ...)
+scale_colour_brewer <- function(name = waiver(), ..., type = "seq", palette = 1,
+                                direction = 1, aesthetics = "colour") {
+  discrete_scale(
+    aesthetics, name = name,
+    palette = pal_brewer(type, palette, direction),
+    ...
+  )
 }
 
 #' @export
 #' @rdname scale_brewer
-scale_fill_brewer <- function(..., type = "seq", palette = 1, direction = 1, aesthetics = "fill") {
-  discrete_scale(aesthetics, palette = pal_brewer(type, palette, direction), ...)
+scale_fill_brewer <- function(name = waiver(), ..., type = "seq", palette = 1,
+                              direction = 1, aesthetics = "fill") {
+  discrete_scale(
+    aesthetics, name = name,
+    palette = pal_brewer(type, palette, direction),
+    ...
+  )
 }
 
 #' @export
 #' @rdname scale_brewer
-scale_colour_distiller <- function(..., type = "seq", palette = 1, direction = -1, values = NULL, space = "Lab", na.value = "grey50", guide = "colourbar", aesthetics = "colour") {
+scale_colour_distiller <- function(name = waiver(), ..., type = "seq",
+                                   palette = 1, direction = -1, values = NULL,
+                                   space = "Lab", na.value = "grey50",
+                                   guide = "colourbar", aesthetics = "colour") {
   # warn about using a qualitative brewer palette to generate the gradient
   type <- arg_match0(type, c("seq", "div", "qual"))
   if (type == "qual") {
@@ -105,7 +118,7 @@ scale_colour_distiller <- function(..., type = "seq", palette = 1, direction = -
     ))
   }
   continuous_scale(
-    aesthetics,
+    aesthetics, name = name,
     palette = pal_gradient_n(pal_brewer(type, palette, direction)(7), values, space),
     na.value = na.value, guide = guide, ...
   )
@@ -115,7 +128,10 @@ scale_colour_distiller <- function(..., type = "seq", palette = 1, direction = -
 
 #' @export
 #' @rdname scale_brewer
-scale_fill_distiller <- function(..., type = "seq", palette = 1, direction = -1, values = NULL, space = "Lab", na.value = "grey50", guide = "colourbar", aesthetics = "fill") {
+scale_fill_distiller <- function(name = waiver(), ..., type = "seq",
+                                 palette = 1, direction = -1, values = NULL,
+                                 space = "Lab", na.value = "grey50",
+                                 guide = "colourbar", aesthetics = "fill") {
   type <- arg_match0(type, c("seq", "div", "qual"))
   if (type == "qual") {
     cli::cli_warn(c(
@@ -124,7 +140,7 @@ scale_fill_distiller <- function(..., type = "seq", palette = 1, direction = -1,
     ))
   }
   continuous_scale(
-    aesthetics,
+    aesthetics, name = name,
     palette = pal_gradient_n(pal_brewer(type, palette, direction)(7), values, space),
     na.value = na.value, guide = guide, ...
   )
@@ -132,7 +148,10 @@ scale_fill_distiller <- function(..., type = "seq", palette = 1, direction = -1,
 
 #' @export
 #' @rdname scale_brewer
-scale_colour_fermenter <- function(..., type = "seq", palette = 1, direction = -1, na.value = "grey50", guide = "coloursteps", aesthetics = "colour") {
+scale_colour_fermenter <- function(name = waiver(), ..., type = "seq",
+                                   palette = 1, direction = -1,
+                                   na.value = "grey50", guide = "coloursteps",
+                                   aesthetics = "colour") {
   # warn about using a qualitative brewer palette to generate the gradient
   type <- arg_match0(type, c("seq", "div", "qual"))
   if (type == "qual") {
@@ -141,12 +160,19 @@ scale_colour_fermenter <- function(..., type = "seq", palette = 1, direction = -
       "i" = "Consider using {.code type = \"seq\"} or {.code type = \"div\"} instead"
     ))
   }
-  binned_scale(aesthetics, palette = pal_binned(pal_brewer(type, palette, direction)), na.value = na.value, guide = guide, ...)
+  binned_scale(
+    aesthetics, name = name,
+    palette = pal_binned(pal_brewer(type, palette, direction)),
+    na.value = na.value, guide = guide,
+    ...
+  )
 }
 
 #' @export
 #' @rdname scale_brewer
-scale_fill_fermenter <- function(..., type = "seq", palette = 1, direction = -1, na.value = "grey50", guide = "coloursteps", aesthetics = "fill") {
+scale_fill_fermenter <- function(name = waiver(), ..., type = "seq", palette = 1,
+                                 direction = -1, na.value = "grey50",
+                                 guide = "coloursteps", aesthetics = "fill") {
   type <- arg_match0(type, c("seq", "div", "qual"))
   if (type == "qual") {
     cli::cli_warn(c(
@@ -154,5 +180,10 @@ scale_fill_fermenter <- function(..., type = "seq", palette = 1, direction = -1,
       "i" = "Consider using {.code type = \"seq\"} or {.code type = \"div\"} instead"
     ))
   }
-  binned_scale(aesthetics, palette = pal_binned(pal_brewer(type, palette, direction)), na.value = na.value, guide = guide, ...)
+  binned_scale(
+    aesthetics, name = name,
+    palette = pal_binned(pal_brewer(type, palette, direction)),
+    na.value = na.value, guide = guide,
+    ...
+  )
 }

--- a/R/scale-discrete-.R
+++ b/R/scale-discrete-.R
@@ -61,18 +61,28 @@
 #'   geom_point() +
 #'   scale_x_discrete(labels = abbreviate)
 #' }
-scale_x_discrete <- function(..., expand = waiver(), guide = waiver(), position = "bottom") {
-  sc <- discrete_scale(c("x", "xmin", "xmax", "xend"), palette = identity, ...,
-    expand = expand, guide = guide, position = position, super = ScaleDiscretePosition)
+scale_x_discrete <- function(name = waiver(), ..., expand = waiver(),
+                             guide = waiver(), position = "bottom") {
+  sc <- discrete_scale(
+    aesthetics = c("x", "xmin", "xmax", "xend"), name = name,
+    palette = identity, ...,
+    expand = expand, guide = guide, position = position,
+    super = ScaleDiscretePosition
+  )
 
   sc$range_c <- ContinuousRange$new()
   sc
 }
 #' @rdname scale_discrete
 #' @export
-scale_y_discrete <- function(..., expand = waiver(), guide = waiver(), position = "left") {
-  sc <- discrete_scale(c("y", "ymin", "ymax", "yend"), palette = identity, ...,
-    expand = expand, guide = guide, position = position, super = ScaleDiscretePosition)
+scale_y_discrete <- function(name = waiver(), ..., expand = waiver(),
+                             guide = waiver(), position = "left") {
+  sc <- discrete_scale(
+    aesthetics = c("y", "ymin", "ymax", "yend"), name = name,
+    palette = identity, ...,
+    expand = expand, guide = guide, position = position,
+    super = ScaleDiscretePosition
+  )
 
   sc$range_c <- ContinuousRange$new()
   sc

--- a/R/scale-gradient.R
+++ b/R/scale-gradient.R
@@ -75,18 +75,30 @@
 #'    geom_point(aes(colour = z1)) +
 #'    scale_colour_gradient(low = "yellow", high = "red", na.value = NA)
 #'
-scale_colour_gradient <- function(..., low = "#132B43", high = "#56B1F7", space = "Lab",
-                                  na.value = "grey50", guide = "colourbar", aesthetics = "colour") {
-  continuous_scale(aesthetics, palette = pal_seq_gradient(low, high, space),
-    na.value = na.value, guide = guide, ...)
+scale_colour_gradient <- function(name = waiver(), ..., low = "#132B43",
+                                  high = "#56B1F7", space = "Lab",
+                                  na.value = "grey50",
+                                  guide = "colourbar", aesthetics = "colour") {
+  continuous_scale(
+    aesthetics, name = name,
+    palette = pal_seq_gradient(low, high, space),
+    na.value = na.value, guide = guide,
+    ...
+  )
 }
 
 #' @rdname scale_gradient
 #' @export
-scale_fill_gradient <- function(..., low = "#132B43", high = "#56B1F7", space = "Lab",
-                                na.value = "grey50", guide = "colourbar", aesthetics = "fill") {
-  continuous_scale(aesthetics, palette = pal_seq_gradient(low, high, space),
-    na.value = na.value, guide = guide, ...)
+scale_fill_gradient <- function(name = waiver(), ..., low = "#132B43",
+                                high = "#56B1F7", space = "Lab",
+                                na.value = "grey50", guide = "colourbar",
+                                aesthetics = "fill") {
+  continuous_scale(
+    aesthetics, name = name,
+    palette = pal_seq_gradient(low, high, space),
+    na.value = na.value, guide = guide,
+    ...
+  )
 }
 
 #' @inheritParams scales::pal_div_gradient
@@ -95,12 +107,13 @@ scale_fill_gradient <- function(..., low = "#132B43", high = "#56B1F7", space = 
 #'   Defaults to 0.
 #' @rdname scale_gradient
 #' @export
-scale_colour_gradient2 <- function(..., low = muted("red"), mid = "white", high = muted("blue"),
+scale_colour_gradient2 <- function(name = waiver(), ..., low = muted("red"),
+                                   mid = "white", high = muted("blue"),
                                    midpoint = 0, space = "Lab", na.value = "grey50",
                                    transform = "identity", guide = "colourbar",
                                    aesthetics = "colour") {
   continuous_scale(
-    aesthetics,
+    aesthetics, name = name,
     palette = div_gradient_pal(low, mid, high, space),
     na.value = na.value, transform = transform, guide = guide, ...,
     rescaler = mid_rescaler(mid = midpoint, transform = transform)
@@ -109,12 +122,13 @@ scale_colour_gradient2 <- function(..., low = muted("red"), mid = "white", high 
 
 #' @rdname scale_gradient
 #' @export
-scale_fill_gradient2 <- function(..., low = muted("red"), mid = "white", high = muted("blue"),
+scale_fill_gradient2 <- function(name = waiver(), ..., low = muted("red"),
+                                 mid = "white", high = muted("blue"),
                                  midpoint = 0, space = "Lab", na.value = "grey50",
                                  transform = "identity", guide = "colourbar",
                                  aesthetics = "fill") {
   continuous_scale(
-    aesthetics,
+    aesthetics, name = name,
     palette = div_gradient_pal(low, mid, high, space),
     na.value = na.value, transform = transform, guide = guide, ...,
     rescaler = mid_rescaler(mid = midpoint, transform = transform)
@@ -138,24 +152,28 @@ mid_rescaler <- function(mid, transform = "identity",
 #' @param colours,colors Vector of colours to use for n-colour gradient.
 #' @rdname scale_gradient
 #' @export
-scale_colour_gradientn <- function(..., colours, values = NULL, space = "Lab", na.value = "grey50",
-                                   guide = "colourbar", aesthetics = "colour", colors) {
+scale_colour_gradientn <- function(name = waiver(), ..., colours, values = NULL,
+                                   space = "Lab", na.value = "grey50",
+                                   guide = "colourbar", aesthetics = "colour",
+                                   colors) {
   colours <- if (missing(colours)) colors else colours
 
   continuous_scale(
-    aesthetics,
+    aesthetics, name = name,
     palette = pal_gradient_n(colours, values, space),
     na.value = na.value, guide = guide, ...
   )
 }
 #' @rdname scale_gradient
 #' @export
-scale_fill_gradientn <- function(..., colours, values = NULL, space = "Lab", na.value = "grey50",
-                                 guide = "colourbar", aesthetics = "fill", colors) {
+scale_fill_gradientn <- function(name = waiver(), ..., colours, values = NULL,
+                                 space = "Lab", na.value = "grey50",
+                                 guide = "colourbar", aesthetics = "fill",
+                                 colors) {
   colours <- if (missing(colours)) colors else colours
 
   continuous_scale(
-    aesthetics,
+    aesthetics, name = name,
     palette = pal_gradient_n(colours, values, space),
     na.value = na.value, guide = guide, ...
   )

--- a/R/scale-grey.R
+++ b/R/scale-grey.R
@@ -27,14 +27,22 @@
 #' ggplot(mtcars, aes(mpg, wt)) +
 #'   geom_point(aes(colour = miss)) +
 #'   scale_colour_grey(na.value = "green")
-scale_colour_grey <- function(..., start = 0.2, end = 0.8, na.value = "red", aesthetics = "colour") {
-  discrete_scale(aesthetics, palette = pal_grey(start, end),
-    na.value = na.value, ...)
+scale_colour_grey <- function(name = waiver(), ..., start = 0.2, end = 0.8,
+                              na.value = "red", aesthetics = "colour") {
+  discrete_scale(
+    aesthetics, name = name,
+    palette = pal_grey(start, end),
+    na.value = na.value, ...
+  )
 }
 
 #' @rdname scale_grey
 #' @export
-scale_fill_grey <- function(..., start = 0.2, end = 0.8, na.value = "red", aesthetics = "fill") {
-  discrete_scale(aesthetics, palette = pal_grey(start, end),
-    na.value = na.value, ...)
+scale_fill_grey <- function(name = waiver(), ..., start = 0.2, end = 0.8,
+                            na.value = "red", aesthetics = "fill") {
+  discrete_scale(
+    aesthetics, name = name,
+    palette = pal_grey(start, end),
+    na.value = na.value, ...
+  )
 }

--- a/R/scale-hue.R
+++ b/R/scale-hue.R
@@ -53,18 +53,26 @@
 #'   geom_point(aes(colour = miss)) +
 #'   scale_colour_hue(na.value = "black")
 #' }
-scale_colour_hue <- function(..., h = c(0, 360) + 15, c = 100, l = 65, h.start = 0,
-                             direction = 1, na.value = "grey50", aesthetics = "colour") {
-  discrete_scale(aesthetics, palette = pal_hue(h, c, l, h.start, direction),
-    na.value = na.value, ...)
+scale_colour_hue <- function(name = waiver(), ..., h = c(0, 360) + 15, c = 100,
+                             l = 65, h.start = 0, direction = 1,
+                             na.value = "grey50", aesthetics = "colour") {
+  discrete_scale(
+    aesthetics, name = name,
+    palette = pal_hue(h, c, l, h.start, direction),
+    na.value = na.value, ...
+  )
 }
 
 #' @rdname scale_hue
 #' @export
-scale_fill_hue <- function(..., h = c(0, 360) + 15, c = 100, l = 65, h.start = 0,
-                           direction = 1, na.value = "grey50", aesthetics = "fill") {
-  discrete_scale(aesthetics, palette = pal_hue(h, c, l, h.start, direction),
-    na.value = na.value, ...)
+scale_fill_hue <- function(name = waiver(), ..., h = c(0, 360) + 15, c = 100,
+                           l = 65, h.start = 0, direction = 1,
+                           na.value = "grey50", aesthetics = "fill") {
+  discrete_scale(
+    aesthetics, name = name,
+    palette = pal_hue(h, c, l, h.start, direction),
+    na.value = na.value, ...
+  )
 }
 
 
@@ -165,18 +173,25 @@ scale_fill_discrete <- function(..., type = getOption("ggplot2.discrete.fill")) 
   }
 }
 
-scale_colour_qualitative <- function(..., type = NULL, h = c(0, 360) + 15, c = 100, l = 65, h.start = 0,
-                                     direction = 1, na.value = "grey50", aesthetics = "colour") {
+scale_colour_qualitative <- function(name = waiver(), ..., type = NULL,
+                                     h = c(0, 360) + 15, c = 100, l = 65,
+                                     h.start = 0, direction = 1,
+                                     na.value = "grey50",
+                                     aesthetics = "colour") {
   discrete_scale(
-    aesthetics, palette = pal_qualitative(type, h, c, l, h.start, direction),
+    aesthetics, name = name,
+    palette = pal_qualitative(type, h, c, l, h.start, direction),
     na.value = na.value, ...
   )
 }
 
-scale_fill_qualitative <- function(..., type = NULL, h = c(0, 360) + 15, c = 100, l = 65, h.start = 0,
-                                   direction = 1, na.value = "grey50", aesthetics = "fill") {
+scale_fill_qualitative <- function(name = waiver(), ..., type = NULL,
+                                   h = c(0, 360) + 15, c = 100, l = 65,
+                                   h.start = 0, direction = 1,
+                                   na.value = "grey50", aesthetics = "fill") {
   discrete_scale(
-    aesthetics, palette = pal_qualitative(type, h, c, l, h.start, direction),
+    aesthetics, name = name,
+    palette = pal_qualitative(type, h, c, l, h.start, direction),
     na.value = na.value, ...
   )
 }

--- a/R/scale-hue.R
+++ b/R/scale-hue.R
@@ -10,6 +10,7 @@
 #'   example, to apply colour settings to the `colour` and `fill` aesthetics at the
 #'   same time, via `aesthetics = c("colour", "fill")`.
 #' @inheritParams scales::pal_hue
+#' @inheritParams discrete_scale
 #' @rdname scale_hue
 #' @export
 #' @family colour scales

--- a/R/scale-identity.R
+++ b/R/scale-identity.R
@@ -21,6 +21,7 @@
 #'   example, to apply colour settings to the `colour` and `fill` aesthetics at the
 #'   same time, via `aesthetics = c("colour", "fill")`.
 #' @param guide Guide to use for this scale. Defaults to `"none"`.
+#' @inheritParams continuous_scale
 #' @family colour scales
 #' @examples
 #' ggplot(luv_colours, aes(u, v)) +

--- a/R/scale-identity.R
+++ b/R/scale-identity.R
@@ -62,91 +62,104 @@ NULL
 
 #' @rdname scale_identity
 #' @export
-scale_colour_identity <- function(..., guide = "none", aesthetics = "colour") {
-  sc <- discrete_scale(aesthetics, palette = pal_identity(), ..., guide = guide,
-    super = ScaleDiscreteIdentity)
-
-  sc
+scale_colour_identity <- function(name = waiver(), ..., guide = "none",
+                                  aesthetics = "colour") {
+  discrete_scale(
+    aesthetics, name = name,
+    palette = pal_identity(), ..., guide = guide,
+    super = ScaleDiscreteIdentity
+  )
 }
 
 #' @rdname scale_identity
 #' @export
-scale_fill_identity <- function(..., guide = "none", aesthetics = "fill") {
-  sc <- discrete_scale(aesthetics, palette = pal_identity(), ..., guide = guide,
-    super = ScaleDiscreteIdentity)
-
-  sc
+scale_fill_identity <- function(name = waiver(), ..., guide = "none",
+                                aesthetics = "fill") {
+  discrete_scale(
+    aesthetics, name = name,
+    palette = pal_identity(), ..., guide = guide,
+    super = ScaleDiscreteIdentity
+  )
 }
 
 #' @rdname scale_identity
 #' @seealso
 #' Other shape scales: [scale_shape()], [scale_shape_manual()].
 #' @export
-scale_shape_identity <- function(..., guide = "none") {
-  sc <- continuous_scale("shape", palette = pal_identity(), ..., guide = guide,
-    super = ScaleContinuousIdentity)
-
-  sc
+scale_shape_identity <- function(name = waiver(), ..., guide = "none") {
+  continuous_scale(
+    "shape", name = name,
+    palette = pal_identity(), ..., guide = guide,
+    super = ScaleContinuousIdentity
+  )
 }
 
 #' @rdname scale_identity
 #' @seealso
 #' Other linetype scales: [scale_linetype()], [scale_linetype_manual()].
 #' @export
-scale_linetype_identity <- function(..., guide = "none") {
-  sc <- discrete_scale("linetype", palette = pal_identity(), ..., guide = guide,
-    super = ScaleDiscreteIdentity)
-
-  sc
+scale_linetype_identity <- function(name = waiver(), ..., guide = "none") {
+  discrete_scale(
+    "linetype", name = name,
+    palette = pal_identity(), ..., guide = guide,
+    super = ScaleDiscreteIdentity
+  )
 }
 
 #' @rdname scale_identity
 #' @seealso
 #' Other alpha scales: [scale_alpha()], [scale_alpha_manual()].
 #' @export
-scale_linewidth_identity <- function(..., guide = "none") {
-  sc <- continuous_scale("linewidth", palette = pal_identity(), ...,
-                         guide = guide, super = ScaleContinuousIdentity)
-
-  sc
+scale_linewidth_identity <- function(name = waiver(), ..., guide = "none") {
+  continuous_scale(
+    "linewidth", name = name,
+    palette = pal_identity(), ...,
+    guide = guide, super = ScaleContinuousIdentity
+  )
 }
 
 #' @rdname scale_identity
 #' @export
-scale_alpha_identity <- function(..., guide = "none") {
-  sc <- continuous_scale("alpha", palette = pal_identity(), ..., guide = guide,
-    super = ScaleContinuousIdentity)
-
-  sc
+scale_alpha_identity <- function(name = waiver(), ..., guide = "none") {
+  continuous_scale(
+    "alpha", name = name,
+    palette = pal_identity(), ..., guide = guide,
+    super = ScaleContinuousIdentity
+  )
 }
 
 #' @rdname scale_identity
 #' @seealso
 #' Other size scales: [scale_size()], [scale_size_manual()].
 #' @export
-scale_size_identity <- function(..., guide = "none") {
-  sc <- continuous_scale("size", palette = pal_identity(), ..., guide = guide,
-    super = ScaleContinuousIdentity)
-
-  sc
+scale_size_identity <- function(name = waiver(), ..., guide = "none") {
+  continuous_scale(
+    "size", name = name,
+    palette = pal_identity(), ..., guide = guide,
+    super = ScaleContinuousIdentity
+  )
 }
 
 #' @rdname scale_identity
 #' @export
-scale_discrete_identity <- function(aesthetics, ..., guide = "none") {
-  sc <- discrete_scale(aesthetics, palette = pal_identity(), ..., guide = guide,
-                       super = ScaleDiscreteIdentity)
-
-  sc
+scale_discrete_identity <- function(aesthetics, name = waiver(), ...,
+                                    guide = "none") {
+  discrete_scale(
+    aesthetics, name = name,
+    palette = pal_identity(), ..., guide = guide,
+    super = ScaleDiscreteIdentity
+  )
 }
 
 #' @rdname scale_identity
 #' @export
-scale_continuous_identity <- function(aesthetics, ..., guide = "none") {
-  sc <- continuous_scale(aesthetics, palette = pal_identity(), ..., guide = guide,
-                         super = ScaleContinuousIdentity)
-
-  sc
+scale_continuous_identity <- function(aesthetics, name = waiver(), ...,
+                                      guide = "none") {
+  continuous_scale(
+    aesthetics, name = name,
+    palette = pal_identity(), ..., guide = guide,
+    super = ScaleContinuousIdentity
+  )
 }
 
 #' @rdname ggplot2-ggproto

--- a/R/scale-linetype.R
+++ b/R/scale-linetype.R
@@ -33,15 +33,24 @@
 #'   scale_linetype_identity() +
 #'   facet_grid(linetype ~ .) +
 #'   theme_void(20)
-scale_linetype <- function(..., na.value = "blank") {
-  discrete_scale("linetype", palette = pal_linetype(),
-    na.value = na.value, ...)
+scale_linetype <- function(name = waiver(), ..., na.value = "blank") {
+  discrete_scale(
+    "linetype", name = name,
+    palette = pal_linetype(),
+    na.value = na.value,
+    ...
+  )
 }
 
 #' @rdname scale_linetype
 #' @export
-scale_linetype_binned <- function(..., na.value = "blank") {
-  binned_scale("linetype", palette = pal_binned(pal_linetype()), ...)
+scale_linetype_binned <- function(name = waiver(), ..., na.value = "blank") {
+  binned_scale(
+    "linetype", name = name,
+    palette = pal_binned(pal_linetype()),
+    na.value = na.value,
+    ...
+  )
 }
 
 #' @rdname scale_linetype

--- a/R/scale-linewidth.R
+++ b/R/scale-linewidth.R
@@ -66,11 +66,11 @@ scale_linewidth_discrete <- function(...) {
 #' @rdname scale_linewidth
 #' @export
 #' @usage NULL
-scale_linewidth_ordinal <- function(..., range = c(2, 6)) {
+scale_linewidth_ordinal <- function(name = waiver(), ..., range = c(2, 6)) {
   force(range)
 
   discrete_scale(
-    "linewidth",
+    "linewidth", name = name,
     palette = function(n) seq(range[1], range[2], length.out = n),
     ...
   )
@@ -79,13 +79,19 @@ scale_linewidth_ordinal <- function(..., range = c(2, 6)) {
 #' @rdname scale_linewidth
 #' @export
 #' @usage NULL
-scale_linewidth_datetime <- function(..., range = c(1, 6)) {
-  datetime_scale("linewidth", "time", palette = pal_rescale(range), ...)
+scale_linewidth_datetime <- function(name = waiver(), ..., range = c(1, 6)) {
+  datetime_scale(
+    "linewidth", transform = "time", name = name,
+    palette = pal_rescale(range), ...
+  )
 }
 
 #' @rdname scale_linewidth
 #' @export
 #' @usage NULL
-scale_linewidth_date <- function(..., range = c(1, 6)) {
-  datetime_scale("linewidth", "date", palette = pal_rescale(range), ...)
+scale_linewidth_date <- function(name = waiver(), ..., range = c(1, 6)) {
+  datetime_scale(
+    "linewidth", transform = "date", name = name,
+    palette = pal_rescale(range), ...
+  )
 }

--- a/R/scale-manual.R
+++ b/R/scale-manual.R
@@ -141,7 +141,8 @@ scale_discrete_manual <- function(aesthetics, ..., values, breaks = waiver()) {
   manual_scale(aesthetics, values, breaks, ...)
 }
 
-manual_scale <- function(aesthetic, values = NULL, breaks = waiver(), ...,
+manual_scale <- function(aesthetic, values = NULL, breaks = waiver(),
+                         name = waiver(), ...,
                          limits = NULL, call = caller_call()) {
   call <- call %||% current_call()
   # check for missing `values` parameter, in lieu of providing
@@ -183,6 +184,9 @@ manual_scale <- function(aesthetic, values = NULL, breaks = waiver(), ...,
     }
     values
   }
-  discrete_scale(aesthetic, palette = pal, breaks = breaks, limits = limits,
-                 call = call, ...)
+  discrete_scale(
+    aesthetic, name = name,
+    palette = pal, breaks = breaks, limits = limits,
+    call = call, ...
+  )
 }

--- a/R/scale-shape.R
+++ b/R/scale-shape.R
@@ -40,14 +40,14 @@
 #'   scale_shape_identity() +
 #'   facet_wrap(~shape) +
 #'   theme_void()
-scale_shape <- function(..., solid = TRUE) {
-  discrete_scale("shape", palette = pal_shape(solid), ...)
+scale_shape <- function(name = waiver(), ..., solid = TRUE) {
+  discrete_scale("shape", name = name, palette = pal_shape(solid), ...)
 }
 
 #' @rdname scale_shape
 #' @export
-scale_shape_binned <- function(..., solid = TRUE) {
-  binned_scale("shape", palette = pal_binned(pal_shape(solid)), ...)
+scale_shape_binned <- function(name = waiver(), ..., solid = TRUE) {
+  binned_scale("shape", name = name, palette = pal_binned(pal_shape(solid)), ...)
 }
 
 #' @rdname scale_shape

--- a/R/scale-size.R
+++ b/R/scale-size.R
@@ -99,11 +99,11 @@ scale_size_discrete <- function(...) {
 #' @rdname scale_size
 #' @export
 #' @usage NULL
-scale_size_ordinal <- function(..., range = c(2, 6)) {
+scale_size_ordinal <- function(name = waiver(), ..., range = c(2, 6)) {
   force(range)
 
   discrete_scale(
-    "size",
+    "size", name = name,
     palette = function(n) {
       area <- seq(range[1] ^ 2, range[2] ^ 2, length.out = n)
       sqrt(area)
@@ -116,30 +116,34 @@ scale_size_ordinal <- function(..., range = c(2, 6)) {
 #' @param max_size Size of largest points.
 #' @export
 #' @rdname scale_size
-scale_size_area <- function(..., max_size = 6) {
-  continuous_scale("size",
+scale_size_area <- function(name = waiver(), ..., max_size = 6) {
+  continuous_scale(
+    "size", name = name,
     palette = abs_area(max_size),
-    rescaler = rescale_max, ...)
+    rescaler = rescale_max, ...
+  )
 }
 
 #' @export
 #' @rdname scale_size
-scale_size_binned_area <- function(..., max_size = 6) {
-  binned_scale("size",
-               palette = abs_area(max_size),
-               rescaler = rescale_max, ...)
-}
-
-#' @rdname scale_size
-#' @export
-#' @usage NULL
-scale_size_datetime <- function(..., range = c(1, 6)) {
-  datetime_scale("size", "time", palette = pal_area(range), ...)
+scale_size_binned_area <- function(name = waiver(), ..., max_size = 6) {
+  binned_scale(
+    "size", name = name,
+    palette = abs_area(max_size),
+    rescaler = rescale_max, ...
+  )
 }
 
 #' @rdname scale_size
 #' @export
 #' @usage NULL
-scale_size_date <- function(..., range = c(1, 6)) {
-  datetime_scale("size", "date", palette = pal_area(range), ...)
+scale_size_datetime <- function(name = waiver(), ..., range = c(1, 6)) {
+  datetime_scale("size", "time", name = name, palette = pal_area(range), ...)
+}
+
+#' @rdname scale_size
+#' @export
+#' @usage NULL
+scale_size_date <- function(name = waiver(), ..., range = c(1, 6)) {
+  datetime_scale("size", "date", name = name, palette = pal_area(range), ...)
 }

--- a/R/scale-steps.R
+++ b/R/scale-steps.R
@@ -44,52 +44,83 @@
 #'   geom_point(aes(colour = z1)) +
 #'   scale_colour_stepsn(colours = terrain.colors(10))
 #' @rdname scale_steps
-scale_colour_steps <- function(..., low = "#132B43", high = "#56B1F7", space = "Lab",
-                               na.value = "grey50", guide = "coloursteps", aesthetics = "colour") {
-  binned_scale(aesthetics, palette = pal_seq_gradient(low, high, space),
-               na.value = na.value, guide = guide, ...)
+scale_colour_steps <- function(name = waiver(), ..., low = "#132B43",
+                               high = "#56B1F7", space = "Lab",
+                               na.value = "grey50", guide = "coloursteps",
+                               aesthetics = "colour") {
+  binned_scale(
+    aesthetics, name = name,
+    palette = pal_seq_gradient(low, high, space),
+    na.value = na.value, guide = guide, ...
+  )
 }
 #' @rdname scale_steps
 #' @export
-scale_colour_steps2 <- function(..., low = muted("red"), mid = "white", high = muted("blue"),
+scale_colour_steps2 <- function(name = waiver(), ..., low = muted("red"),
+                                mid = "white", high = muted("blue"),
                                 midpoint = 0, space = "Lab", na.value = "grey50",
                                 transform = "identity", guide = "coloursteps",
                                 aesthetics = "colour") {
-  binned_scale(aesthetics, palette = div_gradient_pal(low, mid, high, space),
-               na.value = na.value, transform = transform, guide = guide,
-               rescaler = mid_rescaler(mid = midpoint, transform = transform),
-               ...)
+  binned_scale(
+    aesthetics, name = name,
+    palette = div_gradient_pal(low, mid, high, space),
+    na.value = na.value, transform = transform, guide = guide,
+    rescaler = mid_rescaler(mid = midpoint, transform = transform),
+    ...
+  )
 }
 #' @rdname scale_steps
 #' @export
-scale_colour_stepsn <- function(..., colours, values = NULL, space = "Lab", na.value = "grey50",
-                                guide = "coloursteps", aesthetics = "colour", colors) {
+scale_colour_stepsn <- function(name = waiver(), ..., colours, values = NULL,
+                                space = "Lab", na.value = "grey50",
+                                guide = "coloursteps", aesthetics = "colour",
+                                colors) {
   colours <- if (missing(colours)) colors else colours
-  binned_scale(aesthetics, palette = pal_gradient_n(colours, values, space),
-               na.value = na.value, guide = guide, ...)
+  binned_scale(
+    aesthetics, name = name,
+    palette = pal_gradient_n(colours, values, space),
+    na.value = na.value, guide = guide,
+    ...
+  )
 }
 #' @rdname scale_steps
 #' @export
-scale_fill_steps <- function(..., low = "#132B43", high = "#56B1F7", space = "Lab",
-                             na.value = "grey50", guide = "coloursteps", aesthetics = "fill") {
-  binned_scale(aesthetics, palette = pal_seq_gradient(low, high, space),
-               na.value = na.value, guide = guide, ...)
+scale_fill_steps <- function(name = waiver(), ..., low = "#132B43",
+                             high = "#56B1F7", space = "Lab",
+                             na.value = "grey50", guide = "coloursteps",
+                             aesthetics = "fill") {
+  binned_scale(
+    aesthetics, name = name,
+    palette = pal_seq_gradient(low, high, space),
+    na.value = na.value, guide = guide,
+    ...
+  )
 }
 #' @rdname scale_steps
 #' @export
-scale_fill_steps2 <- function(..., low = muted("red"), mid = "white", high = muted("blue"),
+scale_fill_steps2 <- function(name = waiver(), ..., low = muted("red"),
+                              mid = "white", high = muted("blue"),
                               midpoint = 0, space = "Lab", na.value = "grey50",
                               transform = "identity", guide = "coloursteps",
                               aesthetics = "fill") {
-  binned_scale(aesthetics, palette = div_gradient_pal(low, mid, high, space),
-               na.value = na.value, transform = transform, guide = guide,
-               rescaler = mid_rescaler(mid = midpoint, transform = transform), ...)
+  binned_scale(
+    aesthetics, name = name,
+    palette = div_gradient_pal(low, mid, high, space),
+    na.value = na.value, transform = transform, guide = guide,
+    rescaler = mid_rescaler(mid = midpoint, transform = transform),
+    ...
+  )
 }
 #' @rdname scale_steps
 #' @export
-scale_fill_stepsn <- function(..., colours, values = NULL, space = "Lab", na.value = "grey50",
-                                guide = "coloursteps", aesthetics = "fill", colors) {
+scale_fill_stepsn <- function(name = waiver(), ..., colours, values = NULL,
+                              space = "Lab", na.value = "grey50",
+                              guide = "coloursteps", aesthetics = "fill",
+                              colors) {
   colours <- if (missing(colours)) colors else colours
-  binned_scale(aesthetics, palette = pal_gradient_n(colours, values, space),
-               na.value = na.value, guide = guide, ...)
+  binned_scale(
+    aesthetics, name = name,
+    palette = pal_gradient_n(colours, values, space),
+    na.value = na.value, guide = guide, ...
+  )
 }

--- a/R/scale-viridis.R
+++ b/R/scale-viridis.R
@@ -58,10 +58,11 @@
 #' # Use viridis_b to bin continuous data before mapping
 #' v + scale_fill_viridis_b()
 #'
-scale_colour_viridis_d <- function(..., alpha = 1, begin = 0, end = 1,
-                                   direction = 1, option = "D", aesthetics = "colour") {
+scale_colour_viridis_d <- function(name = waiver(), ..., alpha = 1, begin = 0,
+                                   end = 1, direction = 1, option = "D",
+                                   aesthetics = "colour") {
   discrete_scale(
-    aesthetics,
+    aesthetics, name = name,
     palette = pal_viridis(alpha, begin, end, direction, option),
     ...
   )
@@ -69,10 +70,11 @@ scale_colour_viridis_d <- function(..., alpha = 1, begin = 0, end = 1,
 
 #' @export
 #' @rdname scale_viridis
-scale_fill_viridis_d <- function(..., alpha = 1, begin = 0, end = 1,
-                                 direction = 1, option = "D", aesthetics = "fill") {
+scale_fill_viridis_d <- function(name = waiver(), ..., alpha = 1, begin = 0,
+                                 end = 1, direction = 1, option = "D",
+                                 aesthetics = "fill") {
   discrete_scale(
-    aesthetics,
+    aesthetics, name = name,
     palette = pal_viridis(alpha, begin, end, direction, option),
     ...
   )
@@ -80,12 +82,13 @@ scale_fill_viridis_d <- function(..., alpha = 1, begin = 0, end = 1,
 
 #' @export
 #' @rdname scale_viridis
-scale_colour_viridis_c <- function(..., alpha = 1, begin = 0, end = 1,
-                                   direction = 1, option = "D", values = NULL,
-                                   space = "Lab", na.value = "grey50",
-                                   guide = "colourbar", aesthetics = "colour") {
+scale_colour_viridis_c <- function(name = waiver(), ..., alpha = 1, begin = 0,
+                                   end = 1, direction = 1, option = "D",
+                                   values = NULL, space = "Lab",
+                                   na.value = "grey50", guide = "colourbar",
+                                   aesthetics = "colour") {
   continuous_scale(
-    aesthetics,
+    aesthetics, name = name,
     palette = pal_gradient_n(
       pal_viridis(alpha, begin, end, direction, option)(6),
       values,
@@ -99,12 +102,13 @@ scale_colour_viridis_c <- function(..., alpha = 1, begin = 0, end = 1,
 
 #' @export
 #' @rdname scale_viridis
-scale_fill_viridis_c <- function(..., alpha = 1, begin = 0, end = 1,
-                                 direction = 1, option = "D", values = NULL,
-                                 space = "Lab", na.value = "grey50",
-                                 guide = "colourbar", aesthetics = "fill") {
+scale_fill_viridis_c <- function(name = waiver(), ..., alpha = 1, begin = 0,
+                                 end = 1, direction = 1, option = "D",
+                                 values = NULL, space = "Lab",
+                                 na.value = "grey50", guide = "colourbar",
+                                 aesthetics = "fill") {
   continuous_scale(
-    aesthetics,
+    aesthetics, name = name,
     palette = pal_gradient_n(
       pal_viridis(alpha, begin, end, direction, option)(6),
       values,
@@ -118,16 +122,17 @@ scale_fill_viridis_c <- function(..., alpha = 1, begin = 0, end = 1,
 
 #' @export
 #' @rdname scale_viridis
-scale_colour_viridis_b <- function(..., alpha = 1, begin = 0, end = 1,
-                                   direction = 1, option = "D", values = NULL,
-                                   space = "Lab", na.value = "grey50",
-                                   guide = "coloursteps", aesthetics = "colour") {
+scale_colour_viridis_b <- function(name = waiver(), ..., alpha = 1, begin = 0,
+                                   end = 1, direction = 1, option = "D",
+                                   values = NULL, space = "Lab",
+                                   na.value = "grey50", guide = "coloursteps",
+                                   aesthetics = "colour") {
   pal <-  pal_binned(
     pal_viridis(alpha, begin, end, direction, option)
   )
 
   binned_scale(
-    aesthetics,
+    aesthetics, name = name,
     palette = pal,
     na.value = na.value,
     guide = guide,
@@ -137,16 +142,17 @@ scale_colour_viridis_b <- function(..., alpha = 1, begin = 0, end = 1,
 
 #' @export
 #' @rdname scale_viridis
-scale_fill_viridis_b <- function(..., alpha = 1, begin = 0, end = 1,
-                                 direction = 1, option = "D", values = NULL,
-                                 space = "Lab", na.value = "grey50",
-                                 guide = "coloursteps", aesthetics = "fill") {
+scale_fill_viridis_b <- function(name = waiver(), ..., alpha = 1, begin = 0,
+                                 end = 1, direction = 1, option = "D",
+                                 values = NULL, space = "Lab",
+                                 na.value = "grey50", guide = "coloursteps",
+                                 aesthetics = "fill") {
   pal <-  pal_binned(
     pal_viridis(alpha, begin, end, direction, option)
   )
 
   binned_scale(
-    aesthetics,
+    aesthetics, name = name,
     palette = pal,
     na.value = na.value,
     guide = guide,

--- a/R/zxx.R
+++ b/R/zxx.R
@@ -31,15 +31,14 @@ scale_color_ordinal <- scale_colour_ordinal
 #' @export
 #' @rdname scale_gradient
 #' @usage NULL
-scale_colour_datetime <- function(...,
+scale_colour_datetime <- function(name = waiver(), ...,
                                   low = "#132B43",
                                   high = "#56B1F7",
                                   space = "Lab",
                                   na.value = "grey50",
                                   guide = "colourbar") {
   datetime_scale(
-    "colour",
-    "time",
+    aesthetics = "colour", transform = "time", name = name,
     palette = pal_seq_gradient(low, high, space),
     na.value = na.value,
     guide = guide,
@@ -55,15 +54,15 @@ scale_color_datetime <- scale_colour_datetime
 #' @export
 #' @rdname scale_gradient
 #' @usage NULL
-scale_colour_date <- function(...,
+scale_colour_date <- function(name = waiver(),
+                              ...,
                               low = "#132B43",
                               high = "#56B1F7",
                               space = "Lab",
                               na.value = "grey50",
                               guide = "colourbar") {
   datetime_scale(
-    "colour",
-    "date",
+    aesthetics = "colour", transform = "date", name = name,
     palette = pal_seq_gradient(low, high, space),
     na.value = na.value,
     guide = guide,
@@ -110,15 +109,14 @@ pal_ordinal <- function(colours, na.color = "grey50", alpha = TRUE) {
 #' @export
 #' @rdname scale_gradient
 #' @usage NULL
-scale_fill_datetime <- function(...,
+scale_fill_datetime <- function(name = waiver(), ...,
                                 low = "#132B43",
                                 high = "#56B1F7",
                                 space = "Lab",
                                 na.value = "grey50",
                                 guide = "colourbar") {
   datetime_scale(
-    "fill",
-    "time",
+    aesthetics = "fill", transform = "time", name = name,
     palette = pal_seq_gradient(low, high, space),
     na.value = na.value,
     guide = guide,
@@ -129,15 +127,14 @@ scale_fill_datetime <- function(...,
 #' @export
 #' @rdname scale_gradient
 #' @usage NULL
-scale_fill_date <- function(...,
+scale_fill_date <- function(name = waiver(), ...,
                             low = "#132B43",
                             high = "#56B1F7",
                             space = "Lab",
                             na.value = "grey50",
                             guide = "colourbar") {
   datetime_scale(
-    "fill",
-    "date",
+    aesthetics = "fill", transform = "date", name = name,
     palette = pal_seq_gradient(low, high, space),
     na.value = na.value,
     guide = guide,

--- a/man/ggplot2-package.Rd
+++ b/man/ggplot2-package.Rd
@@ -32,6 +32,7 @@ Authors:
   \item Kara Woo (\href{https://orcid.org/0000-0002-5125-4188}{ORCID})
   \item Hiroaki Yutani (\href{https://orcid.org/0000-0002-3385-7233}{ORCID})
   \item Dewey Dunnington (\href{https://orcid.org/0000-0002-9415-4582}{ORCID})
+  \item Teun van den Brand (\href{https://orcid.org/0000-0002-9335-7468}{ORCID})
 }
 
 Other contributors:

--- a/man/scale_alpha.Rd
+++ b/man/scale_alpha.Rd
@@ -10,17 +10,22 @@
 \alias{scale_alpha_date}
 \title{Alpha transparency scales}
 \usage{
-scale_alpha(..., range = c(0.1, 1))
+scale_alpha(name = waiver(), ..., range = c(0.1, 1))
 
-scale_alpha_continuous(..., range = c(0.1, 1))
+scale_alpha_continuous(name = waiver(), ..., range = c(0.1, 1))
 
-scale_alpha_binned(..., range = c(0.1, 1))
+scale_alpha_binned(name = waiver(), ..., range = c(0.1, 1))
 
 scale_alpha_discrete(...)
 
-scale_alpha_ordinal(..., range = c(0.1, 1))
+scale_alpha_ordinal(name = waiver(), ..., range = c(0.1, 1))
 }
 \arguments{
+\item{name}{The name of the scale. Used as the axis or legend title. If
+\code{waiver()}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
+
 \item{...}{Other arguments passed on to \code{\link[=continuous_scale]{continuous_scale()}}, \code{\link[=binned_scale]{binned_scale()}},
 or \code{\link[=discrete_scale]{discrete_scale()}} as appropriate, to control name, limits,
 breaks, labels and so forth.}

--- a/man/scale_brewer.Rd
+++ b/man/scale_brewer.Rd
@@ -13,6 +13,7 @@
 \title{Sequential, diverging and qualitative colour scales from ColorBrewer}
 \usage{
 scale_colour_brewer(
+  name = waiver(),
   ...,
   type = "seq",
   palette = 1,
@@ -21,6 +22,7 @@ scale_colour_brewer(
 )
 
 scale_fill_brewer(
+  name = waiver(),
   ...,
   type = "seq",
   palette = 1,
@@ -29,6 +31,7 @@ scale_fill_brewer(
 )
 
 scale_colour_distiller(
+  name = waiver(),
   ...,
   type = "seq",
   palette = 1,
@@ -41,6 +44,7 @@ scale_colour_distiller(
 )
 
 scale_fill_distiller(
+  name = waiver(),
   ...,
   type = "seq",
   palette = 1,
@@ -53,6 +57,7 @@ scale_fill_distiller(
 )
 
 scale_colour_fermenter(
+  name = waiver(),
   ...,
   type = "seq",
   palette = 1,
@@ -63,6 +68,7 @@ scale_colour_fermenter(
 )
 
 scale_fill_fermenter(
+  name = waiver(),
   ...,
   type = "seq",
   palette = 1,
@@ -73,6 +79,11 @@ scale_fill_fermenter(
 )
 }
 \arguments{
+\item{name}{The name of the scale. Used as the axis or legend title. If
+\code{waiver()}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
+
 \item{...}{Other arguments passed on to \code{\link[=discrete_scale]{discrete_scale()}}, \code{\link[=continuous_scale]{continuous_scale()}},
 or \code{\link[=binned_scale]{binned_scale()}}, for \code{brewer}, \code{distiller}, and \code{fermenter} variants
 respectively, to control name, limits, breaks, labels and so forth.}

--- a/man/scale_discrete.Rd
+++ b/man/scale_discrete.Rd
@@ -5,11 +5,28 @@
 \alias{scale_y_discrete}
 \title{Position scales for discrete data}
 \usage{
-scale_x_discrete(..., expand = waiver(), guide = waiver(), position = "bottom")
+scale_x_discrete(
+  name = waiver(),
+  ...,
+  expand = waiver(),
+  guide = waiver(),
+  position = "bottom"
+)
 
-scale_y_discrete(..., expand = waiver(), guide = waiver(), position = "left")
+scale_y_discrete(
+  name = waiver(),
+  ...,
+  expand = waiver(),
+  guide = waiver(),
+  position = "left"
+)
 }
 \arguments{
+\item{name}{The name of the scale. Used as the axis or legend title. If
+\code{waiver()}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
+
 \item{...}{
   Arguments passed on to \code{\link[=discrete_scale]{discrete_scale}}
   \describe{
@@ -46,10 +63,6 @@ where \code{NA} is always placed at the far right.}
     \item{\code{aesthetics}}{The names of the aesthetics that this scale works with.}
     \item{\code{scale_name}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The name of the scale
 that should be used for error messages associated with this scale.}
-    \item{\code{name}}{The name of the scale. Used as the axis or legend title. If
-\code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic. If \code{NULL}, the legend title will be
-omitted.}
     \item{\code{labels}}{One of:
 \itemize{
 \item \code{NULL} for no labels

--- a/man/scale_gradient.Rd
+++ b/man/scale_gradient.Rd
@@ -19,6 +19,7 @@
 \title{Gradient colour scales}
 \usage{
 scale_colour_gradient(
+  name = waiver(),
   ...,
   low = "#132B43",
   high = "#56B1F7",
@@ -29,6 +30,7 @@ scale_colour_gradient(
 )
 
 scale_fill_gradient(
+  name = waiver(),
   ...,
   low = "#132B43",
   high = "#56B1F7",
@@ -39,6 +41,7 @@ scale_fill_gradient(
 )
 
 scale_colour_gradient2(
+  name = waiver(),
   ...,
   low = muted("red"),
   mid = "white",
@@ -52,6 +55,7 @@ scale_colour_gradient2(
 )
 
 scale_fill_gradient2(
+  name = waiver(),
   ...,
   low = muted("red"),
   mid = "white",
@@ -65,6 +69,7 @@ scale_fill_gradient2(
 )
 
 scale_colour_gradientn(
+  name = waiver(),
   ...,
   colours,
   values = NULL,
@@ -76,6 +81,7 @@ scale_colour_gradientn(
 )
 
 scale_fill_gradientn(
+  name = waiver(),
   ...,
   colours,
   values = NULL,
@@ -87,6 +93,11 @@ scale_fill_gradientn(
 )
 }
 \arguments{
+\item{name}{The name of the scale. Used as the axis or legend title. If
+\code{waiver()}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
+
 \item{...}{
   Arguments passed on to \code{\link[=continuous_scale]{continuous_scale}}
   \describe{
@@ -95,10 +106,6 @@ that should be used for error messages associated with this scale.}
     \item{\code{palette}}{A palette function that when called with a numeric vector with
 values between 0 and 1 returns the corresponding output values
 (e.g., \code{\link[scales:pal_area]{scales::pal_area()}}).}
-    \item{\code{name}}{The name of the scale. Used as the axis or legend title. If
-\code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic. If \code{NULL}, the legend title will be
-omitted.}
     \item{\code{breaks}}{One of:
 \itemize{
 \item \code{NULL} for no breaks

--- a/man/scale_grey.Rd
+++ b/man/scale_grey.Rd
@@ -7,6 +7,7 @@
 \title{Sequential grey colour scales}
 \usage{
 scale_colour_grey(
+  name = waiver(),
   ...,
   start = 0.2,
   end = 0.8,
@@ -15,6 +16,7 @@ scale_colour_grey(
 )
 
 scale_fill_grey(
+  name = waiver(),
   ...,
   start = 0.2,
   end = 0.8,
@@ -23,6 +25,11 @@ scale_fill_grey(
 )
 }
 \arguments{
+\item{name}{The name of the scale. Used as the axis or legend title. If
+\code{waiver()}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
+
 \item{...}{
   Arguments passed on to \code{\link[=discrete_scale]{discrete_scale}}
   \describe{
@@ -55,10 +62,6 @@ missing values, and do so by default. If you want to remove missing values
 from a discrete scale, specify \code{na.translate = FALSE}.}
     \item{\code{scale_name}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The name of the scale
 that should be used for error messages associated with this scale.}
-    \item{\code{name}}{The name of the scale. Used as the axis or legend title. If
-\code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic. If \code{NULL}, the legend title will be
-omitted.}
     \item{\code{labels}}{One of:
 \itemize{
 \item \code{NULL} for no labels

--- a/man/scale_hue.Rd
+++ b/man/scale_hue.Rd
@@ -7,6 +7,7 @@
 \title{Evenly spaced colours for discrete data}
 \usage{
 scale_colour_hue(
+  name = waiver(),
   ...,
   h = c(0, 360) + 15,
   c = 100,
@@ -18,6 +19,7 @@ scale_colour_hue(
 )
 
 scale_fill_hue(
+  name = waiver(),
   ...,
   h = c(0, 360) + 15,
   c = 100,
@@ -29,6 +31,11 @@ scale_fill_hue(
 )
 }
 \arguments{
+\item{name}{The name of the scale. Used as the axis or legend title. If
+\code{waiver()}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
+
 \item{...}{
   Arguments passed on to \code{\link[=discrete_scale]{discrete_scale}}
   \describe{
@@ -61,10 +68,6 @@ missing values, and do so by default. If you want to remove missing values
 from a discrete scale, specify \code{na.translate = FALSE}.}
     \item{\code{scale_name}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The name of the scale
 that should be used for error messages associated with this scale.}
-    \item{\code{name}}{The name of the scale. Used as the axis or legend title. If
-\code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic. If \code{NULL}, the legend title will be
-omitted.}
     \item{\code{labels}}{One of:
 \itemize{
 \item \code{NULL} for no labels

--- a/man/scale_identity.Rd
+++ b/man/scale_identity.Rd
@@ -13,25 +13,35 @@
 \alias{scale_color_identity}
 \title{Use values without scaling}
 \usage{
-scale_colour_identity(..., guide = "none", aesthetics = "colour")
+scale_colour_identity(
+  name = waiver(),
+  ...,
+  guide = "none",
+  aesthetics = "colour"
+)
 
-scale_fill_identity(..., guide = "none", aesthetics = "fill")
+scale_fill_identity(name = waiver(), ..., guide = "none", aesthetics = "fill")
 
-scale_shape_identity(..., guide = "none")
+scale_shape_identity(name = waiver(), ..., guide = "none")
 
-scale_linetype_identity(..., guide = "none")
+scale_linetype_identity(name = waiver(), ..., guide = "none")
 
-scale_linewidth_identity(..., guide = "none")
+scale_linewidth_identity(name = waiver(), ..., guide = "none")
 
-scale_alpha_identity(..., guide = "none")
+scale_alpha_identity(name = waiver(), ..., guide = "none")
 
-scale_size_identity(..., guide = "none")
+scale_size_identity(name = waiver(), ..., guide = "none")
 
-scale_discrete_identity(aesthetics, ..., guide = "none")
+scale_discrete_identity(aesthetics, name = waiver(), ..., guide = "none")
 
-scale_continuous_identity(aesthetics, ..., guide = "none")
+scale_continuous_identity(aesthetics, name = waiver(), ..., guide = "none")
 }
 \arguments{
+\item{name}{The name of the scale. Used as the axis or legend title. If
+\code{waiver()}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
+
 \item{...}{Other arguments passed on to \code{\link[=discrete_scale]{discrete_scale()}} or
 \code{\link[=continuous_scale]{continuous_scale()}}}
 

--- a/man/scale_linetype.Rd
+++ b/man/scale_linetype.Rd
@@ -7,15 +7,20 @@
 \alias{scale_linetype_discrete}
 \title{Scale for line patterns}
 \usage{
-scale_linetype(..., na.value = "blank")
+scale_linetype(name = waiver(), ..., na.value = "blank")
 
-scale_linetype_binned(..., na.value = "blank")
+scale_linetype_binned(name = waiver(), ..., na.value = "blank")
 
 scale_linetype_continuous(...)
 
-scale_linetype_discrete(..., na.value = "blank")
+scale_linetype_discrete(name = waiver(), ..., na.value = "blank")
 }
 \arguments{
+\item{name}{The name of the scale. Used as the axis or legend title. If
+\code{waiver()}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
+
 \item{...}{
   Arguments passed on to \code{\link[=discrete_scale]{discrete_scale}}
   \describe{
@@ -49,10 +54,6 @@ from a discrete scale, specify \code{na.translate = FALSE}.}
     \item{\code{aesthetics}}{The names of the aesthetics that this scale works with.}
     \item{\code{scale_name}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The name of the scale
 that should be used for error messages associated with this scale.}
-    \item{\code{name}}{The name of the scale. Used as the axis or legend title. If
-\code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic. If \code{NULL}, the legend title will be
-omitted.}
     \item{\code{labels}}{One of:
 \itemize{
 \item \code{NULL} for no labels

--- a/man/scale_shape.Rd
+++ b/man/scale_shape.Rd
@@ -8,11 +8,16 @@
 \alias{scale_shape_continuous}
 \title{Scales for shapes, aka glyphs}
 \usage{
-scale_shape(..., solid = TRUE)
+scale_shape(name = waiver(), ..., solid = TRUE)
 
-scale_shape_binned(..., solid = TRUE)
+scale_shape_binned(name = waiver(), ..., solid = TRUE)
 }
 \arguments{
+\item{name}{The name of the scale. Used as the axis or legend title. If
+\code{waiver()}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
+
 \item{...}{
   Arguments passed on to \code{\link[=discrete_scale]{discrete_scale}}
   \describe{
@@ -49,10 +54,6 @@ where \code{NA} is always placed at the far right.}
     \item{\code{aesthetics}}{The names of the aesthetics that this scale works with.}
     \item{\code{scale_name}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The name of the scale
 that should be used for error messages associated with this scale.}
-    \item{\code{name}}{The name of the scale. Used as the axis or legend title. If
-\code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic. If \code{NULL}, the legend title will be
-omitted.}
     \item{\code{labels}}{One of:
 \itemize{
 \item \code{NULL} for no labels

--- a/man/scale_size.Rd
+++ b/man/scale_size.Rd
@@ -48,9 +48,9 @@ scale_size_binned(
   guide = "bins"
 )
 
-scale_size_area(..., max_size = 6)
+scale_size_area(name = waiver(), ..., max_size = 6)
 
-scale_size_binned_area(..., max_size = 6)
+scale_size_binned_area(name = waiver(), ..., max_size = 6)
 }
 \arguments{
 \item{name}{The name of the scale. Used as the axis or legend title. If

--- a/man/scale_steps.Rd
+++ b/man/scale_steps.Rd
@@ -13,6 +13,7 @@
 \title{Binned gradient colour scales}
 \usage{
 scale_colour_steps(
+  name = waiver(),
   ...,
   low = "#132B43",
   high = "#56B1F7",
@@ -23,6 +24,7 @@ scale_colour_steps(
 )
 
 scale_colour_steps2(
+  name = waiver(),
   ...,
   low = muted("red"),
   mid = "white",
@@ -36,6 +38,7 @@ scale_colour_steps2(
 )
 
 scale_colour_stepsn(
+  name = waiver(),
   ...,
   colours,
   values = NULL,
@@ -47,6 +50,7 @@ scale_colour_stepsn(
 )
 
 scale_fill_steps(
+  name = waiver(),
   ...,
   low = "#132B43",
   high = "#56B1F7",
@@ -57,6 +61,7 @@ scale_fill_steps(
 )
 
 scale_fill_steps2(
+  name = waiver(),
   ...,
   low = muted("red"),
   mid = "white",
@@ -70,6 +75,7 @@ scale_fill_steps2(
 )
 
 scale_fill_stepsn(
+  name = waiver(),
   ...,
   colours,
   values = NULL,
@@ -81,6 +87,11 @@ scale_fill_stepsn(
 )
 }
 \arguments{
+\item{name}{The name of the scale. Used as the axis or legend title. If
+\code{waiver()}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
+
 \item{...}{
   Arguments passed on to \code{\link[=binned_scale]{binned_scale}}
   \describe{
@@ -97,10 +108,6 @@ means that values at break positions are part of the lower bin (open on the
 left), whereas they are part of the upper bin when intervals are closed on
 the left (open on the right).}
     \item{\code{show.limits}}{should the limits of the scale appear as ticks}
-    \item{\code{name}}{The name of the scale. Used as the axis or legend title. If
-\code{waiver()}, the default, the name of the scale is taken from the first
-mapping used for that aesthetic. If \code{NULL}, the legend title will be
-omitted.}
     \item{\code{breaks}}{One of:
 \itemize{
 \item \code{NULL} for no breaks

--- a/man/scale_viridis.Rd
+++ b/man/scale_viridis.Rd
@@ -16,6 +16,7 @@
 \title{Viridis colour scales from viridisLite}
 \usage{
 scale_colour_viridis_d(
+  name = waiver(),
   ...,
   alpha = 1,
   begin = 0,
@@ -26,6 +27,7 @@ scale_colour_viridis_d(
 )
 
 scale_fill_viridis_d(
+  name = waiver(),
   ...,
   alpha = 1,
   begin = 0,
@@ -36,6 +38,7 @@ scale_fill_viridis_d(
 )
 
 scale_colour_viridis_c(
+  name = waiver(),
   ...,
   alpha = 1,
   begin = 0,
@@ -50,6 +53,7 @@ scale_colour_viridis_c(
 )
 
 scale_fill_viridis_c(
+  name = waiver(),
   ...,
   alpha = 1,
   begin = 0,
@@ -64,6 +68,7 @@ scale_fill_viridis_c(
 )
 
 scale_colour_viridis_b(
+  name = waiver(),
   ...,
   alpha = 1,
   begin = 0,
@@ -78,6 +83,7 @@ scale_colour_viridis_b(
 )
 
 scale_fill_viridis_b(
+  name = waiver(),
   ...,
   alpha = 1,
   begin = 0,
@@ -92,6 +98,11 @@ scale_fill_viridis_b(
 )
 }
 \arguments{
+\item{name}{The name of the scale. Used as the axis or legend title. If
+\code{waiver()}, the default, the name of the scale is taken from the first
+mapping used for that aesthetic. If \code{NULL}, the legend title will be
+omitted.}
+
 \item{...}{Other arguments passed on to \code{\link[=discrete_scale]{discrete_scale()}},
 \code{\link[=continuous_scale]{continuous_scale()}}, or \code{\link[=binned_scale]{binned_scale()}} to control name, limits, breaks,
 labels and so forth.}

--- a/tests/testthat/test-scale-gradient.R
+++ b/tests/testthat/test-scale-gradient.R
@@ -12,11 +12,11 @@ test_that("points outside the limits are plotted as NA", {
 
 test_that("midpoints are transformed", {
 
-  scale <- scale_colour_gradient2(midpoint = 1, trans = "identity")
+  scale <- scale_colour_gradient2(midpoint = 1, transform = "identity")
   scale$train(c(0, 3))
   expect_equal(scale$rescale(c(0, 3)), c(0.25, 1))
 
-  scale <- scale_colour_gradient2(midpoint = 10, trans = "log10")
+  scale <- scale_colour_gradient2(midpoint = 10, transform = "log10")
   scale$train(scale$transform(c(1, 1000)))
   ans <- scale$rescale(c(0, 3), c(0.25, 1))
 


### PR DESCRIPTION
This PR aims to fix #5535.

Briefly, it explicitly sets the first argument of many scales to the `name` argument. Thereby, we're circumventing the issue that `...` would funnel the first argument to the deprecated `scale_name` argument.