### PR TITLE
Scale_brewer using personal palette

### DIFF
--- a/R/scale-brewer.R
+++ b/R/scale-brewer.R
@@ -1,3 +1,90 @@
+#' @title build_my_palette
+#' 
+#' @description build_my_palette is a function that allows to create a palette with a specific number of colors
+#' @param name the name of the palette or a vector of colors 
+#' @param n the number of colors of the palette
+#' @param type the type of palette: 'discrete' or 'continuous'
+#' @param direction the direction of the palette: 1 or -1
+#'
+#' @return a palette with n colors
+#'
+#' @examples
+#' build_my_palette(name = "pal1", n = 4)
+#' build_my_palette(name = c("red", "blue", "green"))
+build_my_palette = function(name, n, type = c("discrete", "continuous"), direction = 1) {
+  if(is.character(name) && length(name) == 1)
+  {
+    # on this way we can continue to use the palettes from the package RColorBrewer and old code don't need to be changed
+    if(name %in% row.names(RColorBrewer::brewer.pal.info))
+    {
+      palette = RColorBrewer::brewer.pal(n = n, name)
+    }else
+    {
+      stop("name has to be a pallete's name from the package RColorBrewer")
+    }
+  }else if(is.character(name) && length(name) > 1)
+  {
+    palette = name
+  }else if(is.numeric(name))
+  {
+    # select the number oƒ the palette
+    palette = RColorBrewer::brewer.pal(n = n, row.names(RColorBrewer::brewer.pal.info[name,]))
+  }else
+  {
+    stop("name has to be a character for the name of palette or a vector of colors")
+  }
+  if (missing(n)) {
+    n = length(palette)
+  }else if(n > length(palette) & type == "discrete")
+  {
+    warning(paste("n too large, allowed maximum for palette", 
+                  name, "is", length(palette)), 
+            "\nReturning the palette you asked for with some colors repeated\n")
+  }
+  type = match.arg(type)
+  if (direction == -1) {
+    palette <- rev(palette)
+  }
+  out = switch(type,
+               continuous = grDevices::colorRampPalette(palette)(n),
+               discrete = rep(palette,n/length(palette) +1)[1:n] # repeat the palette until the length is n 
+  )
+  structure(out, name = name, class = "palette")
+}
+
+#' @title brewer_my_pal
+#' 
+#' @description brewer_my_pal is a function that allows to create a palette with a specific number of colors
+#'
+#' @description build_my_palette is a function that allows to create a palette with a specific number of colors
+#' @param n the number of colors of the palette
+#' @param type the type of palette: 'discrete' or 'continuous'
+#' @param direction the direction of the palette: 1 or -1
+#'
+#' @return a palette with n colors
+#' @export
+#'
+#' @examples
+brewer_my_pal = function (palette = "Blue", type = "seq", direction = 1, ...)
+{
+  force(direction)
+  # force(palette)
+  # force(type)
+  function(n) {
+    if (n < 3) {
+      pal <- suppressWarnings(build_my_palette(name = palette,  n = n, type = "continuous"))
+    }
+    else {
+      pal <- build_my_palette(name = palette,  n = n, type = "continuous")
+    }
+    pal <- pal[seq_len(n)]
+    if (direction == -1) {
+      pal <- rev(pal)
+    }
+    pal
+  }
+}
+
 #' Sequential, diverging and qualitative colour scales from ColorBrewer
 #'
 #' @description
@@ -8,7 +95,8 @@
 #'
 #' @note
 #' The `distiller` scales extend `brewer` scales by smoothly
-#' interpolating 7 colours from any palette to a continuous scale.
+#' interpolating colours from any palette to a continuous scale. You can choose
+#' the number of colours that you want in the palette, we recommend you to use 6-7 colours.
 #' The `distiller` scales have a default direction = -1. To reverse, use direction = 1.
 #' The `fermenter` scales provide binned versions of the `brewer` scales.
 #'
@@ -26,12 +114,13 @@
 #'      OrRd, PuBu, PuBuGn, PuRd, Purples, RdPu, Reds, YlGn, YlGnBu, YlOrBr, YlOrRd}
 #' }
 #' Modify the palette through the `palette` argument.
+#' You can pass a vector of colours in alternative to the name of the palette.
 #'
