### PR TITLE
Fix linetype regression

### DIFF
--- a/R/scale-linetype.R
+++ b/R/scale-linetype.R
@@ -35,7 +35,7 @@
 #'   scale_linetype_identity() +
 #'   facet_grid(linetype ~ .) +
 #'   theme_void(20)
-scale_linetype <- function(name = waiver(), ..., na.value = "blank") {
+scale_linetype <- function(name = waiver(), ..., na.value = NA) {
   discrete_scale(
     "linetype", name = name,
     palette = pal_linetype(),
@@ -46,7 +46,7 @@ scale_linetype <- function(name = waiver(), ..., na.value = "blank") {
 
 #' @rdname scale_linetype
 #' @export
-scale_linetype_binned <- function(name = waiver(), ..., na.value = "blank") {
+scale_linetype_binned <- function(name = waiver(), ..., na.value = NA) {
   binned_scale(
     "linetype", name = name,
     palette = pal_binned(pal_linetype()),

--- a/R/scale-manual.R
+++ b/R/scale-manual.R
@@ -119,7 +119,7 @@ scale_shape_manual <- function(..., values, breaks = waiver(), na.value = NA) {
 #' @seealso
 #' Other linetype scales: [scale_linetype()], [scale_linetype_identity()].
 #' @export
-scale_linetype_manual <- function(..., values, breaks = waiver(), na.value = "blank") {
+scale_linetype_manual <- function(..., values, breaks = waiver(), na.value = NA) {
   manual_scale("linetype", values, breaks, ..., na.value = na.value)
 }
 

--- a/man/scale_linetype.Rd
+++ b/man/scale_linetype.Rd
@@ -7,13 +7,13 @@
 \alias{scale_linetype_discrete}
 \title{Scale for line patterns}
 \usage{
-scale_linetype(name = waiver(), ..., na.value = "blank")
+scale_linetype(name = waiver(), ..., na.value = NA)
 
-scale_linetype_binned(name = waiver(), ..., na.value = "blank")
+scale_linetype_binned(name = waiver(), ..., na.value = NA)
 
 scale_linetype_continuous(...)
 
-scale_linetype_discrete(name = waiver(), ..., na.value = "blank")
+scale_linetype_discrete(name = waiver(), ..., na.value = NA)
 }
 \arguments{
 \item{name}{The name of the scale. Used as the axis or legend title. If

--- a/man/scale_manual.Rd
+++ b/man/scale_manual.Rd
@@ -32,7 +32,7 @@ scale_size_manual(..., values, breaks = waiver(), na.value = NA)
 
 scale_shape_manual(..., values, breaks = waiver(), na.value = NA)
 
-scale_linetype_manual(..., values, breaks = waiver(), na.value = "blank")
+scale_linetype_manual(..., values, breaks = waiver(), na.value = NA)
 
 scale_linewidth_manual(..., values, breaks = waiver(), na.value = NA)
 

--- a/tests/testthat/test-scale-manual.R
+++ b/tests/testthat/test-scale-manual.R
@@ -176,3 +176,10 @@ test_that("NAs from palette are not translated (#5929)", {
   s3$train(c("8", "6", "4"))
   expect_equal(s3$map(c("4", "6", "8", "10")), c("a", NA, "c", NA))
 })
+
+test_that("numeric linetype palettes are mapped correctly (#6096)", {
+  x  <- c(LETTERS[1:3], NA)
+  sc <- scale_linetype_manual(values = 1:5)
+  sc$train(x)
+  expect_equal(sc$map(x), c(1L, 2L, 3L, NA))
+})


### PR DESCRIPTION
This PR aims to fix #6096.

Briefly, it replaces `na.value = "blank"`, which casts mapped value to characters, to `na.value = NA`, which will cast `NA` to whatever type mapped values have.