### PR TITLE
Fix CI failure by ignoring quantreg

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -64,7 +64,7 @@ jobs:
           extra-packages: >
             any::rcmdcheck,
             Hmisc=?ignore-before-r=4.1.0,
-            quantreg=?ignore-before-r=3.6.0,
+            quantreg=?ignore-before-r=4.3.0,
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
It seems the latest version of quantreg requires very new Matrix package. We can ignore the error.

e.g. https://github.com/tidyverse/ggplot2/actions/runs/9044818946/job/24853881196#step:5:167

```
  Error: 
  ! error in pak subprocess
  Caused by error: 
  ! Could not solve package dependencies:
  * deps::.: Can't install dependency quantreg
  * quantreg: Can't install dependency MatrixModels
  * MatrixModels: Can't install dependency Matrix (>= 1.6-0)
  * Matrix: Needs R >= 4.5
  * Matrix: Needs R >= 4.4.0
  * any::sessioninfo: dependency conflict
  * any::rcmdcheck: dependency conflict
```