### PR TITLE
Remove `palette` from manual scale docs

### DIFF
--- a/R/scale-manual.R
+++ b/R/scale-manual.R
@@ -12,7 +12,7 @@
 #' of aesthetics provided via the `aesthetics` argument.
 #'
 #' @inheritParams scale_x_discrete
-#' @inheritDotParams discrete_scale -expand -position -aesthetics
+#' @inheritDotParams discrete_scale -expand -position -aesthetics -palette
 #' @param aesthetics Character string or vector of character strings listing the
 #'   name(s) of the aesthetic(s) that this scale works with. This can be useful, for
 #'   example, to apply colour settings to the `colour` and `fill` aesthetics at the

--- a/man/scale_manual.Rd
+++ b/man/scale_manual.Rd
@@ -44,9 +44,6 @@ scale_discrete_manual(aesthetics, ..., values, breaks = waiver())
 \item{...}{
   Arguments passed on to \code{\link[=discrete_scale]{discrete_scale}}
   \describe{
-    \item{\code{palette}}{A palette function that when called with a single integer
-argument (the number of levels in the scale) returns the values that
-they should take (e.g., \code{\link[scales:pal_hue]{scales::pal_hue()}}).}
     \item{\code{limits}}{One of:
 \itemize{
 \item \code{NULL} to use the default scale values


### PR DESCRIPTION
This PR aims to fix #5625.

It just removes `palette` from the documentation that `scale_{aes}_manual()` inherits from `discrete_scale()`.