### PR TITLE
Add gradient midpoint example

### DIFF
--- a/R/scale-gradient.R
+++ b/R/scale-gradient.R
@@ -54,6 +54,14 @@
 #'   geom_point(aes(colour = z1)) +
 #'   scale_colour_gradientn(colours = terrain.colors(10))
 #'
+#' # The gradientn scale can be centered by using a rescaler
+#' ggplot(df, aes(x, y)) +
+#'   geom_point(aes(colour = z1)) +
+#'   scale_colour_gradientn(
+#'     colours = c("blue", "dodgerblue", "white", "orange", "red"),
+#'     rescaler = ~ scales::rescale_mid(.x, mid = 0)
+#'   )
+#'
 #' # Equivalent fill scales do the same job for the fill aesthetic
 #' ggplot(faithfuld, aes(waiting, eruptions)) +
 #'   geom_raster(aes(fill = density)) +

--- a/man/scale_gradient.Rd
+++ b/man/scale_gradient.Rd
@@ -260,6 +260,14 @@ ggplot(df, aes(x, y)) +
   geom_point(aes(colour = z1)) +
   scale_colour_gradientn(colours = terrain.colors(10))
 
+# The gradientn scale can be centered by using a rescaler
+ggplot(df, aes(x, y)) +
+  geom_point(aes(colour = z1)) +
+  scale_colour_gradientn(
+    colours = c("blue", "dodgerblue", "white", "orange", "red"),
+    rescaler = ~ scales::rescale_mid(.x, mid = 0)
+  )
+
 # Equivalent fill scales do the same job for the fill aesthetic
 ggplot(faithfuld, aes(waiting, eruptions)) +
   geom_raster(aes(fill = density)) +


### PR DESCRIPTION
This PR aims to fix #3738 and replaces #5824.

Briefly, an example is included to use the `rescaler` argument to center a custom divergent scale.
The example rendered:

``` r
library(ggplot2)
set.seed(1)
df <- data.frame(
  x = runif(100),
  y = runif(100),
  z1 = rnorm(100),
  z2 = abs(rnorm(100))
)

ggplot(df, aes(x, y)) +
  geom_point(aes(colour = z1)) +
  scale_colour_gradientn(
    colours = c("blue", "dodgerblue", "white", "orange", "red"),
    rescaler = ~ scales::rescale_mid(.x, mid = 0)
  )
```

![](https://i.imgur.com/wj0tB8c.png)<!-- -->

<sup>Created on 2024-05-21 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
