### PR TITLE
Debugger for ggproto methods

### DIFF
--- a/R/ggproto.R
+++ b/R/ggproto.R
@@ -349,3 +349,38 @@ format.ggproto_method <- function(x, ...) {
 
 # proto2 TODO: better way of getting formals for self$draw
 ggproto_formals <- function(x) formals(environment(x)$f)
+
+#' Debug wrapper for ggproto methods
+#'
+#' @param method A ggproto method or function to debug.
+#' @param debug One of the following:
+#'  * `"once"` for invoking `debugonce()` (default).
+#'  * `"always"` for invoking `debug()`.
+#'  * `"never"` for invoking `undebug()`.
+#' @param ... Arguments passed to the function invoked by the `debug` argument.
+#'
+#' @return `NULL`, this function is called for its side-effects.
+#' @noRd
+#'
+#' @examples
+#' p <- ggplot(mpg, aes(displ, hwy)) +
+#'   geom_point()
+#'
+#' if (interactive()) {
+#'   ggproto_debug(GeomPoint$draw_panel)
+#' }
+#'
+#' p
+ggproto_debug <- function(method, debug = c("once", "always", "never"), ...) {
+  if (inherits(method, "ggproto_method")) {
+    method <- environment(method)$f
+  }
+  check_function(method)
+  switch(
+    arg_match0(debug, c("once", "always", "never")),
+    once   = debugonce(method, ...),
+    always = debug(method, ...),
+    never  = undebug(method, ...)
+  )
+}
+


### PR DESCRIPTION
This PR aims to fix #5722.

Briefly, it implements a wrapper for `debug()`, `debugonce()` and `undebug()` for ggproto methods.
These can't be debugged in a typical fashion as the relevant functions are wrapped in `<ggproto_method>` classes.
Therefore, we need to extract the relevant function to debug from the method's environment.

A few open ends:
* The debugger isn't exported, but should it?
* I have no idea how to write a test for this.

Not really a great reprex as this is mostly for interactive use, but just showing that the debugger can be activated:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

p <- ggplot(mpg, aes(displ, hwy)) +
  geom_point()

ggproto_debug(GeomPoint$draw_panel)

p
```

![](https://i.imgur.com/rABlbFa.png)<!-- -->

```r
#> debugging in: draw_panel(..., self = self)
#> debug at ~/packages/ggplot2/R/geom-point.R#140: {
#>     if (is.character(data$shape)) {
#>         data$shape <- translate_shape_string(data$shape)
#>     }
#>     coords <- coord$transform(data, panel_params)
#>     stroke_size <- coords$stroke
#>     stroke_size[is.na(stroke_size)] <- 0
#>     ggname("geom_point", pointsGrob(coords$x, coords$y, pch = coords$shape, 
#>         gp = gpar(col = alpha(coords$colour, coords$alpha), fill = fill_alpha(coords$fill, 
#>             coords$alpha), fontsize = coords$size * .pt + stroke_size * 
#>             .stroke/2, lwd = coords$stroke * .stroke/2)))
#> }
#> debug at ~/packages/ggplot2/R/geom-point.R#141: if (is.character(data$shape)) {
#>     data$shape <- translate_shape_string(data$shape)
#> }
#> debug at ~/packages/ggplot2/R/geom-point.R#145: coords <- coord$transform(data, panel_params)
#> debug at ~/packages/ggplot2/R/geom-point.R#146: stroke_size <- coords$stroke
#> debug at ~/packages/ggplot2/R/geom-point.R#147: stroke_size[is.na(stroke_size)] <- 0
#> debug at ~/packages/ggplot2/R/geom-point.R#148: ggname("geom_point", pointsGrob(coords$x, coords$y, pch = coords$shape, 
#>     gp = gpar(col = alpha(coords$colour, coords$alpha), fill = fill_alpha(coords$fill, 
#>         coords$alpha), fontsize = coords$size * .pt + stroke_size * 
#>         .stroke/2, lwd = coords$stroke * .stroke/2)))
#> exiting from: draw_panel(..., self = self)
```
<sup>Created on 2024-02-28 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

