### PR TITLE
setup sides parameter in `geom_rug()`

### DIFF
--- a/R/geom-rug.R
+++ b/R/geom-rug.R
@@ -159,6 +159,11 @@ GeomRug <- ggproto("GeomRug", Geom,
 
   rename_size = TRUE,
 
+  setup_params = function(data, params) {
+    params$sides <- params$sides %||% "bl"
+    params
+  },
+
   handle_na = function(self, data, params) {
     sides_aes <- character()
 


### PR DESCRIPTION
This PR aims to fix #5940.

Briefly, it uses the `setup_params` method to fill in a potentially missing `sides` argument.