### PR TITLE
Fix regression from #6027

### DIFF
--- a/R/coord-.R
+++ b/R/coord-.R
@@ -246,6 +246,9 @@ render_axis <- function(panel_params, axis, scale, position, theme) {
 
 # Elaborates an 'expand' argument for every side (top, right, bottom or left)
 parse_coord_expand <- function(expand) {
+  if (is.numeric(expand) && all(expand %in% c(0, 1))) {
+    expand <- as.logical(expand)
+  }
   check_logical(expand)
   if (anyNA(expand)) {
     cli::cli_abort("{.arg expand} cannot contain missing values.")

--- a/tests/testthat/test-coord-.R
+++ b/tests/testthat/test-coord-.R
@@ -75,6 +75,23 @@ test_that("coords append a column to the layout correctly", {
   expect_equal(test$COORD, c(1, 2, 1))
 })
 
+test_that("parse_coord_expand parses correctly", {
+
+  p <- parse_coord_expand(FALSE)
+  expect_equal(p, rep(FALSE, 4))
+
+  p <- parse_coord_expand(c(FALSE, TRUE))
+  expect_equal(p, c(FALSE, TRUE, FALSE, TRUE))
+
+  p <- parse_coord_expand(c(top = FALSE, left = FALSE))
+  expect_equal(p, c(FALSE, TRUE, TRUE, FALSE))
+
+  # Dependencies might use `expand = 1`
+  p <- parse_coord_expand(c(1, 0))
+  expect_equal(p, c(TRUE, FALSE, TRUE, FALSE))
+
+})
+
 test_that("coord expand takes a vector", {
 
   base <- ggplot() + lims(x = c(0, 10), y = c(0, 10))


### PR DESCRIPTION
This PR fixes a regression introduced by #6027, that is detectable as:

https://github.com/tidyverse/ggplot2/blob/d31c051bb87cd5d5f02e8d19b5c002ad2a129d6c/revdep/problems.md?plain=1#L18570-L18572

The regression occurs when `expand = 0` or `expand = 1` is set in the coord, and this PR makes this valid input again.