### PR TITLE
Be clearer when the `fill` aesthetic applies in points

### DIFF
--- a/R/geom-point.R
+++ b/R/geom-point.R
@@ -27,7 +27,7 @@
 #' `geom_point(alpha = 0.05)`) or very small (e.g.
 #' `geom_point(shape = ".")`).
 #'
-#' @eval rd_aesthetics("geom", "point")
+#' @eval rd_aesthetics("geom", "point", "The `fill` aesthetic only applies to shapes 21-25.")
 #' @inheritParams layer
 #' @param na.rm If `FALSE`, the default, missing values are removed with
 #'   a warning. If `TRUE`, missing values are silently removed.

--- a/man/geom_point.Rd
+++ b/man/geom_point.Rd
@@ -148,6 +148,8 @@ Another technique is to make the points transparent (e.g.
 \item \code{\link[=aes_linetype_size_shape]{size}}
 \item \code{stroke}
 }
+The \code{fill} aesthetic only applies to shapes 21-25.
+
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 }
 

--- a/vignettes/ggplot2-specs.Rmd
+++ b/vignettes/ggplot2-specs.Rmd
@@ -230,7 +230,7 @@ Shapes take five types of values:
 
 ### Colour and fill
 
-Note that shapes 21-24 have both stroke `colour` and a `fill`. The size of the filled part is controlled by `size`, the size of the stroke is controlled by `stroke`. Each is measured in mm, and the total size of the point is the sum of the two. Note that the size is constant along the diagonal in the following figure.
+While `colour` applies to all shapes, `fill` only applies to shapes 21-25, as can be seen above. The size of the filled part is controlled by `size`, the size of the stroke is controlled by `stroke`. Each is measured in mm, and the total size of the point is the sum of the two. Note that the size is constant along the diagonal in the following figure.
 
 ```{r}
 #| fig.alt = "A plot showing a 4-by-4 grid of red points, the top 12 points with


### PR DESCRIPTION
This PR aims to fix #4358.

It just rephrases a sentence in the vignette and adds a note to the `geom_point()` aesthetics section.