### PR TITLE
Robust `position_dodge(preserve = "single")` 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* `position_dodge(preserve = "single")` now handles multi-row geoms better,
+  such as `geom_violin()` (@teunbrand based on @clauswilke's work, #2801).
 * The `arrow.fill` parameter is now applied to more line-based functions: 
   `geom_path()`, `geom_line()`, `geom_step()` `geom_function()`, line 
    geometries in `geom_sf()` and `element_line()`.

--- a/R/position-dodge.R
+++ b/R/position-dodge.R
@@ -111,9 +111,9 @@ PositionDodge <- ggproto("PositionDodge", Position,
     if (identical(self$preserve, "total")) {
       n <- NULL
     } else {
-      panels <- unname(split(data, data$PANEL))
-      ns <- vapply(panels, function(panel) max(table(panel$xmin)), double(1))
-      n <- max(ns)
+      n <- vec_unique(data[c("group", "PANEL", "xmin")])
+      n <- vec_group_id(n[c("PANEL", "xmin")])
+      n <- max(tabulate(n, attr(n, "n")))
     }
 
     list(


### PR DESCRIPTION
This PR aims to fix #2801 and revives #2813.

Briefly, instead of counting the number of rows per `PANEL`/`xmin` interaction, we are counting the number of unique groups per `PANEL`/`xmin` interaction. Argueably, this is the metric that should be counted.

The reprex from the issue now shows violin plots of appropriate widths:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

ggplot(mtcars, aes(factor(cyl), mpg, fill = factor(vs))) +
  geom_violin(position = position_dodge(preserve = "single"))
#> Warning: Groups with fewer than two datapoints have been dropped.
#> ℹ Set `drop = FALSE` to consider such groups for position adjustment purposes.
```

![](https://i.imgur.com/IkUXDkR.png)<!-- -->

<sup>Created on 2024-06-03 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

One concern raised in https://github.com/tidyverse/ggplot2/pull/2813#issuecomment-420779013 was performance. This PR uses {vctrs} and is faster than the current implementation.

<details>

``` r
library(vctrs)

old_strategy <- function(data) {
  panels <- unname(split(data, data$PANEL))
  ns <- vapply(panels, function(panel) max(table(panel$xmin)), double(1))
  max(ns)
}

new_strategy <- function(data) {
  n <- vec_unique(data[c("group", "PANEL", "xmin")])
  n <- vec_group_id(n[c("PANEL", "xmin")])
  max(tabulate(n, attr(n, "n")))
}

data <- 
  transform(
    ggplot2::diamonds, 
    PANEL = 1L, 
    group = interaction(color, clarity), 
    xmin = clarity
  )

# Replicate boxplot: 1-row per group/xmin combination
data <- data[!duplicated(data[c("PANEL", "group", "xmin")]), ]

bench::mark(
  old_strategy(data),
  new_strategy(data)
)
#> # A tibble: 2 × 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 old_strategy(data)   99.6µs  103.6µs     9235.   133.3KB     43.1
#> 2 new_strategy(data)   29.2µs   30.5µs    31879.    16.8KB     38.3

# If we are generous towards the 'old strategy' by having smaller data to split
data <- data[c("PANEL", "group", "xmin")]

bench::mark(
  old_strategy(data),
  new_strategy(data)
)
#> # A tibble: 2 × 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 old_strategy(data)   58.9µs     61µs    16072.    5.62KB     39.7
#> 2 new_strategy(data)   29.3µs   30.2µs    32595.    4.03KB     39.2
```

<sup>Created on 2024-06-03 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

</details>
