### PR TITLE
Drop `zeroGrob()` guides

### DIFF
--- a/R/guides-.R
+++ b/R/guides-.R
@@ -547,7 +547,8 @@ Guides <- ggproto(
         direction = directions[i], params = params[[i]]
       )
     }
-    split(grobs, positions)
+    keep <- !vapply(grobs, is.zero, logical(1))
+    split(grobs[keep], positions[keep])
   },
 
   package_box = function(grobs, position, theme) {

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -477,6 +477,30 @@ test_that("guide_legend uses key.spacing correctly", {
   expect_doppelganger("legend with widely spaced keys", p)
 })
 
+test_that("empty guides are dropped", {
+
+  df <- data.frame(x = 1:2)
+  # Making a guide where all breaks are out-of-bounds
+  p <- ggplot(df, aes(x, x, colour = x)) +
+    geom_point() +
+    scale_colour_continuous(
+      limits = c(0.25, 0.75),
+      breaks = c(1, 2),
+      guide  = "legend"
+    )
+  p <- ggplot_build(p)
+
+  # Empty guide that survives most steps
+  gd <- get_guide_data(p, "colour")
+  expect_equal(nrow(gd), 0)
+
+  # Draw guides
+  guides <- p$plot$guides$draw(theme_gray(), direction = "vertical")
+
+  # All guide-boxes should be empty
+  expect_equal(lengths(guides, use.names = FALSE), rep(0, 5))
+})
+
 # Visual tests ------------------------------------------------------------
 
 test_that("axis guides are drawn correctly", {


### PR DESCRIPTION
This PR to the RC aims to fix a bug uncovered during reverse dependency checks.

Briefly, in some unnatural circumstances you can create a guide that survives all steps but decides to draw a `zeroGrob()`.
`Guides$package_box()` cannot estimate the gtable size of these guides.

``` r
library(ggplot2)

ggplot(mpg[1:2, ], aes(displ, cty, colour = c(1, 4))) +
  geom_point() +
  scale_colour_continuous(
    limits = c(2.4, 2.6), breaks = c(1, 4),
    guide = "legend"
  )
#> Error in upgradeUnit.default(x): Not a unit object
```

<sup>Created on 2024-01-15 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

The solution in this PR is to drop empty guides at the `Guides$draw()` step. The reason we might not want to censor guides as soon as we detect the key is empty, is because some (extension) guides might have genuine reasons for not using a key.

