### PR TITLE
Clarify when `dpi` applies in `ggsave()`

### DIFF
--- a/R/save.R
+++ b/R/save.R
@@ -37,7 +37,8 @@
 #' @param units One of the following units in which the `width` and `height`
 #'   arguments are expressed: `"in"`, `"cm"`, `"mm"` or `"px"`.
 #' @param dpi Plot resolution. Also accepts a string input: "retina" (320),
-#'   "print" (300), or "screen" (72). Applies only to raster output types.
+#'   "print" (300), or "screen" (72). Only applies when converting pixel units,
+#'   as is typical for raster output types.
 #' @param limitsize When `TRUE` (the default), `ggsave()` will not
 #'   save images larger than 50x50 inches, to prevent the common error of
 #'   specifying dimensions in pixels.

--- a/man/ggsave.Rd
+++ b/man/ggsave.Rd
@@ -43,7 +43,8 @@ If not supplied, uses the size of the current graphics device.}
 arguments are expressed: \code{"in"}, \code{"cm"}, \code{"mm"} or \code{"px"}.}
 
 \item{dpi}{Plot resolution. Also accepts a string input: "retina" (320),
-"print" (300), or "screen" (72). Applies only to raster output types.}
+"print" (300), or "screen" (72). Only applies when converting pixel units,
+as is typical for raster output types.}
 
 \item{limitsize}{When \code{TRUE} (the default), \code{ggsave()} will not
 save images larger than 50x50 inches, to prevent the common error of


### PR DESCRIPTION
This PR aims to fix #5497.

Briefly, `dpi` is applied when units are specified in pixels, not *just* for raster output types.
This edits the description to clarify this.