### PR TITLE
`geom_curve()` removes missing data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # ggplot2 (development version)
 
+* `geom_curve()` now appropriately removes missing data instead of throwing
+  errors (@teunbrand, #5831).
 * When facets coerce the faceting variables to factors, the 'ordered' class
   is dropped (@teunbrand, #5666).
 * `update_geom_defaults()` and `update_stat_defaults()` have a reset mechanism

--- a/R/geom-curve.R
+++ b/R/geom-curve.R
@@ -47,6 +47,11 @@ GeomCurve <- ggproto("GeomCurve", GeomSegment,
     if (!coord$is_linear()) {
       cli::cli_warn("{.fn geom_curve} is not implemented for non-linear coordinates")
     }
+    data <- remove_missing(
+      data, na.rm = na.rm,
+      c("x", "y", "xend", "yend", "linetype", "linewidth"),
+      name = "geom_curve"
+    )
 
     trans <- coord$transform(data, panel_params)
 


### PR DESCRIPTION
This PR aims to fix #5831.

Briefly, it now applies `remove_missing()` before forwarding the data to `curveGrob()`. This prevents an issue with when the endpoints are missing values.

In the reprex from the issue below, the `NA` produced by `dplyr::lead()` is appropriately removed and warned about, and the plot renders as expected.

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

dtc <- data.frame(
  node = c("A","B","C"),
  x_connect = c(60,32,80),
  y_connect = c(39,88,110)
)

ggplot(dtc, aes(x = x_connect, y = y_connect)) + 
  geom_point(size=5)+
  geom_curve(aes(xend = dplyr::lead(x_connect), yend = dplyr::lead(y_connect)))
#> Warning: Removed 1 row containing missing values or values outside the scale range
#> (`geom_curve()`).
```

![](https://i.imgur.com/512QpxX.png)<!-- -->

<sup>Created on 2024-04-08 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
