### PR TITLE
Silence length 1 aesthetics warning for `geom_blank()`

### DIFF
--- a/R/geom-blank.R
+++ b/R/geom-blank.R
@@ -36,5 +36,6 @@ geom_blank <- function(mapping = NULL, data = NULL,
 GeomBlank <- ggproto("GeomBlank", Geom,
   default_aes = aes(),
   handle_na = function(data, params) data,
+  check_constant_aes = FALSE,
   draw_panel = function(...) nullGrob()
 )


### PR DESCRIPTION
This PR aims to fix #5772.

It uses the mechanism we included to opt-out of the warning.