### PR TITLE
Fix tiny typo in `labeller` docs

### DIFF
--- a/R/labeller.R
+++ b/R/labeller.R
@@ -320,7 +320,7 @@ as_labeller <- function(x, default = label_value, multi_line = TRUE) {
 #'
 #' This function makes it easy to assign different labellers to
 #' different factors. The labeller can be a function or it can be a
-#' named character vectors that will serve as a lookup table.
+#' named character vector that will serve as a lookup table.
 #'
 #' In case of functions, if the labeller has class `labeller`, it
 #' is directly applied on the data frame of labels. Otherwise, it is


### PR DESCRIPTION
Very small change to fix a grammatical error in the `labeller` function documentation