### PR TITLE
Drop empty groups from bar width calculation

### DIFF
--- a/R/geom-bar.R
+++ b/R/geom-bar.R
@@ -145,7 +145,7 @@ GeomBar <- ggproto("GeomBar", GeomRect,
     data <- flip_data(data, params$flipped_aes)
     data$width <- data$width %||%
       params$width %||% (min(vapply(
-        split(data$x, data$PANEL),
+        split(data$x, data$PANEL, drop = TRUE),
         resolution, numeric(1), zero = FALSE
       )) * 0.9)
     data$just <- params$just %||% 0.5


### PR DESCRIPTION
This PR aims to fix #5632.

As the title suggests, this PR adds a `drop = TRUE` to a `split()` that could return a list with 0-length elements in it. With `drop = TRUE`, those 0-length elements are absent and the calculation proceeds without warnings.