### PR TITLE
Deal with `NULL` margins in legend

### DIFF
--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -652,7 +652,8 @@ keep_key_data <- function(key, data, aes, show) {
   keep
 }
 
-position_margin <- function(position, margin = margin(), gap = unit(0, "pt")) {
+position_margin <- function(position, margin = NULL, gap = unit(0, "pt")) {
+  margin <- margin %||% margin()
   switch(
     position,
     top    = replace(margin, 3, margin[3] + gap),


### PR DESCRIPTION
This PR aims to fix #5738.

Briefly, when `theme(text = element_blank())`, it has no margin. This messes up some assumptions made in the legend that it would have a margin. In this PR, we just use 0-margins when this occurs.