### PR TITLE
Do not use class information for raster resolution calculation 

### DIFF
--- a/R/geom-raster.R
+++ b/R/geom-raster.R
@@ -94,8 +94,8 @@ GeomRaster <- ggproto("GeomRaster", Geom,
     }
 
     # Convert vector of data to raster
-    x_pos <- as.integer((data$x - min(data$x)) / resolution(data$x, FALSE))
-    y_pos <- as.integer((data$y - min(data$y)) / resolution(data$y, FALSE))
+    x_pos <- as.integer((data$x - min(data$x)) / resolution(unclass(data$x), FALSE))
+    y_pos <- as.integer((data$y - min(data$y)) / resolution(unclass(data$y), FALSE))
 
     data <- coord$transform(data, panel_params)
 


### PR DESCRIPTION
This PR to the RC aims to fix a bug uncovered during reverse dependency checks.

When feeding continuous data to `geom_raster()` but using discrete scales confers the `mapped_discrete` class even upon the continuous data. We use the heuristic that `mapped_discrete` values have resolution 1 in https://github.com/tidyverse/ggplot2/pull/5247. This leads to problems in `geom_raster()`:

``` r
library(ggplot2)

t <- c(0.1, 0.9, length.out = 2)
df <- expand.grid(c(0.1, 0.9), c(0.1, 0.9))
df$fill <- LETTERS[1:4]

# Should show 4 squares
ggplot(df, aes(Var1, Var2, fill = fill)) +
  geom_raster() +
  scale_x_discrete() +
  scale_y_discrete()
```

![](https://i.imgur.com/zmV4WJ5.png)<!-- -->

In this PR, the data of `geom_raster()` is `unclass()`'ed so that `resolution` correctly pick up on its continuous nature:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

ggplot(df, aes(Var1, Var2, fill = fill)) +
  geom_raster() +
  scale_x_discrete() +
  scale_y_discrete()
```

![](https://i.imgur.com/O21y3oq.png)<!-- -->

I found out about this using case via the breakage of [stars](https://r-spatial.github.io/stars/articles/stars3.html#geom_stars), where the following example would consume gigabytes of memory due to building an enormous raster. With this PR, this is now more in sync with the size of the original data.

``` r
library(stars)

x <- system.file("tif/L7_ETMs.tif", package = "stars") |>
  read_stars()

ggplot() + 
  geom_stars(data = x) +
  coord_equal() +
  facet_wrap(~band) +
  theme_void() +
  scale_fill_viridis_c() +
  scale_x_discrete(expand = c(0, 0)) +
  scale_y_discrete(expand = c(0, 0))
```

![](https://i.imgur.com/JLsmVNY.png)<!-- -->

<sup>Created on 2024-01-12 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
