### PR TITLE
Fix some lints in the `R` folder

### DIFF
--- a/R/annotation-logticks.R
+++ b/R/annotation-logticks.R
@@ -165,7 +165,7 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
 
       names(xticks)[names(xticks) == "value"] <- x_name   # Rename to 'x' for coordinates$transform
       xticks <- coord$transform(xticks, panel_params)
-      xticks = xticks[xticks$x <= 1 & xticks$x >= 0,]
+      xticks <- xticks[xticks$x <= 1 & xticks$x >= 0,]
 
       if (outside)
         xticks$end = -xticks$end
@@ -203,7 +203,7 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
 
       names(yticks)[names(yticks) == "value"] <- y_name   # Rename to 'y' for coordinates$transform
       yticks <- coord$transform(yticks, panel_params)
-      yticks = yticks[yticks$y <= 1 & yticks$y >= 0,]
+      yticks <- yticks[yticks$y <= 1 & yticks$y >= 0,]
 
       if (outside)
         yticks$end = -yticks$end
@@ -238,7 +238,7 @@ GeomLogticks <- ggproto("GeomLogticks", Geom,
 # - start: on the other axis, start position of the line (usually 0)
 # - end: on the other axis, end position of the line (for example, .1, .2, or .3)
 calc_logticks <- function(base = 10, ticks_per_base = base - 1,
-    minpow = 0, maxpow = minpow + 1, start = 0, shortend = .1, midend = .2, longend = .3) {
+    minpow = 0, maxpow = minpow + 1, start = 0, shortend = 0.1, midend = 0.2, longend = 0.3) {
 
   # Number of blocks of tick marks
   reps <- maxpow - minpow

--- a/R/bin.R
+++ b/R/bin.R
@@ -165,7 +165,7 @@ bin_vector <- function(x, bins, weight = NULL, pad = FALSE) {
   }
 
   # Add row for missings
-  if (any(is.na(bins))) {
+  if (anyNA(bins)) {
     bin_count <- c(bin_count, sum(is.na(bins)))
     bin_widths <- c(bin_widths, NA)
     bin_x <- c(bin_x, NA)

--- a/R/compat-plyr.R
+++ b/R/compat-plyr.R
@@ -54,13 +54,13 @@ rename <- function(x, replace) {
 id_var <- function(x, drop = FALSE) {
   if (length(x) == 0) {
     id <- integer()
-    n = 0L
+    n <- 0L
   } else if (!is.null(attr(x, "n")) && !drop) {
     return(x)
   } else if (is.factor(x) && !drop) {
     x <- addNA(x, ifany = TRUE)
     id <- as.integer(x)
-    n <- length(levels(x))
+    n <- nlevels(x)
   } else {
     levels <- sort(unique0(x), na.last = TRUE)
     id <- match(x, levels)

--- a/R/coord-polar.R
+++ b/R/coord-polar.R
@@ -137,7 +137,7 @@ CoordPolar <- ggproto("CoordPolar", Coord,
       ret[[n]]$sec.labels <- out$sec.labels
     }
 
-    details = list(
+    details <- list(
       x.range = ret$x$range, y.range = ret$y$range,
       x.major = ret$x$major, y.major = ret$y$major,
       x.minor = ret$x$minor, y.minor = ret$y$minor,

--- a/R/coord-sf.R
+++ b/R/coord-sf.R
@@ -416,7 +416,7 @@ sf_rescale01 <- function(x, x_range, y_range) {
 
 # different limits methods
 calc_limits_bbox <- function(method, xlim, ylim, crs, default_crs) {
-  if (any(!is.finite(c(xlim, ylim))) && method != "geometry_bbox") {
+  if (!all(is.finite(c(xlim, ylim))) && method != "geometry_bbox") {
     cli::cli_abort(c(
             "Scale limits cannot be mapped onto spatial coordinates in {.fn coord_sf}.",
       "i" = "Consider setting {.code lims_method = \"geometry_bbox\"} or {.code default_crs = NULL}."
@@ -585,7 +585,7 @@ coord_sf <- function(xlim = NULL, ylim = NULL, expand = TRUE,
 }
 
 parse_axes_labeling <- function(x) {
-  labs = unlist(strsplit(x, ""))
+  labs <- unlist(strsplit(x, ""))
   list(top = labs[1], right = labs[2], bottom = labs[3], left = labs[4])
 }
 

--- a/R/facet-.R
+++ b/R/facet-.R
@@ -678,7 +678,7 @@ find_panel <- function(table) {
 }
 #' @rdname find_panel
 #' @export
-panel_cols = function(table) {
+panel_cols <- function(table) {
   panels <- table$layout[grepl("^panel", table$layout$name), , drop = FALSE]
   unique0(panels[, c('l', 'r')])
 }

--- a/R/facet-grid-.R
+++ b/R/facet-grid-.R
@@ -319,8 +319,8 @@ FacetGrid <- ggproto("FacetGrid", Facet,
     if (length(missing_facets) > 0) {
       to_add <- unique0(layout[missing_facets])
 
-      data_rep <- rep.int(1:nrow(data), nrow(to_add))
-      facet_rep <- rep(1:nrow(to_add), each = nrow(data))
+      data_rep <- rep.int(seq_len(nrow(data)), nrow(to_add))
+      facet_rep <- rep(seq_len(nrow(to_add)), each = nrow(data))
 
       data <- unrowname(data[data_rep, , drop = FALSE])
       facet_vals <- unrowname(vec_cbind(

--- a/R/facet-wrap.R
+++ b/R/facet-wrap.R
@@ -242,8 +242,8 @@ FacetWrap <- ggproto("FacetWrap", Facet,
 
       to_add <- unique0(layout[missing_facets])
 
-      data_rep <- rep.int(1:nrow(data), nrow(to_add))
-      facet_rep <- rep(1:nrow(to_add), each = nrow(data))
+      data_rep <- rep.int(seq_len(nrow(data)), nrow(to_add))
+      facet_rep <- rep(seq_len(nrow(to_add)), each = nrow(data))
 
       data <- data[data_rep, , drop = FALSE]
       facet_vals <- vec_cbind(

--- a/R/fortify-spatial.R
+++ b/R/fortify-spatial.R
@@ -71,7 +71,7 @@ fortify.Polygons <- function(model, data, ...) {
   })
   pieces <- vec_rbind0(!!!pieces)
 
-  pieces$order <- 1:nrow(pieces)
+  pieces$order <- seq_len(nrow(pieces))
   pieces$id <- model@ID
   pieces$piece <- factor(pieces$piece)
   pieces$group <- interaction(pieces$id, pieces$piece)
@@ -89,7 +89,7 @@ fortify.Polygon <- function(model, data, ...) {
 
   df <- as.data.frame(model@coords)
   names(df) <- c("long", "lat")
-  df$order <- 1:nrow(df)
+  df$order <- seq_len(nrow(df))
   df$hole <- model@hole
   df
 }
@@ -124,7 +124,7 @@ fortify.Lines <- function(model, data, ...) {
   })
   pieces <- vec_rbind0(!!!pieces)
 
-  pieces$order <- 1:nrow(pieces)
+  pieces$order <- seq_len(nrow(pieces))
   pieces$id <- model@ID
   pieces$piece <- factor(pieces$piece)
   pieces$group <- interaction(pieces$id, pieces$piece)
@@ -142,7 +142,7 @@ fortify.Line <- function(model, data, ...) {
 
   df <- as.data.frame(model@coords)
   names(df) <- c("long", "lat")
-  df$order <- 1:nrow(df)
+  df$order <- seq_len(nrow(df))
   df
 }
 

--- a/R/geom-dotplot.R
+++ b/R/geom-dotplot.R
@@ -197,25 +197,25 @@ GeomDotplot <- ggproto("GeomDotplot", Geom,
 
     # Set up the stacking function and range
     if (is.null(params$stackdir) || params$stackdir == "up") {
-      stackdots <- function(a)  a - .5
+      stackdots <- function(a)  a - 0.5
       stackaxismin <- 0
       stackaxismax <- 1
     } else if (params$stackdir == "down") {
-      stackdots <- function(a) -a + .5
+      stackdots <- function(a) -a + 0.5
       stackaxismin <- -1
       stackaxismax <- 0
     } else if (params$stackdir == "center") {
       stackdots <- function(a)  a - 1 - max(a - 1) / 2
-      stackaxismin <- -.5
-      stackaxismax <- .5
+      stackaxismin <- -0.5
+      stackaxismax <- 0.5
     } else if (params$stackdir == "centerwhole") {
       stackdots <- function(a)  a - 1 - floor(max(a - 1) / 2)
-      stackaxismin <- -.5
-      stackaxismax <- .5
+      stackaxismin <- -0.5
+      stackaxismax <- 0.5
     }
 
     # Fill the bins: at a given x (or y), if count=3, make 3 entries at that x
-    data <- data[rep(1:nrow(data), data$count), ]
+    data <- data[rep(seq_len(nrow(data)), data$count), ]
 
     # Next part will set the position of each dot within each stack
     # If stackgroups=TRUE, split only on x (or y) and panel; if not stacking, also split by group
@@ -231,7 +231,7 @@ GeomDotplot <- ggproto("GeomDotplot", Geom,
 
     # Within each x, or x+group, set countidx=1,2,3, and set stackpos according to stack function
     data <- dapply(data, plyvars, function(xx) {
-      xx$countidx <- 1:nrow(xx)
+      xx$countidx <- seq_len(nrow(xx))
       xx$stackpos <- stackdots(xx$countidx)
       xx
     })
@@ -281,11 +281,11 @@ GeomDotplot <- ggproto("GeomDotplot", Geom,
       binaxis <- ifelse(binaxis == "x", "y", "x")
 
     if (binaxis == "x") {
-      stackaxis = "y"
+      stackaxis <- "y"
       dotdianpc <- dotsize * tdata$binwidth[1] / (max(panel_params$x.range) - min(panel_params$x.range))
 
     } else if (binaxis == "y") {
-      stackaxis = "x"
+      stackaxis <- "x"
       dotdianpc <- dotsize * tdata$binwidth[1] / (max(panel_params$y.range) - min(panel_params$y.range))
     }
 

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -81,7 +81,7 @@ GeomLabel <- ggproto("GeomLabel", Geom,
 
     size.unit <- resolve_text_unit(size.unit)
 
-    grobs <- lapply(1:nrow(data), function(i) {
+    grobs <- lapply(seq_len(nrow(data)), function(i) {
       row <- data[i, , drop = FALSE]
       labelGrob(lab[i],
         x = unit(row$x, "native"),

--- a/R/geom-segment.R
+++ b/R/geom-segment.R
@@ -134,7 +134,7 @@ GeomSegment <- ggproto("GeomSegment", Geom,
       ))
     }
 
-    data$group <- 1:nrow(data)
+    data$group <- seq_len(nrow(data))
     starts <- subset(data, select = c(-xend, -yend))
     ends <- rename(subset(data, select = c(-x, -y)), c("xend" = "x", "yend" = "y"))
 

--- a/R/geom-smooth.R
+++ b/R/geom-smooth.R
@@ -153,8 +153,8 @@ GeomSmooth <- ggproto("GeomSmooth", Geom,
     ribbon <- transform(data, colour = NA)
     path <- transform(data, alpha = NA)
 
-    ymin = flipped_names(flipped_aes)$ymin
-    ymax = flipped_names(flipped_aes)$ymax
+    ymin <- flipped_names(flipped_aes)$ymin
+    ymax <- flipped_names(flipped_aes)$ymax
     has_ribbon <- se && !is.null(data[[ymax]]) && !is.null(data[[ymin]])
 
     gList(

--- a/R/guide-.R
+++ b/R/guide-.R
@@ -487,7 +487,7 @@ Guide <- ggproto(
 
 # Helper function that may facilitate flipping theme elements by
 # swapping x/y related arguments to `element_grob()`
-flip_element_grob = function(..., flip = FALSE) {
+flip_element_grob <- function(..., flip = FALSE) {
   if (!flip) {
     ans <- element_grob(...)
     return(ans)
@@ -499,7 +499,7 @@ flip_element_grob = function(..., flip = FALSE) {
 }
 
 # The flippable arguments for `flip_element_grob()`.
-flip_names = c(
+flip_names <- c(
   "x"        = "y",
   "y"        = "x",
   "width"    = "height",

--- a/R/guide-axis-stack.R
+++ b/R/guide-axis-stack.R
@@ -41,7 +41,7 @@ guide_axis_stack <- function(first = "axis", ..., title = waiver(), theme = NULL
   # Check available aesthetics
   available <- lapply(axes, `[[`, name = "available_aes")
   available <- vapply(available, function(x) all(c("x", "y") %in% x), logical(1))
-  if (all(!available)) {
+  if (!any(available)) {
     cli::cli_abort(paste0(
       "{.fn guide_axis_stack} can only use guides that handle {.field x} and ",
       "{.field y} aesthetics."
@@ -49,7 +49,7 @@ guide_axis_stack <- function(first = "axis", ..., title = waiver(), theme = NULL
   }
 
   # Remove guides that don't support x/y aesthetics
-  if (any(!available)) {
+  if (!all(available)) {
     remove  <- which(!available)
     removed <- vapply(axes[remove], snake_class, character(1))
     axes[remove] <- NULL

--- a/R/guide-axis.R
+++ b/R/guide-axis.R
@@ -592,23 +592,23 @@ axis_label_element_overrides <- function(axis_position, angle = NULL) {
 
   if (axis_position == "bottom") {
 
-    hjust = if (angle %in% c(0, 180))  0.5 else if (angle < 180) 1 else 0
-    vjust = if (angle %in% c(90, 270)) 0.5 else if (angle > 90 & angle < 270) 0 else 1
+    hjust <- if (angle %in% c(0, 180))  0.5 else if (angle < 180) 1 else 0
+    vjust <- if (angle %in% c(90, 270)) 0.5 else if (angle > 90 & angle < 270) 0 else 1
 
   } else if (axis_position == "left") {
 
-    hjust = if (angle %in% c(90, 270)) 0.5 else if (angle > 90 & angle < 270) 0 else 1
-    vjust = if (angle %in% c(0, 180))  0.5 else if (angle < 180) 0 else 1
+    hjust <- if (angle %in% c(90, 270)) 0.5 else if (angle > 90 & angle < 270) 0 else 1
+    vjust <- if (angle %in% c(0, 180))  0.5 else if (angle < 180) 0 else 1
 
   } else if (axis_position == "top") {
 
-    hjust = if (angle %in% c(0, 180))  0.5 else if (angle < 180) 0 else 1
-    vjust = if (angle %in% c(90, 270)) 0.5 else if (angle > 90 & angle < 270) 1 else 0
+    hjust <- if (angle %in% c(0, 180))  0.5 else if (angle < 180) 0 else 1
+    vjust <- if (angle %in% c(90, 270)) 0.5 else if (angle > 90 & angle < 270) 1 else 0
 
   } else if (axis_position == "right") {
 
-    hjust = if (angle %in% c(90, 270)) 0.5 else if (angle > 90 & angle < 270) 1 else 0
-    vjust = if (angle %in% c(0, 180))  0.5 else if (angle < 180) 1 else 0
+    hjust <- if (angle %in% c(90, 270)) 0.5 else if (angle > 90 & angle < 270) 1 else 0
+    vjust <- if (angle %in% c(0, 180))  0.5 else if (angle < 180) 1 else 0
 
   }
 

--- a/R/guide-bins.R
+++ b/R/guide-bins.R
@@ -326,7 +326,7 @@ GuideBins <- ggproto(
   }
 )
 
-parse_binned_breaks = function(scale, breaks = scale$get_breaks()) {
+parse_binned_breaks <- function(scale, breaks = scale$get_breaks()) {
 
   breaks <- breaks[!is.na(breaks)]
   if (length(breaks) == 0) {

--- a/R/guide-colorbar.R
+++ b/R/guide-colorbar.R
@@ -366,12 +366,12 @@ GuideColourbar <- ggproto(
       if (params$direction == "horizontal") {
         width  <- 1 / nrow(decor)
         height <- 1
-        x <- (seq(nrow(decor)) - 1) * width
+        x <- (seq_len(nrow(decor)) - 1) * width
         y <- 0
       } else {
         width  <- 1
         height <- 1 / nrow(decor)
-        y <- (seq(nrow(decor)) - 1) * height
+        y <- (seq_len(nrow(decor)) - 1) * height
         x <- 0
       }
       grob <- rectGrob(

--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -631,7 +631,7 @@ keep_key_data <- function(key, data, aes, show) {
   if (isTRUE(any(show)) || length(show) == 0) {
     return(TRUE)
   }
-  if (isTRUE(all(!show))) {
+  if (isTRUE(!any(show))) {
     return(FALSE)
   }
   # Second, we go find if the value is actually present in the data.

--- a/R/guides-.R
+++ b/R/guides-.R
@@ -194,7 +194,7 @@ Guides <- ggproto(
     if (is.character(index)) {
       index <- match(index, self$aesthetics)
     }
-    if (any(is.na(index)) || length(index) == 0) {
+    if (anyNA(index) || length(index) == 0) {
       return(NULL)
     }
     if (length(index) == 1) {
@@ -209,7 +209,7 @@ Guides <- ggproto(
     if (is.character(index)) {
       index <- match(index, self$aesthetics)
     }
-    if (any(is.na(index)) || length(index) == 0) {
+    if (anyNA(index) || length(index) == 0) {
       return(NULL)
     }
     if (length(index) == 1) {

--- a/R/legend-draw.R
+++ b/R/legend-draw.R
@@ -207,7 +207,7 @@ draw_key_vpath <- function(data, params, size) {
 #' @export
 #' @rdname draw_key
 draw_key_dotplot <- function(data, params, size) {
-  pointsGrob(0.5, 0.5, size = unit(.5, "npc"),
+  pointsGrob(0.5, 0.5, size = unit(0.5, "npc"),
     pch = 21,
     gp = gg_par(
       col = alpha(data$colour %||% "black", data$alpha),

--- a/R/limits.R
+++ b/R/limits.R
@@ -116,7 +116,7 @@ limits.numeric <- function(lims, var, call = caller_env()) {
   if (length(lims) != 2) {
     cli::cli_abort("{.arg {var}} must be a two-element vector.", call = call)
   }
-  if (!any(is.na(lims)) && lims[1] > lims[2]) {
+  if (!anyNA(lims) && lims[1] > lims[2]) {
     trans <- "reverse"
   } else {
     trans <- "identity"

--- a/R/margins.R
+++ b/R/margins.R
@@ -198,7 +198,7 @@ justify_grobs <- function(grobs, x = NULL, y = NULL, hjust = 0.5, vjust = 0.5,
     )
   }
   else {
-    children = gList(grobs)
+    children <- gList(grobs)
   }
 
 

--- a/R/plot-build.R
+++ b/R/plot-build.R
@@ -250,18 +250,18 @@ ggplot_gtable.ggplot_built <- function(data) {
 
   pans <- plot_table$layout[grepl("^panel", plot_table$layout$name), , drop = FALSE]
   if (title_pos == "panel") {
-    title_l = min(pans$l)
-    title_r = max(pans$r)
+    title_l <- min(pans$l)
+    title_r <- max(pans$r)
   } else {
-    title_l = 1
-    title_r = ncol(plot_table)
+    title_l <- 1
+    title_r <- ncol(plot_table)
   }
   if (caption_pos == "panel") {
-    caption_l = min(pans$l)
-    caption_r = max(pans$r)
+    caption_l <- min(pans$l)
+    caption_r <- max(pans$r)
   } else {
-    caption_l = 1
-    caption_r = ncol(plot_table)
+    caption_l <- 1
+    caption_r <- ncol(plot_table)
   }
 
   plot_table <- gtable_add_rows(plot_table, subtitle_height, pos = 0)

--- a/R/position-dodge.R
+++ b/R/position-dodge.R
@@ -175,7 +175,7 @@ pos_dodge <- function(df, width, n = NULL) {
   groupidx <- match(df$group, unique0(df$group))
 
   # Find the center for each group, then use that to calculate xmin and xmax
-  df$x <- df$x + width * ((groupidx - 0.5) / n - .5)
+  df$x <- df$x + width * ((groupidx - 0.5) / n - 0.5)
   df$xmin <- df$x - d_width / n / 2
   df$xmax <- df$x + d_width / n / 2
 

--- a/R/position-dodge2.R
+++ b/R/position-dodge2.R
@@ -113,7 +113,7 @@ pos_dodge2 <- function(df, width, n = NULL, padding = 0.1) {
   df$x <- (df$xmin + df$xmax) / 2
 
   # If no elements occupy the same position, there is no need to add padding
-  if (!any(duplicated(df$xid))) {
+  if (!anyDuplicated(df$xid) > 0) {
     return(df)
   }
 

--- a/R/save.R
+++ b/R/save.R
@@ -197,7 +197,7 @@ plot_dim <- function(dim = c(NA, NA), scale = 1, units = "in",
 
   dim <- to_inches(dim) * scale
 
-  if (any(is.na(dim))) {
+  if (anyNA(dim)) {
     if (length(grDevices::dev.list()) == 0) {
       default_dim <- c(7, 7)
     } else {

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -123,7 +123,7 @@ continuous_scale <- function(aesthetics, scale_name = deprecated(), palette, nam
   position <- arg_match0(position, c("left", "right", "top", "bottom"))
 
   # If the scale is non-positional, break = NULL means removing the guide
-  if (is.null(breaks) && all(!is_position_aes(aesthetics))) {
+  if (is.null(breaks) && !any(is_position_aes(aesthetics))) {
     guide <- "none"
   }
 

--- a/R/scale-binned.R
+++ b/R/scale-binned.R
@@ -92,7 +92,7 @@ ScaleBinnedPosition <- ggproto("ScaleBinnedPosition", ScaleBinned,
         include.lowest = TRUE,
         right = self$right
       )
-      (x - x_binned + .5) * diff(all_breaks)[x_binned] + all_breaks[x_binned]
+      (x - x_binned + 0.5) * diff(all_breaks)[x_binned] + all_breaks[x_binned]
     } else {
       x <- as.numeric(self$oob(x, limits))
       x <- ifelse(!is.na(x), x, self$na.value)

--- a/R/scale-expansion.R
+++ b/R/scale-expansion.R
@@ -69,7 +69,7 @@ expand_range4 <- function(limits, expand) {
     cli::cli_abort("{.arg expand} must be a numeric vector with 2 or 4 elements.")
   }
 
-  if (all(!is.finite(limits))) {
+  if (!any(is.finite(limits))) {
     return(c(-Inf, Inf))
   }
 

--- a/R/scale-manual.R
+++ b/R/scale-manual.R
@@ -176,7 +176,7 @@ manual_scale <- function(aesthetic, values = NULL, breaks = waiver(),
     if (length(breaks) <= length(values)) {
       names(values) <- breaks
     } else {
-      names(values) <- breaks[1:length(values)]
+      names(values) <- breaks[seq_along(values)]
     }
   }
 

--- a/R/stat-bindot.R
+++ b/R/stat-bindot.R
@@ -143,14 +143,14 @@ densitybin <- function(x, weight = NULL, binwidth = NULL, method = method, range
 
     # Sort weight and x, by x
     weight <- weight[order(x)]
-    x      <- x[order(x)]
+    x      <- sort(x, na.last = TRUE)
 
     cbin    <- 0                      # Current bin ID
     bin     <- rep.int(NA, length(x)) # The bin ID for each observation
     binend  <- -Inf                   # End position of current bin (scan left to right)
 
     # Scan list and put dots in bins
-    for (i in 1:length(x)) {
+    for (i in seq_along(x)) {
         # If past end of bin, start a new bin at this point
         if (x[i] >= binend) {
             binend <- x[i] + binwidth

--- a/R/stat-density.R
+++ b/R/stat-density.R
@@ -239,7 +239,7 @@ reflect_density <- function(dens, bounds, from, to) {
 # Similar to stats::density.default
 # Once R4.3.0 is the lowest supported version, this function can be replaced by
 # using `density(..., warnWbw = FALSE)`.
-precompute_bw = function(x, bw = "nrd0") {
+precompute_bw <- function(x, bw = "nrd0") {
   bw <- bw[1]
   if (is.character(bw)) {
     bw <- to_lower_ascii(bw)

--- a/R/stat-ecdf.R
+++ b/R/stat-ecdf.R
@@ -147,7 +147,7 @@ wecdf <- function(x, weights = NULL) {
   x <- x[ord]
   weights <- weights[ord]
 
-  if (any(!is.finite(weights))) {
+  if (!all(is.finite(weights))) {
     cli::cli_warn(c(paste0(
       "The {.field weight} aesthetic does not support non-finite or ",
       "{.code NA} values."

--- a/R/stat-qq-line.R
+++ b/R/stat-qq-line.R
@@ -11,7 +11,7 @@ geom_qq_line <- function(mapping = NULL,
                          ...,
                          distribution = stats::qnorm,
                          dparams = list(),
-                         line.p = c(.25, .75),
+                         line.p = c(0.25, 0.75),
                          fullrange = FALSE,
                          na.rm = FALSE,
                          show.legend = NA,
@@ -56,7 +56,7 @@ StatQqLine <- ggproto("StatQqLine", Stat,
                            distribution = stats::qnorm,
                            dparams = list(),
                            na.rm = FALSE,
-                           line.p = c(.25, .75),
+                           line.p = c(0.25, 0.75),
                            fullrange = FALSE) {
 
     sample <- sort(data$sample)

--- a/R/stat-smooth-methods.R
+++ b/R/stat-smooth-methods.R
@@ -60,7 +60,7 @@ predictdf.loess <- function(model, xseq, se, level) {
 
   if (se) {
     y <- pred$fit
-    ci <- pred$se.fit * stats::qt(level / 2 + .5, pred$df)
+    ci <- pred$se.fit * stats::qt(level / 2 + 0.5, pred$df)
     ymin <- y - ci
     ymax <- y + ci
     base::data.frame(x = xseq, y, ymin, ymax, se = pred$se.fit)
@@ -79,7 +79,7 @@ predictdf.locfit <- function(model, xseq, se, level) {
 
   if (se) {
     y <- pred$fit
-    ci <- pred$se.fit * stats::qt(level / 2 + .5, model$dp["df2"])
+    ci <- pred$se.fit * stats::qt(level / 2 + 0.5, model$dp["df2"])
     ymin <- y - ci
     ymax <- y + ci
     base::data.frame(x = xseq, y, ymin, ymax, se = pred$se.fit)

--- a/R/stat-summary-bin.R
+++ b/R/stat-summary-bin.R
@@ -23,15 +23,15 @@ stat_summary_bin <- function(mapping = NULL, data = NULL,
                              fun.ymax = deprecated()) {
   if (lifecycle::is_present(fun.y)) {
     deprecate_warn0("3.3.0", "stat_summary_bin(fun.y)", "stat_summary_bin(fun)")
-    fun = fun %||% fun.y
+    fun <- fun %||% fun.y
   }
   if (lifecycle::is_present(fun.ymin)) {
     deprecate_warn0("3.3.0", "stat_summary_bin(fun.ymin)", "stat_summary_bin(fun.min)")
-    fun.min = fun.min %||% fun.ymin
+    fun.min <- fun.min %||% fun.ymin
   }
   if (lifecycle::is_present(fun.ymax)) {
     deprecate_warn0("3.3.0", "stat_summary_bin(fun.ymax)", "stat_summary_bin(fun.max)")
-    fun.max = fun.max %||% fun.ymax
+    fun.max <- fun.max %||% fun.ymax
   }
   layer(
     data = data,

--- a/R/stat-summary.R
+++ b/R/stat-summary.R
@@ -143,15 +143,15 @@ stat_summary <- function(mapping = NULL, data = NULL,
                          fun.ymax = deprecated()) {
   if (lifecycle::is_present(fun.y)) {
     deprecate_warn0("3.3.0", "stat_summary(fun.y)", "stat_summary(fun)")
-    fun = fun %||% fun.y
+    fun <- fun %||% fun.y
   }
   if (lifecycle::is_present(fun.ymin)) {
     deprecate_warn0("3.3.0", "stat_summary(fun.ymin)", "stat_summary(fun.min)")
-    fun.min = fun.min %||% fun.ymin
+    fun.min <- fun.min %||% fun.ymin
   }
   if (lifecycle::is_present(fun.ymax)) {
     deprecate_warn0("3.3.0", "stat_summary(fun.ymax)", "stat_summary(fun.max)")
-    fun.max = fun.max %||% fun.ymax
+    fun.max <- fun.max %||% fun.ymax
   }
   layer(
     data = data,

--- a/R/summarise-plot.R
+++ b/R/summarise-plot.R
@@ -61,7 +61,7 @@ NULL
 
 #' @rdname summarise_plot
 #' @export
-summarise_layout = function(p) {
+summarise_layout <- function(p) {
   check_inherits(p, "ggplot_built")
   l <- p$layout
 
@@ -98,7 +98,7 @@ summarise_layout = function(p) {
 
 #' @rdname summarise_plot
 #' @export
-summarise_coord = function(p) {
+summarise_coord <- function(p) {
   check_inherits(p, "ggplot_built")
 
   # Given a transform object, find the log base; if the transform object is

--- a/R/utilities-checks.R
+++ b/R/utilities-checks.R
@@ -182,7 +182,7 @@ check_inherits <- function(x,
 #'
 #' # Possibly throw an error
 #' try(check_device("glyphs", action = "abort"))
-check_device = function(feature, action = "warn", op = NULL, maybe = FALSE,
+check_device <- function(feature, action = "warn", op = NULL, maybe = FALSE,
                         call = caller_env()) {
 
   check_bool(maybe, allow_na = TRUE)


### PR DESCRIPTION
Hello, I'm building a new package to find and automatically fix lints in R code: [`flint`](https://flint.etiennebacher.com/).

I'm using real-life, large packages to check its performance and `ggplot2` is one of them. Since I already test on this, there's no additional cost for me in proposing those changes.

FYI, those changes were all generated by `flint::fix_dir("R")`.

There are many changes but most of them are trivial:
- replace `any(is.na())` by `anyNA()`
- replace the `=` assignment by `<-` (since both are used across the codebase, I guess `<-` should be the default)
- add a leading 0 to decimal (e.g `.1` -> `0.1`)

and a few other things.

`flint` is quite new and linter rules are necessarily a bit opinionated, so some of those changes might not be to your taste, but I'd be happy to have some feedback on this.