### PR TITLE
`geom_smooth()`: Updated documentation, "confidence intervals" to "confidence bands"

### DIFF
--- a/R/geom-smooth.R
+++ b/R/geom-smooth.R
@@ -9,7 +9,7 @@
 #' `predictdf()` generic and its methods.  For most methods the standard
 #' error bounds are computed using the [predict()] method -- the
 #' exceptions are `loess()`, which uses a t-based approximation, and
-#' `glm()`, where the normal confidence interval is constructed on the link
+#' `glm()`, where the normal confidence band is constructed on the link
 #' scale and then back-transformed to the response scale.
 #'
 #' @eval rd_orientation()

--- a/R/stat-smooth.R
+++ b/R/stat-smooth.R
@@ -18,7 +18,7 @@
 #'   `y ~ poly(x, 2)`, `y ~ log(x)`. `NULL` by default, in which case
 #'   `method = NULL` implies `formula = y ~ x` when there are fewer than 1,000
 #'   observations and `formula = y ~ s(x, bs = "cs")` otherwise.
-#' @param se Display confidence interval around smooth? (`TRUE` by default, see
+#' @param se Display confidence band around smooth? (`TRUE` by default, see
 #'   `level` to control.)
 #' @param fullrange If `TRUE`, the smoothing line gets expanded to the range of the plot,
 #'   potentially beyond the data. This does not extend the line into any additional padding
@@ -26,7 +26,7 @@
 #' @param xseq A numeric vector of values at which the smoother is evaluated.
 #'   When `NULL` (default), `xseq` is internally evaluated as a sequence of `n`
 #'   equally spaced points for continuous data.
-#' @param level Level of confidence interval to use (0.95 by default).
+#' @param level Level of confidence band to use (0.95 by default).
 #' @param span Controls the amount of smoothing for the default loess smoother.
 #'   Smaller numbers produce wigglier lines, larger numbers produce smoother
 #'   lines. Only used with loess, i.e. when `method = "loess"`,
@@ -40,8 +40,8 @@
 #'   .details = "`stat_smooth()` provides the following variables, some of
 #'   which depend on the orientation:",
 #'   "y|x" = "Predicted value.",
-#'   "ymin|xmin" = "Lower pointwise confidence interval around the mean.",
-#'   "ymax|xmax" = "Upper pointwise confidence interval around the mean.",
+#'   "ymin|xmin" = "Lower pointwise confidence band around the mean.",
+#'   "ymax|xmax" = "Upper pointwise confidence band around the mean.",
 #'   "se" = "Standard error."
 #' )
 #' @export

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -125,7 +125,7 @@ model that \code{method = NULL} would use, then set
 \code{method = NULL} implies \code{formula = y ~ x} when there are fewer than 1,000
 observations and \code{formula = y ~ s(x, bs = "cs")} otherwise.}
 
-\item{se}{Display confidence interval around smooth? (\code{TRUE} by default, see
+\item{se}{Display confidence band around smooth? (\code{TRUE} by default, see
 \code{level} to control.)}
 
 \item{na.rm}{If \code{FALSE}, the default, missing values are removed with
@@ -168,7 +168,7 @@ created by \code{expansion}.}
 When \code{NULL} (default), \code{xseq} is internally evaluated as a sequence of \code{n}
 equally spaced points for continuous data.}
 
-\item{level}{Level of confidence interval to use (0.95 by default).}
+\item{level}{Level of confidence band to use (0.95 by default).}
 
 \item{method.args}{List of additional arguments passed on to the modelling
 function defined by \code{method}.}
@@ -184,7 +184,7 @@ Calculation is performed by the (currently undocumented)
 \code{predictdf()} generic and its methods.  For most methods the standard
 error bounds are computed using the \code{\link[=predict]{predict()}} method -- the
 exceptions are \code{loess()}, which uses a t-based approximation, and
-\code{glm()}, where the normal confidence interval is constructed on the link
+\code{glm()}, where the normal confidence band is constructed on the link
 scale and then back-transformed to the response scale.
 }
 \section{Orientation}{
@@ -216,8 +216,8 @@ Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.
 These are calculated by the 'stat' part of layers and can be accessed with \link[=aes_eval]{delayed evaluation}. \code{stat_smooth()} provides the following variables, some of  which depend on the orientation:
 \itemize{
 \item \code{after_stat(y)} \emph{or} \code{after_stat(x)}\cr Predicted value.
-\item \code{after_stat(ymin)} \emph{or} \code{after_stat(xmin)}\cr Lower pointwise confidence interval around the mean.
-\item \code{after_stat(ymax)} \emph{or} \code{after_stat(xmax)}\cr Upper pointwise confidence interval around the mean.
+\item \code{after_stat(ymin)} \emph{or} \code{after_stat(xmin)}\cr Lower pointwise confidence band around the mean.
+\item \code{after_stat(ymax)} \emph{or} \code{after_stat(xmax)}\cr Upper pointwise confidence band around the mean.
 \item \code{after_stat(se)}\cr Standard error.
 }
 }


### PR DESCRIPTION
Fixes #6025