### PR TITLE
Do not munch data too much

### DIFF
--- a/R/coord-munch.R
+++ b/R/coord-munch.R
@@ -61,7 +61,7 @@ munch_data <- function(data, dist = NULL, segment_length = 0.01) {
   }
 
   # How many endpoints for each old segment, not counting the last one
-  extra <- pmax(floor(dist / segment_length), 1)
+  extra <- pmin(pmax(floor(dist / segment_length), 1), 1e4)
   extra[is.na(extra)] <- 1
   # Generate extra pieces for x and y values
   # The final point must be manually inserted at the end


### PR DESCRIPTION
This PR to the RC aims to fix a bug uncovered during reverse dependency checks.

Briefly, for reasons beyond my understanding, `coord_munch()` might receive a very large segment, let's say `1e20` for `x` or `y`. It might then attempt to break up this large segment into many tiny pieces. You'd then get `failed to allocate vector of 7Gb` types of errors. Setting an upper limit on the number of pieces prevents this unreasonable demand on the machine's memory.