### PR TITLE
`plot` as first argument of `ggsave()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* `plot` is now the first argument of `ggsave()`. `plot` and `filename` are
+  swapped when `plot` is a string and `filename` is a plot, to preserve some
+  backward compatibility (#3523).
 * (Internal) Applying defaults in `geom_sf()` has moved from the internal 
   `sf_grob()` to `GeomSf$use_defaults()` (@teunbrand).
 * `facet_wrap()` has new options for the `dir` argument to more precisely

--- a/R/save.R
+++ b/R/save.R
@@ -60,15 +60,15 @@
 #'   geom_point()
 #'
 #' # here, the device is inferred from the filename extension
-#' ggsave("mtcars.pdf")
-#' ggsave("mtcars.png")
+#' ggsave(filename = "mtcars.pdf")
+#' ggsave(filename = "mtcars.png")
 #'
 #' # setting dimensions of the plot
-#' ggsave("mtcars.pdf", width = 4, height = 4)
-#' ggsave("mtcars.pdf", width = 20, height = 20, units = "cm")
+#' ggsave(filename = "mtcars.pdf", width = 4, height = 4)
+#' ggsave(filename = "mtcars.pdf", width = 20, height = 20, units = "cm")
 #'
 #' # passing device-specific arguments to '...'
-#' ggsave("mtcars.pdf", colormodel = "cmyk")
+#' ggsave(filename = "mtcars.pdf", colormodel = "cmyk")
 #'
 #' # delete files with base::unlink()
 #' unlink("mtcars.pdf")
@@ -77,7 +77,7 @@
 #' # specify device when saving to a file with unknown extension
 #' # (for example a server supplied temporary file)
 #' file <- tempfile()
-#' ggsave(file, device = "pdf")
+#' ggsave(filename = file, device = "pdf")
 #' unlink(file)
 #'
 #' # save plot to file without using ggsave
@@ -89,12 +89,18 @@
 #' dev.off()
 #'
 #' }
-ggsave <- function(filename, plot = last_plot(),
+ggsave <- function(plot = last_plot(), filename,
                    device = NULL, path = NULL, scale = 1,
                    width = NA, height = NA, units = c("in", "cm", "mm", "px"),
                    dpi = 300, limitsize = TRUE, bg = NULL,
                    create.dir = FALSE,
                    ...) {
+  if (is.character(plot) && is.ggplot(filename)) {
+    tmp <- filename
+    filename <- plot
+    plot <- tmp
+  }
+
   filename <- check_path(path, filename, create.dir)
 
   dpi <- parse_dpi(dpi)

--- a/man/ggsave.Rd
+++ b/man/ggsave.Rd
@@ -5,8 +5,8 @@
 \title{Save a ggplot (or other grid object) with sensible defaults}
 \usage{
 ggsave(
-  filename,
   plot = last_plot(),
+  filename,
   device = NULL,
   path = NULL,
   scale = 1,
@@ -21,9 +21,9 @@ ggsave(
 )
 }
 \arguments{
-\item{filename}{File name to create on disk.}
-
 \item{plot}{Plot to save, defaults to last plot displayed.}
+
+\item{filename}{File name to create on disk.}
 
 \item{device}{Device to use. Can either be a device function
 (e.g. \link{png}), or one of "eps", "ps", "tex" (pictex),
@@ -93,15 +93,15 @@ ggplot(mtcars, aes(mpg, wt)) +
   geom_point()
 
 # here, the device is inferred from the filename extension
-ggsave("mtcars.pdf")
-ggsave("mtcars.png")
+ggsave(filename = "mtcars.pdf")
+ggsave(filename = "mtcars.png")
 
 # setting dimensions of the plot
-ggsave("mtcars.pdf", width = 4, height = 4)
-ggsave("mtcars.pdf", width = 20, height = 20, units = "cm")
+ggsave(filename = "mtcars.pdf", width = 4, height = 4)
+ggsave(filename = "mtcars.pdf", width = 20, height = 20, units = "cm")
 
 # passing device-specific arguments to '...'
-ggsave("mtcars.pdf", colormodel = "cmyk")
+ggsave(filename = "mtcars.pdf", colormodel = "cmyk")
 
 # delete files with base::unlink()
 unlink("mtcars.pdf")
@@ -110,7 +110,7 @@ unlink("mtcars.png")
 # specify device when saving to a file with unknown extension
 # (for example a server supplied temporary file)
 file <- tempfile()
-ggsave(file, device = "pdf")
+ggsave(filename = file, device = "pdf")
 unlink(file)
 
 # save plot to file without using ggsave


### PR DESCRIPTION
This PR aims to fix #3523.

Briefly, `plot` is now the first argument, but when `plot` is a character and `filename` is a plot (as per previous syntax), these arguments will be swapped.