### PR TITLE
Ingest plain patterns as lists in `layer()`

### DIFF
--- a/R/geom-.R
+++ b/R/geom-.R
@@ -126,9 +126,6 @@ Geom <- ggproto("Geom",
       deprecate_soft0("3.4.0", I("Using the `size` aesthetic in this geom"), I("`linewidth` in the `default_aes` field and elsewhere"))
       default_aes$linewidth <- default_aes$size
     }
-    if (is_pattern(params$fill)) {
-      params$fill <- list(params$fill)
-    }
 
     # Fill in missing aesthetics with their defaults
     missing_aes <- setdiff(names(default_aes), names(data))

--- a/R/layer.R
+++ b/R/layer.R
@@ -124,6 +124,12 @@ layer <- function(geom = NULL, stat = NULL,
 
   all <- c(geom$parameters(TRUE), stat$parameters(TRUE), geom$aesthetics())
 
+  # Take care of plain patterns provided as aesthetic
+  pattern <- vapply(aes_params, is_pattern, logical(1))
+  if (any(pattern)) {
+    aes_params[pattern] <- lapply(aes_params[pattern], list)
+  }
+
   # Warn about extra params and aesthetics
   extra_param <- setdiff(names(params), all)
   # Take care of size->linewidth renaming in layer params


### PR DESCRIPTION
This PR to the RC branch aims to fix #5593.

Briefly, instead of coercing a plain pattern to a list in `Geom$use_defaults()`, it does so in the `layer()` function.
This has two consequences:
1.  Other internals, like `GuideLegend$get_layer_key()` or `Geom$use_defaults()` don't have to deal with plain patterns.
2. If a pattern is provided to another aesthetic than 'fill', it is also coerced to a list, opening up 'fill'-variant aesthetics for patterns. For example, a package might use a 'fill_box' aesthetic for a geom.

Reprex from #5593:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

grad <- grid::linearGradient(pal_viridis()(10))

ggplot(mpg, aes(factor(cyl), colour = "fixed")) +
  geom_bar(fill = grad)
```

![](https://i.imgur.com/1CcixjT.png)<!-- -->

<sup>Created on 2023-12-18 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
