### PR TITLE
Extra documentation for `ggplot_add()`

### DIFF
--- a/R/plot-construction.R
+++ b/R/plot-construction.R
@@ -84,9 +84,32 @@ add_ggplot <- function(p, object, objectname) {
 #' @param object_name The name of the object to add
 #'
 #' @return A modified ggplot object
+#' @details
+#' Custom methods for `ggplot_add()` are intended to update the `plot` variable
+#' using information from a custom `object`. This can become convenient when
+#' writing extensions that don't build on the pre-existing grammar like
+#' layers, facets, coords and themes. The `ggplot_add()` function is never
+#' intended to be used directly, but it is triggered when an object is added
+#' to a plot via the `+` operator. Please note that the full `plot` object is
+#' exposed at this point, which comes with the responsibility of returning
+#' the plot intact.
 #'
 #' @keywords internal
 #' @export
+#' @examples
+#' # making a new method for the generic
+#' # in this example, we apply a text element to the text theme setting
+#' ggplot_add.element_text <- function(object, plot, object_name) {
+#'   plot + theme(text = object)
+#' }
+#'
+#' # we can now use `+` to add our object to a plot
+#' ggplot(mpg, aes(displ, cty)) +
+#'   geom_point() +
+#'   element_text(colour = "red")
+#'
+#' # clean-up
+#' rm(ggplot_add.element_text)
 ggplot_add <- function(object, plot, object_name) {
   UseMethod("ggplot_add")
 }
@@ -155,7 +178,7 @@ ggplot_add.Facet <- function(object, plot, object_name) {
 #' @export
 ggplot_add.list <- function(object, plot, object_name) {
   for (o in object) {
-    plot <- plot %+% o
+    plot <- ggplot_add(o, plot, object_name)
   }
   plot
 }

--- a/man/ggplot_add.Rd
+++ b/man/ggplot_add.Rd
@@ -20,4 +20,29 @@ A modified ggplot object
 This generic allows you to add your own methods for adding custom objects to
 a ggplot with \link{+.gg}.
 }
+\details{
+Custom methods for \code{ggplot_add()} are intended to update the \code{plot} variable
+using information from a custom \code{object}. This can become convenient when
+writing extensions that don't build on the pre-existing grammar like
+layers, facets, coords and themes. The \code{ggplot_add()} function is never
+intended to be used directly, but it is triggered when an object is added
+to a plot via the \code{+} operator. Please note that the full \code{plot} object is
+exposed at this point, which comes with the responsibility of returning
+the plot intact.
+}
+\examples{
+# making a new method for the generic
+# in this example, we apply a text element to the text theme setting
+ggplot_add.element_text <- function(object, plot, object_name) {
+  plot + theme(text = object)
+}
+
+# we can now use `+` to add our object to a plot
+ggplot(mpg, aes(displ, cty)) +
+  geom_point() +
+  element_text(colour = "red")
+
+# clean-up
+rm(ggplot_add.element_text)
+}
 \keyword{internal}


### PR DESCRIPTION
This PR aims to fix #4984.

Briefly, it adds some details and an example to the documentation of `ggplot_add()`.
I'm not sure the example for `element_text()` is the most appropriate one, but I'd be happy to swap out that example for a better one.