### PR TITLE
Fallback for `dir = 'h'/'v'`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,7 +44,8 @@
 * (Internal) Applying defaults in `geom_sf()` has moved from the internal 
   `sf_grob()` to `GeomSf$use_defaults()` (@teunbrand).
 * `facet_wrap()` has new options for the `dir` argument to more precisely
-  control panel directions (@teunbrand, #5212)
+  control panel directions. Internally `dir = "h"` or `dir = "v"` is deprecated 
+  (@teunbrand, #5212).
 * Prevented `facet_wrap(..., drop = FALSE)` from throwing spurious errors when
   a character facetting variable contained `NA`s (@teunbrand, #5485).
 * When facets coerce the faceting variables to factors, the 'ordered' class

--- a/R/facet-wrap.R
+++ b/R/facet-wrap.R
@@ -586,6 +586,21 @@ wrap_layout <- function(id, dims, dir) {
   as.table <- TRUE
   n <- attr(id, "n")
 
+  if (nchar(dir) != 2) {
+    # Should only occur when `as.table` was not incorporated into `dir`
+    dir <- switch(dir, h = "lt", v = "tl")
+    deprecate_soft0(
+      "3.5.2",
+      what = I("Internal use of `dir = \"h\"` and `dir = \"v\"` in `facet_wrap()`"),
+      details = I(c(
+        "The `dir` argument should incorporate the `as.table` argument.",
+        paste0("Falling back to `dir = \"", dir, "\"`.")
+      ))
+    )
+  }
+
+  dir <- arg_match0(dir, c("lt", "tl", "lb", "bl", "rt", "tr", "rb", "br"))
+
   ROW <- switch(
     dir,
     lt = , rt = (id - 1L) %/% dims[2] + 1L,

--- a/tests/testthat/test-facet-.R
+++ b/tests/testthat/test-facet-.R
@@ -325,6 +325,18 @@ test_that("facet_wrap `axes` can draw inner axes.", {
   expect_equal(sum(vapply(left, inherits, logical(1), "absoluteGrob")), 2)
 })
 
+test_that("facet_wrap throws deprecation messages", {
+  withr::local_options(lifecycle_verbosity = "warning")
+
+  facet <- facet_wrap(vars(year))
+  facet$params$dir <- "h"
+
+  lifecycle::expect_deprecated(
+    ggplot_build(ggplot(mpg, aes(displ, hwy)) + geom_point() + facet),
+    "Internal use of"
+  )
+})
+
 # Variable combinations ---------------------------------------------------
 
 test_that("zero-length vars in combine_vars() generates zero combinations", {


### PR DESCRIPTION
This PR aims to fix #5898 and replaces #5900.

Briefly, it is not `as.table` that we need to preserve, but old-style `dir = 'h'/'v'` need to be translated.
This PR has a fallback for these old options and soft-deprecates their use.

Developers might see the following in their testthat runs:
``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2
library(deeptime)

options(lifecycle_verbosity = "warning")

df <- data.frame(x = 1:10, y = 1:10, period = c("Permian", "Triassic"))
ggplot(df) +
  geom_point(aes(x, y)) +
  facet_wrap_color(vars(period), colors = periods)
#> Warning: Internal use of `dir = "h"` and `dir = "v"` in `facet_wrap()` was deprecated in
#> ggplot2 3.5.2.
#> ℹ The `dir` argument should incorporate the `as.table` argument.
#> ℹ Falling back to `dir = "lt"`.
#> Call `lifecycle::last_lifecycle_warnings()` to see where this warning was
#> generated.
```

![](https://i.imgur.com/qIu46Ea.png)<!-- -->

<sup>Created on 2024-05-24 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
