### PR TITLE
'geom_rug()' prints a warning when 'na.rm = FALSE'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # ggplot2 (development version)
 
+* `geom_rug()` prints a warning when `na.rm = FALSE`, as per documentation (#)
 * The `arrow.fill` parameter is now applied to more line-based functions: 
   `geom_path()`, `geom_line()`, `geom_step()` `geom_function()`, line 
    geometries in `geom_sf()` and `element_line()`.

--- a/R/geom-rug.R
+++ b/R/geom-rug.R
@@ -88,6 +88,20 @@ geom_rug <- function(mapping = NULL, data = NULL,
 GeomRug <- ggproto("GeomRug", Geom,
   optional_aes = c("x", "y"),
 
+  setup_params = function(self, data, params) {
+    self$required_aes <- character()
+
+    if (grepl("b|t", params$sides)) {
+      self$required_aes <- c(self$required_aes, "x")
+    }
+
+    if (grepl("l|r", params$sides)) {
+      self$required_aes <- c(self$required_aes, "y")
+    }
+
+    params
+  },
+
   draw_panel = function(self, data, panel_params, coord, lineend = "butt",
                         sides = "bl", outside = FALSE, length = unit(0.03, "npc")) {
     data <- check_linewidth(data, snake_class(self))


### PR DESCRIPTION
Fixes issue #5905.
When presented with missing values, 'geom_rug()' was not printing a warning message, contrary to the documentation.
A warning message is now printed when 'na.rm = FALSE' and suppressed when 'na.rm = TRUE', as expected.