### PR TITLE
Remove `expand` and `position` from non-position scale docs

### DIFF
--- a/R/scale-gradient.R
+++ b/R/scale-gradient.R
@@ -16,7 +16,7 @@
 #' @param low,high Colours for low and high ends of the gradient.
 #' @param guide Type of legend. Use `"colourbar"` for continuous
 #'   colour bar, or `"legend"` for discrete colour legend.
-#' @inheritDotParams continuous_scale -na.value -guide -aesthetics
+#' @inheritDotParams continuous_scale -na.value -guide -aesthetics -expand -position
 #' @seealso [scales::pal_seq_gradient()] for details on underlying
 #'   palette, [scale_colour_steps()] for binned variants of these scales.
 #'

--- a/R/scale-grey.R
+++ b/R/scale-grey.R
@@ -5,7 +5,7 @@
 #'
 #' @inheritParams scales::pal_grey
 #' @inheritParams scale_colour_hue
-#' @inheritDotParams discrete_scale
+#' @inheritDotParams discrete_scale -expand -position
 #' @family colour scales
 #' @seealso
 #' The documentation on [colour aesthetics][aes_colour_fill_alpha].

--- a/R/scale-hue.R
+++ b/R/scale-hue.R
@@ -4,7 +4,7 @@
 #' It does not generate colour-blind safe palettes.
 #'
 #' @param na.value Colour to use for missing values
-#' @inheritDotParams discrete_scale -aesthetics
+#' @inheritDotParams discrete_scale -aesthetics -expand -position
 #' @param aesthetics Character string or vector of character strings listing the
 #'   name(s) of the aesthetic(s) that this scale works with. This can be useful, for
 #'   example, to apply colour settings to the `colour` and `fill` aesthetics at the

--- a/R/scale-size.R
+++ b/R/scale-size.R
@@ -112,7 +112,7 @@ scale_size_ordinal <- function(name = waiver(), ..., range = c(2, 6)) {
   )
 }
 
-#' @inheritDotParams continuous_scale -aesthetics -scale_name -palette -rescaler
+#' @inheritDotParams continuous_scale -aesthetics -scale_name -palette -rescaler -expand -position
 #' @param max_size Size of largest points.
 #' @export
 #' @rdname scale_size

--- a/R/scale-steps.R
+++ b/R/scale-steps.R
@@ -13,7 +13,7 @@
 #' Munsell colour system.
 #'
 #' @inheritParams scale_colour_gradient
-#' @inheritDotParams binned_scale -aesthetics -scale_name -palette -na.value -guide -rescaler
+#' @inheritDotParams binned_scale -aesthetics -scale_name -palette -na.value -guide -rescaler -expand -position
 #'
 #' @seealso [scales::pal_seq_gradient()] for details on underlying
 #'   palette, [scale_colour_gradient()] for continuous scales without binning.

--- a/man/scale_gradient.Rd
+++ b/man/scale_gradient.Rd
@@ -172,14 +172,6 @@ bounds values with \code{NA}.
 }}
     \item{\code{trans}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated in favour of
 \code{transform}.}
-    \item{\code{expand}}{For position scales, a vector of range expansion constants used to add some
-padding around the data to ensure that they are placed some distance
-away from the axes. Use the convenience function \code{\link[=expansion]{expansion()}}
-to generate the values for the \code{expand} argument. The defaults are to
-expand the scale by 5\% on each side for continuous variables, and by
-0.6 units on each side for discrete variables.}
-    \item{\code{position}}{For position scales, The position of the axis.
-\code{left} or \code{right} for y axes, \code{top} or \code{bottom} for x axes.}
     \item{\code{call}}{The \code{call} used to construct the scale for reporting messages.}
     \item{\code{super}}{The super class to use for the constructed scale}
   }}

--- a/man/scale_grey.Rd
+++ b/man/scale_grey.Rd
@@ -75,14 +75,6 @@ notation.
 }}
     \item{\code{guide}}{A function used to create a guide or its name. See
 \code{\link[=guides]{guides()}} for more information.}
