### PR TITLE
`.data` pronoun speedup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 
 # ggplot2 (development version)
 
+* Fixed performance loss when the `.data` pronoun is used in `aes()` (#5730).
 * Fixed bug where discrete scales could not map aesthetics only consisting of
   `NA`s (#5623)
 * Facet evaluation is better at dealing with inherited errors 

--- a/R/aes.R
+++ b/R/aes.R
@@ -430,7 +430,7 @@ alternative_aes_extract_usage <- function(x) {
 }
 
 extract_target_is_likely_data <- function(x, data, env) {
-  if (!is.name(x[[2]])) {
+  if (!is.name(x[[2]]) || identical(x[[2]], quote(.data))) {
     return(FALSE)
   }
 


### PR DESCRIPTION
This PR aims to fix #5730.

Briefly, using the `.data` pronoun caused the plot to slow down by a non-trivial amount of time. This PR rectifies this by considering the pronoun as 'non-data'. To explain a bit further, here follows the diagnosis. 

`unrowname()` throws errors with pronouns:

``` r
x <- rlang::eval_tidy(quote(.data), mtcars)
print(x)
#> <pronoun>

ggplot2:::unrowname(x)
#> Error in `ggplot2:::unrowname()`:
#> ! Can only remove rownames from <data.frame> and <matrix> objects.
```

<sup>Created on 2024-02-29 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

And `unrowname()` is used to compare to see if a part of an expression evaluates to the plot data here:

https://github.com/tidyverse/ggplot2/blob/bc3e40144cb971cc1d86a05a171b373b15f54fcf/R/aes.R#L437-L440

As this is in a `tryCatch()` block, the errors that `unrowname()` throws for pronouns are silenced. However, formatting the error message is still relatively expensive.

In this PR, we circumvent this problem by recognising that the `.data` pronoun is not the same as the regular plot data, thereby bypassing the check in the lines above.

As a benchmark, we see that standard evaluation and with pronoun are in the same range with this PR:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

df <- mtcars
df$name <- rownames(mtcars)

p <- ggplot(df) +
  geom_point() +
  geom_text() +
  facet_grid(gear ~ cyl)

standard <- p + aes(x = mpg, y = disp, label = name, colour = factor(cyl))
pronoun  <- p + aes(
  x = .data[["mpg"]], 
  y = .data[["disp"]], 
  label = .data[["name"]],
  colour = factor(.data[["cyl"]])
)

bench::mark(
  ggplot_build(standard),
  ggplot_build(pronoun),
  check = FALSE, min_iterations = 10
)
#> # A tibble: 2 × 6
#>   expression                  min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>             <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 ggplot_build(standard)   67.4ms   68.4ms      14.7    6.17MB    14.7 
#> 2 ggplot_build(pronoun)      68ms   69.4ms      14.4    1.96MB     9.61
```

<sup>Created on 2024-02-29 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

For reference, this is the same benchmark result, but on the current main branch:

```r
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 × 6
#>   expression                  min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>             <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 ggplot_build(standard)   67.5ms   71.4ms     13.8     6.17MB     6.91
#> 2 ggplot_build(pronoun)     175ms  180.1ms      5.52    4.48MB     5.52
```