### PR TITLE
Fix mistake in alignment docs for `geom_text()`

### DIFF
--- a/R/geom-text.R
+++ b/R/geom-text.R
@@ -31,8 +31,8 @@
 #'
 #' @section Alignment:
 #' You can modify text alignment with the `vjust` and `hjust`
-#' aesthetics. These can either be a number between 0 (right/bottom) and
-#' 1 (top/left) or a character (`"left"`, `"middle"`, `"right"`, `"bottom"`,
+#' aesthetics. These can either be a number between 0 (left/bottom) and
+#' 1 (top/right) or a character (`"left"`, `"middle"`, `"right"`, `"bottom"`,
 #' `"center"`, `"top"`). There are two special alignments: `"inward"` and
 #' `"outward"`. Inward always aligns text towards the center, and outward
 #' aligns it away from the center.

--- a/R/geom-text.R
+++ b/R/geom-text.R
@@ -32,7 +32,7 @@
 #' @section Alignment:
 #' You can modify text alignment with the `vjust` and `hjust`
 #' aesthetics. These can either be a number between 0 (left/bottom) and
-#' 1 (top/right) or a character (`"left"`, `"middle"`, `"right"`, `"bottom"`,
+#' 1 (right/top) or a character (`"left"`, `"middle"`, `"right"`, `"bottom"`,
 #' `"center"`, `"top"`). There are two special alignments: `"inward"` and
 #' `"outward"`. Inward always aligns text towards the center, and outward
 #' aligns it away from the center.

--- a/man/geom_text.Rd
+++ b/man/geom_text.Rd
@@ -209,8 +209,8 @@ the background colour of the label.
 \section{Alignment}{
 
 You can modify text alignment with the \code{vjust} and \code{hjust}
-aesthetics. These can either be a number between 0 (right/bottom) and
-1 (top/left) or a character (\code{"left"}, \code{"middle"}, \code{"right"}, \code{"bottom"},
+aesthetics. These can either be a number between 0 (left/bottom) and
+1 (top/right) or a character (\code{"left"}, \code{"middle"}, \code{"right"}, \code{"bottom"},
 \code{"center"}, \code{"top"}). There are two special alignments: \code{"inward"} and
 \code{"outward"}. Inward always aligns text towards the center, and outward
 aligns it away from the center.

--- a/man/geom_text.Rd
+++ b/man/geom_text.Rd
@@ -210,7 +210,7 @@ the background colour of the label.
 
 You can modify text alignment with the \code{vjust} and \code{hjust}
 aesthetics. These can either be a number between 0 (left/bottom) and
-1 (top/right) or a character (\code{"left"}, \code{"middle"}, \code{"right"}, \code{"bottom"},
+1 (right/top) or a character (\code{"left"}, \code{"middle"}, \code{"right"}, \code{"bottom"},
 \code{"center"}, \code{"top"}). There are two special alignments: \code{"inward"} and
 \code{"outward"}. Inward always aligns text towards the center, and outward
 aligns it away from the center.


### PR DESCRIPTION
This PR fixes #6033. The title pretty much covers the PR's content.