-    \item{\code{expand}}{For position scales, a vector of range expansion constants used to add some
-padding around the data to ensure that they are placed some distance
-away from the axes. Use the convenience function \code{\link[=expansion]{expansion()}}
-to generate the values for the \code{expand} argument. The defaults are to
-expand the scale by 5\% on each side for continuous variables, and by
-0.6 units on each side for discrete variables.}
-    \item{\code{position}}{For position scales, The position of the axis.
-\code{left} or \code{right} for y axes, \code{top} or \code{bottom} for x axes.}
     \item{\code{call}}{The \code{call} used to construct the scale for reporting messages.}
     \item{\code{super}}{The super class to use for the constructed scale}
   }}

--- a/man/scale_hue.Rd
+++ b/man/scale_hue.Rd
@@ -81,14 +81,6 @@ notation.
 }}
     \item{\code{guide}}{A function used to create a guide or its name. See
 \code{\link[=guides]{guides()}} for more information.}
-    \item{\code{expand}}{For position scales, a vector of range expansion constants used to add some
-padding around the data to ensure that they are placed some distance
-away from the axes. Use the convenience function \code{\link[=expansion]{expansion()}}
-to generate the values for the \code{expand} argument. The defaults are to
-expand the scale by 5\% on each side for continuous variables, and by
-0.6 units on each side for discrete variables.}
-    \item{\code{position}}{For position scales, The position of the axis.
-\code{left} or \code{right} for y axes, \code{top} or \code{bottom} for x axes.}
     \item{\code{call}}{The \code{call} used to construct the scale for reporting messages.}
     \item{\code{super}}{The super class to use for the constructed scale}
   }}

--- a/man/scale_size.Rd
+++ b/man/scale_size.Rd
@@ -152,14 +152,6 @@ bounds values with \code{NA}.
 \item \code{\link[scales:oob]{scales::squish_infinite()}} for squishing infinite values into range.
 }}
     \item{\code{na.value}}{Missing values will be replaced with this value.}
-    \item{\code{expand}}{For position scales, a vector of range expansion constants used to add some
-padding around the data to ensure that they are placed some distance
-away from the axes. Use the convenience function \code{\link[=expansion]{expansion()}}
-to generate the values for the \code{expand} argument. The defaults are to
-expand the scale by 5\% on each side for continuous variables, and by
-0.6 units on each side for discrete variables.}
-    \item{\code{position}}{For position scales, The position of the axis.
-\code{left} or \code{right} for y axes, \code{top} or \code{bottom} for x axes.}
     \item{\code{call}}{The \code{call} used to construct the scale for reporting messages.}
     \item{\code{super}}{The super class to use for the constructed scale}
   }}

--- a/man/scale_steps.Rd
+++ b/man/scale_steps.Rd
@@ -153,14 +153,6 @@ bounds values with \code{NA}.
 }}
     \item{\code{trans}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Deprecated in favour of
 \code{transform}.}
-    \item{\code{expand}}{For position scales, a vector of range expansion constants used to add some
-padding around the data to ensure that they are placed some distance
-away from the axes. Use the convenience function \code{\link[=expansion]{expansion()}}
-to generate the values for the \code{expand} argument. The defaults are to
-expand the scale by 5\% on each side for continuous variables, and by
-0.6 units on each side for discrete variables.}
-    \item{\code{position}}{For position scales, The position of the axis.
-\code{left} or \code{right} for y axes, \code{top} or \code{bottom} for x axes.}
     \item{\code{call}}{The \code{call} used to construct the scale for reporting messages.}
     \item{\code{super}}{The super class to use for the constructed scale}
   }}


### PR DESCRIPTION
This PR aims to fix #5698.

Briefly, through `@inheritDotParams`, some non-position scales inherited the documentation for the `expand` and `position` arguments that only work for position scales. This PR removes these.