### PR TITLE
Fix missing `labels` slot

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -130,7 +130,8 @@ ggplot.default <- function(data = NULL, mapping = aes(), ...,
     coordinates = coord_cartesian(default = TRUE),
     facet = facet_null(),
     plot_env = environment,
-    layout = ggproto(NULL, Layout)
+    layout = ggproto(NULL, Layout),
+    labels = list()
   ), class = c("gg", "ggplot"))
 
   set_last_plot(p)


### PR DESCRIPTION
This PR aims to fix part of #6008.

Briefly, reverse dependencies sometimes make assumptions about `length(ggplot())` or `names(ggplot())`. In #5879 we removed the `labels` field, causing these assumptions to no longer hold. This PR brings back the `labels` field to make these assumptions valid again.