### PR TITLE
Ignore empty arguments in `theme()`

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -320,7 +320,7 @@ find_args <- function(...) {
   vals <- mget(args, envir = env)
   vals <- vals[!vapply(vals, is_missing_arg, logical(1))]
 
-  modify_list(vals, list2(..., `...` = NULL))
+  modify_list(vals, dots_list(..., `...` = NULL, .ignore_empty = "all"))
 }
 
 # Used in annotations to ensure printed even when no


### PR DESCRIPTION
This PR to the RC aims to fix a bug uncovered in revdepchecks affecting ~32 packages.

One such example is this:
https://github.com/tidyverse/ggplot2/blob/rc/3.5.0/revdep/problems.md#newly-broken-126

Briefly, due to allowing splicing in `theme()`, we're no longer ignoring trailing arguments.
The fix is to explicitly ignore empty arguments using `dots_list()` instead of `list2()`.

A reprex to reproduce the issue:
``` r
library(ggplot2) # RC branch

theme(axis.title = element_text(), )
#> Error in `list2()` at ggplot2/R/utilities.R:323:3:
#> ! Argument 1 can't be empty.
```

Fixed behaviour:
``` r
devtools::load_all("~/packages/ggplot2/") # This PR
#> ℹ Loading ggplot2

theme(axis.title = element_text(), )
#> List of 1
#>  $ axis.title:List of 11
#>   ..$ family       : NULL
#>   ..$ face         : NULL
#>   ..$ colour       : NULL
#>   ..$ size         : NULL
#>   ..$ hjust        : NULL
#>   ..$ vjust        : NULL
#>   ..$ angle        : NULL
#>   ..$ lineheight   : NULL
#>   ..$ margin       : NULL
#>   ..$ debug        : NULL
#>   ..$ inherit.blank: logi FALSE
#>   ..- attr(*, "class")= chr [1:2] "element_text" "element"
#>  - attr(*, "class")= chr [1:2] "theme" "gg"
#>  - attr(*, "complete")= logi FALSE
#>  - attr(*, "validate")= logi TRUE
```

<sup>Created on 2023-12-21 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
