### PR TITLE
Make facet section of `summary()` more terse

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* The `summary()` method for ggplots is now more terse about facets 
+  (@teunbrand, #5989).
 * `guide_bins()`, `guide_colourbar()` and `guide_coloursteps()` gain an `angle`
   argument to overrule theme settings, similar to `guide_axis(angle)` 
   (@teunbrand, #4594).

--- a/R/summary.R
+++ b/R/summary.R
@@ -29,8 +29,9 @@ summary.ggplot <- function(object, ...) {
     cat("scales:  ", paste(object$scales$input(), collapse = ", "), "\n")
   }
 
-  cat("faceting: ")
-  print(object$facet)
+  vars <- object$facet$vars()
+  vars <- if (length(vars) > 0) paste0("~", vars) else "<empty>"
+  cat("faceting: ", paste0(vars, collapse = ", "), "\n")
 
   if (length(object$layers) > 0)
     cat("-----------------------------------\n")

--- a/tests/testthat/_snaps/utilities.md
+++ b/tests/testthat/_snaps/utilities.md
@@ -54,3 +54,19 @@
 
     Can't recycle `..1` (size 4) to match `..2` (size 0).
 
+# summary method gives a nice summary
+
+    Code
+      summary(p)
+    Output
+      data: manufacturer, model, displ, year, cyl, trans, drv, cty, hwy, fl,
+        class [234x11]
+      mapping:  x = ~displ, y = ~hwy, colour = ~drv
+      scales:   x, xmin, xmax, xend, xintercept, xmin_final, xmax_final, xlower, xmiddle, xupper, x0, colour 
+      faceting:  ~year, ~cyl 
+      -----------------------------------
+      geom_point: na.rm = FALSE
+      stat_identity: na.rm = FALSE
+      position_identity 
+      
+

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -196,3 +196,16 @@ test_that("expose/ignore_data() can round-trip a data.frame", {
   expect_equal(test, df[, c("a", "c", "b", "d")])
 
 })
+
+test_that("summary method gives a nice summary", {
+  # This test isn't important enough to break anything on CRAN
+  skip_on_cran()
+
+  p <- ggplot(mpg, aes(displ, hwy, colour = drv)) +
+    geom_point() +
+    scale_x_continuous() +
+    scale_colour_brewer() +
+    facet_grid(year ~ cyl)
+
+  expect_snapshot(summary(p))
+})


### PR DESCRIPTION
This PR aims to fix #5989.

Briefly, `summary.ggplot()` no longer prints the whole facet ggproto object, but rather prints the variables used for facetting.

Some examples with various facets:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2
p <- ggplot(mpg, aes(displ, hwy)) +
  geom_point()

summary(p)
#> data: manufacturer, model, displ, year, cyl, trans, drv, cty, hwy, fl,
#>   class [234x11]
#> mapping:  x = ~displ, y = ~hwy
#> faceting:  <empty> 
#> -----------------------------------
#> geom_point: na.rm = FALSE
#> stat_identity: na.rm = FALSE
#> position_identity

summary(p + facet_wrap(~drv))
#> data: manufacturer, model, displ, year, cyl, trans, drv, cty, hwy, fl,
#>   class [234x11]
#> mapping:  x = ~displ, y = ~hwy
#> faceting:  ~drv 
#> -----------------------------------
#> geom_point: na.rm = FALSE
#> stat_identity: na.rm = FALSE
#> position_identity

summary(p + facet_grid(drv ~ year))
#> data: manufacturer, model, displ, year, cyl, trans, drv, cty, hwy, fl,
#>   class [234x11]
#> mapping:  x = ~displ, y = ~hwy
#> faceting:  ~drv, ~year 
#> -----------------------------------
#> geom_point: na.rm = FALSE
#> stat_identity: na.rm = FALSE
#> position_identity

# Reasonable results for extension facets
summary(p + ggforce::facet_matrix(~drv))
#> data: manufacturer, model, displ, year, cyl, trans, drv, cty, hwy, fl,
#>   class [234x11]
#> mapping:  x = ~displ, y = ~hwy
#> faceting:  ~row_data, ~col_data 
#> -----------------------------------
#> geom_point: na.rm = FALSE
#> stat_identity: na.rm = FALSE
#> position_identity
```

<sup>Created on 2024-09-04 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
