### PR TITLE
Expose position arg on geom_hline() and geom_vline()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -99,6 +99,8 @@
   the `nbin` argument (@teunbrand, #5882, #5036)
 * `after_stat()` and `after_scale()` throw warnings when the computed aesthetics
   are not of the correct length (#5901).
+* `geom_hline()` and `geom_vline()` now have `position` argument
+  (@yutannihilation, #4285).
 
 # ggplot2 3.5.1
 

--- a/R/geom-hline.R
+++ b/R/geom-hline.R
@@ -4,6 +4,7 @@ NULL
 #' @export
 #' @rdname geom_abline
 geom_hline <- function(mapping = NULL, data = NULL,
+                       position = "identity",
                        ...,
                        yintercept,
                        na.rm = FALSE,
@@ -29,7 +30,7 @@ geom_hline <- function(mapping = NULL, data = NULL,
     mapping = mapping,
     stat = StatIdentity,
     geom = GeomHline,
-    position = PositionIdentity,
+    position = position,
     show.legend = show.legend,
     inherit.aes = FALSE,
     params = list2(

--- a/R/geom-vline.R
+++ b/R/geom-vline.R
@@ -4,6 +4,7 @@ NULL
 #' @export
 #' @rdname geom_abline
 geom_vline <- function(mapping = NULL, data = NULL,
+                       position = "identity",
                        ...,
                        xintercept,
                        na.rm = FALSE,
@@ -29,7 +30,7 @@ geom_vline <- function(mapping = NULL, data = NULL,
     mapping = mapping,
     stat = StatIdentity,
     geom = GeomVline,
-    position = PositionIdentity,
+    position = position,
     show.legend = show.legend,
     inherit.aes = FALSE,
     params = list2(

--- a/man/geom_abline.Rd
+++ b/man/geom_abline.Rd
@@ -19,6 +19,7 @@ geom_abline(
 geom_hline(
   mapping = NULL,
   data = NULL,
+  position = "identity",
   ...,
   yintercept,
   na.rm = FALSE,
@@ -28,6 +29,7 @@ geom_hline(
 geom_vline(
   mapping = NULL,
   data = NULL,
+  position = "identity",
   ...,
   xintercept,
   na.rm = FALSE,
@@ -88,6 +90,19 @@ a warning. If \code{TRUE}, missing values are silently removed.}
 \code{FALSE} never includes, and \code{TRUE} always includes.
 It can also be a named logical vector to finely select the aesthetics to
 display.}
+
+\item{position}{A position adjustment to use on the data for this layer. This
+can be used in various ways, including to prevent overplotting and
+improving the display. The \code{position} argument accepts the following:
+\itemize{
+\item The result of calling a position function, such as \code{position_jitter()}.
+This method allows for passing extra arguments to the position.
+\item A string naming the position adjustment. To give the position as a
+string, strip the function name of the \code{position_} prefix. For example,
+to use \code{position_jitter()}, give the position as \code{"jitter"}.
+\item For more information and other ways to specify the position, see the
+\link[=layer_positions]{layer position} documentation.
+}}
 
 \item{xintercept, yintercept, slope, intercept}{Parameters that control the
 position of the line. If these are set, \code{data}, \code{mapping} and


### PR DESCRIPTION
Reopen #4286, which aimed to fix #4285.

As suggested by @teunbrand, I confirmed now the code works without the `as.numeric()` tweak if I merge the changes of  #5640.

``` r
mydata <- data.frame(
  x = factor(c("1", "2", "3")),
  y = c(3, 4, 5)
)
mydata$splits <- factor(mydata$x, labels = c("baseline", "Cycle 1", "Cycle 1"))

devtools::load_all("~/GitHub/ggplot2/")
#> ℹ Loading ggplot2
```

``` r

pos <- position_nudge(x = -0.1)

# works
ggplot(mydata, aes(x, y)) +
  geom_point(size = 3, position = pos) +
  geom_vline(
    aes(xintercept = as.numeric(x)),
    alpha = 0.2, linewidth = 5,
    colour = "red",
    position = pos
  )
```

![](https://i.imgur.com/Omoib9h.png)<!-- -->

``` r

# didn't work, but now works!
ggplot(mydata, aes(x, y)) +
  geom_point(size = 3, position = pos) +
  geom_vline(
    aes(xintercept = x),
    alpha = 0.2, linewidth = 5,
    colour = "red",
    position = pos
  )
```

![](https://i.imgur.com/LNNBThs.png)<!-- -->

<sup>Created on 2024-07-01 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
