### PR TITLE
Let `Layer$compute_geom_2()` handle legend defaults

### DIFF
--- a/R/geom-.R
+++ b/R/geom-.R
@@ -114,7 +114,7 @@ Geom <- ggproto("Geom",
   setup_data = function(data, params) data,
 
   # Combine data with defaults and set aesthetics from parameters
-  use_defaults = function(self, data, params = list(), modifiers = aes(), default_aes = NULL) {
+  use_defaults = function(self, data, params = list(), modifiers = aes(), default_aes = NULL, ...) {
     default_aes <- default_aes %||% self$default_aes
 
     # Inherit size as linewidth if no linewidth aesthetic and param exist

--- a/R/geom-sf.R
+++ b/R/geom-sf.R
@@ -134,17 +134,18 @@ GeomSf <- ggproto("GeomSf", Geom,
   use_defaults = function(self, data, params = list(), modifiers = aes(),
                           default_aes = NULL, ...) {
     data <- ggproto_parent(Geom, self)$use_defaults(data, params, modifiers, default_aes)
-    # Early exit for e.g. legend data that don't have geometry columns
     if (!"geometry" %in% names(data)) {
       return(data)
     }
 
-    # Devise splitting index for geometry types
+    # geometry column is a character if we're populating legend keys
     type <- if (is.character(data$geometry)) {
       data$geometry
     } else {
       sf_types[sf::st_geometry_type(data$geometry)]
     }
+
+    # Devise splitting index for geometry types
     type <- factor(type, c("point", "line", "other", "collection"))
     index <- split(seq_len(nrow(data)), type)
 
@@ -207,26 +208,14 @@ GeomSf <- ggproto("GeomSf", Geom,
   },
 
   draw_key = function(data, params, size) {
-    data <- modify_list(default_aesthetics(params$legend), data)
-    if (params$legend == "point") {
-      draw_key_point(data, params, size)
-    } else if (params$legend == "line") {
-      draw_key_path(data, params, size)
-    } else {
+    switch(
+      params$legend %||% "other",
+      point = draw_key_point(data, params, size),
+      line  = draw_key_path(data, params, size),
       draw_key_polygon(data, params, size)
-    }
+    )
   }
 )
-
-default_aesthetics <- function(type) {
-  if (type == "point") {
-    GeomPoint$default_aes
-  } else if (type == "line") {
-    GeomLine$default_aes
-  } else  {
-    modify_list(GeomPolygon$default_aes, list(fill = "grey90", colour = "grey35"))
-  }
-}
 
 sf_grob <- function(x, lineend = "butt", linejoin = "round", linemitre = 10,
                     arrow = NULL, arrow.fill = NULL, na.rm = TRUE) {

--- a/R/geom-sf.R
+++ b/R/geom-sf.R
@@ -131,7 +131,8 @@ GeomSf <- ggproto("GeomSf", Geom,
     stroke = 0.5
   ),
 
-  use_defaults = function(self, data, params = list(), modifiers = aes(), default_aes = NULL) {
+  use_defaults = function(self, data, params = list(), modifiers = aes(),
+                          default_aes = NULL, ...) {
     data <- ggproto_parent(Geom, self)$use_defaults(data, params, modifiers, default_aes)
     # Early exit for e.g. legend data that don't have geometry columns
     if (!"geometry" %in% names(data)) {
@@ -139,7 +140,11 @@ GeomSf <- ggproto("GeomSf", Geom,
     }
 
     # Devise splitting index for geometry types
-    type <- sf_types[sf::st_geometry_type(data$geometry)]
+    type <- if (is.character(data$geometry)) {
+      data$geometry
+    } else {
+      sf_types[sf::st_geometry_type(data$geometry)]
+    }
     type <- factor(type, c("point", "line", "other", "collection"))
     index <- split(seq_len(nrow(data)), type)
 

--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -225,35 +225,35 @@ GuideLegend <- ggproto(
 
   get_layer_key = function(params, layers, data) {
 
+    # Return empty guides as-is
     if (nrow(params$key) < 1) {
       return(params)
     }
 
     decor <- Map(layer = layers, df = data, f = function(layer, df) {
 
+      # Subset key to the column with aesthetic matching the layer
       matched_aes <- matched_aes(layer, params)
+      key <- params$key[matched_aes]
 
+      # Filter static aesthetics to those with single values
+      single_params <- lengths(layer$aes_params) == 1L
+      single_params <- layer$aes_params[single_params]
+
+      # Use layer to populate defaults
+      key <- layer$compute_geom_2(key, single_params)
+
+      # Filter non-existing levels
       if (length(matched_aes) > 0) {
-        # Filter out aesthetics that can't be applied to the legend
-        n <- lengths(layer$aes_params, use.names = FALSE)
-        layer_params <- layer$aes_params[n == 1]
-
-        aesthetics  <- layer$computed_mapping
-        is_modified <- is_scaled_aes(aesthetics) | is_staged_aes(aesthetics)
-        modifiers   <- aesthetics[is_modified]
-
-        data <- layer$geom$use_defaults(params$key[matched_aes], layer_params, modifiers)
-        data$.draw <- keep_key_data(params$key, df, matched_aes, layer$show.legend)
-      } else {
-        reps <- rep(1, nrow(params$key))
-        data <- layer$geom$use_defaults(NULL, layer$aes_params)[reps, ]
+        key$.draw <- keep_key_data(params$key, df, matched_aes, layer$show.legend)
       }
 
-      data <- modify_list(data, params$override.aes)
+      # Apply overrides
+      key <- modify_list(key, params$override.aes)
 
       list(
         draw_key = layer$geom$draw_key,
-        data     = data,
+        data     = key,
         params   = c(layer$computed_geom_params, layer$computed_stat_params)
       )
     })

--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -225,6 +225,10 @@ GuideLegend <- ggproto(
 
   get_layer_key = function(params, layers, data) {
 
+    if (nrow(params$key) < 1) {
+      return(params)
+    }
+
     decor <- Map(layer = layers, df = data, f = function(layer, df) {
 
       matched_aes <- matched_aes(layer, params)

--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -235,6 +235,7 @@ GuideLegend <- ggproto(
       # Subset key to the column with aesthetic matching the layer
       matched_aes <- matched_aes(layer, params)
       key <- params$key[matched_aes]
+      key$.id <- seq_len(nrow(key))
 
       # Filter static aesthetics to those with single values
       single_params <- lengths(layer$aes_params) == 1L

--- a/R/layer-sf.R
+++ b/R/layer-sf.R
@@ -38,10 +38,6 @@ layer_sf <- function(geom = NULL, stat = NULL,
 LayerSf <- ggproto("LayerSf", Layer,
   legend_key_type = NULL,
 
-  # This field carry state throughout rendering but will always be
-  # calculated before use
-  computed_legend_key_type = NULL,
-
   setup_layer = function(self, data, plot) {
     # process generic layer setup first
     data <- ggproto_parent(Layer, self)$setup_layer(data, plot)
@@ -56,34 +52,22 @@ LayerSf <- ggproto("LayerSf", Layer,
         self$computed_mapping$geometry <- sym(geometry_col)
       }
     }
-
-    # automatically determine the legend type
-    if (is.null(self$legend_key_type)) {
-      # first, set default value in case downstream tests fail
-      self$computed_legend_key_type <- "polygon"
-
-      # now check if the type should not be polygon
-      if (!is.null(self$computed_mapping$geometry) && quo_is_symbol(self$computed_mapping$geometry)) {
-        geometry_column <- as_name(self$computed_mapping$geometry)
-        if (inherits(data[[geometry_column]], "sfc")) {
-          sf_type <- detect_sf_type(data[[geometry_column]])
-          if (sf_type == "point") {
-            self$computed_legend_key_type <- "point"
-          } else if (sf_type == "line") {
-            self$computed_legend_key_type <- "line"
-          }
-        }
-      }
-    } else {
-      self$computed_legend_key_type <- self$legend_key_type
-    }
     data
   },
   compute_geom_1 = function(self, data) {
     data <- ggproto_parent(Layer, self)$compute_geom_1(data)
 
+    # Determine the legend type
+    legend_type <- self$legend_key_type
+    if (is.null(legend_type)) {
+      legend_type <- switch(
+        detect_sf_type(data$geometry),
+        point = "point", line = "line", "other"
+      )
+    }
+
     # Add legend type after computed_geom_params has been calculated
-    self$computed_geom_params$legend <- self$computed_legend_key_type
+    self$computed_geom_params$legend <- legend_type
     data
   }
 )
@@ -113,6 +97,9 @@ scale_type.sfc <- function(x) "identity"
 
 # helper function to determine the geometry type of sf object
 detect_sf_type <- function(sf) {
+  if (is.null(sf)) {
+    return("other")
+  }
   geometry_type <- unique0(as.character(sf::st_geometry_type(sf)))
   if (length(geometry_type) != 1)  geometry_type <- "GEOMETRY"
   sf_types[geometry_type]

--- a/R/layer-sf.R
+++ b/R/layer-sf.R
@@ -69,6 +69,11 @@ LayerSf <- ggproto("LayerSf", Layer,
     # Add legend type after computed_geom_params has been calculated
     self$computed_geom_params$legend <- legend_type
     data
+  },
+
+  compute_geom_2 = function(self, data, params = self$aes_params, ...) {
+    data$geometry <- data$geometry %||% self$computed_geom_params$legend
+    ggproto_parent(Layer, self)$compute_geom_2(data, params, ...)
   }
 )
 

--- a/R/layer.R
+++ b/R/layer.R
@@ -438,14 +438,14 @@ Layer <- ggproto("Layer", NULL,
     self$position$compute_layer(data, params, layout)
   },
 
-  compute_geom_2 = function(self, data) {
+  compute_geom_2 = function(self, data, params = self$aes_params, ...) {
     # Combine aesthetics, defaults, & params
     if (empty(data)) return(data)
 
     aesthetics <- self$computed_mapping
     modifiers <- aesthetics[is_scaled_aes(aesthetics) | is_staged_aes(aesthetics)]
 
-    self$geom$use_defaults(data, self$aes_params, modifiers)
+    self$geom$use_defaults(data, params, modifiers, ...)
   },
 
   finish_statistics = function(self, data) {

--- a/tests/testthat/_snaps/geom-sf/geom-sf-line-legend.svg
+++ b/tests/testthat/_snaps/geom-sf/geom-sf-line-legend.svg
@@ -1,0 +1,82 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTUuMjZ8NjY0Ljc0fDAuMDB8NTc2LjAw'>
+    <rect x='55.26' y='0.00' width='609.48' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTUuMjZ8NjY0Ljc0fDAuMDB8NTc2LjAw)'>
+<rect x='55.26' y='0.00' width='609.48' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNzcuOTB8NjEyLjgyfDIyLjc4fDU1Ny43MQ=='>
+    <rect x='77.90' y='22.78' width='534.92' height='534.92' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNzcuOTB8NjEyLjgyfDIyLjc4fDU1Ny43MQ==)'>
+<rect x='77.90' y='22.78' width='534.92' height='534.92' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='102.22,533.39 264.31,371.29 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<polyline points='426.41,209.20 588.51,47.10 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<rect x='77.90' y='22.78' width='534.92' height='534.92' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='72.97' y='536.42' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='72.97' y='455.37' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.5</text>
+<text x='72.97' y='374.32' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>4.0</text>
+<text x='72.97' y='293.27' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>4.5</text>
+<text x='72.97' y='212.22' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text x='72.97' y='131.18' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.5</text>
+<text x='72.97' y='50.13' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>6.0</text>
+<polyline points='75.16,533.39 77.90,533.39 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='75.16,452.34 77.90,452.34 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='75.16,371.29 77.90,371.29 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='75.16,290.24 77.90,290.24 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='75.16,209.20 77.90,209.20 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='75.16,128.15 77.90,128.15 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='75.16,47.10 77.90,47.10 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='102.22,560.45 102.22,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='183.27,560.45 183.27,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='264.31,560.45 264.31,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='345.36,560.45 345.36,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='426.41,560.45 426.41,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='507.46,560.45 507.46,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='588.51,560.45 588.51,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='102.22' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='183.27' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='264.31' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text x='345.36' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='426.41' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='507.46' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.5</text>
+<text x='588.51' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>4.0</text>
+<rect x='623.78' y='265.30' width='35.48' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='623.78' y='274.01' style='font-size: 11.00px; font-family: sans;' textLength='14.06px' lengthAdjust='spacingAndGlyphs'>col</text>
+<rect x='623.78' y='280.63' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='625.51' y1='289.27' x2='639.34' y2='289.27' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<rect x='623.78' y='297.91' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='625.51' y1='306.55' x2='639.34' y2='306.55' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<text x='646.54' y='292.30' style='font-size: 8.80px; font-family: sans;' textLength='12.72px' lengthAdjust='spacingAndGlyphs'>bar</text>
+<text x='646.54' y='309.58' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>foo</text>
+<text x='77.90' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='118.16px' lengthAdjust='spacingAndGlyphs'>geom_sf line legend</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/geom-sf/geom-sf-point-legend.svg
+++ b/tests/testthat/_snaps/geom-sf/geom-sf-point-legend.svg
@@ -1,0 +1,78 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTUuMjZ8NjY0Ljc0fDAuMDB8NTc2LjAw'>
+    <rect x='55.26' y='0.00' width='609.48' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTUuMjZ8NjY0Ljc0fDAuMDB8NTc2LjAw)'>
+<rect x='55.26' y='0.00' width='609.48' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNzcuOTB8NjEyLjgyfDIyLjc4fDU1Ny43MQ=='>
+    <rect x='77.90' y='22.78' width='534.92' height='534.92' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNzcuOTB8NjEyLjgyfDIyLjc4fDU1Ny43MQ==)'>
+<rect x='77.90' y='22.78' width='534.92' height='534.92' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='102.22' cy='533.39' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; stroke-linecap: butt; fill: #00BFC4;' />
+<circle cx='588.51' cy='47.10' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; stroke-linecap: butt; fill: #F8766D;' />
+<rect x='77.90' y='22.78' width='534.92' height='534.92' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='72.97' y='536.42' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='72.97' y='439.16' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.2</text>
+<text x='72.97' y='341.90' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.4</text>
+<text x='72.97' y='244.64' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.6</text>
+<text x='72.97' y='147.38' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.8</text>
+<text x='72.97' y='50.13' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>4.0</text>
+<polyline points='75.16,533.39 77.90,533.39 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='75.16,436.13 77.90,436.13 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='75.16,338.87 77.90,338.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='75.16,241.62 77.90,241.62 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='75.16,144.36 77.90,144.36 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='75.16,47.10 77.90,47.10 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='102.22,560.45 102.22,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='199.48,560.45 199.48,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='296.73,560.45 296.73,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='393.99,560.45 393.99,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='491.25,560.45 491.25,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='588.51,560.45 588.51,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='102.22' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='199.48' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.2</text>
+<text x='296.73' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.4</text>
+<text x='393.99' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.6</text>
+<text x='491.25' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.8</text>
+<text x='588.51' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<rect x='623.78' y='265.30' width='35.48' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='623.78' y='274.01' style='font-size: 11.00px; font-family: sans;' textLength='14.06px' lengthAdjust='spacingAndGlyphs'>col</text>
+<rect x='623.78' y='280.63' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='632.42' cy='289.27' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<rect x='623.78' y='297.91' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='632.42' cy='306.55' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<text x='646.54' y='292.30' style='font-size: 8.80px; font-family: sans;' textLength='12.72px' lengthAdjust='spacingAndGlyphs'>bar</text>
+<text x='646.54' y='309.58' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>foo</text>
+<text x='77.90' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='126.24px' lengthAdjust='spacingAndGlyphs'>geom_sf point legend</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/geom-sf/geom-sf-polygon-legend.svg
+++ b/tests/testthat/_snaps/geom-sf/geom-sf-polygon-legend.svg
@@ -1,0 +1,82 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTUuMjZ8NjY0Ljc0fDAuMDB8NTc2LjAw'>
+    <rect x='55.26' y='0.00' width='609.48' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTUuMjZ8NjY0Ljc0fDAuMDB8NTc2LjAw)'>
+<rect x='55.26' y='0.00' width='609.48' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNzcuOTB8NjEyLjgyfDIyLjc4fDU1Ny43MQ=='>
+    <rect x='77.90' y='22.78' width='534.92' height='534.92' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNzcuOTB8NjEyLjgyfDIyLjc4fDU1Ny43MQ==)'>
+<rect x='77.90' y='22.78' width='534.92' height='534.92' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<path d='M 102.22 533.39 L 264.31 533.39 L 264.31 371.29 L 102.22 533.39 Z' style='fill-rule: evenodd; fill: #E5E5E5; stroke-width: 0.43; stroke: #00BFC4; stroke-linecap: butt;' />
+<path d='M 426.41 209.20 L 426.41 47.10 L 588.51 47.10 L 426.41 209.20 Z' style='fill-rule: evenodd; fill: #E5E5E5; stroke-width: 0.43; stroke: #F8766D; stroke-linecap: butt;' />
+<rect x='77.90' y='22.78' width='534.92' height='534.92' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='72.97' y='536.42' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='72.97' y='455.37' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.5</text>
+<text x='72.97' y='374.32' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>4.0</text>
+<text x='72.97' y='293.27' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>4.5</text>
+<text x='72.97' y='212.22' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text x='72.97' y='131.18' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.5</text>
+<text x='72.97' y='50.13' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>6.0</text>
+<polyline points='75.16,533.39 77.90,533.39 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='75.16,452.34 77.90,452.34 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='75.16,371.29 77.90,371.29 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='75.16,290.24 77.90,290.24 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='75.16,209.20 77.90,209.20 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='75.16,128.15 77.90,128.15 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='75.16,47.10 77.90,47.10 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='102.22,560.45 102.22,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='183.27,560.45 183.27,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='264.31,560.45 264.31,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='345.36,560.45 345.36,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='426.41,560.45 426.41,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='507.46,560.45 507.46,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='588.51,560.45 588.51,557.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='102.22' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='183.27' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.5</text>
+<text x='264.31' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.0</text>
+<text x='345.36' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='426.41' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='507.46' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>3.5</text>
+<text x='588.51' y='568.69' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>4.0</text>
+<rect x='623.78' y='265.30' width='35.48' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='623.78' y='274.01' style='font-size: 11.00px; font-family: sans;' textLength='14.06px' lengthAdjust='spacingAndGlyphs'>col</text>
+<rect x='623.78' y='280.63' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='624.07' y='280.91' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #E5E5E5;' />
+<rect x='623.78' y='297.91' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='624.07' y='298.19' width='16.71' height='16.71' style='stroke-width: 0.43; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #E5E5E5;' />
+<text x='646.54' y='292.30' style='font-size: 8.80px; font-family: sans;' textLength='12.72px' lengthAdjust='spacingAndGlyphs'>bar</text>
+<text x='646.54' y='309.58' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>foo</text>
+<text x='77.90' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='143.86px' lengthAdjust='spacingAndGlyphs'>geom_sf polygon legend</text>
+</g>
+</svg>

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -37,7 +37,7 @@ test_that("geom_sf() determines the legend type automatically", {
   expect_identical(fun_geom_sf(mls, TRUE)$plot$layers[[1]]$computed_geom_params$legend, "line")
 
   expect_identical(fun_geom_sf(mpol, TRUE)$plot$layers[[1]]$show.legend, TRUE)
-  expect_identical(fun_geom_sf(mpol, TRUE)$plot$layers[[1]]$computed_geom_params$legend, "polygon")
+  expect_identical(fun_geom_sf(mpol, TRUE)$plot$layers[[1]]$computed_geom_params$legend, "other")
 
   # test that automatic choice can be overridden manually
   expect_identical(fun_geom_sf(mp, "point")$plot$layers[[1]]$show.legend, TRUE)
@@ -74,13 +74,6 @@ test_that("geom_sf() determines the legend type from mapped geometry column", {
     ggplot(d_sf) + geom_sf(aes(geometry = g_line, colour = "a"))
   )
   expect_identical(p$plot$layers[[1]]$computed_geom_params$legend, "line")
-
-  # If `geometry` is not a symbol, `LayerSf$setup_layer()` gives up guessing
-  # the legend type, and falls back to "polygon"
-  p <- ggplot_build(
-    ggplot(d_sf) + geom_sf(aes(geometry = identity(g_point), colour = "a"))
-  )
-  expect_identical(p$plot$layers[[1]]$computed_geom_params$legend, "polygon")
 })
 
 test_that("geom_sf() removes rows containing missing aes", {

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -196,6 +196,47 @@ test_that("geom_sf draws correctly", {
   )
 })
 
+test_that("geom_sf data type renders appropriate legends", {
+  skip_if_not_installed("sf")
+  p <- ggplot() + geom_sf(aes(colour = col))
+
+  # Point data
+  data <- sf::st_as_sf(
+    data.frame(lon = c(1, 2), lat = c(3, 4), col = c("foo", "bar")),
+    coords = c("lon", "lat")
+  )
+  expect_doppelganger(
+    "geom_sf point legend",
+    p %+% data
+  )
+
+  # Line data
+  data <- sf::st_as_sf(
+    sf::st_sfc(
+      sf::st_linestring(x = cbind(1:2, 3:4)),
+      sf::st_linestring(x = cbind(3:4, 5:6))
+    ),
+    col = c("foo", "bar")
+  )
+  expect_doppelganger(
+    "geom_sf line legend",
+    p %+% data
+  )
+
+  # Polygon data
+  data <- sf::st_as_sf(
+    sf::st_sfc(
+      sf::st_polygon(list(cbind(c(1, 2, 2, 1), c(3, 3, 4, 3)))),
+      sf::st_polygon(list(cbind(c(3, 3, 4, 3), c(5, 6, 6, 5))))
+    ),
+    col = c("foo", "bar")
+  )
+  expect_doppelganger(
+    "geom_sf polygon legend",
+    p %+% data
+  )
+})
+
 test_that("geom_sf uses combinations of geometry correctly", {
   skip_if_not_installed("sf")
 

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -552,6 +552,25 @@ test_that("bins can be parsed by guides for all scale types", {
   )
 })
 
+test_that("legends can be forced to display unrelated geoms", {
+
+  df <- data.frame(x = 1:2)
+
+  p <- ggplot(df, aes(x, x)) +
+    geom_tile(fill = "red", show.legend = TRUE) +
+    scale_colour_discrete(
+      limits = c("A", "B")
+    )
+
+  b <- ggplot_build(p)
+  legend <- b$plot$guides$params[[1]]
+
+  expect_equal(
+    legend$decor[[1]]$data$fill,
+    c("red", "red")
+  )
+})
+
 # Visual tests ------------------------------------------------------------
 
 test_that("axis guides are drawn correctly", {


### PR DESCRIPTION
This PR is an amendment to #5834, as it didn't handle the non-standard defaults for `geom_sf()` legends.

Briefly, this PR let's `Layer$compute_geom_2()` instead of `Geom$use_defaults()` handle populating legend keys with defaults.

The legend code was mirroring `Layer$compute_geom_2()` in many ways anyway, so this shouldn't be much of a stretch.
This ensures that the layer could impose some of its non-aesthetic parameters on the legend keys.
That is needed to resolve the defaults for the correct legend type in `geom_sf()`, which we'd need for #5833.

In addition the following changes are made:

* `Layer$compute_geom_2()` now accepts a custom `params` object, as legends only pass static aesthetics when they are of length 1.
* The sf legend detection mechanism has moved from `LayerSf$setup_layer()` to `LayerSf$compute_geom_1()`. This allows for more readable code and abolishes the stateful `computed_legend_key_type` field in `LayerSf`.
* There is now a visual test for `geom_sf()`'s legend types, because we had detected problems in revdepchecks that weren't covered in our own tests.
* There is now a test for legend keys when a geom does not having matching aesthetics, which we didn't cover before.
