### PR TITLE
Restore rather than recalculate scales in `FacetWrap` with `CoordFlip`

### DIFF
--- a/R/facet-wrap.R
+++ b/R/facet-wrap.R
@@ -447,16 +447,8 @@ FacetWrap <- ggproto("FacetWrap", Facet,
 
   draw_panels = function(self, panels, layout, x_scales, y_scales, ranges, coord, data, theme, params) {
     if (inherits(coord, "CoordFlip")) {
-      if (params$free$x) {
-        layout$SCALE_X <- seq_len(nrow(layout))
-      } else {
-        layout$SCALE_X <- 1L
-      }
-      if (params$free$y) {
-        layout$SCALE_Y <- seq_len(nrow(layout))
-      } else {
-        layout$SCALE_Y <- 1L
-      }
+      # Switch the scales back
+      layout[c("SCALE_X", "SCALE_Y")] <- layout[c("SCALE_Y", "SCALE_X")]
     }
 
     panel_order <- order(layout$ROW, layout$COL)


### PR DESCRIPTION
Currently `FacetWrap$draw_panels()` recalculates `layout$SCALE_X` and `layout$SCALE_Y` if used with `coord_flip()`. This PR changes the behaviour to instead restore the scales as calculated by `$compute_layout()`.

This is relevant when a subclass of `FacetWrap` has a customised layout, but could still otherwise call `FacetWrap$draw_panels()`, like in [ggragged](https://github.com/mikmart/ggragged/blob/513525d100ed636e29bebadd7f29391193246ceb/R/facet_ragged_cols.R#L38).

Fixes mikmart/ggragged#2.