### PR TITLE
Roll back updates to `update_geom/stat_defaults()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,6 @@
 
 * When facets coerce the faceting variables to factors, the 'ordered' class
   is dropped (@teunbrand, #5666).
-* `update_geom_defaults()` and `update_stat_defaults()` have a reset mechanism
-  when using `new = NULL` and invisible return the previous defaults (#4993).
 * `coord_map()` and `coord_polar()` throw informative warnings when used
   with the guide system (#5707).
 * When passing a function to `stat_contour(breaks)`, that function is used to

--- a/R/geom-defaults.R
+++ b/R/geom-defaults.R
@@ -3,9 +3,7 @@
 #' @param stat,geom Name of geom/stat to modify (like `"point"` or
 #'   `"bin"`), or a Geom/Stat object (like `GeomPoint` or
 #'   `StatBin`).
-#' @param new One of the following:
-#'  * A named list of aesthetics to serve as new defaults.
-#'  * `NULL` to reset the defaults.
+#' @param new Named list of aesthetics.
 #' @keywords internal
 #' @export
 #' @examples
@@ -18,7 +16,7 @@
 #' ggplot(mtcars, aes(mpg, wt)) + geom_point()
 #'
 #' # reset default
-#' update_geom_defaults("point", NULL)
+#' update_geom_defaults("point", aes(color = "black"))
 #'
 #'
 #' # updating a stat's default aesthetic settings
@@ -31,45 +29,27 @@
 #'   geom_function(fun = dnorm, color = "red")
 #'
 #' # reset default
-#' update_stat_defaults("bin", NULL)
+#' update_stat_defaults("bin", aes(y = after_stat(count)))
 #'
 #' @rdname update_defaults
 update_geom_defaults <- function(geom, new) {
-  update_defaults(geom, "Geom", new, env = parent.frame())
+  g <- check_subclass(geom, "Geom", env = parent.frame())
+  old <- g$default_aes
+  new <- rename_aes(new)
+  new_names_order <- unique(c(names(old), names(new)))
+  new <- defaults(new, old)[new_names_order]
+  g$default_aes[names(new)] <- new
+  invisible()
 }
 
 #' @rdname update_defaults
 #' @export
 update_stat_defaults <- function(stat, new) {
-  update_defaults(stat, "Stat", new, env = parent.frame())
-}
-
-cache_defaults <- new_environment()
-
-update_defaults <- function(name, subclass, new, env = parent.frame()) {
-  obj   <- check_subclass(name, subclass, env = env)
-  index <- snake_class(obj)
-
-  if (is.null(new)) { # Reset from cache
-
-    old <- cache_defaults[[index]]
-    if (!is.null(old)) {
-      new <- update_defaults(name, subclass, new = old, env = env)
-    }
-    invisible(new)
-
-  } else { # Update default aesthetics
-
-    old <- obj$default_aes
-    # Only update cache the first time defaults are changed
-    if (!exists(index, envir = cache_defaults)) {
-      cache_defaults[[index]] <- old
-    }
-    new <- rename_aes(new)
-    name_order <- unique(c(names(old), names(new)))
-    new <- defaults(new, old)[name_order]
-    obj$default_aes[names(new)] <- new
-    invisible(old)
-
-  }
+  g <- check_subclass(stat, "Stat", env = parent.frame())
+  old <- g$default_aes
+  new <- rename_aes(new)
+  new_names_order <- unique(c(names(old), names(new)))
+  new <- defaults(new, old)[new_names_order]
+  g$default_aes[names(new)] <- new
+  invisible()
 }

--- a/man/update_defaults.Rd
+++ b/man/update_defaults.Rd
@@ -10,11 +10,7 @@ update_geom_defaults(geom, new)
 update_stat_defaults(stat, new)
 }
 \arguments{
-\item{new}{One of the following:
-\itemize{
-\item A named list of aesthetics to serve as new defaults.
-\item \code{NULL} to reset the defaults.
-}}
+\item{new}{Named list of aesthetics.}
 
 \item{stat, geom}{Name of geom/stat to modify (like \code{"point"} or
 \code{"bin"}), or a Geom/Stat object (like \code{GeomPoint} or
@@ -33,7 +29,7 @@ GeomPoint$default_aes
 ggplot(mtcars, aes(mpg, wt)) + geom_point()
 
 # reset default
-update_geom_defaults("point", NULL)
+update_geom_defaults("point", aes(color = "black"))
 
 
 # updating a stat's default aesthetic settings
@@ -46,7 +42,7 @@ ggplot(data.frame(x = rnorm(1e3)), aes(x)) +
   geom_function(fun = dnorm, color = "red")
 
 # reset default
-update_stat_defaults("bin", NULL)
+update_stat_defaults("bin", aes(y = after_stat(count)))
 
 }
 \keyword{internal}

--- a/tests/testthat/test-geom-.R
+++ b/tests/testthat/test-geom-.R
@@ -6,21 +6,7 @@ test_that("aesthetic checking in geom throws correct errors", {
   expect_snapshot_error(check_aesthetics(aes, 4))
 })
 
-test_that("geom defaults can be set and reset", {
-  l <- geom_point()
-  test <- l$geom$use_defaults(data_frame0())
-  expect_equal(test$colour, "black")
 
-  inv <- update_geom_defaults("point", list(colour = "red"))
-  test <- l$geom$use_defaults(data_frame0())
-  expect_equal(test$colour, "red")
-  expect_equal(inv$colour, "black")
-
-  inv <- update_geom_defaults("point", NULL)
-  test <- l$geom$use_defaults(data_frame0())
-  expect_equal(test$colour, "black")
-  expect_equal(inv$colour, "red")
-})
 
 test_that("updating geom aesthetic defaults preserves class and order", {
 
@@ -37,7 +23,7 @@ test_that("updating geom aesthetic defaults preserves class and order", {
 
   expect_equal(updated_defaults, intended_defaults)
 
-  update_geom_defaults("point", NULL)
+  update_geom_defaults("point", original_defaults)
 
 })
 
@@ -60,6 +46,6 @@ test_that("updating stat aesthetic defaults preserves class and order", {
 
   expect_equal(updated_defaults, intended_defaults)
 
-  update_stat_defaults("bin", NULL)
+  update_stat_defaults("bin", original_defaults)
 
 })


### PR DESCRIPTION
This PR reverts #5781 in the prep/3.5.1 branch.

Briefly, #5781 was giving some grief with reverse dependencies so this PR allows us to postpone #5781 to a later release.