### PR TITLE
Mention static aesthetic caveat

### DIFF
--- a/R/geom-point.R
+++ b/R/geom-point.R
@@ -40,7 +40,9 @@
 #'     value and apply to the layer as a whole. For example, `colour = "red"`
 #'     or `linewidth = 3`. The geom's documentation has an **Aesthetics**
 #'     section that lists the available options. The 'required' aesthetics
-#'     cannot be passed on to the `params`.
+#'     cannot be passed on to the `params`. Please note that while passing
+#'     unmapped aesthetics as vectors is technically possible, the order and
+#'     required length is not guaranteed to be parallel to the input data.
 #'   * When constructing a layer using
 #'     a `stat_*()` function, the `...` argument can be used to pass on
 #'     parameters to the `geom` part of the layer. An example of this is

--- a/man/annotate.Rd
+++ b/man/annotate.Rd
@@ -34,7 +34,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_abline.Rd
+++ b/man/geom_abline.Rd
@@ -62,7 +62,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_bar.Rd
+++ b/man/geom_bar.Rd
@@ -89,7 +89,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_bin_2d.Rd
+++ b/man/geom_bin_2d.Rd
@@ -76,7 +76,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_blank.Rd
+++ b/man/geom_blank.Rd
@@ -71,7 +71,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_boxplot.Rd
+++ b/man/geom_boxplot.Rd
@@ -86,7 +86,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_contour.Rd
+++ b/man/geom_contour.Rd
@@ -123,7 +123,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_count.Rd
+++ b/man/geom_count.Rd
@@ -71,7 +71,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_density.Rd
+++ b/man/geom_density.Rd
@@ -80,7 +80,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_dotplot.Rd
+++ b/man/geom_dotplot.Rd
@@ -70,7 +70,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_errorbarh.Rd
+++ b/man/geom_errorbarh.Rd
@@ -72,7 +72,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_function.Rd
+++ b/man/geom_function.Rd
@@ -75,7 +75,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_hex.Rd
+++ b/man/geom_hex.Rd
@@ -74,7 +74,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_histogram.Rd
+++ b/man/geom_histogram.Rd
@@ -95,7 +95,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_jitter.Rd
+++ b/man/geom_jitter.Rd
@@ -74,7 +74,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_linerange.Rd
+++ b/man/geom_linerange.Rd
@@ -115,7 +115,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_map.Rd
+++ b/man/geom_map.Rd
@@ -59,7 +59,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_path.Rd
+++ b/man/geom_path.Rd
@@ -102,7 +102,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_point.Rd
+++ b/man/geom_point.Rd
@@ -72,7 +72,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_polygon.Rd
+++ b/man/geom_polygon.Rd
@@ -78,7 +78,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_qq.Rd
+++ b/man/geom_qq.Rd
@@ -120,7 +120,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_quantile.Rd
+++ b/man/geom_quantile.Rd
@@ -78,7 +78,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_ribbon.Rd
+++ b/man/geom_ribbon.Rd
@@ -100,7 +100,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_rug.Rd
+++ b/man/geom_rug.Rd
@@ -75,7 +75,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_segment.Rd
+++ b/man/geom_segment.Rd
@@ -94,7 +94,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -85,7 +85,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_spoke.Rd
+++ b/man/geom_spoke.Rd
@@ -73,7 +73,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_text.Rd
+++ b/man/geom_text.Rd
@@ -96,7 +96,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_tile.Rd
+++ b/man/geom_tile.Rd
@@ -101,7 +101,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/geom_violin.Rd
+++ b/man/geom_violin.Rd
@@ -84,7 +84,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/ggsf.Rd
+++ b/man/ggsf.Rd
@@ -246,7 +246,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/stat_ecdf.Rd
+++ b/man/stat_ecdf.Rd
@@ -74,7 +74,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/stat_ellipse.Rd
+++ b/man/stat_ellipse.Rd
@@ -75,7 +75,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/stat_identity.Rd
+++ b/man/stat_identity.Rd
@@ -71,7 +71,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/stat_sf_coordinates.Rd
+++ b/man/stat_sf_coordinates.Rd
@@ -95,7 +95,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/stat_summary.Rd
+++ b/man/stat_summary.Rd
@@ -105,7 +105,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/stat_summary_2d.Rd
+++ b/man/stat_summary_2d.Rd
@@ -95,7 +95,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is

--- a/man/stat_unique.Rd
+++ b/man/stat_unique.Rd
@@ -72,7 +72,9 @@ of the 4 categories below are ignored.
 value and apply to the layer as a whole. For example, \code{colour = "red"}
 or \code{linewidth = 3}. The geom's documentation has an \strong{Aesthetics}
 section that lists the available options. The 'required' aesthetics
-cannot be passed on to the \code{params}.
+cannot be passed on to the \code{params}. Please note that while passing
+unmapped aesthetics as vectors is technically possible, the order and
+required length is not guaranteed to be parallel to the input data.
 \item When constructing a layer using
 a \verb{stat_*()} function, the \code{...} argument can be used to pass on
 parameters to the \code{geom} part of the layer. An example of this is


### PR DESCRIPTION
This PR aims to fix #4821.

Briefly, the discussion in the linked issue suggested either better warnings or better documentation for the problem of passing a length 2+ vector as static aesthetic outside of `aes()`. I argued in favour of keeping current behaviour without warnings, so this PR adjusts the documentation instead. It tries to make clear that there are no guarantees about vectors passed as static aesthetics.

