### PR TITLE
List `"centre"` as option for `legend.box.just`

### DIFF
--- a/R/theme.R
+++ b/R/theme.R
@@ -110,8 +110,8 @@
 #' @param legend.box arrangement of multiple legends ("horizontal" or
 #'   "vertical")
 #' @param legend.box.just justification of each legend within the overall
-#'   bounding box, when there are multiple legends ("top", "bottom", "left", or
-#'   "right")
+#'   bounding box, when there are multiple legends ("top", "bottom", "left",
+#'   "right", "center" or "centre")
 #' @param legend.box.margin margins around the full legend area, as specified
 #'   using [margin()]
 #' @param legend.box.background background of legend area ([element_rect()];

--- a/man/theme.Rd
+++ b/man/theme.Rd
@@ -262,8 +262,8 @@ string. Can be \code{"panel"} (default) to align legends to the panels or
 "vertical")}
 
 \item{legend.box.just}{justification of each legend within the overall
-bounding box, when there are multiple legends ("top", "bottom", "left", or
-"right")}
+bounding box, when there are multiple legends ("top", "bottom", "left",
+"right", "center" or "centre")}
 
 \item{legend.box.margin}{margins around the full legend area, as specified
 using \code{\link[=margin]{margin()}}}


### PR DESCRIPTION
This PR aims to fix #4196.

It just lists `"centre"`/`"center"` as an option, which was already accepted, just not documented as such.