### PR TITLE
Don't require dplyr for `fortify.tbl()`

### DIFF
--- a/R/fortify.R
+++ b/R/fortify.R
@@ -17,10 +17,7 @@ fortify.data.frame <- function(model, data, ...) model
 #' @export
 fortify.tbl_df <- function(model, data, ...) model
 #' @export
-fortify.tbl <- function(model, data, ...) {
-  check_installed("dplyr", reason = "to work with `tbl` objects.")
-  dplyr::collect(model)
-}
+fortify.tbl <- function(model, data, ...) as.data.frame(model)
 #' @export
 fortify.NULL <- function(model, data, ...) waiver()
 #' @export


### PR DESCRIPTION
This PR aims to fix #4786.

Briefly, it attempts to exploit that some `as.data.frame()` methods will implicitly use `collect()` to realise a local data.frame.
For example:
``` r
dbplyr:::as.data.frame.tbl_sql
#> function (x, row.names = NULL, optional = NULL, ..., n = Inf) 
#> {
#>     as.data.frame(collect(x, n = n))
#> }
#> <bytecode: 0x000001b7f118b958>
#> <environment: namespace:dbplyr>
```
This should ensure that you can still work with e.g. `<tbl_sql>` classes that will be `collect()`'ed while not requiring {dplyr} for the `fortify.tbl()` method. Example demonstrating we can still use lazy data.frames:
``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2
library(dbplyr)
con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
dplyr::copy_to(con, mtcars)
df <- dplyr::tbl(con, "mtcars")

ggplot(df, aes(mpg, disp)) +
  geom_point()
```

![](https://i.imgur.com/DjUk6bl.png)<!-- -->

<sup>Created on 2024-07-02 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
