### PR TITLE
Fix 6088

### DIFF
--- a/R/position-stack.R
+++ b/R/position-stack.R
@@ -153,8 +153,14 @@ PositionStack <- ggproto("PositionStack", Position,
   setup_params = function(self, data) {
     flipped_aes <- has_flipped_aes(data)
     data <- flip_data(data, flipped_aes)
+    var <- self$var %||% stack_var(data)
+    if (!vec_duplicate_any(data$x)) {
+      # We skip stacking when all data have different x positions so that
+      # there is nothing to stack
+      var <- NULL
+    }
     list(
-      var = self$var %||% stack_var(data),
+      var = var,
       fill = self$fill,
       vjust = self$vjust,
       reverse = self$reverse,
@@ -184,10 +190,6 @@ PositionStack <- ggproto("PositionStack", Position,
     data <- flip_data(data, params$flipped_aes)
     if (is.null(params$var)) {
       return(data)
-    }
-    if (!vec_duplicate_any(data$x)) {
-      # Every x is unique, nothing to stack here
-      return(flip_data(data, params$flipped_aes))
     }
 
     negative <- data$ymax < 0

--- a/tests/testthat/test-position-stack.R
+++ b/tests/testthat/test-position-stack.R
@@ -25,6 +25,12 @@ test_that("negative and positive values are handled separately", {
 
   expect_equal(dat$ymin[dat$x == 2], c(0, -3))
   expect_equal(dat$ymax[dat$x == 2], c(2, 0))
+
+  # Test only negatives #6088
+  df <- data_frame0(x = c(1, 1, 2, 2), y = c(-1, -1, -1, -1), g = LETTERS[1:4])
+  dat <- get_layer_data(ggplot(df, aes(x, y, fill = factor(g))) + geom_col())
+  expect_equal(dat$ymax, dat$ymin + 1)
+  expect_equal(dat$ymin, c(-2, -1, -2, -1))
 })
 
 test_that("can request reverse stacking", {


### PR DESCRIPTION
This PR aims to fix #6088.

Briefly, #5789 introduced an early exit but this unfortunately happened after data had already been transformed.
This PR performs the check earlier, and encodes this as `var = NULL`, which will early exit subsequent functions without data transformation.

Reprex from issue:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

data.frame(
  x = c(-1, 1),
  y = c("x", "y")
) |> 
  ggplot(aes(x, y)) +
  geom_col()
```

![](https://i.imgur.com/RFGR6TW.png)<!-- -->

<sup>Created on 2024-09-16 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
