### PR TITLE
Corrected documentation stat_bin(binwidth) Fixes # 5960

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -78,7 +78,7 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Collate: 
     'ggproto.R'
     'ggplot-global.R'

--- a/R/stat-bin.R
+++ b/R/stat-bin.R
@@ -1,8 +1,7 @@
 #' @param binwidth The width of the bins. Can be specified as a numeric value
-#'   or as a function that calculates width from unscaled x. Here, "unscaled x"
-#'   refers to the original x values in the data, before application of any
-#'   scale transformation. When specifying a function along with a grouping
-#'   structure, the function will be called once per group.
+#'   or as a function that takes x after scale transformation as input and
+#'   returns a single numeric value. When specifying a function along with a
+#'   grouping structure, the function will be called once per group.
 #'   The default is to use the number of bins in `bins`,
 #'   covering the range of the data. You should always override
 #'   this value, exploring multiple widths to find the best to illustrate the

--- a/man/geom_histogram.Rd
+++ b/man/geom_histogram.Rd
@@ -128,10 +128,9 @@ that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[=borders]{borders()}}.}
 
 \item{binwidth}{The width of the bins. Can be specified as a numeric value
-or as a function that calculates width from unscaled x. Here, "unscaled x"
-refers to the original x values in the data, before application of any
-scale transformation. When specifying a function along with a grouping
-structure, the function will be called once per group.
+or as a function that takes x after scale transformation as input and
+returns a single numeric value. When specifying a function along with a
+grouping structure, the function will be called once per group.
 The default is to use the number of bins in \code{bins},
 covering the range of the data. You should always override
 this value, exploring multiple widths to find the best to illustrate the

--- a/man/stat_summary.Rd
+++ b/man/stat_summary.Rd
@@ -135,10 +135,9 @@ single number.}
 \item{bins}{Number of bins. Overridden by \code{binwidth}. Defaults to 30.}
 
 \item{binwidth}{The width of the bins. Can be specified as a numeric value
-or as a function that calculates width from unscaled x. Here, "unscaled x"
-refers to the original x values in the data, before application of any
-scale transformation. When specifying a function along with a grouping
-structure, the function will be called once per group.
+or as a function that takes x after scale transformation as input and
+returns a single numeric value. When specifying a function along with a
+grouping structure, the function will be called once per group.
 The default is to use the number of bins in \code{bins},
 covering the range of the data. You should always override
 this value, exploring multiple widths to find the best to illustrate the


### PR DESCRIPTION
Fix #5960 Changed in documentation the text  - _here"unscaled x"_ - to - _takes x after scale transformation_ - because the function takes transformed values.