### PR TITLE
Deduplicate `geom_function()` examples

### DIFF
--- a/R/geom-function.R
+++ b/R/geom-function.R
@@ -42,14 +42,14 @@
 #'   geom_function(aes(colour = "t, df = 1"), fun = dt, args = list(df = 1))
 #'
 #' # Using a custom anonymous function
-#' base + geom_function(fun = function(x) 0.5*exp(-abs(x)))
-#'
-#' base + geom_function(fun = ~ 0.5*exp(-abs(.x)))
-#'
-#' # Using a custom named function
-#' f <- function(x) 0.5*exp(-abs(x))
-#'
-#' base + geom_function(fun = f)
+#' base + geom_function(fun = function(x) 0.5 * exp(-abs(x)))
+#' # or using lambda syntax:
+#' # base + geom_function(fun = ~ 0.5 * exp(-abs(.x)))
+#' # or in R4.1.0 and above:
+#' # base + geom_function(fun = \(x) 0.5 * exp(-abs(x)))
+#' # or using a custom named function:
+#' # f <- function(x) 0.5 * exp(-abs(x))
+#' # base + geom_function(fun = f)
 #'
 #' # Using xlim to restrict the range of function
 #' ggplot(data.frame(x = rnorm(100)), aes(x)) +

--- a/man/geom_function.Rd
+++ b/man/geom_function.Rd
@@ -146,14 +146,14 @@ base +
   geom_function(aes(colour = "t, df = 1"), fun = dt, args = list(df = 1))
 
 # Using a custom anonymous function
-base + geom_function(fun = function(x) 0.5*exp(-abs(x)))
-
-base + geom_function(fun = ~ 0.5*exp(-abs(.x)))
-
-# Using a custom named function
-f <- function(x) 0.5*exp(-abs(x))
-
-base + geom_function(fun = f)
+base + geom_function(fun = function(x) 0.5 * exp(-abs(x)))
+# or using lambda syntax:
+# base + geom_function(fun = ~ 0.5 * exp(-abs(.x)))
+# or in R4.1.0 and above:
+# base + geom_function(fun = \(x) 0.5 * exp(-abs(x)))
+# or using a custom named function:
+# f <- function(x) 0.5 * exp(-abs(x))
+# base + geom_function(fun = f)
 
 # Using xlim to restrict the range of function
 ggplot(data.frame(x = rnorm(100)), aes(x)) +


### PR DESCRIPTION
This PR aims to fix #3181.

Briefly, it comments out various options of providing the function to `geom_function()`. I didn't find the duplicated examples for facets mentioned in #3181, so I think removing the duplicates for `geom_functino()` suffices.