### PR TITLE
More sorting options for `facet_wrap()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # ggplot2 (development version)
 
+* `facet_wrap()` has new options for the `dir` argument to more precisely
+  control panel directions (@teunbrand, #5212)
 * When facets coerce the faceting variables to factors, the 'ordered' class
   is dropped (@teunbrand, #5666).
 * `coord_map()` and `coord_polar()` throw informative warnings when used

--- a/R/facet-wrap.R
+++ b/R/facet-wrap.R
@@ -101,7 +101,15 @@ facet_wrap <- function(facets, nrow = NULL, ncol = NULL, scales = "fixed",
                        strip.position = 'top', axes = "margins",
                        axis.labels = "all") {
   scales <- arg_match0(scales %||% "fixed", c("fixed", "free_x", "free_y", "free"))
-  dir <- arg_match0(dir, c("h", "v"))
+  dir <- arg_match0(dir, c("h", "v", "lt", "tl", "lb", "bl", "rt", "tr", "rb", "br"))
+  if (nchar(dir) == 1) {
+    dir <- base::switch(
+      dir,
+      h = if (as.table) "lt" else "lb",
+      v = if (as.table) "tl" else "tr"
+    )
+  }
+
   free <- list(
     x = any(scales %in% c("free_x", "free")),
     y = any(scales %in% c("free_y", "free"))
@@ -149,7 +157,6 @@ facet_wrap <- function(facets, nrow = NULL, ncol = NULL, scales = "fixed",
     params = list(
       facets = facets,
       free = free,
-      as.table = as.table,
       strip.position = strip.position,
       drop = drop,
       ncol = ncol,

--- a/man/facet_wrap.Rd
+++ b/man/facet_wrap.Rd
@@ -65,7 +65,12 @@ data will automatically be dropped. If \code{FALSE}, all factor levels
 will be shown, regardless of whether or not they appear in the data.}
 
 \item{dir}{Direction: either \code{"h"} for horizontal, the default, or \code{"v"},
-for vertical.}
+for vertical. When \code{"h"} or \code{"v"} will be combined with \code{as.table} to
+set final layout. Alternatively, a combination of \code{"t"} (top) or
+\code{"b"} (bottom) with \code{"l"} (left) or \code{"r"} (right) to set a layout directly.
+These two letters give the starting position and the first letter gives
+the growing direction. For example \code{"rt"} will place the first panel in
+the top-right and starts filling in panels right-to-left.}
 
 \item{strip.position}{By default, the labels are displayed on the top of
 the plot. Using \code{strip.position} it is possible to place the labels on

--- a/tests/testthat/test-facet-layout.R
+++ b/tests/testthat/test-facet-layout.R
@@ -32,6 +32,44 @@ test_that("grid: includes all combinations", {
   expect_equal(nrow(all), 4)
 })
 
+test_that("wrap: layout sorting is correct", {
+
+  dummy <- list(data_frame0(x = 1:5))
+
+  test <- panel_layout(facet_wrap(~x, dir = "lt"), dummy)
+  expect_equal(test$ROW, rep(c(1,2), c(3, 2)))
+  expect_equal(test$COL, c(1:3, 1:2))
+
+  test <- panel_layout(facet_wrap(~x, dir = "tl"), dummy)
+  expect_equal(test$ROW, c(1, 2, 1, 2, 1))
+  expect_equal(test$COL, c(1, 1, 2, 2, 3))
+
+  test <- panel_layout(facet_wrap(~x, dir = "lb"), dummy)
+  expect_equal(test$ROW, c(2, 2, 2, 1, 1))
+  expect_equal(test$COL, c(1, 2, 3, 1, 2))
+
+  test <- panel_layout(facet_wrap(~x, dir = "bl"), dummy)
+  expect_equal(test$ROW, c(2, 1, 2, 1, 2))
+  expect_equal(test$COL, c(1, 1, 2, 2, 3))
+
+  test <- panel_layout(facet_wrap(~x, dir = "rt"), dummy)
+  expect_equal(test$ROW, c(1, 1, 1, 2, 2))
+  expect_equal(test$COL, c(3, 2, 1, 3, 2))
+
+  test <- panel_layout(facet_wrap(~x, dir = "tr"), dummy)
+  expect_equal(test$ROW, c(1, 2, 1, 2, 1))
+  expect_equal(test$COL, c(3, 3, 2, 2, 1))
+
+  test <- panel_layout(facet_wrap(~x, dir = "rb"), dummy)
+  expect_equal(test$ROW, c(2, 2, 2, 1, 1))
+  expect_equal(test$COL, c(3, 2, 1, 3, 2))
+
+  test <- panel_layout(facet_wrap(~x, dir = "br"), dummy)
+  expect_equal(test$ROW, c(2, 1, 2, 1, 2))
+  expect_equal(test$COL, c(3, 3, 2, 2, 1))
+
+})
+
 test_that("wrap and grid are equivalent for 1d data", {
   rowg <- panel_layout(facet_grid(a~.), list(a))
   roww <- panel_layout(facet_wrap(~a, ncol = 1), list(a))


### PR DESCRIPTION
This PR aims to fix #5212.

Briefly, it adds more options for the `dir` argument to layout the panels in various ways. The `as.table` argument gets absorbed into `dir` when the previous way of declaring `dir = "v"` or `dir = "h"` is used.

The new options for `dir` are:
* `"lt"`: start in the top-left, start filling left-to-right.
* `"tl"`: start in the top-left, start filling top-to-bottom.
* `"lb"`: start in the bottom-left, start filling left-to-right.
* `"bl"`: start in the bottom-left, start filling bottom-to-top.
* `"rt"`: start in the top-right, start filling right-to-left.
* `"tr"`: start in the top-right, start filling top-to-bottom.
* `"rb"`: start in the bottom-right, start filling right-to-left.
* `"br"` start in the bottom-right, start filling bottom-to-top

Using `as.table` with any of the options above has no effect.

As an example where blank panels are set at the beginning:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

ggplot(mpg, aes(displ, hwy)) +
  geom_point() +
  facet_wrap(~ class, dir = "rb")
```

![](https://i.imgur.com/YDhE3ch.png)<!-- -->

<sup>Created on 2024-04-22 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
