### PR TITLE
Un-namespace `stage()` calls

### DIFF
--- a/R/aes.R
+++ b/R/aes.R
@@ -208,6 +208,9 @@ standardise_aes_symbols <- function(x) {
 
   # Don't walk through function heads
   x[-1] <- lapply(x[-1], standardise_aes_symbols)
+  if (is_call(x, "stage", ns = "ggplot2")) {
+    x[[1]] <- call("stage")[[1]]
+  }
 
   x
 }


### PR DESCRIPTION
This PR also aims to fix #6104. It is mutually exclusive with #6107.

Briefly, this approach surgically tries to intercept `ggplot2::stage()` calls and change them to `stage()` calls, so that the function masking magic continues to work.

While more surgical than #6107 I feel this is more fussy.