### PR TITLE
Discrete minor ticks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # ggplot2 (development version)
 
+* Discrete scales now support `minor_breaks`. This may only make sense in
+  discrete position scales, where it affects the placement of minor ticks
+  and minor gridlines (#5434).
 * Fixed performance loss when the `.data` pronoun is used in `aes()` (#5730).
 * Fixed bug where discrete scales could not map aesthetics only consisting of
   `NA`s (#5623)

--- a/R/guide-axis.R
+++ b/R/guide-axis.R
@@ -133,6 +133,11 @@ GuideAxis <- ggproto(
 
     if (nrow(major) > 0) {
       major$.type <- "major"
+      if (!vec_is(minor$.value, major$.value)) {
+        # If we have mixed types of values, which may happen in discrete scales,
+        # discard minor values in favour of the major values.
+        minor$.value <- NULL
+      }
       vec_rbind(major, minor)
     } else {
       minor

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -199,7 +199,8 @@ continuous_scale <- function(aesthetics, scale_name = deprecated(), palette, nam
 #' The `r link_book("new scales section", "extensions#sec-new-scales")`
 #' @keywords internal
 discrete_scale <- function(aesthetics, scale_name = deprecated(), palette, name = waiver(),
-                           breaks = waiver(), labels = waiver(), limits = NULL, expand = waiver(),
+                           breaks = waiver(), minor_breaks = waiver(),
+                           labels = waiver(), limits = NULL, expand = waiver(),
                            na.translate = TRUE, na.value = NA, drop = TRUE,
                            guide = "legend", position = "left",
                            call = caller_call(),
@@ -217,6 +218,7 @@ discrete_scale <- function(aesthetics, scale_name = deprecated(), palette, name 
   limits <- allow_lambda(limits)
   breaks <- allow_lambda(breaks)
   labels <- allow_lambda(labels)
+  minor_breaks <- allow_lambda(minor_breaks)
 
   if (!is.function(limits) && (length(limits) > 0) && !is.discrete(limits)) {
     cli::cli_warn(c(
@@ -246,6 +248,7 @@ discrete_scale <- function(aesthetics, scale_name = deprecated(), palette, name 
 
     name = name,
     breaks = breaks,
+    minor_breaks = minor_breaks,
     labels = labels,
     drop = drop,
     guide = guide,

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -1023,7 +1023,34 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
     structure(in_domain, pos = match(in_domain, breaks))
   },
 
-  get_breaks_minor = function(...) NULL,
+  get_breaks_minor = function(self, n = 2, b = self$break_positions(),
+                              limits = self$get_limits()) {
+    breaks <- self$minor_breaks
+    # The default is to draw no minor ticks
+    if (is.null(breaks %|W|% NULL)) {
+      return(NULL)
+    }
+    if (is.function(breaks)) {
+      # Ensure function gets supplied numeric limits and breaks
+      if (!is.numeric(b)) {
+        b <- self$map(b)
+      }
+      if (!is.numeric(limits)) {
+        limits <- self$map(limits)
+        limits <- self$dimension(self$expand, limits)
+      }
+
+      # Allow for two types of minor breaks specifications
+      break_fun <- fetch_ggproto(self, "minor_breaks")
+      arg_names <- fn_fmls_names(break_fun)
+      if (length(arg_names) == 1L) {
+        breaks <- break_fun(limits)
+      } else {
+        breaks <- break_fun(limits, b)
+      }
+    }
+    breaks
+  },
 
   get_labels = function(self, breaks = self$get_breaks()) {
     if (self$is_empty()) {

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -23,13 +23,13 @@
 #'     Also accepts rlang [lambda][rlang::as_function()] function notation.
 #' @param minor_breaks One of:
 #'   - `NULL` for no minor breaks
-#'   - `waiver()` for the default breaks (one minor break between
-#'     each major break)
+#'   - `waiver()` for the default breaks (none for discrete, one minor break
+#'     between each major break for continuous)
 #'   - A numeric vector of positions
 #'   - A function that given the limits returns a vector of minor breaks. Also
 #'     accepts rlang [lambda][rlang::as_function()] function notation. When
 #'     the function has two arguments, it will be given the limits and major
-#'     breaks.
+#'     break positions.
 #' @param n.breaks An integer guiding the number of major breaks. The algorithm
 #'   may choose a slightly different number to ensure nice break labels. Will
 #'   only have an effect if `breaks = waiver()`. Use `NULL` to use the default

--- a/R/scale-view.R
+++ b/R/scale-view.R
@@ -15,17 +15,16 @@
 view_scale_primary <- function(scale, limits = scale$get_limits(),
                                continuous_range = scale$dimension(limits = limits)) {
 
+  # continuous_range can be specified in arbitrary order, but
+  # scales expect the one in ascending order.
+  continuous_scale_sorted <- sort(continuous_range)
   if(!scale$is_discrete()) {
-    # continuous_range can be specified in arbitrary order, but
-    # continuous scales expect the one in ascending order.
-    continuous_scale_sorted <- sort(continuous_range)
     breaks <- scale$get_breaks(continuous_scale_sorted)
-    minor_breaks <- scale$get_breaks_minor(b = breaks, limits = continuous_scale_sorted)
     breaks <- censor(breaks, continuous_scale_sorted, only.finite = FALSE)
   } else {
     breaks <- scale$get_breaks(limits)
-    minor_breaks <- scale$get_breaks_minor(b = breaks, limits = limits)
   }
+  minor_breaks <- scale$get_breaks_minor(b = breaks, limits = continuous_scale_sorted)
   minor_breaks <- censor(minor_breaks, continuous_range, only.finite = FALSE)
 
   ggproto(NULL, ViewScale,

--- a/man/continuous_scale.Rd
+++ b/man/continuous_scale.Rd
@@ -56,13 +56,13 @@ Also accepts rlang \link[rlang:as_function]{lambda} function notation.
 \item{minor_breaks}{One of:
 \itemize{
 \item \code{NULL} for no minor breaks
-\item \code{waiver()} for the default breaks (one minor break between
-each major break)
+\item \code{waiver()} for the default breaks (none for discrete, one minor break
+between each major break for continuous)
 \item A numeric vector of positions
 \item A function that given the limits returns a vector of minor breaks. Also
 accepts rlang \link[rlang:as_function]{lambda} function notation. When
 the function has two arguments, it will be given the limits and major
-breaks.
+break positions.
 }}
 
 \item{n.breaks}{An integer guiding the number of major breaks. The algorithm

--- a/man/discrete_scale.Rd
+++ b/man/discrete_scale.Rd
@@ -10,6 +10,7 @@ discrete_scale(
   palette,
   name = waiver(),
   breaks = waiver(),
+  minor_breaks = waiver(),
   labels = waiver(),
   limits = NULL,
   expand = waiver(),
@@ -45,6 +46,18 @@ omitted.}
 \item A function that takes the limits as input and returns breaks
 as output. Also accepts rlang \link[rlang:as_function]{lambda} function
 notation.
+}}
+
+\item{minor_breaks}{One of:
+\itemize{
+\item \code{NULL} for no minor breaks
+\item \code{waiver()} for the default breaks (none for discrete, one minor break
+between each major break for continuous)
+\item A numeric vector of positions
+\item A function that given the limits returns a vector of minor breaks. Also
+accepts rlang \link[rlang:as_function]{lambda} function notation. When
+the function has two arguments, it will be given the limits and major
+break positions.
 }}
 
 \item{labels}{One of:

--- a/man/scale_continuous.Rd
+++ b/man/scale_continuous.Rd
@@ -78,13 +78,13 @@ Also accepts rlang \link[rlang:as_function]{lambda} function notation.
 \item{minor_breaks}{One of:
 \itemize{
 \item \code{NULL} for no minor breaks
-\item \code{waiver()} for the default breaks (one minor break between
-each major break)
+\item \code{waiver()} for the default breaks (none for discrete, one minor break
+between each major break for continuous)
 \item A numeric vector of positions
 \item A function that given the limits returns a vector of minor breaks. Also
 accepts rlang \link[rlang:as_function]{lambda} function notation. When
 the function has two arguments, it will be given the limits and major
-breaks.
+break positions.
 }}
 
 \item{n.breaks}{An integer guiding the number of major breaks. The algorithm

--- a/man/scale_discrete.Rd
+++ b/man/scale_discrete.Rd
@@ -63,6 +63,17 @@ where \code{NA} is always placed at the far right.}
     \item{\code{aesthetics}}{The names of the aesthetics that this scale works with.}
     \item{\code{scale_name}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The name of the scale
 that should be used for error messages associated with this scale.}
+    \item{\code{minor_breaks}}{One of:
+\itemize{
+\item \code{NULL} for no minor breaks
+\item \code{waiver()} for the default breaks (none for discrete, one minor break
+between each major break for continuous)
+\item A numeric vector of positions
+\item A function that given the limits returns a vector of minor breaks. Also
+accepts rlang \link[rlang:as_function]{lambda} function notation. When
+the function has two arguments, it will be given the limits and major
+break positions.
+}}
     \item{\code{labels}}{One of:
 \itemize{
 \item \code{NULL} for no labels

--- a/man/scale_gradient.Rd
+++ b/man/scale_gradient.Rd
@@ -120,13 +120,13 @@ Also accepts rlang \link[rlang:as_function]{lambda} function notation.
     \item{\code{minor_breaks}}{One of:
 \itemize{
 \item \code{NULL} for no minor breaks
-\item \code{waiver()} for the default breaks (one minor break between
-each major break)
+\item \code{waiver()} for the default breaks (none for discrete, one minor break
+between each major break for continuous)
 \item A numeric vector of positions
 \item A function that given the limits returns a vector of minor breaks. Also
 accepts rlang \link[rlang:as_function]{lambda} function notation. When
 the function has two arguments, it will be given the limits and major
-breaks.
+break positions.
 }}
     \item{\code{n.breaks}}{An integer guiding the number of major breaks. The algorithm
 may choose a slightly different number to ensure nice break labels. Will

--- a/man/scale_grey.Rd
+++ b/man/scale_grey.Rd
@@ -62,6 +62,17 @@ missing values, and do so by default. If you want to remove missing values
 from a discrete scale, specify \code{na.translate = FALSE}.}
     \item{\code{scale_name}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The name of the scale
 that should be used for error messages associated with this scale.}
+    \item{\code{minor_breaks}}{One of:
+\itemize{
+\item \code{NULL} for no minor breaks
+\item \code{waiver()} for the default breaks (none for discrete, one minor break
+between each major break for continuous)
+\item A numeric vector of positions
+\item A function that given the limits returns a vector of minor breaks. Also
+accepts rlang \link[rlang:as_function]{lambda} function notation. When
+the function has two arguments, it will be given the limits and major
+break positions.
+}}
     \item{\code{labels}}{One of:
 \itemize{
 \item \code{NULL} for no labels

--- a/man/scale_hue.Rd
+++ b/man/scale_hue.Rd
@@ -68,6 +68,17 @@ missing values, and do so by default. If you want to remove missing values
 from a discrete scale, specify \code{na.translate = FALSE}.}
     \item{\code{scale_name}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The name of the scale
 that should be used for error messages associated with this scale.}
+    \item{\code{minor_breaks}}{One of:
+\itemize{
+\item \code{NULL} for no minor breaks
+\item \code{waiver()} for the default breaks (none for discrete, one minor break
+between each major break for continuous)
+\item A numeric vector of positions
+\item A function that given the limits returns a vector of minor breaks. Also
+accepts rlang \link[rlang:as_function]{lambda} function notation. When
+the function has two arguments, it will be given the limits and major
+break positions.
+}}
     \item{\code{labels}}{One of:
 \itemize{
 \item \code{NULL} for no labels

--- a/man/scale_linetype.Rd
+++ b/man/scale_linetype.Rd
@@ -54,6 +54,17 @@ from a discrete scale, specify \code{na.translate = FALSE}.}
     \item{\code{aesthetics}}{The names of the aesthetics that this scale works with.}
     \item{\code{scale_name}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The name of the scale
 that should be used for error messages associated with this scale.}
+    \item{\code{minor_breaks}}{One of:
+\itemize{
+\item \code{NULL} for no minor breaks
+\item \code{waiver()} for the default breaks (none for discrete, one minor break
+between each major break for continuous)
+\item A numeric vector of positions
+\item A function that given the limits returns a vector of minor breaks. Also
+accepts rlang \link[rlang:as_function]{lambda} function notation. When
+the function has two arguments, it will be given the limits and major
+break positions.
+}}
     \item{\code{labels}}{One of:
 \itemize{
 \item \code{NULL} for no labels

--- a/man/scale_manual.Rd
+++ b/man/scale_manual.Rd
@@ -68,6 +68,17 @@ that should be used for error messages associated with this scale.}
 \code{waiver()}, the default, the name of the scale is taken from the first
 mapping used for that aesthetic. If \code{NULL}, the legend title will be
 omitted.}
+    \item{\code{minor_breaks}}{One of:
+\itemize{
+\item \code{NULL} for no minor breaks
+\item \code{waiver()} for the default breaks (none for discrete, one minor break
+between each major break for continuous)
+\item A numeric vector of positions
+\item A function that given the limits returns a vector of minor breaks. Also
+accepts rlang \link[rlang:as_function]{lambda} function notation. When
+the function has two arguments, it will be given the limits and major
+break positions.
+}}
     \item{\code{labels}}{One of:
 \itemize{
 \item \code{NULL} for no labels

--- a/man/scale_shape.Rd
+++ b/man/scale_shape.Rd
@@ -54,6 +54,17 @@ where \code{NA} is always placed at the far right.}
     \item{\code{aesthetics}}{The names of the aesthetics that this scale works with.}
     \item{\code{scale_name}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The name of the scale
 that should be used for error messages associated with this scale.}
+    \item{\code{minor_breaks}}{One of:
+\itemize{
+\item \code{NULL} for no minor breaks
+\item \code{waiver()} for the default breaks (none for discrete, one minor break
+between each major break for continuous)
+\item A numeric vector of positions
+\item A function that given the limits returns a vector of minor breaks. Also
+accepts rlang \link[rlang:as_function]{lambda} function notation. When
+the function has two arguments, it will be given the limits and major
+break positions.
+}}
     \item{\code{labels}}{One of:
 \itemize{
 \item \code{NULL} for no labels

--- a/man/scale_size.Rd
+++ b/man/scale_size.Rd
@@ -134,13 +134,13 @@ breaks are given explicitly.}
     \item{\code{minor_breaks}}{One of:
 \itemize{
 \item \code{NULL} for no minor breaks
-\item \code{waiver()} for the default breaks (one minor break between
-each major break)
+\item \code{waiver()} for the default breaks (none for discrete, one minor break
+between each major break for continuous)
 \item A numeric vector of positions
 \item A function that given the limits returns a vector of minor breaks. Also
 accepts rlang \link[rlang:as_function]{lambda} function notation. When
 the function has two arguments, it will be given the limits and major
-breaks.
+break positions.
 }}
     \item{\code{oob}}{One of:
 \itemize{


### PR DESCRIPTION
This PR aims to fix #5434.

Briefly, it adds a `minor_ticks` argument to discrete scales, which I imagine is only useful for position scales.
It controls where minor panel grid lines and minor tick marks are placed, so you can do things like the following:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

ggplot(mpg, aes(class, fill = factor(cyl))) +
  geom_bar(position = position_dodge(preserve = "single")) +
  scale_x_discrete(
    minor_breaks = breaks_width(1, 0.5),
    guide = guide_axis(minor.ticks = TRUE)
  ) +
  theme(
    panel.grid.major.x = element_blank(),
    axis.minor.ticks.length.x.bottom = unit(11, "pt"),
    axis.ticks.length.x.bottom = unit(0, "pt"),
    axis.text.x.bottom = element_text(margin = margin(t = -8.75))
  )
```

![](https://i.imgur.com/ABMd3Th.png)<!-- -->

Because the minor breaks are computed on the mapped breaks/limits, rather than on <character> limits, they don't have compatible `.value` columns that can be combined with discrete `.value` columns, so the guide drops such incompatible values.

``` r
get_guide_data(aesthetic = "x")
#>             x     .value     .label .type y
#> 1  0.08333333    2seater    2seater major 0
#> 2  0.22222222    compact    compact major 0
#> 3  0.36111111    midsize    midsize major 0
#> 4  0.50000000    minivan    minivan major 0
#> 5  0.63888889     pickup     pickup major 0
#> 6  0.77777778 subcompact subcompact major 0
#> 7  0.91666667        suv        suv major 0
#> 8  0.01388889       <NA>       <NA> minor 0
#> 9  0.15277778       <NA>       <NA> minor 0
#> 10 0.29166667       <NA>       <NA> minor 0
#> 11 0.43055556       <NA>       <NA> minor 0
#> 12 0.56944444       <NA>       <NA> minor 0
#> 13 0.70833333       <NA>       <NA> minor 0
#> 14 0.84722222       <NA>       <NA> minor 0
#> 15 0.98611111       <NA>       <NA> minor 0
```

<sup>Created on 2024-03-15 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

As a small note, the `minor_breaks` argument uses snake_case for consistency with continuous scales rather than dot.case.
