### PR TITLE
Exclude labels from `aes_params` field

### DIFF
--- a/R/labels.R
+++ b/R/labels.R
@@ -24,9 +24,11 @@ setup_plot_labels <- function(plot, layers, data) {
   # Find labels from every layer
   for (i in seq_along(layers)) {
     layer <- layers[[i]]
+    exclude <- names(layer$aes_params)
     mapping <- layer$computed_mapping
     mapping <- strip_stage(mapping)
     mapping <- strip_dots(mapping, strip_pronoun = TRUE)
+    mapping <- mapping[setdiff(names(mapping), exclude)]
 
     # Acquire default labels
     mapping_default <- make_labels(mapping)

--- a/tests/testthat/test-labels.R
+++ b/tests/testthat/test-labels.R
@@ -74,6 +74,21 @@ test_that("Labels can be extracted from attributes", {
   expect_equal(labels$y, "disp")
 })
 
+test_that("Labels from static aesthetics are ignored (#6003)", {
+
+  df <- data.frame(x = 1, y = 1, f = 1)
+
+  p <- ggplot(df, aes(x, y, colour = f)) + geom_point()
+  labels <- ggplot_build(p)$plot$labels
+
+  expect_equal(labels$colour, "f")
+
+  p <- ggplot(df, aes(x, y, colour = f)) + geom_point(colour = "blue")
+  labels <- ggplot_build(p)$plot$labels
+
+  expect_null(labels$colour)
+})
+
 test_that("alt text is returned", {
   p <- ggplot(mtcars, aes(mpg, disp)) +
     geom_point()


### PR DESCRIPTION
This PR aims to fix #6003.

Briefly, any aesthetic in `layer$computed_mapping` that has an equivalent in `layer$aes_params` is excluded from contributing to the labels. Reprex from issue, please note the label at the colourbar is `G` and not `<<< G >>>` or `g` from the 1st layer.
``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

d <- data.frame(x = 1, y = 2, g = 3)
d2 <- d
colnames(d2) <- c("X", "Y", "G")

attr(d[[1L]], "label") <- "<<< X >>>"
attr(d[[2L]], "label") <- "<<< Y >>>"
attr(d[[3L]], "label") <- "<<< G >>>"

ggplot() +
  geom_point(data = d, aes(x, y, colour = g), colour = "grey") + 
  geom_point(data = d2, aes(X, Y, colour = G))
```

![](https://i.imgur.com/5h8INII.png)<!-- -->

<sup>Created on 2024-07-17 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
