### PR TITLE
Adding the option `seed = 0` into the jitter argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -78,7 +78,7 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Collate: 
     'ggproto.R'
     'ggplot-global.R'

--- a/R/position-jitter.R
+++ b/R/position-jitter.R
@@ -41,7 +41,7 @@
 #'   geom_jitter(position = position_jitter(width = 0.1, height = 0.1))
 #'
 #' # Create a jitter object for reproducible jitter:
-#' jitter <- position_jitter(width = 0.1, height = 0.1)
+#' jitter <- position_jitter(width = 0.1, height = 0.1, seed = 0)
 #' ggplot(mtcars, aes(am, vs)) +
 #'   geom_point(position = jitter) +
 #'   geom_point(position = jitter, color = "red", aes(am + 0.2, vs + 0.2))

--- a/man/position_jitter.Rd
+++ b/man/position_jitter.Rd
@@ -49,7 +49,7 @@ ggplot(mtcars, aes(am, vs)) +
   geom_jitter(position = position_jitter(width = 0.1, height = 0.1))
 
 # Create a jitter object for reproducible jitter:
-jitter <- position_jitter(width = 0.1, height = 0.1)
+jitter <- position_jitter(width = 0.1, height = 0.1, seed = 0)
 ggplot(mtcars, aes(am, vs)) +
   geom_point(position = jitter) +
   geom_point(position = jitter, color = "red", aes(am + 0.2, vs + 0.2))


### PR DESCRIPTION
Fixes #5875

documentation update