### PR TITLE
Fix some lints in the `tests` folder

### DIFF
--- a/tests/testthat/test-aes-calculated.R
+++ b/tests/testthat/test-aes-calculated.R
@@ -6,7 +6,7 @@ test_that("names surrounded by .. is calculated", {
   expect_equal(is_calculated_aes(aes(..x.., ..x, x..)), c(TRUE, FALSE, FALSE))
 
   # even when nested
-  expect_equal(is_calculated_aes(aes(f(..x..))), TRUE)
+  expect_true(is_calculated_aes(aes(f(..x..))))
 })
 
 test_that("call to stat() is calculated", {

--- a/tests/testthat/test-aes-grouping.R
+++ b/tests/testthat/test-aes-grouping.R
@@ -26,7 +26,7 @@ test_that("no error for aes(groupS)", {
   g <- add_group(df2)
 
   expect_equal(nrow(g), nrow(df2))
-  expect_equal(names(g), c("x", "y", "groupS", "group"))
+  expect_named(g, c("x", "y", "groupS", "group"))
 })
 
 test_that("label is not used as a grouping var", {

--- a/tests/testthat/test-coord-.R
+++ b/tests/testthat/test-coord-.R
@@ -37,8 +37,7 @@ test_that("guide names are not removed by `train_panel_guides()`", {
   layout$setup_panel_guides(guides_list(NULL), plot$layers)
 
   # Line showing change in outcome
-  expect_equal(names(layout$panel_params[[1]]$guides$aesthetics),
-               c("x", "y", "x.sec", "y.sec"))
+  expect_named(layout$panel_params[[1]]$guides$aesthetics, c("x", "y", "x.sec", "y.sec"))
 })
 
 test_that("check coord limits errors only on bad inputs", {

--- a/tests/testthat/test-coord-polar.R
+++ b/tests/testthat/test-coord-polar.R
@@ -1,7 +1,7 @@
 test_that("polar distance is calculated correctly", {
   dat <- data_frame(
     theta = c(0, 2*pi,   2,   6, 6, 1,    1,  0),
-    r     = c(0,    0, 0.5, 0.5, 1, 1, 0.75, .5))
+    r     = c(0,    0, 0.5, 0.5, 1, 1, 0.75, 0.5))
 
   scales <- list(
     x = scale_x_continuous(limits = c(0, 2*pi)),
@@ -176,7 +176,7 @@ test_that("polar coordinates draw correctly", {
 
   dat <- data_frame(
     theta = c(0, 2*pi,   2,   6, 6, 1,    1,  0),
-    r     = c(0,    0, 0.5, 0.5, 1, 1, 0.75, .5),
+    r     = c(0,    0, 0.5, 0.5, 1, 1, 0.75, 0.5),
     g     = 1:8
   )
   expect_doppelganger("Rays, circular arcs, and spiral arcs",

--- a/tests/testthat/test-coord-train.R
+++ b/tests/testthat/test-coord-train.R
@@ -5,7 +5,7 @@ test_that("NA's don't appear in breaks", {
     ns <- names(trained)[grepl("(\\.major)|(\\.minor)$", names(trained))]
 
     for (n in ns) {
-      if (!is.null(trained[n]) && any(is.na(trained[n])))
+      if (!is.null(trained[n]) && anyNA(trained[n]))
         return(TRUE)
     }
 
@@ -19,8 +19,8 @@ test_that("NA's don't appear in breaks", {
   # This is a test to make sure the later tests will be useful!
   # It's possible that changes to the way that breaks are calculated will
   # make it so that scale_break_positions will no longer give NA for range 1, 12
-  expect_true(any(is.na(scale_x$break_positions())))
-  expect_true(any(is.na(scale_y$break_positions())))
+  expect_true(anyNA(scale_x$break_positions()))
+  expect_true(anyNA(scale_y$break_positions()))
 
   # Check the various types of coords to make sure they don't have NA breaks
   expect_false(any_NA_major_minor(coord_polar()$setup_panel_params(scale_x, scale_y)))

--- a/tests/testthat/test-coord_sf.R
+++ b/tests/testthat/test-coord_sf.R
@@ -309,8 +309,8 @@ test_that("sf_transform_xy() works", {
   # transform back
   out2 <- sf_transform_xy(out, 4326, 3347)
   expect_identical(data$city, out2$city)
-  expect_true(all(abs(out2$x - data$x) < .01))
-  expect_true(all(abs(out2$y - data$y) < .01))
+  expect_true(all(abs(out2$x - data$x) < 0.01))
+  expect_true(all(abs(out2$y - data$y) < 0.01))
 
 })
 

--- a/tests/testthat/test-empty-data.R
+++ b/tests/testthat/test-empty-data.R
@@ -88,13 +88,13 @@ test_that("empty layers still generate one grob per panel", {
     geom_point() +
     facet_wrap(~y)
 
-  expect_equal(length(get_layer_grob(d)), 3)
+  expect_length(get_layer_grob(d), 3)
 })
 
 test_that("missing layers generate one grob per panel", {
   df <- data_frame(x = 1:4, y = rep(1:2, 2), g = rep(1:2, 2))
   base <- ggplot(df, aes(x, y)) + geom_point(shape = NA, na.rm = TRUE)
 
-  expect_equal(length(get_layer_grob(base)), 1)
-  expect_equal(length(get_layer_grob(base + facet_wrap(~ g))), 2)
+  expect_length(get_layer_grob(base), 1)
+  expect_length(get_layer_grob(base + facet_wrap(~ g)), 2)
 })

--- a/tests/testthat/test-facet-strips.R
+++ b/tests/testthat/test-facet-strips.R
@@ -143,16 +143,16 @@ test_that("padding is only added if axis is present", {
       strip.switch.pad.grid = unit(10, "mm")
     )
   pg <- ggplotGrob(p)
-  expect_equal(length(pg$heights), 19)
-  expect_equal(length(pg$widths), 18)
+  expect_length(pg$heights, 19)
+  expect_length(pg$widths, 18)
 
   pg <- ggplotGrob(
     p + scale_x_continuous(position = "top") +
       scale_y_continuous(position = "right")
   )
-  expect_equal(length(pg$heights), 20)
+  expect_length(pg$heights, 20)
   expect_equal(as.character(pg$heights[9]), "1cm")
-  expect_equal(length(pg$widths), 19)
+  expect_length(pg$widths, 19)
   expect_equal(as.character(pg$widths[13]), "1cm")
 
   # Also add padding with negative ticks and no text (#5251)
@@ -160,7 +160,7 @@ test_that("padding is only added if axis is present", {
     p + scale_x_continuous(labels = NULL, position = "top") +
       theme(axis.ticks.length.x.top = unit(-2, "mm"))
   )
-  expect_equal(length(pg$heights), 20)
+  expect_length(pg$heights, 20)
   expect_equal(as.character(pg$heights[9]), "1cm")
 
   # Inverse should be true when strips are switched
@@ -172,17 +172,17 @@ test_that("padding is only added if axis is present", {
     )
 
   pg <- ggplotGrob(p)
-  expect_equal(length(pg$heights), 20)
+  expect_length(pg$heights, 20)
   expect_equal(as.character(pg$heights[13]), "1cm")
-  expect_equal(length(pg$widths), 19)
+  expect_length(pg$widths, 19)
   expect_equal(as.character(pg$widths[7]), "1cm")
 
   pg <- ggplotGrob(
     p + scale_x_continuous(position = "top") +
       scale_y_continuous(position = "right")
   )
-  expect_equal(length(pg$heights), 19)
-  expect_equal(length(pg$widths), 18)
+  expect_length(pg$heights, 19)
+  expect_length(pg$widths, 18)
 })
 
 test_that("y strip labels are rotated when strips are switched", {

--- a/tests/testthat/test-fortify.R
+++ b/tests/testthat/test-fortify.R
@@ -11,7 +11,7 @@ test_that("spatial polygons have correct ordering", {
         y - dely,y - dely,y + dely,y + dely,y - dely), ncol = 2))
   }
 
-  make_hole <- function(x = 0, y = 0, height = .5, width = .5){
+  make_hole <- function(x = 0, y = 0, height = 0.5, width = 0.5){
     p <- make_square(x = x, y = y, height = height, width = width)
     p@hole <- TRUE
     p

--- a/tests/testthat/test-geom-boxplot.R
+++ b/tests/testthat/test-geom-boxplot.R
@@ -73,7 +73,7 @@ test_that("boxes with variable widths do not overlap", {
   d <- get_layer_data(p)[c("xmin", "xmax")]
   xid <- find_x_overlaps(d)
 
-  expect_false(anyDuplicated(xid) > 0)
+  expect_false(any(duplicated(xid)))
 })
 
 test_that("boxplots with a group size >1 error", {

--- a/tests/testthat/test-geom-boxplot.R
+++ b/tests/testthat/test-geom-boxplot.R
@@ -73,7 +73,7 @@ test_that("boxes with variable widths do not overlap", {
   d <- get_layer_data(p)[c("xmin", "xmax")]
   xid <- find_x_overlaps(d)
 
-  expect_false(any(duplicated(xid)))
+  expect_false(anyDuplicated(xid) > 0)
 })
 
 test_that("boxplots with a group size >1 error", {

--- a/tests/testthat/test-geom-dotplot.R
+++ b/tests/testthat/test-geom-dotplot.R
@@ -17,7 +17,7 @@ test_that("dodging works", {
   ndodge <- 3
 
   # The amount of space allocated within each dodge group
-  dwidth <- .9 / ndodge
+  dwidth <- 0.9 / ndodge
 
   # This should be the x position for each before dodging
   xbase <- ceiling(df$group / ndodge)
@@ -36,20 +36,20 @@ test_that("dodging works", {
 
 test_that("binning works", {
   bp <- ggplot(dat, aes(y)) +
-    geom_dotplot(binwidth = .4, method = "histodot")
+    geom_dotplot(binwidth = 0.4, method = "histodot")
   x <- get_layer_data(bp)$x
 
   # Need ugly hack to make sure mod function doesn't give values like -3.99999
   # due to floating point error
-  expect_true(all(abs((x - min(x) + 1e-7) %% .4) < 1e-6))
+  expect_true(all(abs((x - min(x) + 1e-7) %% 0.4) < 1e-6))
 
   bp <- ggplot(dat, aes(x = y)) +
-    geom_dotplot(binwidth = .4, method = "dotdensity")
+    geom_dotplot(binwidth = 0.4, method = "dotdensity")
   x <- get_layer_data(bp)$x
 
   # This one doesn't ensure that dotdensity works, but it does check that it's not
   # doing fixed bin sizes
-  expect_false(all(abs((x - min(x) + 1e-7) %% .4) < 1e-6))
+  expect_false(all(abs((x - min(x) + 1e-7) %% 0.4) < 1e-6))
 })
 
 test_that("NA's result in warning from stat_bindot", {
@@ -58,7 +58,7 @@ test_that("NA's result in warning from stat_bindot", {
   dat$x[c(2,10)] <- NA
 
   # Need to assign it to a var here so that it doesn't automatically print
-  expect_snapshot_warning(ggplot_build(ggplot(dat, aes(x)) + geom_dotplot(binwidth = .2)))
+  expect_snapshot_warning(ggplot_build(ggplot(dat, aes(x)) + geom_dotplot(binwidth = 0.2)))
 })
 
 test_that("when binning on y-axis, limits depend on the panel", {
@@ -92,99 +92,99 @@ test_that("geom_dotplot draws correctly", {
 
   # Basic dotplot with binning along x axis
   expect_doppelganger("basic dotplot with dot-density binning, binwidth = .4",
-    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4)
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = 0.4)
   )
   expect_doppelganger("histodot binning (equal bin spacing)",
-    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, method = "histodot")
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = 0.4, method = "histodot")
   )
   expect_doppelganger("dots stacked closer: stackratio=.5, fill=white",
-    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, stackratio = .5, fill = "white")
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = 0.4, stackratio = 0.5, fill = "white")
   )
   expect_doppelganger("larger dots: dotsize=1.5, fill=white",
-    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, dotsize = 1.4, fill = "white")
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = 0.4, dotsize = 1.4, fill = "white")
   )
 
   # Stacking methods
   expect_doppelganger("stack up",
-    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, stackdir = "up")
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = 0.4, stackdir = "up")
   )
   expect_doppelganger("stack down",
-    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, stackdir = "down")
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = 0.4, stackdir = "down")
   )
   expect_doppelganger("stack center",
-    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, stackdir = "center")
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = 0.4, stackdir = "center")
   )
   expect_doppelganger("stack centerwhole",
-    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, stackdir = "centerwhole")
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = 0.4, stackdir = "centerwhole")
   )
 
   # Stacking methods with coord_flip
   expect_doppelganger("stack up with coord_flip",
-    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, stackdir = "up") + coord_flip()
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = 0.4, stackdir = "up") + coord_flip()
   )
   expect_doppelganger("stack down with coord_flip",
-    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, stackdir = "down") + coord_flip()
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = 0.4, stackdir = "down") + coord_flip()
   )
   expect_doppelganger("stack center with coord_flip",
-    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, stackdir = "center") + coord_flip()
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = 0.4, stackdir = "center") + coord_flip()
   )
   expect_doppelganger("stack centerwhole with coord_flip",
-    ggplot(dat, aes(x)) + geom_dotplot(binwidth = .4, stackdir = "centerwhole") + coord_flip()
+    ggplot(dat, aes(x)) + geom_dotplot(binwidth = 0.4, stackdir = "centerwhole") + coord_flip()
   )
 
   # Binning along x, with groups
   expect_doppelganger("multiple groups, bins not aligned",
-    ggplot(dat, aes(x, fill = g)) + geom_dotplot(binwidth = .4, alpha = .4)
+    ggplot(dat, aes(x, fill = g)) + geom_dotplot(binwidth = 0.4, alpha = 0.4)
   )
   expect_doppelganger("multiple groups, bins aligned",
-    ggplot(dat, aes(x, fill = g)) + geom_dotplot(binwidth = .4, alpha = .4, binpositions = "all")
+    ggplot(dat, aes(x, fill = g)) + geom_dotplot(binwidth = 0.4, alpha = 0.4, binpositions = "all")
   )
 
   # Binning along y axis
   expect_doppelganger("bin along y, stack center",
-    ggplot(dat, aes(0, x)) + geom_dotplot(binwidth = .4, binaxis = "y", stackdir = "center")
+    ggplot(dat, aes(0, x)) + geom_dotplot(binwidth = 0.4, binaxis = "y", stackdir = "center")
   )
   expect_doppelganger("bin along y, stack centerwhole",
-    ggplot(dat, aes(0, x)) + geom_dotplot(binwidth = .4, binaxis = "y", stackdir = "centerwhole")
+    ggplot(dat, aes(0, x)) + geom_dotplot(binwidth = 0.4, binaxis = "y", stackdir = "centerwhole")
   )
   expect_doppelganger("bin along y, stack centerwhole, histodot",
-    ggplot(dat, aes(0, x)) + geom_dotplot(binwidth = .4, binaxis = "y", stackdir = "centerwhole", method = "histodot")
+    ggplot(dat, aes(0, x)) + geom_dotplot(binwidth = 0.4, binaxis = "y", stackdir = "centerwhole", method = "histodot")
   )
 
   # Binning along y, with multiple grouping factors
   dat2 <- data_frame(x = rep(factor(LETTERS[1:3]), 30), y = rnorm(90), g = rep(factor(LETTERS[1:2]), 45))
 
   expect_doppelganger("bin x, three y groups, stack centerwhole",
-    ggplot(dat2, aes(y, x)) + geom_dotplot(binwidth = .25, binaxis = "x", stackdir = "centerwhole")
+    ggplot(dat2, aes(y, x)) + geom_dotplot(binwidth = 0.25, binaxis = "x", stackdir = "centerwhole")
   )
   expect_doppelganger("bin y, three x groups, stack centerwhole",
-    ggplot(dat2, aes(x, y)) + geom_dotplot(binwidth = .25, binaxis = "y", stackdir = "centerwhole")
+    ggplot(dat2, aes(x, y)) + geom_dotplot(binwidth = 0.25, binaxis = "y", stackdir = "centerwhole")
   )
   expect_doppelganger("bin y, three x groups, bins aligned across groups",
-    ggplot(dat2, aes(x, y)) + geom_dotplot(binwidth = .25, binaxis = "y", stackdir = "center", binpositions = "all")
+    ggplot(dat2, aes(x, y)) + geom_dotplot(binwidth = 0.25, binaxis = "y", stackdir = "center", binpositions = "all")
   )
   expect_doppelganger("bin y, three x groups, bins aligned, coord_flip",
-    ggplot(dat2, aes(x, y)) + geom_dotplot(binwidth = .25, binaxis = "y", stackdir = "center", binpositions = "all") +
+    ggplot(dat2, aes(x, y)) + geom_dotplot(binwidth = 0.25, binaxis = "y", stackdir = "center", binpositions = "all") +
       coord_flip()
   )
   expect_doppelganger("bin y, dodged",
-    ggplot(dat2, aes("foo", y, fill = x)) + scale_y_continuous(breaks = seq(-4, 4, .4)) +
-      geom_dotplot(binwidth = .25, position = "dodge", binaxis = "y", stackdir = "center")
+    ggplot(dat2, aes("foo", y, fill = x)) + scale_y_continuous(breaks = seq(-4, 4, 0.4)) +
+      geom_dotplot(binwidth = 0.25, position = "dodge", binaxis = "y", stackdir = "center")
   )
   expect_doppelganger("bin y, dodged, coord_flip",
-    ggplot(dat2, aes("foo", y, fill = x)) + scale_y_continuous(breaks = seq(-4, 4, .4)) +
-      geom_dotplot(binwidth = .25, position = "dodge", binaxis = "y", stackdir = "center") +
+    ggplot(dat2, aes("foo", y, fill = x)) + scale_y_continuous(breaks = seq(-4, 4, 0.4)) +
+      geom_dotplot(binwidth = 0.25, position = "dodge", binaxis = "y", stackdir = "center") +
       coord_flip()
   )
   expect_doppelganger("bin y, three x groups, fill and dodge",
-    ggplot(dat2, aes(x, y, fill = g)) + scale_y_continuous(breaks = seq(-4 ,4, .4)) +
-      geom_dotplot(binwidth = .2, position = "dodge", binaxis = "y", stackdir = "center")
+    ggplot(dat2, aes(x, y, fill = g)) + scale_y_continuous(breaks = seq(-4 ,4, 0.4)) +
+      geom_dotplot(binwidth = 0.2, position = "dodge", binaxis = "y", stackdir = "center")
   )
   expect_doppelganger("bin y, continous x-axis, grouping by x",
-    ggplot(dat2, aes(as.numeric(x), y, group = x)) + geom_dotplot(binwidth = .2, binaxis = "y", stackdir = "center")
+    ggplot(dat2, aes(as.numeric(x), y, group = x)) + geom_dotplot(binwidth = 0.2, binaxis = "y", stackdir = "center")
   )
   expect_doppelganger("bin y, continous x-axis, single x group",
-    ggplot(dat2, aes(as.numeric(x), y)) + geom_dotplot(binwidth = .2, binaxis = "y", stackdir = "center")
+    ggplot(dat2, aes(as.numeric(x), y)) + geom_dotplot(binwidth = 0.2, binaxis = "y", stackdir = "center")
   )
 
   # border width and size
@@ -198,31 +198,31 @@ test_that("geom_dotplot draws correctly", {
         stroke = rep(c(1, 2), length.out = nrow(dat))
       )
     ) +
-      geom_dotplot(binwidth = .4, fill = "red", col = "blue") +
+      geom_dotplot(binwidth = 0.4, fill = "red", col = "blue") +
       continuous_scale("stroke", palette = function(x) scales::rescale(x, to = c(1, 6))) +
       guides(linetype = guide_legend(order = 1))
   )
 
   # Stacking groups
   expect_doppelganger("3 stackgroups, dot-density with aligned bins",
-    ggplot(dat2, aes(y, fill = x)) + geom_dotplot(binwidth = .25, stackgroups = TRUE, binpositions = "all", alpha = 0.5)
+    ggplot(dat2, aes(y, fill = x)) + geom_dotplot(binwidth = 0.25, stackgroups = TRUE, binpositions = "all", alpha = 0.5)
   )
   expect_doppelganger("3 stackgroups, histodot",
-    ggplot(dat2, aes(y, fill = x)) + geom_dotplot(binwidth = .25, stackgroups = TRUE, method = "histodot", alpha = 0.5)
+    ggplot(dat2, aes(y, fill = x)) + geom_dotplot(binwidth = 0.25, stackgroups = TRUE, method = "histodot", alpha = 0.5)
   )
   expect_doppelganger("3 stackgroups, bin y, histodot",
-    ggplot(dat2, aes(1, y, fill = x)) + geom_dotplot(binaxis = "y", binwidth = .25, stackgroups = TRUE, method = "histodot", alpha = 0.5)
+    ggplot(dat2, aes(1, y, fill = x)) + geom_dotplot(binaxis = "y", binwidth = 0.25, stackgroups = TRUE, method = "histodot", alpha = 0.5)
   )
 
   # This one is currently broken but it would be a really rare case, and it
   # probably requires a really ugly hack to fix
   expect_doppelganger("bin y, dodging, 3 stackgroups, histodot",
     ggplot(dat2, aes(x, y, fill = g)) +
-      geom_dotplot(binaxis = "y", binwidth = .25, stackgroups = TRUE, method = "histodot",
+      geom_dotplot(binaxis = "y", binwidth = 0.25, stackgroups = TRUE, method = "histodot",
                    alpha = 0.5, stackdir = "centerwhole")
   )
   expect_doppelganger("facets, 3 groups, histodot, stackgroups",
-    ggplot(dat2, aes(y, fill = g)) + geom_dotplot(binwidth = .25, stackgroups = TRUE, method = "histodot", alpha = 0.5) +
+    ggplot(dat2, aes(y, fill = g)) + geom_dotplot(binwidth = 0.25, stackgroups = TRUE, method = "histodot", alpha = 0.5) +
       facet_grid(x ~ .)
   )
 
@@ -231,10 +231,10 @@ test_that("geom_dotplot draws correctly", {
   dat2$x[c(1, 10)] <- NA
 
   expect_warning(expect_doppelganger("2 NA values, dot-density binning, binwidth = .4",
-    ggplot(dat2, aes(x)) + geom_dotplot(binwidth = .4)
+    ggplot(dat2, aes(x)) + geom_dotplot(binwidth = 0.4)
   ))
   expect_warning(expect_doppelganger("2 NA values, bin along y, stack center",
-    ggplot(dat2, aes(0, x)) + geom_dotplot(binwidth = .4, binaxis = "y", stackdir = "center")
+    ggplot(dat2, aes(0, x)) + geom_dotplot(binwidth = 0.4, binaxis = "y", stackdir = "center")
   ))
 })
 

--- a/tests/testthat/test-geom-path.R
+++ b/tests/testthat/test-geom-path.R
@@ -1,8 +1,8 @@
 test_that("keep_mid_true drops leading/trailing FALSE", {
-  expect_equal(keep_mid_true(c(F, F)), c(F, F))
-  expect_equal(keep_mid_true(c(F, T, F, T, F)), c(F, T, T, T, F))
-  expect_equal(keep_mid_true(c(T, T, F, T, F)), c(T, T, T, T, F))
-  expect_equal(keep_mid_true(c(F, T, F, T, T)), c(F, T, T, T, T))
+  expect_equal(keep_mid_true(c(FALSE, FALSE)), c(FALSE, FALSE))
+  expect_equal(keep_mid_true(c(FALSE, TRUE, FALSE, TRUE, FALSE)), c(FALSE, TRUE, TRUE, TRUE, FALSE))
+  expect_equal(keep_mid_true(c(TRUE, TRUE, FALSE, TRUE, FALSE)), c(TRUE, TRUE, TRUE, TRUE, FALSE))
+  expect_equal(keep_mid_true(c(FALSE, TRUE, FALSE, TRUE, TRUE)), c(FALSE, TRUE, TRUE, TRUE, TRUE))
 })
 
 test_that("geom_path() throws meaningful error on bad combination of varying aesthetics", {

--- a/tests/testthat/test-geom-rug.R
+++ b/tests/testthat/test-geom-rug.R
@@ -1,4 +1,4 @@
-n = 10
+n <- 10
 df <- data_frame(x = 1:n, y = (1:n)^3)
 p <- ggplot(df, aes(x, y)) + geom_point() + geom_rug(sides = 'l')
 
@@ -7,16 +7,16 @@ test_that("coord_flip flips the rugs", {
   b <- get_layer_grob(p + coord_flip(), 2)
 
   # Rugs along y-axis, all x coordinates are the same
-  expect_equal(length(a[[1]]$children[[1]]$x0), 1)
-  expect_equal(length(a[[1]]$children[[1]]$x1), 1)
-  expect_equal(length(a[[1]]$children[[1]]$y0), n)
-  expect_equal(length(a[[1]]$children[[1]]$y1), n)
+  expect_length(a[[1]]$children[[1]]$x0, 1)
+  expect_length(a[[1]]$children[[1]]$x1, 1)
+  expect_length(a[[1]]$children[[1]]$y0, n)
+  expect_length(a[[1]]$children[[1]]$y1, n)
 
   # Rugs along x-axis, all y coordinates are the same
-  expect_equal(length(b[[1]]$children[[1]]$x0), n)
-  expect_equal(length(b[[1]]$children[[1]]$x1), n)
-  expect_equal(length(b[[1]]$children[[1]]$y0), 1)
-  expect_equal(length(b[[1]]$children[[1]]$y1), 1)
+  expect_length(b[[1]]$children[[1]]$x0, n)
+  expect_length(b[[1]]$children[[1]]$x1, n)
+  expect_length(b[[1]]$children[[1]]$y0, 1)
+  expect_length(b[[1]]$children[[1]]$y1, 1)
 })
 
 test_that("Rug length needs unit object", {

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -30,23 +30,23 @@ test_that("geom_sf() determines the legend type automatically", {
   }
 
   # test the automatic choice
-  expect_identical(fun_geom_sf(mp, TRUE)$plot$layers[[1]]$show.legend, TRUE)
+  expect_true(fun_geom_sf(mp, TRUE)$plot$layers[[1]]$show.legend)
   expect_identical(fun_geom_sf(mp, TRUE)$plot$layers[[1]]$computed_geom_params$legend, "point")
 
-  expect_identical(fun_geom_sf(mls, TRUE)$plot$layers[[1]]$show.legend, TRUE)
+  expect_true(fun_geom_sf(mls, TRUE)$plot$layers[[1]]$show.legend)
   expect_identical(fun_geom_sf(mls, TRUE)$plot$layers[[1]]$computed_geom_params$legend, "line")
 
-  expect_identical(fun_geom_sf(mpol, TRUE)$plot$layers[[1]]$show.legend, TRUE)
+  expect_true(fun_geom_sf(mpol, TRUE)$plot$layers[[1]]$show.legend)
   expect_identical(fun_geom_sf(mpol, TRUE)$plot$layers[[1]]$computed_geom_params$legend, "other")
 
   # test that automatic choice can be overridden manually
-  expect_identical(fun_geom_sf(mp, "point")$plot$layers[[1]]$show.legend, TRUE)
+  expect_true(fun_geom_sf(mp, "point")$plot$layers[[1]]$show.legend)
   expect_identical(fun_geom_sf(mp, "point")$plot$layers[[1]]$computed_geom_params$legend, "point")
 
-  expect_identical(fun_geom_sf(mls, "point")$plot$layers[[1]]$show.legend, TRUE)
+  expect_true(fun_geom_sf(mls, "point")$plot$layers[[1]]$show.legend)
   expect_identical(fun_geom_sf(mls, "point")$plot$layers[[1]]$computed_geom_params$legend, "point")
 
-  expect_identical(fun_geom_sf(mpol, "point")$plot$layers[[1]]$show.legend, TRUE)
+  expect_true(fun_geom_sf(mpol, "point")$plot$layers[[1]]$show.legend)
   expect_identical(fun_geom_sf(mpol, "point")$plot$layers[[1]]$computed_geom_params$legend, "point")
 })
 

--- a/tests/testthat/test-geom-violin.R
+++ b/tests/testthat/test-geom-violin.R
@@ -43,7 +43,7 @@ test_that("quantiles do not fail on zero-range data", {
   p <- ggplot(zero.range.data) + geom_violin(aes(1, y), draw_quantiles = 0.5)
 
   # This should return without error and have length one
-  expect_equal(length(get_layer_grob(p)), 1)
+  expect_length(get_layer_grob(p), 1)
 })
 
 test_that("quantiles fails outside 0-1 bound", {
@@ -81,7 +81,7 @@ test_that("quantiles do not issue warning", {
 test_that("geom_violin draws correctly", {
   set.seed(111)
   dat <- data_frame(x = rep(factor(LETTERS[1:3]), 30), y = rnorm(90))
-  dat <- dat[dat$x != "C" | c(T, F),]  # Keep half the C's
+  dat <- dat[dat$x != "C" | c(TRUE, FALSE),]  # Keep half the C's
 
   expect_doppelganger("basic",
     ggplot(dat, aes(x = x, y = y)) + geom_violin()
@@ -90,13 +90,13 @@ test_that("geom_violin draws correctly", {
     ggplot(dat, aes(x = x, y = y)) + geom_violin(scale = "count"),
   )
   expect_doppelganger("narrower (width=.5)",
-    ggplot(dat, aes(x = x, y = y)) + geom_violin(width = .5)
+    ggplot(dat, aes(x = x, y = y)) + geom_violin(width = 0.5)
   )
   expect_doppelganger("with tails and points",
     ggplot(dat, aes(x = x, y = y)) + geom_violin(trim = FALSE) + geom_point(shape = 21)
   )
   expect_doppelganger("with smaller bandwidth and points",
-    ggplot(dat, aes(x = x, y = y)) + geom_violin(adjust = .3) + geom_point(shape = 21)
+    ggplot(dat, aes(x = x, y = y)) + geom_violin(adjust = 0.3) + geom_point(shape = 21)
   )
   expect_doppelganger("dodging",
     ggplot(dat, aes(x = "foo", y = y, fill = x)) + geom_violin()
@@ -126,6 +126,6 @@ test_that("geom_violin draws correctly", {
   )
   expect_doppelganger("grouping on x and fill, dodge width = 0.5",
     ggplot(dat2, aes(x = x, y = y, fill = g)) +
-      geom_violin(position = position_dodge(width = .5))
+      geom_violin(position = position_dodge(width = 0.5))
   )
 })

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -44,7 +44,7 @@ test_that("colourbar trains without labels", {
   sc <- scale_colour_continuous(limits = c(0, 4), labels = NULL)
 
   out <- g$train(scale = sc)
-  expect_equal(names(out$key), c("colour", ".value"))
+  expect_named(out$key, c("colour", ".value"))
 })
 
 test_that("Colorbar respects show.legend in layer", {
@@ -213,7 +213,7 @@ test_that("guide merging for guide_legend() works as expected", {
 })
 
 test_that("size = NA doesn't throw rendering errors", {
-  df = data.frame(
+  df <- data.frame(
     x = c(1, 2),
     group = c("a","b")
   )
@@ -903,7 +903,7 @@ test_that("guides are positioned correctly", {
   p2 <- p2 + theme(legend.position = "inside")
   # Placement of legend inside
   expect_doppelganger("legend inside plot, centered",
-    p2 + theme(legend.position.inside = c(.5, .5))
+    p2 + theme(legend.position.inside = c(0.5, 0.5))
   )
   expect_doppelganger("legend inside plot, bottom left",
     p2 + theme(legend.justification = c(0,0), legend.position.inside = c(0,0))
@@ -912,7 +912,7 @@ test_that("guides are positioned correctly", {
     p2 + theme(legend.justification = c(1,1), legend.position.inside = c(1,1))
   )
   expect_doppelganger("legend inside plot, bottom left of legend at center",
-    p2 + theme(legend.justification = c(0,0), legend.position.inside = c(.5,.5))
+    p2 + theme(legend.justification = c(0,0), legend.position.inside = c(0.5,0.5))
   )
 })
 

--- a/tests/testthat/test-layer.R
+++ b/tests/testthat/test-layer.R
@@ -80,7 +80,7 @@ test_that("if an aes is mapped to a function that returns NULL, it is removed", 
   df <- data_frame(x = 1:10)
   null <- function(...) NULL
   p <- cdata(ggplot(df, aes(x, null())))
-  expect_identical(names(p[[1]]), c("x", "PANEL", "group"))
+  expect_named(p[[1]], c("x", "PANEL", "group"))
 })
 
 test_that("layers are stateless except for the computed params", {

--- a/tests/testthat/test-position-dodge2.R
+++ b/tests/testthat/test-position-dodge2.R
@@ -32,7 +32,7 @@ test_that("rectangles are dodged", {
   p <- ggplot(df, aes(xmin = xmin, xmax = xmax, ymin = ymin, ymax = ymax)) +
     geom_rect(aes(fill = fill), position = "dodge2", alpha = 0.8)
 
-  expect_false(anyDuplicated(find_x_overlaps(get_layer_data(p))) > 0)
+  expect_false(any(duplicated(find_x_overlaps(get_layer_data(p)))))
 })
 
 test_that("cols at the same x position are dodged", {
@@ -44,7 +44,7 @@ test_that("cols at the same x position are dodged", {
   p <- ggplot(df, aes(1, n, fill = x)) +
     geom_col(position = "dodge2", alpha = 0.5)
 
-  expect_false(anyDuplicated(find_x_overlaps(get_layer_data(p))) > 0)
+  expect_false(any(duplicated(find_x_overlaps(get_layer_data(p)))))
 })
 
 test_that("padding argument controls space between elements", {

--- a/tests/testthat/test-position-dodge2.R
+++ b/tests/testthat/test-position-dodge2.R
@@ -32,7 +32,7 @@ test_that("rectangles are dodged", {
   p <- ggplot(df, aes(xmin = xmin, xmax = xmax, ymin = ymin, ymax = ymax)) +
     geom_rect(aes(fill = fill), position = "dodge2", alpha = 0.8)
 
-  expect_false(any(duplicated(find_x_overlaps(get_layer_data(p)))))
+  expect_false(anyDuplicated(find_x_overlaps(get_layer_data(p))) > 0)
 })
 
 test_that("cols at the same x position are dodged", {
@@ -44,7 +44,7 @@ test_that("cols at the same x position are dodged", {
   p <- ggplot(df, aes(1, n, fill = x)) +
     geom_col(position = "dodge2", alpha = 0.5)
 
-  expect_false(any(duplicated(find_x_overlaps(get_layer_data(p)))))
+  expect_false(anyDuplicated(find_x_overlaps(get_layer_data(p))) > 0)
 })
 
 test_that("padding argument controls space between elements", {

--- a/tests/testthat/test-scale-type.R
+++ b/tests/testthat/test-scale-type.R
@@ -1,9 +1,9 @@
 test_that("no scale for NULL aesthetic", {
-  expect_equal(find_scale("colour", NULL), NULL)
+  expect_null(find_scale("colour", NULL))
 })
 
 test_that("no scale for Inf aesthetic", {
-  expect_equal(find_scale("colour", Inf), NULL)
+  expect_null(find_scale("colour", Inf))
 })
 
 test_that("message + continuous for unknown type", {

--- a/tests/testthat/test-scales-breaks-labels.R
+++ b/tests/testthat/test-scales-breaks-labels.R
@@ -47,9 +47,9 @@ test_that("out-of-range breaks are dropped", {
   # Limits are specified, and all breaks are out of range
   sc <- scale_x_continuous(breaks = c(1,5), labels = letters[c(1,5)], limits = c(2, 4))
   bi <- sc$break_info()
-  expect_equal(length(bi$labels), 0)
-  expect_equal(length(bi$major), 0)
-  expect_equal(length(bi$major_source), 0)
+  expect_length(bi$labels, 0)
+  expect_length(bi$major, 0)
+  expect_length(bi$major_source, 0)
 
   # limits aren't specified, automatic labels
   # limits are set by the data
@@ -72,36 +72,36 @@ test_that("out-of-range breaks are dropped", {
   sc <- scale_x_continuous(breaks = c(1,5), labels = letters[c(1,5)])
   sc$train_df(data_frame(x = 2:4))
   bi <- sc$break_info()
-  expect_equal(length(bi$labels), 0)
-  expect_equal(length(bi$major), 0)
-  expect_equal(length(bi$major_source), 0)
+  expect_length(bi$labels, 0)
+  expect_length(bi$major, 0)
+  expect_length(bi$major_source, 0)
 })
 
 test_that("no minor breaks when only one break", {
   sc1 <- scale_x_discrete(limits = "a")
   sc2 <- scale_x_continuous(limits = 1)
 
-  expect_equal(length(sc1$get_breaks_minor()), 0)
-  expect_equal(length(sc2$get_breaks_minor()), 0)
+  expect_length(sc1$get_breaks_minor(), 0)
+  expect_length(sc2$get_breaks_minor(), 0)
 })
 
 init_scale <- function(...) {
   sc <- scale_x_discrete(...)
   sc$train(factor(1:100))
-  expect_equal(length(sc$get_limits()), 100)
+  expect_length(sc$get_limits(), 100)
   sc
 }
 
 test_that("discrete labels match breaks", {
 
   sc <- init_scale(breaks = 0:5 * 10)
-  expect_equal(length(sc$get_breaks()), 5)
-  expect_equal(length(sc$get_labels()), 5)
+  expect_length(sc$get_breaks(), 5)
+  expect_length(sc$get_labels(), 5)
   expect_equal(sc$get_labels(), sc$get_breaks(), ignore_attr = TRUE)
 
   sc <- init_scale(breaks = 0:5 * 10, labels = letters[1:6])
-  expect_equal(length(sc$get_breaks()), 5)
-  expect_equal(length(sc$get_labels()), 5)
+  expect_length(sc$get_breaks(), 5)
+  expect_length(sc$get_labels(), 5)
   expect_equal(sc$get_labels(), letters[2:6])
 
   sc <- init_scale(breaks = 0:5 * 10, labels =
@@ -110,8 +110,8 @@ test_that("discrete labels match breaks", {
 
   pick_5 <- function(x) sample(x, 5)
   sc <- init_scale(breaks = pick_5)
-  expect_equal(length(sc$get_breaks()), 5)
-  expect_equal(length(sc$get_labels()), 5)
+  expect_length(sc$get_breaks(), 5)
+  expect_length(sc$get_labels(), 5)
 })
 
 test_that("scale breaks work with numeric log transformation", {
@@ -141,30 +141,30 @@ test_that("passing continuous limits to a discrete scale generates a warning", {
 })
 
 test_that("suppressing breaks, minor_breask, and labels works", {
-  expect_equal(scale_x_continuous(breaks = NULL, limits = c(1, 3))$get_breaks(), NULL)
-  expect_equal(scale_x_discrete(breaks = NULL, limits = c("one", "three"))$get_breaks(), NULL)
-  expect_equal(scale_x_continuous(minor_breaks = NULL, limits = c(1, 3))$get_breaks_minor(), NULL)
+  expect_null(scale_x_continuous(breaks = NULL, limits = c(1, 3))$get_breaks())
+  expect_null(scale_x_discrete(breaks = NULL, limits = c("one", "three"))$get_breaks())
+  expect_null(scale_x_continuous(minor_breaks = NULL, limits = c(1, 3))$get_breaks_minor())
 
-  expect_equal(scale_x_continuous(labels = NULL, limits = c(1, 3))$get_labels(), NULL)
-  expect_equal(scale_x_discrete(labels = NULL, limits = c("one", "three"))$get_labels(), NULL)
+  expect_null(scale_x_continuous(labels = NULL, limits = c(1, 3))$get_labels())
+  expect_null(scale_x_discrete(labels = NULL, limits = c("one", "three"))$get_labels())
 
   # date, datetime
   lims <- as.Date(c("2000/1/1", "2000/2/1"))
-  expect_equal(scale_x_date(breaks = NULL, limits = lims)$get_breaks(), NULL)
+  expect_null(scale_x_date(breaks = NULL, limits = lims)$get_breaks())
   # NA is defunct, should throw error
   expect_error(scale_x_date(breaks = NA, limits = lims)$get_breaks())
-  expect_equal(scale_x_date(labels = NULL, limits = lims)$get_labels(), NULL)
+  expect_null(scale_x_date(labels = NULL, limits = lims)$get_labels())
   expect_error(scale_x_date(labels = NA, limits = lims)$get_labels())
-  expect_equal(scale_x_date(minor_breaks = NULL, limits = lims)$get_breaks_minor(), NULL)
+  expect_null(scale_x_date(minor_breaks = NULL, limits = lims)$get_breaks_minor())
   expect_error(scale_x_date(minor_breaks = NA, limits = lims)$get_breaks_minor())
 
   # date, datetime
   lims <- as.POSIXct(c("2000/1/1 0:0:0", "2010/1/1 0:0:0"))
-  expect_equal(scale_x_datetime(breaks = NULL, limits = lims)$get_breaks(), NULL)
+  expect_null(scale_x_datetime(breaks = NULL, limits = lims)$get_breaks())
   expect_error(scale_x_datetime(breaks = NA, limits = lims)$get_breaks())
-  expect_equal(scale_x_datetime(labels = NULL, limits = lims)$get_labels(), NULL)
+  expect_null(scale_x_datetime(labels = NULL, limits = lims)$get_labels())
   expect_error(scale_x_datetime(labels = NA, limits = lims)$get_labels())
-  expect_equal(scale_x_datetime(minor_breaks = NULL, limits = lims)$get_breaks_minor(), NULL)
+  expect_null(scale_x_datetime(minor_breaks = NULL, limits = lims)$get_breaks_minor())
   expect_error(scale_x_datetime(minor_breaks = NA, limits = lims)$get_breaks_minor())
 })
 

--- a/tests/testthat/test-scales.R
+++ b/tests/testthat/test-scales.R
@@ -2,10 +2,10 @@ test_that("building a plot does not affect its scales", {
   dat <- data_frame(x = rnorm(20), y = rnorm(20))
 
   p <- ggplot(dat, aes(x, y)) + geom_point()
-  expect_equal(length(p$scales$scales), 0)
+  expect_length(p$scales$scales, 0)
 
   ggplot_build(p)
-  expect_equal(length(p$scales$scales), 0)
+  expect_length(p$scales$scales, 0)
 })
 
 test_that("ranges update only for variables listed in aesthetics", {

--- a/tests/testthat/test-sec-axis.R
+++ b/tests/testthat/test-sec-axis.R
@@ -242,7 +242,7 @@ test_that("sec_axis() respects custom transformations", {
   expect_doppelganger(
     "sec_axis, custom transform",
     ggplot(dat, aes(x = x, y = y)) +
-      geom_line(linewidth = 1, na.rm = T) +
+      geom_line(linewidth = 1, na.rm = TRUE) +
       scale_y_continuous(
         transform =
           magnify_trans_log(interval_low = 0.5, interval_high = 1, reducer = 0.5, reducer2 = 8), breaks =
@@ -364,21 +364,21 @@ test_that("sec_axis() works for power transformations (monotonicity test doesn't
     scale_y_continuous(sec.axis = sec_axis(transform = ~ .^0.5))
   scale <- get_panel_scales(p)$y
   breaks <- scale$break_info()
-  expect_equal(breaks$major, sqrt(breaks$sec.major), tolerance = .005)
+  expect_equal(breaks$major, sqrt(breaks$sec.major), tolerance = 0.005)
 
   p <- ggplot(foo, aes(x, y)) +
     geom_point() +
     scale_x_sqrt(sec.axis = dup_axis())
   scale <- get_panel_scales(p)$x
   breaks <- scale$break_info()
-  expect_equal(breaks$major, breaks$sec.major, tolerance = .001)
+  expect_equal(breaks$major, breaks$sec.major, tolerance = 0.001)
 
   p <- ggplot(foo, aes(x, y)) +
     geom_point() +
     scale_x_sqrt(sec.axis = sec_axis(~ . * 100))
   scale <- get_panel_scales(p)$x
   breaks <- scale$break_info()
-  expect_equal(breaks$major, breaks$sec.major, tolerance = .001)
+  expect_equal(breaks$major, breaks$sec.major, tolerance = 0.001)
 })
 
 test_that("discrete scales can have secondary axes", {

--- a/tests/testthat/test-stat-density.R
+++ b/tests/testthat/test-stat-density.R
@@ -123,7 +123,7 @@ test_that("compute_density returns useful df and throws warning when <2 values",
   expect_warning(dens <- compute_density(1, NULL, from = 0, to = 0))
 
   expect_equal(nrow(dens), 1)
-  expect_equal(names(dens), c("x", "density", "scaled", "ndensity", "count", "wdensity", "n"))
+  expect_named(dens, c("x", "density", "scaled", "ndensity", "count", "wdensity", "n"))
   expect_type(dens$x, "double")
 })
 

--- a/tests/testthat/test-stat-function.R
+++ b/tests/testthat/test-stat-function.R
@@ -18,8 +18,8 @@ test_that("uses scale limits, not data limits", {
   expect_equal(ret$y[c(1, 101)], ret_log$y[c(1, 101)])
   expect_equal(range(ret$x), c(0.1, 100))
   expect_equal(range(ret_log$x), c(-1, 2))
-  expect_false(any(is.na(ret$y)))
-  expect_false(any(is.na(ret_log$y)))
+  expect_false(anyNA(ret$y))
+  expect_false(anyNA(ret_log$y))
 })
 
 test_that("works in plots without any data", {

--- a/tests/testthat/test-stat-ydensity.R
+++ b/tests/testthat/test-stat-ydensity.R
@@ -17,13 +17,13 @@ test_that("`drop = FALSE` preserves groups with 1 observations", {
     ld <- get_layer_data(p + geom_violin(drop = TRUE)),
     "Groups with fewer than two datapoints have been dropped"
   )
-  expect_equal(length(unique(ld$x)), 3)
+  expect_length(unique(ld$x), 3)
 
   expect_warning(
     ld <- get_layer_data(p + geom_violin(drop = FALSE)),
     "Cannot compute density for groups with fewer than two datapoints"
   )
-  expect_equal(length(unique(ld$x)), 4)
+  expect_length(unique(ld$x), 4)
 })
 
 test_that("mapped_discrete class is preserved", {

--- a/tests/testthat/test-stats.R
+++ b/tests/testthat/test-stats.R
@@ -3,12 +3,12 @@ test_that("plot succeeds even if some computation fails", {
   p1 <- ggplot(df, aes(x, y)) + geom_point()
 
   b1 <- ggplot_build(p1)
-  expect_equal(length(b1$data), 1)
+  expect_length(b1$data, 1)
 
   p2 <- p1 + stat_summary(fun = function(x) stop("Failed computation"))
 
   expect_warning(b2 <- ggplot_build(p2), "Computation failed")
-  expect_equal(length(b2$data), 2)
+  expect_length(b2$data, 2)
 })
 
 test_that("error message is thrown when aesthetics are missing", {

--- a/tests/testthat/test-theme.R
+++ b/tests/testthat/test-theme.R
@@ -412,7 +412,7 @@ test_that("current theme can be updated with new elements", {
   )
 
   # theme calculation for nonexisting element returns NULL
-  expect_identical(calc_element("abcde", plot_theme(b1)), NULL)
+  expect_null(calc_element("abcde", plot_theme(b1)))
 
   # element tree gets merged properly
   register_theme_elements(
@@ -730,12 +730,12 @@ test_that("axes ticks can have independent lengths", {
     scale_x_continuous(sec.axis = dup_axis()) +
     scale_y_continuous(sec.axis = dup_axis()) +
     theme(
-      axis.ticks.length.x.top = unit(-.5, "cm"),
-      axis.ticks.length.x.bottom = unit(-.25, "cm"),
-      axis.ticks.length.y.left = unit(.25, "cm"),
-      axis.ticks.length.y.right = unit(.5, "cm"),
-      axis.text.x.bottom = element_text(margin = margin(t = .25, unit = "cm")),
-      axis.text.x.top = element_text(margin = margin(b = .25, unit = "cm"))
+      axis.ticks.length.x.top = unit(-0.5, "cm"),
+      axis.ticks.length.x.bottom = unit(-0.25, "cm"),
+      axis.ticks.length.y.left = unit(0.25, "cm"),
+      axis.ticks.length.y.right = unit(0.5, "cm"),
+      axis.text.x.bottom = element_text(margin = margin(t = 0.25, unit = "cm")),
+      axis.text.x.top = element_text(margin = margin(b = 0.25, unit = "cm"))
     )
   expect_doppelganger("ticks_length", plot)
 })

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -2,14 +2,14 @@ test_that("finite_cases.data.frame", {
   finite_cases <- function(x) cases(x, is_finite)
 
   # All finite --------------------------------------------------------------
-  expect_identical(finite_cases(data_frame(x = 4)),              TRUE)          # 1x1
-  expect_identical(finite_cases(data_frame(x = 4, y = 11)),      TRUE)          # 1x2
+  expect_true(finite_cases(data_frame(x = 4)))          # 1x1
+  expect_true(finite_cases(data_frame(x = 4, y = 11)))          # 1x2
   expect_identical(finite_cases(data_frame(x = 4:5)),            c(TRUE, TRUE)) # 2x1
   expect_identical(finite_cases(data_frame(x = 4:5, y = 11:12)), c(TRUE, TRUE)) # 2x2
 
   # Has one NA --------------------------------------------------------------
-  expect_identical(finite_cases(data_frame(x = NA)),                      FALSE)           # 1x1
-  expect_identical(finite_cases(data_frame(x = 4, y = NA)),               FALSE)           # 1x2
+  expect_false(finite_cases(data_frame(x = NA)))           # 1x1
+  expect_false(finite_cases(data_frame(x = 4, y = NA)))           # 1x2
   expect_identical(finite_cases(data_frame(x = c(4, NA))),                c(TRUE,  FALSE)) # 2x1
   expect_identical(finite_cases(data_frame(x = c(4, NA), y = c(11, NA))), c(TRUE,  FALSE)) # 2x2
   expect_identical(finite_cases(data_frame(x = c(4, NA), y = c(NA, 12))), c(FALSE, FALSE)) # 2x2
@@ -17,7 +17,7 @@ test_that("finite_cases.data.frame", {
 
   # Testing NaN and Inf, using miscellaneous data shapes --------------------
   expect_identical(finite_cases(data_frame(x = c(4, NaN))),                c(TRUE, FALSE))
-  expect_identical(finite_cases(data_frame(x = Inf)),                      FALSE)
+  expect_false(finite_cases(data_frame(x = Inf)))
   expect_identical(finite_cases(data_frame(x = c(4, 5), y = c(-Inf, 12))), c(FALSE, TRUE))
 })
 
@@ -87,7 +87,7 @@ test_that("parse_safe works with multi expressions", {
 })
 
 test_that("x and y aesthetics have the same length", {
-  expect_equal(length(ggplot_global$x_aes), length(ggplot_global$y_aes))
+  expect_length(ggplot_global$x_aes, length(ggplot_global$y_aes))
 })
 
 test_that("check_required_aesthetics() errors on missing", {
@@ -189,8 +189,8 @@ test_that("expose/ignore_data() can round-trip a data.frame", {
   # data.frame with ignored columns
   df <- data_frame0(a = 1:3, b = I(4:6), c = LETTERS[1:3], d = I(LETTERS[4:6]))
   test <- .ignore_data(df)[[1]]
-  expect_equal(names(test), c("a", "c", ".ignored"))
-  expect_equal(names(test$.ignored), c("b", "d"))
+  expect_named(test, c("a", "c", ".ignored"))
+  expect_named(test$.ignored, c("b", "d"))
 
   test <- .expose_data(test)[[1]]
   expect_equal(test, df[, c("a", "c", "b", "d")])


### PR DESCRIPTION
Same as #6050 but used `flint::fix_dir("tests")` this time (to avoid having too many changed files in the same PR).

Changes include:

* `expect_equal(names(x), ...) -> expect_named(x, ...)`
* `expect_equal(x, NULL) -> expect_null(x)`
* `expect_equal(x, TRUE) -> expect_true(x)`

and more.