### PR TITLE
Redocument `stat_summary_bin()`'s  `breaks` argument.

### DIFF
--- a/R/stat-summary-bin.R
+++ b/R/stat-summary-bin.R
@@ -1,5 +1,7 @@
 #' @rdname stat_summary
 #' @inheritParams stat_bin
+#' @param breaks Alternatively, you can supply a numeric vector giving the bin
+#'   boundaries.
 #' @export
 stat_summary_bin <- function(mapping = NULL, data = NULL,
                              geom = "pointrange", position = "identity",

--- a/R/stat-summary-bin.R
+++ b/R/stat-summary-bin.R
@@ -1,7 +1,7 @@
 #' @rdname stat_summary
 #' @inheritParams stat_bin
 #' @param breaks Alternatively, you can supply a numeric vector giving the bin
-#'   boundaries.
+#'   boundaries. Overrides `binwidth` and `bins`.
 #' @export
 stat_summary_bin <- function(mapping = NULL, data = NULL,
                              geom = "pointrange", position = "identity",

--- a/man/stat_summary.Rd
+++ b/man/stat_summary.Rd
@@ -145,9 +145,8 @@ stories in your data.
 The bin width of a date variable is the number of days in each time; the
 bin width of a time variable is the number of seconds.}
 
-\item{breaks}{Alternatively, you can supply a numeric vector giving
-the bin boundaries. Overrides \code{binwidth}, \code{bins}, \code{center},
-and \code{boundary}.}
+\item{breaks}{Alternatively, you can supply a numeric vector giving the bin
+boundaries.}
 
 \item{na.rm}{If \code{FALSE}, the default, missing values are removed with
 a warning. If \code{TRUE}, missing values are silently removed.}

--- a/man/stat_summary.Rd
+++ b/man/stat_summary.Rd
@@ -146,7 +146,7 @@ The bin width of a date variable is the number of days in each time; the
 bin width of a time variable is the number of seconds.}
 
 \item{breaks}{Alternatively, you can supply a numeric vector giving the bin
-boundaries.}
+boundaries. Overrides \code{binwidth} and \code{bins}.}
 
 \item{na.rm}{If \code{FALSE}, the default, missing values are removed with
 a warning. If \code{TRUE}, missing values are silently removed.}


### PR DESCRIPTION
This PR aims to fix #3480.

Briefly, `stat_summary_bin()` inherits documentation from `stat_bin()`, but doesn't have `boundary` or `center`.
This PR removes the mention of these arguments from the docs, preventing confusion demonstrated in #3480.