### PR TITLE
Guides setup parameters before declaring key

### DIFF
--- a/R/guide-.R
+++ b/R/guide-.R
@@ -297,11 +297,12 @@ Guide <- ggproto(
   draw = function(self, theme, position = NULL, direction = NULL,
                   params = self$params) {
 
-    key <- params$key
-
-    # Setup parameters and theme
+    # Setup parameters
     params <- replace_null(params, position = position, direction = direction)
     params <- self$setup_params(params)
+    key    <- params$key
+
+    # Setup style options
     elems  <- self$setup_elements(params, self$elements, theme)
     elems  <- self$override_elements(params, elems, theme)
 


### PR DESCRIPTION
This PR to the RC fixes a mild annoyance of mine in guide behaviour.

Briefly, this PR restores the opportunity encode position and/or direction information into the key.

Elaborating some more: prior to #5483, guides had the opportunity to encode position/direction information in the key.
Since position/direction is now resolved at the `ggplot_gtable()` stage, guide keys have no such opportunity anymore.
By using the `Guide$setup_params()` method before taking the key from the parameters, this opportunity is restored.
I came across this while messing about with guide extensions, and while not crucial for the guides in ggplot2, it is nice to have for other guide extensions.