-#' @inheritParams scales::pal_brewer
 #' @inheritParams scale_colour_hue
 #' @inheritParams scale_colour_gradient
 #' @inheritParams scales::pal_gradient_n
-#' @param palette If a string, will use that named palette. If a number, will index into
+#' @param palette If a string, will use that named palette. If a vector, will use 
+#'   the colours inside to the vector. If a number, will index into
 #'   the list of palettes of appropriate `type`. The list of available palettes can found
 #'   in the Palettes section.
 #' @param ... Other arguments passed on to [discrete_scale()], [continuous_scale()],
@@ -55,6 +144,9 @@
 #' # Select brewer palette to use, see ?scales::pal_brewer for more details
 #' d + scale_colour_brewer(palette = "Greens")
 #' d + scale_colour_brewer(palette = "Set1")
+#' 
+#' # Use your own palette
+#' d + scale_colour_brewer(palette = c("#E41A1C", "#377EB8", "#4DAF4A"))
 #'
 #' \donttest{
 #' # scale_fill_brewer works just the same as
@@ -84,20 +176,20 @@
 #' v + scale_fill_fermenter()
 #'
 scale_colour_brewer <- function(..., type = "seq", palette = 1, direction = 1, aesthetics = "colour") {
-  discrete_scale(aesthetics, palette = pal_brewer(type, palette, direction), ...)
+  discrete_scale(aesthetics, "brewer", palette = brewer_my_pal(type = type, palette =  palette, direction =  direction), ...)
 }
 
 #' @export
 #' @rdname scale_brewer
 scale_fill_brewer <- function(..., type = "seq", palette = 1, direction = 1, aesthetics = "fill") {
-  discrete_scale(aesthetics, palette = pal_brewer(type, palette, direction), ...)
+  discrete_scale(aesthetics, "brewer", palette = brewer_my_pal(type = type, palette =  palette, direction = direction), ...)
 }
 
 #' @export
 #' @rdname scale_brewer
