### PR TITLE
Put deprecated `trans` last in `dup_axis()`

### DIFF
--- a/R/axis-secondary.R
+++ b/R/axis-secondary.R
@@ -119,8 +119,8 @@ sec_axis <- function(transform = NULL,
 #' @rdname sec_axis
 #'
 #' @export
-dup_axis <- function(transform = ~., trans = deprecated(),
-                     name = derive(), breaks = derive(), labels = derive(), guide = derive()) {
+dup_axis <- function(transform = ~., name = derive(), breaks = derive(),
+                     labels = derive(), guide = derive(), trans = deprecated()) {
   sec_axis(transform, trans = trans, name, breaks, labels, guide)
 }
 


### PR DESCRIPTION
This PR to the RC aims to fix a reverse dependency check issue with `dup_axis()`.

Briefly: we renamed `trans` to `transform`, but kept the deprecated `trans` argument as the second argument.
Folks use position-based argument matching, so that the `trans` argument gets populated with what should go into the `name` argument. This PR restores the original order by putting the deprecated argument last.