### PR TITLE
Fill potentially missing arguments in facets

### DIFF
--- a/R/facet-grid-.R
+++ b/R/facet-grid-.R
@@ -338,6 +338,10 @@ FacetGrid <- ggproto("FacetGrid", Facet,
       cli::cli_abort("{.fn {snake_class(coord)}} doesn't support free scales.")
     }
 
+    # Fill missing parameters for backward compatibility
+    params$draw_axes   <- params$draw_axes   %||% list(x = FALSE, y = FALSE)
+    params$axis_labels <- params$axis_labels %||% list(x = TRUE,  y = TRUE)
+
     if (!params$axis_labels$x) {
       cols <- seq_len(nrow(layout))
       x_axis_order <- as.integer(layout$PANEL[order(layout$ROW, layout$COL)])

--- a/R/facet-wrap.R
+++ b/R/facet-wrap.R
@@ -275,6 +275,10 @@ FacetWrap <- ggproto("FacetWrap", Facet,
     panels <- panels[panel_order]
     panel_pos <- convertInd(layout$ROW, layout$COL, nrow)
 
+    # Fill missing parameters for backward compatibility
+    params$draw_axes   <- params$draw_axes   %||% list(x = FALSE, y = FALSE)
+    params$axis_labels <- params$axis_labels %||% list(x = TRUE,  y = TRUE)
+
     x_axis_order <- if (params$axis_labels$x) layout$SCALE_X else seq(n)
     y_axis_order <- if (params$axis_labels$y) layout$SCALE_Y else seq(n)
 


### PR DESCRIPTION
This PR to the RC aims to fix an issue uncovered during reverse dependency checks.

Briefly, we introduced `axes` and `axis.labels` arguments in `facet_grid()` and `facet_wrap()`.
Extensions likely do not have these arguments forwarded to the facet's parameters and may be missing, causing errors in the panel drawing stage.
This PR fills these parameters when they are absent, so that extensions continue to work.