### PR TITLE
Propogate `guide_axis_stack(spacing)` argument.

### DIFF
--- a/R/guide-axis-stack.R
+++ b/R/guide-axis-stack.R
@@ -66,6 +66,7 @@ guide_axis_stack <- function(first = "axis", ..., title = waiver(), theme = NULL
     theme = theme,
     guides = axes,
     guide_params = params,
+    spacing = spacing,
     available_aes = c("x", "y", "theta", "r"),
     order = order,
     position = position,
@@ -86,6 +87,7 @@ GuideAxisStack <- ggproto(
     guides    = list(),
     # List of parameters to each guide
     guide_params = list(),
+    spacing   = NULL,
     # Standard guide stuff
     name      = "stacked_axis",
     title     = waiver(),


### PR DESCRIPTION
The aims of this PR to the RC is to fix a bug found with the `spacing` argument in `guide_axis_stack()`.

Briefly, it is currently ignored because it isn't passed to `new_guide()`.

``` r
library(ggplot2)

ggplot(mpg, aes(displ, hwy)) +
  geom_point() +
  guides(x = guide_axis_stack("axis", "axis", spacing = unit(1, "cm")))
```

![](https://i.imgur.com/92m2Wzf.png)<!-- -->

With this PR, spacing is applied properly:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

ggplot(mpg, aes(displ, hwy)) +
  geom_point() +
  guides(x = guide_axis_stack("axis", "axis", spacing = unit(1, "cm")))
```

![](https://i.imgur.com/IhghkF8.png)<!-- -->

<sup>Created on 2023-12-27 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