-scale_colour_distiller <- function(..., type = "seq", palette = 1, direction = -1, values = NULL, space = "Lab", na.value = "grey50", guide = "colourbar", aesthetics = "colour") {
+scale_colour_distiller <- function(..., type = "seq", palette = 1, direction = -1, values = NULL, space = "Lab", na.value = "grey50", guide = "colourbar", aesthetics = "colour", n_colors = 7) {
   # warn about using a qualitative brewer palette to generate the gradient
-  type <- arg_match0(type, c("seq", "div", "qual"))
+  type <- rlang::arg_match0(type, c("seq", "div", "qual"))
   if (type == "qual") {
     cli::cli_warn(c(
       "Using a discrete colour palette in a continuous scale",
@@ -106,7 +198,12 @@ scale_colour_distiller <- function(..., type = "seq", palette = 1, direction = -
   }
   continuous_scale(
     aesthetics,
-    palette = pal_gradient_n(pal_brewer(type, palette, direction)(7), values, space),
+    "distiller",
+    scales::gradient_n_pal(build_my_palette(name = palette,
+                                              n = n_colors,
+                                              type = "continuous"),
+                             values,
+                             space),
     na.value = na.value, guide = guide, ...
   )
   # NB: 6-7 colours per palette gives nice gradients; more results in more saturated colours which do not look as good
@@ -115,8 +212,8 @@ scale_colour_distiller <- function(..., type = "seq", palette = 1, direction = -
 
 #' @export
 #' @rdname scale_brewer
-scale_fill_distiller <- function(..., type = "seq", palette = 1, direction = -1, values = NULL, space = "Lab", na.value = "grey50", guide = "colourbar", aesthetics = "fill") {
-  type <- arg_match0(type, c("seq", "div", "qual"))
+scale_fill_distiller <- function(..., type = "seq", palette = 1, direction = -1, values = NULL, space = "Lab", na.value = "grey50", guide = "colourbar", aesthetics = "fill", n_colors = 7) {
+  type <- rlang::arg_match0(type, c("seq", "div", "qual"))
   if (type == "qual") {
     cli::cli_warn(c(
       "Using a discrete colour palette in a continuous scale",
@@ -125,7 +222,12 @@ scale_fill_distiller <- function(..., type = "seq", palette = 1, direction = -1,
   }
   continuous_scale(
     aesthetics,
-    palette = pal_gradient_n(pal_brewer(type, palette, direction)(7), values, space),
+    "distiller",
+    scales::gradient_n_pal(build_my_palette(name = palette,
+                                              n = n_colors,
+                                              type = "continuous"),
+                             values,
+                             space),
     na.value = na.value, guide = guide, ...
   )
 }
@@ -134,25 +236,25 @@ scale_fill_distiller <- function(..., type = "seq", palette = 1, direction = -1,
 #' @rdname scale_brewer
 scale_colour_fermenter <- function(..., type = "seq", palette = 1, direction = -1, na.value = "grey50", guide = "coloursteps", aesthetics = "colour") {
   # warn about using a qualitative brewer palette to generate the gradient
-  type <- arg_match0(type, c("seq", "div", "qual"))
+  type <- rlang::arg_match0(type, c("seq", "div", "qual"))
   if (type == "qual") {
     cli::cli_warn(c(
       "Using a discrete colour palette in a binned scale",
       "i" = "Consider using {.code type = \"seq\"} or {.code type = \"div\"} instead"
     ))
   }
-  binned_scale(aesthetics, palette = pal_binned(pal_brewer(type, palette, direction)), na.value = na.value, guide = guide, ...)
+  binned_scale(aesthetics, "fermenter", ggplot2:::binned_pal(brewer_my_pal(type = type, palette = palette, direction = direction)), na.value = na.value, guide = guide, ...)
 }
 
 #' @export
 #' @rdname scale_brewer
 scale_fill_fermenter <- function(..., type = "seq", palette = 1, direction = -1, na.value = "grey50", guide = "coloursteps", aesthetics = "fill") {
-  type <- arg_match0(type, c("seq", "div", "qual"))
+  type <- rlang::arg_match0(type, c("seq", "div", "qual"))
   if (type == "qual") {
     cli::cli_warn(c(
       "Using a discrete colour palette in a binned scale",
       "i" = "Consider using {.code type = \"seq\"} or {.code type = \"div\"} instead"
     ))
   }
-  binned_scale(aesthetics, palette = pal_binned(pal_brewer(type, palette, direction)), na.value = na.value, guide = guide, ...)
+  binned_scale(aesthetics, "fermenter", ggplot2:::binned_pal(brewer_my_pal(type = type, palette = palette, direction = direction)), na.value = na.value, guide = guide, ...)
 }


### PR DESCRIPTION
I've personalized `pal_brewer` (from `RColorBrewer`'s package), and it's called in every scale_brewer function. Now the users can put inside a string vector with colors and it will create the scale of colors choosing automatically the numbers of colors.

To don't create issues in the package update, I've kept that if a user passes a string to `palette`, it will look for an `RColorBrewer`'s palette, without the need to update the new code.

### Examples
``` r
ggplot(faithfuld) +
geom_tile(aes(waiting, eruptions, fill = density)) +
scale_fill_fermenter(palette = c("#04e762", "#f5b700", "#00a1e4", "#dc0073"), direction = -1)
```
![image](https://github.com/tidyverse/ggplot2/assets/61795785/18bcc760-08d8-4a6e-8631-29cb1d74972a)


``` r
USArrests %>% 
  mutate(Arrest = rowSums(.)) %>% 
  rownames_to_column("State") %>%
  tibble() %>% 
  mutate(State = reorder(State, Arrest)) %>%
  ggplot(aes(x = Arrest, y = State, fill = State)) + 
  geom_col() +
  scale_fill_brewer(palette = c("#04e762", "#f5b700", "#dc0073"), type = "qual") +
  theme_minimal() +
  theme(legend.position = "none",
        axis.text.y = element_text(colour = build_my_palette(name = c("#04e762", "#f5b700", "#dc0073"),
                                                             n = 50,
                                                             type = "continuous"))
        )
```
![image](https://github.com/tidyverse/ggplot2/assets/61795785/dd2ff099-6717-4d1a-ae16-da5c1a0349e1)

``` r
trees %>% 
  ggplot(aes(x = Girth, y = Height, color = Volume)) +
  geom_point(size = 5) +
  scale_colour_distiller(palette = c("#04e762", "#f5b700", "#00a1e4"),
                           direction = -1) +
  theme_minimal()
``` 
![image](https://github.com/tidyverse/ggplot2/assets/61795785/dc779b92-9e73-4901-b82c-1d2a34fb525b)

