### PR TITLE
flip justification along with angle

### DIFF
--- a/R/coord-radial.R
+++ b/R/coord-radial.R
@@ -233,7 +233,7 @@ CoordRadial <- ggproto("CoordRadial", Coord,
     data$y <- rescale(data$r * cos(data$theta) + 0.5, from = bbox$y)
 
     if (self$rotate_angle && "angle" %in% names(data)) {
-      data$angle <- flip_text_angle(data$angle - rad2deg(data$theta))
+      data <- flip_data_text_angle(data)
     }
 
     data
@@ -526,6 +526,23 @@ flip_text_angle <- function(angle) {
   flip <- angle > 90 & angle < 270
   angle[flip] <- angle[flip] + 180
   angle
+}
+
+flip_data_text_angle <- function(data) {
+  if (!all(c("angle", "theta") %in% names(data))) {
+    return(data)
+  }
+  angle <- (data$angle - rad2deg(data$theta)) %% 360
+  flip  <- angle > 90 & angle < 270
+  angle[flip] <- angle[flip] + 180
+  data$angle <- angle
+  if ("hjust" %in% names(data)) {
+    data$hjust[flip] <- 1 - data$hjust[flip]
+  }
+  if ("vjust" %in% names(data)) {
+    data$vjust[flip] <- 1 - data$vjust[flip]
+  }
+  data
 }
 
 


### PR DESCRIPTION
This PR to the RC aims to fix #5599.

The reprex from that issue with correct label justification:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

ggplot(mtcars, aes(x = seq_along(disp), y = disp)) +
  geom_col() +
  geom_text(aes(y = Inf, label = rownames(mtcars)), hjust = 1, angle = 90) +
  coord_radial(rotate_angle = TRUE)
```

![](https://i.imgur.com/LAXamZ7.png)<!-- -->

<sup>Created on 2023-12-18 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
