### PR TITLE
Use `group` to dodge in `position_jitterdodge()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # ggplot2 (development version)
 
+* `position_jitterdodge()` now dodges by `group` (@teunbrand, #3656)
 * The `arrow.fill` parameter is now applied to more line-based functions: 
   `geom_path()`, `geom_line()`, `geom_step()` `geom_function()`, line 
    geometries in `geom_sf()` and `element_line()`.

--- a/R/position-jitterdodge.R
+++ b/R/position-jitterdodge.R
@@ -47,17 +47,9 @@ PositionJitterdodge <- ggproto("PositionJitterdodge", Position,
     flipped_aes <- has_flipped_aes(data)
     data <- flip_data(data, flipped_aes)
     width <- self$jitter.width %||% (resolution(data$x, zero = FALSE, TRUE) * 0.4)
-    # Adjust the x transformation based on the number of 'dodge' variables
-    possible_dodge <- c("fill", "colour", "linetype", "shape", "size", "alpha")
-    dodgecols <- intersect(possible_dodge, colnames(data))
-    if (length(dodgecols) == 0) {
-      cli::cli_abort(c(
-        "{.fn position_jitterdodge} requires at least one aesthetic to dodge by.",
-        i = "Use one of {.or {.val {possible_dodge}}} aesthetics."
-        ))
-    }
-    ndodge    <- lapply(data[dodgecols], levels)  # returns NULL for numeric, i.e. non-dodge layers
-    ndodge    <- vec_unique_count(unlist(ndodge))
+
+    ndodge <- split(data$group, list(data$PANEL, data$x))
+    ndodge <- max(vapply(ndodge, vec_unique_count, integer(1)))
 
     list(
       dodge.width = self$dodge.width,

--- a/R/position-jitterdodge.R
+++ b/R/position-jitterdodge.R
@@ -48,8 +48,9 @@ PositionJitterdodge <- ggproto("PositionJitterdodge", Position,
     data <- flip_data(data, flipped_aes)
     width <- self$jitter.width %||% (resolution(data$x, zero = FALSE, TRUE) * 0.4)
 
-    ndodge <- split(data$group, list(data$PANEL, data$x))
-    ndodge <- max(vapply(ndodge, vec_unique_count, integer(1)))
+    ndodge <- vec_unique(data[c("group", "PANEL", "x")])
+    ndodge <- vec_group_id(ndodge[c("PANEL", "x")])
+    ndodge <- max(tabulate(ndodge, attr(ndodge, "n")))
 
     list(
       dodge.width = self$dodge.width %||% 0.75,

--- a/R/position-jitterdodge.R
+++ b/R/position-jitterdodge.R
@@ -52,8 +52,8 @@ PositionJitterdodge <- ggproto("PositionJitterdodge", Position,
     ndodge <- max(vapply(ndodge, vec_unique_count, integer(1)))
 
     list(
-      dodge.width = self$dodge.width,
-      jitter.height = self$jitter.height,
+      dodge.width = self$dodge.width %||% 0.75,
+      jitter.height = self$jitter.height %||% 0,
       jitter.width = width / (ndodge + 2),
       seed = self$seed,
       flipped_aes = flipped_aes

--- a/tests/testthat/_snaps/position-jitterdodge.md
+++ b/tests/testthat/_snaps/position-jitterdodge.md
@@ -1,8 +1,0 @@
-# position_jitterdodge() fails with meaningful error
-
-    Problem while computing position.
-    i Error occurred in the 1st layer.
-    Caused by error in `setup_params()`:
-    ! `position_jitterdodge()` requires at least one aesthetic to dodge by.
-    i Use one of "fill", "colour", "linetype", "shape", "size", or "alpha" aesthetics.
-

--- a/tests/testthat/test-position-jitterdodge.R
+++ b/tests/testthat/test-position-jitterdodge.R
@@ -1,8 +1,3 @@
-test_that("position_jitterdodge() fails with meaningful error", {
-  p <- ggplot(mtcars) + geom_point(aes(disp, mpg), position = 'jitterdodge')
-  expect_snapshot_error(ggplot_build(p))
-})
-
 test_that("position_jitterdodge preserves widths", {
   ld <- layer_data(
     ggplot(mtcars, aes(factor(cyl), fill = factor(am))) +


### PR DESCRIPTION
This PR aims to fix #3656.

Briefly, instead of dodging by a set of aesthetics, it uses the innate `group` to dodge.
Also using `position = "jitterdodge"` no longer fails due to missing parameters.

Some examples:

If there is no `group` it just jitters:
``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2
p <- ggplot(mpg, aes("x", displ)) +
  geom_point(position = "jitterdodge")

p
```

![](https://i.imgur.com/ZAIQW2I.png)<!-- -->

If there is an explicit group, that is used to dodge:
``` r
p + aes(group = drv)
```

![](https://i.imgur.com/8d58hvN.png)<!-- -->

If there is an implicit automatic group, it dodges by that:
``` r
p + aes(colour = drv)
```

![](https://i.imgur.com/A8iIdCx.png)<!-- -->

Explicit groups can be used to override implicit ones:
``` r
p + aes(group = drv, colour = factor(cyl))
```

![](https://i.imgur.com/VdJACWN.png)<!-- -->

<sup>Created on 2024-05-31 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
