### PR TITLE
Guide custom theme

### DIFF
--- a/R/guide-custom.R
+++ b/R/guide-custom.R
@@ -114,6 +114,10 @@ GuideCustom <- ggproto(
   draw = function(self, theme, position = NULL, direction = NULL,
                   params = self$params) {
 
+    if (is.zero(params$grob)) {
+      return(zeroGrob())
+    }
+
     # Render title
     params$direction <- params$direction %||% direction
     elems <- self$setup_elements(params, self$elements, theme)

--- a/man/guide_custom.Rd
+++ b/man/guide_custom.Rd
@@ -9,8 +9,7 @@ guide_custom(
   width = grobWidth(grob),
   height = grobHeight(grob),
   title = NULL,
-  title.position = "top",
-  margin = NULL,
+  theme = NULL,
   position = NULL,
   order = 0
 )
@@ -24,13 +23,12 @@ in \code{\link[grid:unit]{grid::unit()}}s.}
 \item{title}{A character string or expression indicating the title of guide.
 If \code{NULL} (default), no title is shown.}
 
-\item{title.position}{A character string indicating the position of a title.
-One of \code{"top"} (default), \code{"bottom"}, \code{"left"} or \code{"right"}.}
+\item{theme}{A \code{\link[=theme]{theme}} object to style the guide individually or
+differently from the plot's theme settings. The \code{theme} argument in the
+guide overrides, and is combined with, the plot's theme.}
 
-\item{margin}{Margins around the guide. See \code{\link[=margin]{margin()}} for more details. If
-\code{NULL} (default), margins are taken from the \code{legend.margin} theme setting.}
-
-\item{position}{Currently not in use.}
+\item{position}{A character string indicating where the legend should be
+placed relative to the plot panels.}
 
 \item{order}{positive integer less than 99 that specifies the order of
 this guide among multiple guides. This controls the order in which


### PR DESCRIPTION
This PR to the RC aims to fix #5601.

Briefly, it applies the same refactoring in #5554 to `guide_custom()`.

Quick demonstration that the theme inheritance is correct: grey fill from guide's theme and blue outline from the plot's theme.

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

ggplot(mpg, aes(displ, hwy)) +
  geom_point() +
  guides(custom = guide_custom(
    title = "My circle",
    circleGrob(r = unit(1, "cm")),
    theme = theme(legend.background = element_rect(fill = 'grey90'))
  )) +
  theme(legend.background = element_rect(colour = "blue"))
```

![](https://i.imgur.com/Ri1Zk50.png)<!-- -->

<sup>Created on 2023-12-20 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
