### PR TITLE
Update `scale_alpha()` examples

### DIFF
--- a/R/scale-alpha.R
+++ b/R/scale-alpha.R
@@ -21,9 +21,14 @@
 #' p <- ggplot(mpg, aes(displ, hwy)) +
 #'   geom_point(aes(alpha = year))
 #'
+#' # The default range of 0.1-1.0 leaves all data visible
 #' p
+#'
+#' # Include 0 in the range to make data invisible
+#' p + scale_alpha(range = c(0, 1))
+#'
+#' # Changing the title
 #' p + scale_alpha("cylinders")
-#' p + scale_alpha(range = c(0.4, 0.8))
 scale_alpha <- function(name = waiver(), ..., range = c(0.1, 1)) {
   continuous_scale("alpha", name = name, palette = pal_rescale(range), ...)
 }

--- a/man/scale_alpha.Rd
+++ b/man/scale_alpha.Rd
@@ -42,9 +42,14 @@ that is the most common use of alpha, and it saves a bit of typing.
 p <- ggplot(mpg, aes(displ, hwy)) +
   geom_point(aes(alpha = year))
 
+# The default range of 0.1-1.0 leaves all data visible
 p
+
+# Include 0 in the range to make data invisible
+p + scale_alpha(range = c(0, 1))
+
+# Changing the title
 p + scale_alpha("cylinders")
-p + scale_alpha(range = c(0.4, 0.8))
 }
 \seealso{
 The documentation on \link[=aes_colour_fill_alpha]{colour aesthetics}.


### PR DESCRIPTION
This PR aims to fix #2865.

Rendered examples:

``` r
library(ggplot2)
p <- ggplot(mpg, aes(displ, hwy)) +
  geom_point(aes(alpha = year))

# The default range of 0.1-1.0 leaves all data visible
p
```

![](https://i.imgur.com/ZzY7H28.png)<!-- -->

``` r

# Include 0 in the range to make data invisible
p + scale_alpha(range = c(0, 1))
```

![](https://i.imgur.com/OSriUXx.png)<!-- -->

``` r

# Changing the title
p + scale_alpha("cylinders")
```

![](https://i.imgur.com/jluiZuj.png)<!-- -->

<sup>Created on 2024-02-02 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
