### PR TITLE
Update code of showing the default size of `geom_text()`

### DIFF
--- a/vignettes/articles/faq-customising.Rmd
+++ b/vignettes/articles/faq-customising.Rmd
@@ -497,10 +497,10 @@ ggplot(mpg, aes(x = hwy, y = cty)) +
 
 ### What is the default size of `geom_text()` and how can I change the font size of `geom_text()`?
 
-The default font size of `geom_text()` is 3.88.
+The default font size of `geom_text()` is about 3.87.
 
 ```{r}
-GeomLabel$default_aes$size
+get_geom_defaults(geom_text)$size
 ```
 
 You can change the size using the `size` argument in `geom_text()` for a single plot. If you want to use the same updated size, you can set this with `update_geom_defaults()`, e.g. `update_geom_defaults("text", list(size = 6))`.


### PR DESCRIPTION
It seems this description needs updated.

https://ggplot2.tidyverse.org/dev/articles/faq-customising.html#fonts

![image](https://github.com/user-attachments/assets/1c626104-ffe7-4ecc-9ae5-5ed5a40f0ab5)
