### PR TITLE
Bump vctrs version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Imports:
     scales (>= 1.3.0),
     stats,
     tibble,
-    vctrs (>= 0.5.0),
+    vctrs (>= 0.6.0),
     withr (>= 2.5.0)
 Suggests:
     covr,


### PR DESCRIPTION
This PR aims to fix #5810.

Briefly, `vec_run_sizes()` was introduced in {vctrs} 0.6.0 and we use it in ggplot2, so we should require at least that version of vctrs.