### PR TITLE
Discard empty colourbars

### DIFF
--- a/R/guide-colorbar.R
+++ b/R/guide-colorbar.R
@@ -224,7 +224,11 @@ GuideColourbar <- ggproto(
       cli::cli_warn("{.fn guide_colourbar} needs continuous scales.")
       return(NULL)
     }
-    Guide$extract_key(scale, aesthetic, ...)
+    key <- Guide$extract_key(scale, aesthetic, ...)
+    if (NROW(key) == 0) {
+      return(NULL)
+    }
+    key
   },
 
   extract_decor = function(scale, aesthetic, nbin = 300, reverse = FALSE, alpha = NA, ...) {


### PR DESCRIPTION
This PR to the RC solves a reverse dependency issue.

Briefly, if scale limits are set to e.g. `c(0, NA)`, but all values are `NA`, the limits never get updated to finite values, causing a problem for the colourbar. This PR intercepts such problems by discarding colourbars that have 0 breaks.

