### PR TITLE
Change `fill` of `GeomRibbon` to match with the previous default colour

### DIFF
--- a/R/geom-ribbon.R
+++ b/R/geom-ribbon.R
@@ -98,7 +98,7 @@ geom_ribbon <- function(mapping = NULL, data = NULL,
 GeomRibbon <- ggproto("GeomRibbon", Geom,
   default_aes = aes(
     colour = NA,
-    fill = from_theme(col_mix(ink, paper, 0.799)),
+    fill = from_theme(col_mix(ink, paper, 0.2)),
     linewidth = from_theme(borderwidth),
     linetype = from_theme(bordertype),
     alpha = NA),


### PR DESCRIPTION
This fixes an unintentional change in https://github.com/tidyverse/ggplot2/pull/5833.

---

**v3.5.1** (https://ggplot2.tidyverse.org/reference/geom_ribbon.html#ref-examples):
![image](https://github.com/user-attachments/assets/882e4d5c-dcfa-4484-acba-41e7e5743ada)

**dev** (https://ggplot2.tidyverse.org/dev/reference/geom_ribbon.html#ref-examples):
![image](https://github.com/user-attachments/assets/4e39a3e1-a4b7-489d-b9c5-81c961727af8)
