### PR TITLE
Guard against old discrete scales with identity palettes

### DIFF
--- a/R/scale-.R
+++ b/R/scale-.R
@@ -232,7 +232,7 @@ discrete_scale <- function(aesthetics, scale_name = deprecated(), palette, name 
 
   # If the scale is non-positional, break = NULL means removing the guide
   is_position <- any(is_position_aes(aesthetics))
-  if (is.null(breaks) && !position) {
+  if (is.null(breaks) && !is_position) {
     guide <- "none"
   }
   if (is_position && identical(palette, identity)) {

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -231,8 +231,12 @@ discrete_scale <- function(aesthetics, scale_name = deprecated(), palette, name 
   position <- arg_match0(position, c("left", "right", "top", "bottom"))
 
   # If the scale is non-positional, break = NULL means removing the guide
-  if (is.null(breaks) && all(!is_position_aes(aesthetics))) {
+  is_position <- any(is_position_aes(aesthetics))
+  if (is.null(breaks) && !position) {
     guide <- "none"
+  }
+  if (is_position && identical(palette, identity)) {
+    palette <- seq_len
   }
 
   ggproto(NULL, super,

--- a/R/scale-discrete-.R
+++ b/R/scale-discrete-.R
@@ -140,6 +140,10 @@ ScaleDiscretePosition <- ggproto("ScaleDiscretePosition", ScaleDiscrete,
 
   map = function(self, x, limits = self$get_limits()) {
     if (is.discrete(x)) {
+      # Guard against old use of having identity palettes
+      if (identical(.subset2(self, "palette"), identity)) {
+        self$palette <- seq_len
+      }
       values <- self$palette(length(limits))
       if (!is.numeric(values)) {
         cli::cli_abort(

--- a/R/scale-discrete-.R
+++ b/R/scale-discrete-.R
@@ -140,10 +140,6 @@ ScaleDiscretePosition <- ggproto("ScaleDiscretePosition", ScaleDiscrete,
 
   map = function(self, x, limits = self$get_limits()) {
     if (is.discrete(x)) {
-      # Guard against old use of having identity palettes
-      if (identical(.subset2(self, "palette"), identity)) {
-        self$palette <- seq_len
-      }
       values <- self$palette(length(limits))
       if (!is.numeric(values)) {
         cli::cli_abort(


### PR DESCRIPTION
This PR is an amendement to #5770.

Briefly, we introduced the `palette` argument, but revdep check show that some people contstruct their discrete position scales using `discrete_scale(..., palette = identity)`. The identity palette is problematic as it doesn't return the expected values. This PR replaces identity palettes with `seq_len` to keep consistent behaviour with older scales.