### PR TITLE
Update minimum R version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ License: MIT + file LICENSE
 URL: https://ggplot2.tidyverse.org, https://github.com/tidyverse/ggplot2
 BugReports: https://github.com/tidyverse/ggplot2/issues
 Depends:
-    R (>= 3.5)
+    R (>= 4.0)
 Imports: 
     cli,
     glue,


### PR DESCRIPTION
`ggplot2` will no longer install on R versions earlier than 4.0.0. This is due to a recursive dependency on lattice (via [mgcv](https://cran.r-project.org/web/packages/mgcv/index.html) -> [nlme](https://cran.r-project.org/web/packages/nlme/index.html)).
Lattice updated to require R >= 4.0.0 [last year](https://cran.r-project.org/web/packages/lattice/index.html).