### PR TITLE
Making bw argument in stat_density case insensitive

### DIFF
--- a/R/stat-density.R
+++ b/R/stat-density.R
@@ -242,6 +242,7 @@ reflect_density <- function(dens, bounds, from, to) {
 precompute_bw = function(x, bw = "nrd0") {
   bw <- bw[1]
   if (is.character(bw)) {
+    bw <- to_lower_ascii(bw)
     bw <- arg_match0(bw, c("nrd0", "nrd", "ucv", "bcv", "sj", "sj-ste", "sj-dpi"))
     bw <- switch(
       to_lower_ascii(bw),


### PR DESCRIPTION
Fixes #5941 

Not sure if this is necessary because the error message is very descriptive already.