### PR TITLE
Do not censor date breaks

### DIFF
--- a/R/scale-date.R
+++ b/R/scale-date.R
@@ -405,7 +405,6 @@ ScaleContinuousDate <- ggproto("ScaleContinuousDate", ScaleContinuous,
       return(NULL)
     }
     breaks <- floor(breaks)
-    breaks[breaks >= limits[1] & breaks <= limits[2]]
   },
   break_info = function(self, range = NULL) {
     breaks <- ggproto_parent(ScaleContinuous, self)$break_info(range)


### PR DESCRIPTION
This PR to the RC aims to fix a bug uncovered during reverse dependency checks.

Briefly, in #5569 we moved the censoring of breaks from the scales to the guides.
`ScaleContinuousDate` was overlooked, since it didn't do the usual `scales::censor()`.
In turn, the scale could censor a break, which may result in mismatched labels/breaks.
In this PR, we remove the scale's censoring, because we handle that elsewhere now.

To reproduce issue with current RC:

``` r
library(ggplot2)

limits <- as.Date(c("2000-01-01", "2010-01-01"))

df <- data.frame(x = limits, y = 1:2)

ggplot(df, aes(x, y)) +
  geom_point() +
  scale_x_date(
    breaks = as.Date(c("2000-01-01", "2011-01-01")), #2nd breaks is oob
    labels = c("2000", "2011")
  )
#> Error in `scale_x_date()`:
#> ! `breaks` and `labels` have different lengths.
```

With this PR, the out-of-bounds break simply isn't rendered.

```r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

ggplot(df, aes(x, y)) +
  geom_point() +
  scale_x_date(
    breaks = as.Date(c("2000-01-01", "2011-01-01")),
    labels = c("2000", "2011")
  )
```

![](https://i.imgur.com/tEhbGeA.png)<!-- -->

<sup>Created on 2024-01-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
