### PR TITLE
Update example in `theme()` documentation

### DIFF
--- a/R/theme.R
+++ b/R/theme.R
@@ -272,7 +272,8 @@
 #' # Or place legends inside the plot using relative coordinates between 0 and 1
 #' # legend.justification sets the corner that the position refers to
 #' p2 + theme(
-#'   legend.position = c(.95, .95),
+#'   legend.position = "inside",
+#'   legend.position.inside = c(.95, .95),
 #'   legend.justification = c("right", "top"),
 #'   legend.box.just = "right",
 #'   legend.margin = margin(6, 6, 6, 6)

--- a/man/theme.Rd
+++ b/man/theme.Rd
@@ -455,7 +455,8 @@ p2 + theme(legend.position = "bottom")
 # Or place legends inside the plot using relative coordinates between 0 and 1
 # legend.justification sets the corner that the position refers to
 p2 + theme(
-  legend.position = c(.95, .95),
+  legend.position = "inside",
+  legend.position.inside = c(.95, .95),
   legend.justification = c("right", "top"),
   legend.box.just = "right",
   legend.margin = margin(6, 6, 6, 6)


### PR DESCRIPTION
This PR aims to fix #5766.

Briefly, one example used the old (pre-3.5.0) way of setting a legend inside the panel bounds. This PR updates that example.