### PR TITLE
Sort scale and viewscale limits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # ggplot2 (development version)
 
+* `continuous_scale()` passes sorted limits to scale (@teunbrand, #5918)
 * The `arrow.fill` parameter is now applied to more line-based functions: 
   `geom_path()`, `geom_line()`, `geom_step()` `geom_function()`, line 
    geometries in `geom_sf()` and `element_line()`.

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -127,11 +127,6 @@ continuous_scale <- function(aesthetics, scale_name = deprecated(), palette, nam
     guide <- "none"
   }
 
-  transform <- as.transform(transform)
-  if (!is.null(limits) && !is.function(limits)) {
-    limits <- transform$transform(limits)
-  }
-
   # Convert formula to function if appropriate
   limits   <- allow_lambda(limits)
   breaks   <- allow_lambda(breaks)
@@ -139,6 +134,14 @@ continuous_scale <- function(aesthetics, scale_name = deprecated(), palette, nam
   rescaler <- allow_lambda(rescaler)
   oob      <- allow_lambda(oob)
   minor_breaks <- allow_lambda(minor_breaks)
+
+  transform <- as.transform(transform)
+  if (!is.null(limits) && !is.function(limits)) {
+    limits <- transform$transform(limits)
+    if (!anyNA(limits)) {
+      limits <- sort(limits)
+    }
+  }
 
   ggproto(NULL, super,
     call = call,

--- a/R/scale-view.R
+++ b/R/scale-view.R
@@ -35,7 +35,7 @@ view_scale_primary <- function(scale, limits = scale$get_limits(),
     name = scale$name,
     scale_is_discrete = scale$is_discrete(),
     limits = limits,
-    continuous_range = continuous_range,
+    continuous_range = continuous_scale_sorted,
     breaks = breaks,
     minor_breaks = minor_breaks
   )


### PR DESCRIPTION
This PR aims to fix #5918.

Briefly, `continuous_scale()` now sorts the limits and position guides get passed sorted ranges.

The order of the limits should now only matter when choosing e.g. `limits = c(NA, 10)` to substitute the `NA` for the data limits. Examples below are from the issue.

Regular scale, flipped limits:
``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

ggplot() + scale_x_continuous(limits = c(10, 0))
```

![](https://i.imgur.com/rAXJPCz.png)<!-- -->

Reverse scale, sorted limits:
``` r
ggplot() + scale_x_reverse(limits = c(0, 10))
```

![](https://i.imgur.com/EwlL2Xz.png)<!-- -->

<sup>Created on 2024-05-31 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
