### PR TITLE
Protection for position scale's `call` parameter

### DIFF
--- a/R/scale-continuous.R
+++ b/R/scale-continuous.R
@@ -202,12 +202,9 @@ scale_y_sqrt <- function(...) {
 # Helpers -----------------------------------------------------------------
 
 scale_override_call <- function(call = NULL) {
-  if (is.null(call)) {
+  if (is.null(call) || is.function(call[[1]])) {
     return(TRUE)
   }
-  try_fetch(
-    !any(startsWith(as.character(call[[1]]), "scale_")),
-    error = function(cnd) TRUE
-  )
+  !any(startsWith(as.character(call[[1]])), "scale_")
 }
 

--- a/R/scale-continuous.R
+++ b/R/scale-continuous.R
@@ -86,7 +86,7 @@ scale_x_continuous <- function(name = waiver(), breaks = waiver(),
                                guide = waiver(), position = "bottom",
                                sec.axis = waiver()) {
   call <- caller_call()
-  if (is.null(call) || !any(startsWith(as.character(call[[1]]), "scale_"))) {
+  if (scale_override_call(call)) {
     call <- current_call()
   }
   sc <- continuous_scale(
@@ -113,7 +113,7 @@ scale_y_continuous <- function(name = waiver(), breaks = waiver(),
                                guide = waiver(), position = "left",
                                sec.axis = waiver()) {
   call <- caller_call()
-  if (is.null(call) || !any(startsWith(as.character(call[[1]]), "scale_"))) {
+  if (scale_override_call(call)) {
     call <- current_call()
   }
   sc <- continuous_scale(
@@ -198,3 +198,16 @@ scale_x_sqrt <- function(...) {
 scale_y_sqrt <- function(...) {
   scale_y_continuous(..., transform = transform_sqrt())
 }
+
+# Helpers -----------------------------------------------------------------
+
+scale_override_call <- function(call = NULL) {
+  if (is.null(call)) {
+    return(TRUE)
+  }
+  try_fetch(
+    !any(startsWith(as.character(call[[1]])), "scale_"),
+    error = function(cnd) TRUE
+  )
+}
+

--- a/R/scale-continuous.R
+++ b/R/scale-continuous.R
@@ -206,7 +206,7 @@ scale_override_call <- function(call = NULL) {
     return(TRUE)
   }
   try_fetch(
-    !any(startsWith(as.character(call[[1]])), "scale_"),
+    !any(startsWith(as.character(call[[1]]), "scale_")),
     error = function(cnd) TRUE
   )
 }


### PR DESCRIPTION
This PR to the RC aims to fix a bug uncovered in revdepchecks affecting ~44 packages.

One such example is this:
https://github.com/tidyverse/ggplot2/blob/rc/3.5.0/revdep/problems.md#newly-broken-29

Briefly, if a position scale is invoked in an non-standard way, where the first element of the call is not a name, it provoked an error.
To reproduce this error, the code below causes a function to be the scale's `call[[1]]`:
``` r
library(ggplot2) # RC branch

f <- function() {
  ggplot(mpg, aes(displ, hwy)) +
    geom_point() +
    scale_y_continuous()
}
do.call(f, list())
#> Error in as.character(call[[1]]): cannot coerce type 'closure' to vector of type 'character'
```
This is now wrapped in a `try_fetch()` block so that this does not cause a failure. If `call[[1]]` is not coercible to a character, it is presumed that the scale was *not* called as part of a scale-wrapper (like `scale_y_log10()`) and the call gets replaced with `current_call()`.
This circumvents the error:
``` r
devtools::load_all("~/packages/ggplot2/") # This PR
#> ℹ Loading ggplot2
do.call(f, list())
```

![](https://i.imgur.com/2xoQ2PQ.png)<!-- -->

<sup>Created on 2023-12-21 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
