### PR TITLE
Pass missing arguments in `guide_coloursteps()`

### DIFF
--- a/R/guide-colorsteps.R
+++ b/R/guide-colorsteps.R
@@ -52,6 +52,7 @@ guide_coloursteps <- function(
   even.steps  = TRUE,
   show.limits = NULL,
   direction = NULL,
+  position = NULL,
   reverse = FALSE,
   order = 0,
   available_aes = c("colour", "color", "fill"),
@@ -67,9 +68,11 @@ guide_coloursteps <- function(
     alpha = alpha,
     even.steps  = even.steps,
     show.limits = show.limits,
+    position = position,
     direction = direction,
     reverse = reverse,
     order = order,
+    available_aes = available_aes,
     super = GuideColoursteps
   )
 }


### PR DESCRIPTION
This PR aims to fix #5930.

Briefly, I forgot to pass `position` and `available_aes` to `new_guide()`, which this PR fixes.

Reprex from issue:
``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

ggplot(mpg, aes(displ, hwy, colour = cty)) +
  geom_point() +
  guides(color=guide_colorsteps(position = "bottom"))
```

![](https://i.imgur.com/FlEIP2V.png)<!-- -->

<sup>Created on 2024-06-04 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

