### PR TITLE
Mention secondary transformation must be *strictly* monotonic

### DIFF
--- a/R/axis-secondary.R
+++ b/R/axis-secondary.R
@@ -4,7 +4,7 @@
 #' secondary axis, positioned opposite of the primary axis. All secondary
 #' axes must be based on a one-to-one transformation of the primary axes.
 #'
-#' @param transform A formula or function of transformation
+#' @param transform A formula or function of a strictly monotonic transformation
 #'
 #' @param trans `r lifecycle::badge("deprecated")`
 #'
@@ -205,7 +205,9 @@ AxisSecondary <- ggproto("AxisSecondary", NULL,
 
     # Test for monotonicity
     if (!is_unique(sign(diff(full_range))))
-      cli::cli_abort("Transformation for secondary axes must be monotonic.")
+      cli::cli_abort(
+        "Transformation for secondary axes must be strictly monotonic."
+      )
   },
 
   break_info = function(self, range, scale) {

--- a/man/sec_axis.Rd
+++ b/man/sec_axis.Rd
@@ -27,7 +27,7 @@ dup_axis(
 derive()
 }
 \arguments{
-\item{transform}{A formula or function of transformation}
+\item{transform}{A formula or function of a strictly monotonic transformation}
 
 \item{name}{The name of the secondary axis}
 

--- a/tests/testthat/_snaps/sec-axis.md
+++ b/tests/testthat/_snaps/sec-axis.md
@@ -8,5 +8,5 @@
 
 ---
 
-    Transformation for secondary axes must be monotonic.
+    Transformation for secondary axes must be strictly monotonic.
 


### PR DESCRIPTION
This PR aims to fix #5579.

Briefly, the error mentions that the transformation must be strictly monotonic, as well as the docs.