### PR TITLE
Text key justification

### DIFF
--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -73,12 +73,8 @@ GeomLabel <- ggproto("GeomLabel", Geom,
     }
 
     data <- coord$transform(data, panel_params)
-    if (is.character(data$vjust)) {
-      data$vjust <- compute_just(data$vjust, data$y, data$x, data$angle)
-    }
-    if (is.character(data$hjust)) {
-      data$hjust <- compute_just(data$hjust, data$x, data$y, data$angle)
-    }
+    data$vjust <- compute_just(data$vjust, data$y, data$x, data$angle)
+    data$hjust <- compute_just(data$hjust, data$x, data$y, data$angle)
     if (!inherits(label.padding, "margin")) {
       label.padding <- rep(label.padding, length.out = 4)
     }

--- a/R/geom-text.R
+++ b/R/geom-text.R
@@ -220,12 +220,8 @@ GeomText <- ggproto("GeomText", Geom,
 
     data <- coord$transform(data, panel_params)
 
-    if (is.character(data$vjust)) {
-      data$vjust <- compute_just(data$vjust, data$y, data$x, data$angle)
-    }
-    if (is.character(data$hjust)) {
-      data$hjust <- compute_just(data$hjust, data$x, data$y, data$angle)
-    }
+    data$vjust <- compute_just(data$vjust, data$y, data$x, data$angle)
+    data$hjust <- compute_just(data$hjust, data$x, data$y, data$angle)
 
     size.unit <- resolve_text_unit(size.unit)
 
@@ -248,7 +244,10 @@ GeomText <- ggproto("GeomText", Geom,
   draw_key = draw_key_text
 )
 
-compute_just <- function(just, a, b = a, angle = 0) {
+compute_just <- function(just, a = 0.5, b = a, angle = 0) {
+  if (!is.character(just)) {
+    return(just)
+  }
   #  As justification direction is relative to the text, not the plotting area
   #  we need to swap x and y if text direction is rotated so that hjust is
   #  applied along y and vjust along x.

--- a/R/legend-draw.R
+++ b/R/legend-draw.R
@@ -258,17 +258,16 @@ draw_key_smooth <- function(data, params, size) {
 #' @export
 #' @rdname draw_key
 draw_key_text <- function(data, params, size) {
-  data <- replace_null(
-    unclass(data),
-    label = "a", hjust = 0.5, vjust = 0.5, angle = 0
-  )
-  just <- rotate_just(data$angle, data$hjust, data$vjust)
-  grob <- titleGrob(
+  data  <- replace_null(unclass(data), label = "a", angle = 0)
+  hjust <- compute_just(data$hjust %||% 0.5)
+  vjust <- compute_just(data$vjust %||% 0.5)
+  just  <- rotate_just(data$angle, hjust, vjust)
+  grob  <- titleGrob(
     data$label,
     x = unit(just$hjust, "npc"), y = unit(just$vjust, "npc"),
     angle = data$angle,
-    hjust = data$hjust,
-    vjust = data$vjust,
+    hjust = hjust,
+    vjust = vjust,
     gp = gpar(
       col = alpha(data$colour %||% data$fill %||% "black", data$alpha),
       fontfamily = data$family   %||% "",
@@ -286,12 +285,11 @@ draw_key_text <- function(data, params, size) {
 #' @export
 #' @rdname draw_key
 draw_key_label <- function(data, params, size) {
-  data <- replace_null(
-    unclass(data),
-    label = "a", hjust = 0.5, vjust = 0.5, angle = 0
-  )
+  data <- replace_null(unclass(data), label = "a", angle = 0)
   params$label.size <- params$label.size %||% 0.25
-  just <- rotate_just(data$angle, data$hjust, data$vjust)
+  hjust <- compute_just(data$hjust %||% 0.5)
+  vjust <- compute_just(data$vjust %||% 0.5)
+  just  <- rotate_just(data$angle, hjust, vjust)
   padding <- rep(params$label.padding %||% unit(0.25, "lines"), length.out = 4)
   descent <- font_descent(
     family = data$family %||% "",
@@ -303,7 +301,7 @@ draw_key_label <- function(data, params, size) {
     x = unit(just$hjust, "npc"),
     y = unit(just$vjust, "npc") + descent,
     angle = data$angle,
-    just = c(data$hjust, data$vjust),
+    just = c(hjust, vjust),
     padding = padding,
     r = params$label.r %||% unit(0.15, "lines"),
     text.gp = gpar(

--- a/R/margins.R
+++ b/R/margins.R
@@ -253,6 +253,15 @@ rotate_just <- function(angle, hjust, vjust) {
 
   angle <- (angle %||% 0) %% 360
 
+  if (is.character(hjust)) {
+    hjust <- match(hjust, c("left", "right")) - 1
+    hjust[is.na(hjust)] <- 0.5
+  }
+  if (is.character(vjust)) {
+    vjust <- match(vjust, c("bottom", "top")) - 1
+    vjust[is.na(vjust)] <- 0.5
+  }
+
   # Apply recycle rules
   size  <- vec_size_common(angle, hjust, vjust)
   angle <- vec_recycle(angle, size)


### PR DESCRIPTION
This PR to the RC aims to fix #5614.

Briefly, the issue at hand is that the `draw_key_text()` and `draw_key_label()` functions did not know how to handle character-based justification such as `"right"` or `"outward"`.  This PR fixes that by resolving the justification through `compute_just()`.

As a related change, `rotate_just()` now also handles character justification.

The reprex from #5614:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

mycars <- mtcars
mycars$name <- rownames(mycars)

ggplot(mycars, aes(wt, mpg, label = name)) +
  geom_text(aes(size = wt), nudge_x = -0.1, hjust = "right")
```

![](https://i.imgur.com/DcdGsgC.png)<!-- -->

<sup>Created on 2024-01-02 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
