### PR TITLE
Preserve theme class

### DIFF
--- a/R/theme.R
+++ b/R/theme.R
@@ -576,8 +576,9 @@ plot_theme <- function(x, default = theme_get()) {
   # Check that all elements have the correct class (element_text, unit, etc)
   validate_theme(theme)
 
-
-  theme[intersect(names(theme), names(get_element_tree()))]
+  # Remove elements that are not registered
+  theme[setdiff(names(theme), names(get_element_tree()))] <- NULL
+  theme
 }
 
 #' Modify properties of an element in a theme object


### PR DESCRIPTION
This PR aims to fix a revdep failure reported in #5822.

Subsetting a theme drops the <theme> class:

``` r
library(ggplot2)
class(theme())
#> [1] "theme" "gg"
class(theme()[])
#> [1] "list"
```

<sup>Created on 2024-04-03 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

We subsetted the theme in #5743 to drop unknown elements, but an extension (mine, guilty as charged) relied on classed behaviour of theme settings (invoking `add_theme()` via `+`). This PR replaced the subsetting operation with assigning `NULL` to unknown theme settings, preserving the <theme> class.
