### PR TITLE
Give `midpoint` argument to gradient scales

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # ggplot2 (development version)
 
+* `scale_{fill/colour}_gradientn()` and `scale_{fill/colour}_stepsn()` gain
+  a `midpoint` argument to make it easier to build divergent scales 
+  (@teunbrand, #3738).
 * When facets coerce the faceting variables to factors, the 'ordered' class
   is dropped (@teunbrand, #5666).
 * `update_geom_defaults()` and `update_stat_defaults()` have a reset mechanism

--- a/R/scale-gradient.R
+++ b/R/scale-gradient.R
@@ -103,8 +103,9 @@ scale_fill_gradient <- function(name = waiver(), ..., low = "#132B43",
 
 #' @inheritParams scales::pal_div_gradient
 #' @inheritParams continuous_scale
-#' @param midpoint The midpoint (in data value) of the diverging scale.
-#'   Defaults to 0.
+#' @param midpoint The midpoint (in data value) for diverging scales.
+#'   Can be set to `NULL` to skip centering the palette. The `midpoint` argument
+#'   is incompatible with setting a `rescaler` argument.
 #' @rdname scale_gradient
 #' @export
 scale_colour_gradient2 <- function(name = waiver(), ..., low = muted("red"),

--- a/R/scale-gradient.R
+++ b/R/scale-gradient.R
@@ -158,13 +158,15 @@ mid_rescaler <- function(mid, transform = "identity",
 scale_colour_gradientn <- function(name = waiver(), ..., colours, values = NULL,
                                    space = "Lab", na.value = "grey50",
                                    guide = "colourbar", aesthetics = "colour",
-                                   colors) {
+                                   midpoint = NULL, transform = "identity",
+                                   rescaler = NULL, colors) {
   colours <- if (missing(colours)) colors else colours
 
   continuous_scale(
     aesthetics, name = name,
     palette = pal_gradient_n(colours, values, space),
-    na.value = na.value, guide = guide, ...
+    rescaler = rescaler %||% mid_rescaler(midpoint, transform),
+    na.value = na.value, guide = guide, transform = transform, ...
   )
 }
 #' @rdname scale_gradient
@@ -172,12 +174,14 @@ scale_colour_gradientn <- function(name = waiver(), ..., colours, values = NULL,
 scale_fill_gradientn <- function(name = waiver(), ..., colours, values = NULL,
                                  space = "Lab", na.value = "grey50",
                                  guide = "colourbar", aesthetics = "fill",
-                                 colors) {
+                                 midpoint = NULL, transform = "identity",
+                                 rescaler = NULL, colors) {
   colours <- if (missing(colours)) colors else colours
 
   continuous_scale(
     aesthetics, name = name,
     palette = pal_gradient_n(colours, values, space),
-    na.value = na.value, guide = guide, ...
+    rescaler = rescaler %||% mid_rescaler(midpoint, transform),
+    na.value = na.value, guide = guide, transform = transform, ...
   )
 }

--- a/R/scale-gradient.R
+++ b/R/scale-gradient.R
@@ -137,6 +137,9 @@ scale_fill_gradient2 <- function(name = waiver(), ..., low = muted("red"),
 
 mid_rescaler <- function(mid, transform = "identity",
                          arg = caller_arg(mid), call = caller_env()) {
+  if (is.null(mid)) {
+    return(rescale)
+  }
   transform <- as.trans(transform)
   trans_mid <- transform$transform(mid)
   check_transformation(

--- a/R/scale-steps.R
+++ b/R/scale-steps.R
@@ -77,12 +77,14 @@ scale_colour_steps2 <- function(name = waiver(), ..., low = muted("red"),
 scale_colour_stepsn <- function(name = waiver(), ..., colours, values = NULL,
                                 space = "Lab", na.value = "grey50",
                                 guide = "coloursteps", aesthetics = "colour",
-                                colors) {
+                                midpoint = NULL, transform = "identity",
+                                rescaler = NULL, colors) {
   colours <- if (missing(colours)) colors else colours
   binned_scale(
     aesthetics, name = name,
     palette = pal_gradient_n(colours, values, space),
-    na.value = na.value, guide = guide,
+    na.value = na.value, guide = guide, transform = transform,
+    rescaler = rescaler %||% mid_rescaler(midpoint, transform),
     ...
   )
 }
@@ -119,11 +121,14 @@ scale_fill_steps2 <- function(name = waiver(), ..., low = muted("red"),
 scale_fill_stepsn <- function(name = waiver(), ..., colours, values = NULL,
                               space = "Lab", na.value = "grey50",
                               guide = "coloursteps", aesthetics = "fill",
-                              colors) {
+                              transform = "identity", midpoint = NULL,
+                              rescaler = NULL, colors) {
   colours <- if (missing(colours)) colors else colours
   binned_scale(
     aesthetics, name = name,
     palette = pal_gradient_n(colours, values, space),
-    na.value = na.value, guide = guide, ...
+    na.value = na.value, guide = guide, transform = transform,
+    rescaler = rescaler %||% mid_rescaler(midpoint, transform),
+    ...
   )
 }

--- a/man/scale_gradient.Rd
+++ b/man/scale_gradient.Rd
@@ -77,6 +77,9 @@ scale_colour_gradientn(
   na.value = "grey50",
   guide = "colourbar",
   aesthetics = "colour",
+  midpoint = NULL,
+  transform = "identity",
+  rescaler = NULL,
   colors
 )
 
@@ -89,6 +92,9 @@ scale_fill_gradientn(
   na.value = "grey50",
   guide = "colourbar",
   aesthetics = "fill",
+  midpoint = NULL,
+  transform = "identity",
+  rescaler = NULL,
   colors
 )
 }
@@ -155,12 +161,6 @@ Note that setting limits on positional scales will \strong{remove} data outside 
 If the purpose is to zoom, use the limit argument in the coordinate system
 (see \code{\link[=coord_cartesian]{coord_cartesian()}}).
 }}
-    \item{\code{rescaler}}{A function used to scale the input values to the
-range [0, 1]. This is always \code{\link[scales:rescale]{scales::rescale()}}, except for
-diverging and n colour gradients (i.e., \code{\link[=scale_colour_gradient2]{scale_colour_gradient2()}},
-\code{\link[=scale_colour_gradientn]{scale_colour_gradientn()}}). The \code{rescaler} is ignored by position
-scales, which always use \code{\link[scales:rescale]{scales::rescale()}}. Also accepts rlang
-\link[rlang:as_function]{lambda} function notation.}
     \item{\code{oob}}{One of:
 \itemize{
 \item Function that handles limits outside of the scale limits
@@ -194,8 +194,9 @@ same time, via \code{aesthetics = c("colour", "fill")}.}
 
 \item{mid}{colour for mid point}
 
-\item{midpoint}{The midpoint (in data value) of the diverging scale.
-Defaults to 0.}
+\item{midpoint}{The midpoint (in data value) for diverging scales.
+Can be set to \code{NULL} to skip centering the palette. The \code{midpoint} argument
+is incompatible with setting a \code{rescaler} argument.}
 
 \item{transform}{For continuous scales, the name of a transformation object
 or the object itself. Built-in transformations include "asn", "atanh",
@@ -216,6 +217,13 @@ You can create your own transformation with \code{\link[scales:new_transform]{sc
 this vector gives the position (between 0 and 1) for each colour in the
 \code{colours} vector. See \code{\link[scales:rescale]{rescale()}} for a convenience function
 to map an arbitrary range to between 0 and 1.}
+
+\item{rescaler}{A function used to scale the input values to the
+range [0, 1]. This is always \code{\link[scales:rescale]{scales::rescale()}}, except for
+diverging and n colour gradients (i.e., \code{\link[=scale_colour_gradient2]{scale_colour_gradient2()}},
+\code{\link[=scale_colour_gradientn]{scale_colour_gradientn()}}). The \code{rescaler} is ignored by position
+scales, which always use \code{\link[scales:rescale]{scales::rescale()}}. Also accepts rlang
+\link[rlang:as_function]{lambda} function notation.}
 }
 \description{
 \verb{scale_*_gradient} creates a two colour gradient (low-high),

--- a/man/scale_steps.Rd
+++ b/man/scale_steps.Rd
@@ -175,8 +175,9 @@ same time, via \code{aesthetics = c("colour", "fill")}.}
 
 \item{mid}{colour for mid point}
 
-\item{midpoint}{The midpoint (in data value) of the diverging scale.
-Defaults to 0.}
+\item{midpoint}{The midpoint (in data value) for diverging scales.
+Can be set to \code{NULL} to skip centering the palette. The \code{midpoint} argument
+is incompatible with setting a \code{rescaler} argument.}
 
 \item{transform}{For continuous scales, the name of a transformation object
 or the object itself. Built-in transformations include "asn", "atanh",

--- a/man/scale_steps.Rd
+++ b/man/scale_steps.Rd
@@ -46,6 +46,9 @@ scale_colour_stepsn(
   na.value = "grey50",
   guide = "coloursteps",
   aesthetics = "colour",
+  midpoint = NULL,
+  transform = "identity",
+  rescaler = NULL,
   colors
 )
 
@@ -83,6 +86,9 @@ scale_fill_stepsn(
   na.value = "grey50",
   guide = "coloursteps",
   aesthetics = "fill",
+  transform = "identity",
+  midpoint = NULL,
+  rescaler = NULL,
   colors
 )
 }
@@ -198,6 +204,13 @@ You can create your own transformation with \code{\link[scales:new_transform]{sc
 this vector gives the position (between 0 and 1) for each colour in the
 \code{colours} vector. See \code{\link[scales:rescale]{rescale()}} for a convenience function
 to map an arbitrary range to between 0 and 1.}
+
+\item{rescaler}{A function used to scale the input values to the
+range [0, 1]. This is always \code{\link[scales:rescale]{scales::rescale()}}, except for
+diverging and n colour gradients (i.e., \code{\link[=scale_colour_gradient2]{scale_colour_gradient2()}},
+\code{\link[=scale_colour_gradientn]{scale_colour_gradientn()}}). The \code{rescaler} is ignored by position
+scales, which always use \code{\link[scales:rescale]{scales::rescale()}}. Also accepts rlang
+\link[rlang:as_function]{lambda} function notation.}
 }
 \description{
 \verb{scale_*_steps} creates a two colour binned gradient (low-high),


### PR DESCRIPTION
This PR aims to fix #3738.

In short, it adds a `midpoint` argument to `scale_{fill/colour}_gradientn()` and `scale_{fill/colour}_stepsn()` functions.

The approach somewhat diverges from the `gradient2`/`steps2` variant, which will not accept `rescaler` arguments. The `gradientn`/`stepsn` variants will accept a `rescaler`, but it overrides any `midpoint` setting.

Reprex:
``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

p <- ggplot(mpg, aes(displ, hwy, colour = cty)) + geom_point()

p + scale_colour_gradientn(
  colours = c("purple", "white", "green"),
  midpoint = 15
)
```

![](https://i.imgur.com/ZsMMX5m.png)<!-- -->

``` r

p + scale_colour_stepsn(
  colours = c("purple", "white", "green"),
  midpoint = 15
)
```

![](https://i.imgur.com/TFXv72A.png)<!-- -->

<sup>Created on 2024-04-03 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
