### PR TITLE
Ignore empty non-mapped aesthetics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* Passing empty unmapped aesthetics to layers raises a warning instead of
+  throwing an error (@teunbrand, #6009).
 * Missing values from discrete palettes are no longer translated 
   (@teunbrand, #5929).
 * Fixed bug in `facet_grid(margins = TRUE)` when using expresssions 

--- a/R/layer.R
+++ b/R/layer.R
@@ -152,6 +152,15 @@ layer <- function(geom = NULL, stat = NULL,
   if (any(pattern)) {
     aes_params[pattern] <- lapply(aes_params[pattern], list)
   }
+  # Drop empty aesthetics
+  empty_aes <- names(aes_params)[lengths(aes_params) == 0]
+  if (length(empty_aes) > 0) {
+    cli::cli_warn(
+      "Ignoring empty aesthetic{?s}: {.arg {empty_aes}}.",
+      call = call_env
+    )
+    aes_params <- aes_params[setdiff(names(aes_params), empty_aes)]
+  }
 
   # Warn about extra params and aesthetics
   extra_param <- setdiff(names(params), all)

--- a/tests/testthat/test-layer.R
+++ b/tests/testthat/test-layer.R
@@ -25,6 +25,13 @@ test_that("unknown aesthetics create warning", {
   expect_warning(geom_point(aes(blah = "red")), "unknown aesthetics")
 })
 
+test_that("empty aesthetics create warning", {
+  expect_warning(
+    geom_point(fill = NULL, shape = character()),
+    "Ignoring empty aesthetics"
+  )
+})
+
 test_that("invalid aesthetics throws errors", {
   # We want to test error and ignore the scale search message
   suppressMessages({


### PR DESCRIPTION
This PR aims to fix #6009.

Briefly, when passing `NULL` or 0-length aesthetics in `layer()` it will raise a warning. Previously, this would raise an error. 
As far as I know, there isn't any situation in which it is desirable to pass a 0-length aesthetic. Even if the data has 0-rows, nothing should be shown and no information is to be derived from a 0-length aesthetic. Note that this PR only applies to aesthetics passed outside the `aes()` function.
