### PR TITLE
Restore `legend.byrow`

### DIFF
--- a/R/guide-.R
+++ b/R/guide-.R
@@ -329,7 +329,7 @@ Guide <- ggproto(
 
     # Arrange and assemble grobs
     sizes  <- self$measure_grobs(grobs, params, elems)
-    layout <- self$arrange_layout(key, sizes, params)
+    layout <- self$arrange_layout(key, sizes, params, elems)
     self$assemble_drawing(grobs, layout, sizes, params, elems)
   },
 
@@ -340,7 +340,7 @@ Guide <- ggproto(
   },
 
   # Takes care of where grobs should be added to the output gtable.
-  arrange_layout = function(key, sizes, params) {
+  arrange_layout = function(key, sizes, params, elements) {
     return(invisible())
   },
 

--- a/R/guide-axis-theta.R
+++ b/R/guide-axis-theta.R
@@ -306,7 +306,7 @@ GuideAxisTheta <- ggproto(
     list(offset = max(height))
   },
 
-  arrange_layout = function(key, sizes, params) {
+  arrange_layout = function(key, sizes, params, elements) {
     NULL
   },
 

--- a/R/guide-axis.R
+++ b/R/guide-axis.R
@@ -386,7 +386,7 @@ GuideAxis <- ggproto(
     sizes
   },
 
-  arrange_layout = function(key, sizes, params) {
+  arrange_layout = function(key, sizes, params, elements) {
 
     layout <- seq_along(sizes)
 

--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -471,12 +471,7 @@ GuideLegend <- ggproto(
     )
     heights <- head(vec_interleave(!!!heights), -1)
 
-    list(
-      widths  = widths,
-      heights = heights,
-      padding = elements$padding,
-      label_position = elements$text_position
-    )
+    list(widths = widths, heights = heights)
   },
 
   arrange_layout = function(key, sizes, params, elements) {
@@ -485,7 +480,7 @@ GuideLegend <- ggproto(
     dim <- c(params$nrow %||% 1L, params$ncol %||% 1L)
 
     # Find rows / columns of legend items
-    if (params$byrow %||% FALSE) {
+    if (elements$byrow %||% FALSE) {
       row <- ceiling(break_seq / dim[2L])
       col <- (break_seq - 1L) %% dim[2L] + 1L
     } else {
@@ -497,7 +492,7 @@ GuideLegend <- ggproto(
     key_col <- col * 2 - 1
 
     # Make gaps for key-label spacing depending on label position
-    position <- sizes$label_position
+    position <- elements$text_position
     key_row <- key_row + switch(position, top  = row, bottom = row - 1, 0)
     lab_row <- key_row + switch(position, top  = -1,  bottom = 1,       0)
     key_col <- key_col + switch(position, left = col, right  = col - 1, 0)

--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -479,7 +479,7 @@ GuideLegend <- ggproto(
     )
   },
 
-  arrange_layout = function(key, sizes, params) {
+  arrange_layout = function(key, sizes, params, elements) {
 
     break_seq <- seq_len(params$n_breaks %||% 1L)
     dim <- c(params$nrow %||% 1L, params$ncol %||% 1L)

--- a/tests/testthat/_snaps/guides/legend-byrow-true.svg
+++ b/tests/testthat/_snaps/guides/legend-byrow-true.svg
@@ -1,0 +1,75 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMjcuOTB8NjA1Ljc0fDIyLjc4fDU0NS4xMQ=='>
+    <rect x='27.90' y='22.78' width='577.84' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjcuOTB8NjA1Ljc0fDIyLjc4fDU0NS4xMQ==)'>
+<rect x='27.90' y='22.78' width='577.84' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='54.16' cy='521.37' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='159.23' cy='426.40' r='1.95' style='stroke-width: 0.71; stroke: #B79F00; fill: #B79F00;' />
+<circle cx='264.29' cy='331.43' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<circle cx='369.35' cy='236.46' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='474.41' cy='141.49' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
+<circle cx='579.47' cy='46.53' r='1.95' style='stroke-width: 0.71; stroke: #F564E3; fill: #F564E3;' />
+<rect x='27.90' y='22.78' width='577.84' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='22.97' y='429.43' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='22.97' y='239.49' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='22.97' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<polyline points='25.16,426.40 27.90,426.40 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='25.16,236.46 27.90,236.46 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='25.16,46.53 27.90,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='159.23,547.85 159.23,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='369.35,547.85 369.35,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='579.47,547.85 579.47,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='159.23' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='369.35' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='579.47' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='316.82' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<rect x='616.70' y='259.00' width='97.82' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='616.70' y='267.71' style='font-size: 11.00px; font-family: sans;' textLength='3.06px' lengthAdjust='spacingAndGlyphs'>f</text>
+<rect x='616.70' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='625.34' cy='282.97' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<rect x='651.29' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='659.93' cy='282.97' r='1.95' style='stroke-width: 0.71; stroke: #B79F00; fill: #B79F00;' />
+<rect x='685.40' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='694.04' cy='282.97' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
+<rect x='616.70' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='625.34' cy='300.25' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<rect x='651.29' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='659.93' cy='300.25' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
+<rect x='685.40' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='694.04' cy='300.25' r='1.95' style='stroke-width: 0.71; stroke: #F564E3; fill: #F564E3;' />
+<text x='639.46' y='286.00' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>A</text>
+<text x='674.05' y='286.00' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>B</text>
+<text x='708.16' y='286.00' style='font-size: 8.80px; font-family: sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>C</text>
+<text x='639.46' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='6.36px' lengthAdjust='spacingAndGlyphs'>D</text>
+<text x='674.05' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='5.87px' lengthAdjust='spacingAndGlyphs'>E</text>
+<text x='708.16' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='5.38px' lengthAdjust='spacingAndGlyphs'>F</text>
+<text x='27.90' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='129.52px' lengthAdjust='spacingAndGlyphs'>legend.byrow = TRUE</text>
+</g>
+</svg>

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -1161,6 +1161,23 @@ test_that("guides() warns if unnamed guides are provided", {
   expect_null(guides())
 })
 
+test_that("legend.byrow works in `guide_legend()`", {
+
+  df <- data.frame(x = 1:6, f = LETTERS[1:6])
+
+  p <- ggplot(df, aes(x, x, colour = f)) +
+    geom_point() +
+    scale_colour_discrete(
+      guide = guide_legend(
+        ncol = 3,
+        theme = theme(legend.byrow = TRUE)
+      )
+    )
+
+  expect_doppelganger("legend.byrow = TRUE", p)
+
+})
+
 test_that("old S3 guides can be implemented", {
 
   my_env <- env()


### PR DESCRIPTION
This PR to the RC aims to fix #5661.

Briefly the `legend.byrow` setting wasn't working because the code assumed it was in `params` whereas we swapped it to `elements` later. 

This made me realise that `Guide$arrange_layout()` needed access to the `elements` (instead of sneakily passing it through `size` ), so this PR also adds `elements` as an argument. 

I was also surprised that there was no test for the `legend.byrow` setting, so I added one.