### PR TITLE
Clarify that limits are given after expansion

### DIFF
--- a/R/scale-.R
+++ b/R/scale-.R
@@ -19,6 +19,7 @@
 #'   - A numeric vector of positions
 #'   - A function that takes the limits as input and returns breaks
 #'     as output (e.g., a function returned by [scales::extended_breaks()]).
+#'     Note that for position scales, limits are provided after scale expansion.
 #'     Also accepts rlang [lambda][rlang::as_function()] function notation.
 #' @param minor_breaks One of:
 #'   - `NULL` for no minor breaks

--- a/man/binned_scale.Rd
+++ b/man/binned_scale.Rd
@@ -51,6 +51,7 @@ omitted.}
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
 as output (e.g., a function returned by \code{\link[scales:breaks_extended]{scales::extended_breaks()}}).
+Note that for position scales, limits are provided after scale expansion.
 Also accepts rlang \link[rlang:as_function]{lambda} function notation.
 }}
 

--- a/man/continuous_scale.Rd
+++ b/man/continuous_scale.Rd
@@ -49,6 +49,7 @@ omitted.}
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
 as output (e.g., a function returned by \code{\link[scales:breaks_extended]{scales::extended_breaks()}}).
+Note that for position scales, limits are provided after scale expansion.
 Also accepts rlang \link[rlang:as_function]{lambda} function notation.
 }}
 

--- a/man/scale_binned.Rd
+++ b/man/scale_binned.Rd
@@ -64,6 +64,7 @@ breaks are given explicitly.}
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
 as output (e.g., a function returned by \code{\link[scales:breaks_extended]{scales::extended_breaks()}}).
+Note that for position scales, limits are provided after scale expansion.
 Also accepts rlang \link[rlang:as_function]{lambda} function notation.
 }}
 

--- a/man/scale_continuous.Rd
+++ b/man/scale_continuous.Rd
@@ -71,6 +71,7 @@ omitted.}
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
 as output (e.g., a function returned by \code{\link[scales:breaks_extended]{scales::extended_breaks()}}).
+Note that for position scales, limits are provided after scale expansion.
 Also accepts rlang \link[rlang:as_function]{lambda} function notation.
 }}
 

--- a/man/scale_gradient.Rd
+++ b/man/scale_gradient.Rd
@@ -114,6 +114,7 @@ values between 0 and 1 returns the corresponding output values
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
 as output (e.g., a function returned by \code{\link[scales:breaks_extended]{scales::extended_breaks()}}).
+Note that for position scales, limits are provided after scale expansion.
 Also accepts rlang \link[rlang:as_function]{lambda} function notation.
 }}
     \item{\code{minor_breaks}}{One of:

--- a/man/scale_linewidth.Rd
+++ b/man/scale_linewidth.Rd
@@ -48,6 +48,7 @@ omitted.}
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
 as output (e.g., a function returned by \code{\link[scales:breaks_extended]{scales::extended_breaks()}}).
+Note that for position scales, limits are provided after scale expansion.
 Also accepts rlang \link[rlang:as_function]{lambda} function notation.
 }}
 

--- a/man/scale_size.Rd
+++ b/man/scale_size.Rd
@@ -66,6 +66,7 @@ omitted.}
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
 as output (e.g., a function returned by \code{\link[scales:breaks_extended]{scales::extended_breaks()}}).
+Note that for position scales, limits are provided after scale expansion.
 Also accepts rlang \link[rlang:as_function]{lambda} function notation.
 }}
 

--- a/man/scale_steps.Rd
+++ b/man/scale_steps.Rd
@@ -116,6 +116,7 @@ the left (open on the right).}
 \item A numeric vector of positions
 \item A function that takes the limits as input and returns breaks
 as output (e.g., a function returned by \code{\link[scales:breaks_extended]{scales::extended_breaks()}}).
+Note that for position scales, limits are provided after scale expansion.
 Also accepts rlang \link[rlang:as_function]{lambda} function notation.
 }}
     \item{\code{labels}}{One of:


### PR DESCRIPTION
This PR aims to fix #3445.

It simply adds a line to the function option for breaks that position scales get expanded limits. Since discrete scales document their own `breaks` param, this should only appear in continuous and binned scales.