### PR TITLE
Fix partial match in deprecated guide arguments

### DIFF
--- a/R/guide-.R
+++ b/R/guide-.R
@@ -51,7 +51,7 @@ new_guide <- function(..., available_aes = "any", super) {
   # Validate theme settings
   if (!is.null(params$theme)) {
     check_object(params$theme, is.theme, what = "a {.cls theme} object")
-    validate_theme(params$theme)
+    validate_theme(params$theme, call = caller_env())
     params$direction <- params$direction %||% params$theme$legend.direction
   }
 

--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -781,7 +781,7 @@ deprecated_guide_args <- function(
     unit(x, default.unit)
   }
 
-  theme <- theme %||% list()
+  theme <- theme %||% theme()
 
   # Resolve straightforward arguments
   theme <- replace_null(

--- a/R/theme.R
+++ b/R/theme.R
@@ -529,13 +529,13 @@ is_theme_validate <- function(x) {
   isTRUE(validate %||% TRUE)
 }
 
-validate_theme <- function(theme, tree = get_element_tree()) {
+validate_theme <- function(theme, tree = get_element_tree(), call = caller_env()) {
   if (!is_theme_validate(theme)) {
     return()
   }
   mapply(
     validate_element, theme, names(theme),
-    MoreArgs = list(element_tree = tree)
+    MoreArgs = list(element_tree = tree, call = call)
   )
 }
 


### PR DESCRIPTION
This PR to the RC aims to fix a bug uncovered in revdepchecks affecting ~28 packages.

One such example is this:
https://github.com/tidyverse/ggplot2/blob/rc/3.5.0/revdep/problems.md#newly-broken-21

Briefly, `title.position` gets partially matched to `legend.title` instead of `legend.title.position`.
The fix is not to use a `list()` as theme placeholder but an empty `theme()` (where we disallow partial matching).

A reprex to reproduce the issue:
``` r
library(ggplot2) # RC branch

guide_colourbar(title.position = "top")
#> Error in `mapply()` at ggplot2/R/theme.R:536:3:
#> ! The `legend.title` theme element must be a <element_text> object.
```

In addition, I found that the reported call for `mapply()` was uninformative, so I wired some calls to `validate_theme()`.
Now it reports the guide constructor.

``` r
devtools::load_all("~/packages/ggplot2") # This PR
#> ℹ Loading ggplot2

# Correctly has `legend.title.position` now
x <- guide_colourbar(title.position = "top")
x$params$theme
#> List of 1
#>  $ legend.title.position: chr "top"
#>  - attr(*, "class")= chr [1:2] "theme" "gg"
#>  - attr(*, "complete")= logi FALSE
#>  - attr(*, "validate")= logi TRUE

# New call
guide_colourbar(title.theme = element_rect())
#> Error in `guide_colourbar()`:
#> ! The `legend.title` theme element must be a <element_text> object.
```

<sup>Created on 2023-12-21 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

