### PR TITLE
Swap `vec_in()` for `%in%`

### DIFF
--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -724,7 +724,7 @@ keep_key_data <- function(key, data, aes, show) {
   }
   keep <- rep(FALSE, nrow(key))
   for (column in match) {
-    keep <- keep | vec_in(key$.value, data[[column]])
+    keep <- keep | key$.value %in% data[[column]]
   }
   keep
 }


### PR DESCRIPTION
This PR to the RC aims to fix a bug uncovered in revdepchecks affecting ~19 packages.

One such example is this:
https://github.com/tidyverse/ggplot2/blob/rc/3.5.0/revdep/problems.md#newly-broken-119

Briefly, `vec_in()` is too strict in that it cannot compare incompatible vectors, like `logical` and `character` vectors.
To reproduce this error, combine a logical and character level for the same aesthetic.
The fix is to replace `vec_in()` with `%in%`.

``` r
library(ggplot2) # RC branch

ggplot(mpg, aes(displ, hwy)) +
  geom_point(aes(colour = hwy > 30)) +
  geom_line(aes(colour = "foo"))
#> Error in `vec_in()` at ggplot2/R/guide-legend.R:727:5:
#> ! Can't combine <character> and <logical>.
```

How it should work:

```r
devtools::load_all("~/packages/ggplot2") # This PR
#> ℹ Loading ggplot2

ggplot(mpg, aes(displ, hwy)) +
  geom_point(aes(colour = hwy > 30)) +
  geom_line(aes(colour = "foo"))
```

![](https://i.imgur.com/4pneSOY.png)<!-- -->

<sup>Created on 2023-12-21 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
