### PR TITLE
Fix for `position_dodge(preserve = "single")` with location based data

### DIFF
--- a/R/position-dodge.R
+++ b/R/position-dodge.R
@@ -106,6 +106,11 @@ PositionDodge <- ggproto("PositionDodge", Position,
   reverse = NULL,
   setup_params = function(self, data) {
     flipped_aes <- has_flipped_aes(data, default = self$orientation == "y")
+    check_required_aesthetics(
+      if (flipped_aes) "y|ymin" else "x|xmin",
+      names(data), snake_class(self)
+    )
+
     data <- flip_data(data, flipped_aes)
     if (is.null(data$xmin) && is.null(data$xmax) && is.null(self$width)) {
       cli::cli_warn(c(

--- a/R/position-dodge.R
+++ b/R/position-dodge.R
@@ -117,8 +117,10 @@ PositionDodge <- ggproto("PositionDodge", Position,
     if (identical(self$preserve, "total")) {
       n <- NULL
     } else {
-      n <- vec_unique(data[c("group", "PANEL", "xmin")])
-      n <- vec_group_id(n[c("PANEL", "xmin")])
+      data$xmin <- data$xmin %||% data$x
+      cols <- intersect(colnames(data), c("group", "PANEL", "xmin"))
+      n <- vec_unique(data[cols])
+      n <- vec_group_id(n[setdiff(cols, "group")])
       n <- max(tabulate(n, attr(n, "n")))
     }
 

--- a/tests/testthat/test-position_dodge.R
+++ b/tests/testthat/test-position_dodge.R
@@ -37,3 +37,19 @@ test_that("position_dodge() can reverse the dodge order", {
   ld <- get_layer_data(p + geom_col(position = position_dodge(reverse = FALSE)))
   expect_equal(ld$label[order(ld$x)], c("A", "A", "B", "B", "C"))
 })
+
+test_that("position_dodge warns about missing required aesthetics", {
+
+  # Bit of a contrived geom to not have a required 'x' aesthetic
+  GeomDummy <- ggproto(NULL, GeomPoint, required_aes = NULL, optional_aes = "x")
+
+  p <- ggplot(mtcars, aes(cyl, disp, colour = factor(vs))) +
+    layer(
+      geom = GeomDummy,
+      stat = "identity",
+      position = position_dodge(width = 0.5),
+      mapping = aes(x = NULL)
+    )
+
+  expect_error(ggplot_build(p), "requires the following missing aesthetics")
+})


### PR DESCRIPTION
This PR aims to fix #5995 and fix #3647.

Briefly, when `xmin` is absent from the data, `x` is used to count the number of groups per location.
In addition, some guardrails are in place to not use non-existing columns in the calculation.

Reprex from issue:
``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

palmerpenguins::penguins |>
  dplyr::count(species, sex) |>
  ggplot(
    aes(x = sex,
        y = n,
        fill = species,
        label = n),
  ) +
  geom_col(
    position = position_dodge(preserve = "single"),
    width = 0.75,
    alpha = 0.9,
  ) +
  geom_text(
    colour = "black",
    position = position_dodge(width = 0.75, preserve = "single"),
    vjust = 1.33,
  )
```

![](https://i.imgur.com/ahbzQNh.png)<!-- -->

<sup>Created on 2024-07-15 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
