### PR TITLE
Revert #5657

### DIFF
--- a/R/geom-.R
+++ b/R/geom-.R
@@ -172,8 +172,16 @@ Geom <- ggproto("Geom",
 
     # Override mappings with params
     aes_params <- intersect(self$aesthetics(), names(params))
-    check_aesthetics(params[aes_params], nrow(data))
-    vec_cbind(data[setdiff(names(data), aes_params)], !!!params[aes_params])
+    new_params <- params[aes_params]
+    check_aesthetics(new_params, nrow(data))
+    data[aes_params] <- new_params
+
+    # Restore any AsIs classes (#5656)
+    is_asis <- which(vapply(new_params, inherits, what = "AsIs", logical(1)))
+    for (i in aes_params[is_asis]) {
+      data[[i]] <- I(data[[i]])
+    }
+    data
   },
 
   # Most parameters for the geom are taken automatically from draw_panel() or


### PR DESCRIPTION
This PR to the RC aims to fix a revdep bug.

Briefly, in #5657, we used `vec_cbind()` to preserve AsIs vectors. However, {vctrs} does not treat expressions as vectors. Any geom declaring an expression outside of `aes()` would fail. This PR restores the old subassignment method, but instead explicitly restores AsIs vectors.