### PR TITLE
`annotate()` gives warning when passing `position` or `stat`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * Patterns and gradients are now also enabled in `geom_sf()` 
   (@teunbrand, #5716).
 * `stat_bin()` deals with non-finite breaks better (@teunbrand, #5665).
+* `annotate()` now warns about `stat` or `position` arguments (@teunbrand, #5151)
 
 # ggplot2 3.5.0
 

--- a/R/annotation.R
+++ b/R/annotation.R
@@ -74,12 +74,19 @@ annotate <- function(geom, x = NULL, y = NULL, xmin = NULL, xmax = NULL,
   }
 
   data <- data_frame0(!!!position, .size = n)
+
+  params <- list2(na.rm = na.rm, ...)
+  reject <- intersect(names(params), c("position", "stat"))
+  if (length(reject) > 0) {
+    cli::cli_warn(
+      "{.fn annotate} can't accept {.or {.arg {reject}}} argument{?s}."
+    )
+    params <- params[setdiff(names(params), reject)]
+  }
+
   layer(
     geom = geom,
-    params = list(
-      na.rm = na.rm,
-      ...
-    ),
+    params = params,
     stat = StatIdentity,
     position = PositionIdentity,
     data = data,

--- a/tests/testthat/_snaps/annotate.md
+++ b/tests/testthat/_snaps/annotate.md
@@ -34,3 +34,7 @@
     Using the `size` aesthetic in this geom was deprecated in ggplot2 3.5.0.
     i Please use `linewidth` instead.
 
+# annotate() warns about `stat` or `position` arguments
+
+    `annotate()` can't accept `stat` or `position` arguments.
+

--- a/tests/testthat/test-annotate.R
+++ b/tests/testthat/test-annotate.R
@@ -80,3 +80,9 @@ test_that("annotate() checks aesthetic lengths match", {
 test_that("annotation_logticks warns about deprecated `size` argument", {
   expect_snapshot_warning(annotation_logticks(size = 5))
 })
+
+test_that("annotate() warns about `stat` or `position` arguments", {
+  expect_snapshot_warning(
+    annotate("point", 1:3, 1:3, stat = "density", position = "dodge")
+  )
+})


### PR DESCRIPTION
This PR aims to fix #5151.

Briefly, `annotate()` is hardcoded to use `StatIdentity` and `PositionIdentity` so any `stat` or `position` argument to `annotate()` ends up in the `params` to the layer. This PR warns about such cases and pre-emptively removes these arguments.

Demo:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

ggplot(mpg, aes(displ, hwy)) +
  geom_point() +
  annotate(
    "point", x = 3, y = 40,
    position = position_jitter()
  )
#> Warning: `annotate()` can't accept `position` argument.
```

![](https://i.imgur.com/yd3F8Oh.png)<!-- -->

<sup>Created on 2024-03-05 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
