### PR TITLE
Fix regression from #5967

### DIFF
--- a/R/plot-construction.R
+++ b/R/plot-construction.R
@@ -196,7 +196,7 @@ new_layer_names <- function(layer, existing) {
   new_name <- layer$name
   if (is.null(new_name)) {
     # Construct a name from the layer's call
-    new_name <- call_name(layer$constructor)
+    new_name <- call_name(layer$constructor) %||% snake_class(layer$geom)
 
     if (new_name %in% existing) {
       names <- c(existing, new_name)


### PR DESCRIPTION
This PR fixes a regression from #5967 that is detectable as:

https://github.com/tidyverse/ggplot2/blob/d31c051bb87cd5d5f02e8d19b5c002ad2a129d6c/revdep/problems.md?plain=1#L155-L156

Briefly, this error occurs when the constructor call doesn't get captured cleanly, like in the following case:

``` r
library(ggplot2)
rlang::call_name(do.call(geom_point, list())$constructor)
#> NULL
```

<sup>Created on 2024-09-10 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

In this PR, we construct a fallback name based on the geom's ggproto class.