### PR TITLE
Restore `geom_sf()`'s `linetype` aesthetic

### DIFF
--- a/R/geom-sf.R
+++ b/R/geom-sf.R
@@ -238,7 +238,8 @@ GeomSf <- ggproto("GeomSf", Geom,
     linewidth[is_point] <- stroke[is_point]
 
     gp <- gpar(
-      col = colour, fill = fill, fontsize = font_size, lwd = linewidth,
+      col = colour, fill = fill, fontsize = font_size,
+      lwd = linewidth, lty = data$linetype,
       lineend = lineend, linejoin = linejoin, linemitre = linemitre
     )
 

--- a/tests/testthat/_snaps/geom-sf/north-carolina-county-boundaries.svg
+++ b/tests/testthat/_snaps/geom-sf/north-carolina-county-boundaries.svg
@@ -36,7 +36,7 @@
 </defs>
 <g clip-path='url(#cpNzUuNTB8NjgxLjEzfDIyLjc4fDU1Ny41Mw==)'>
 <rect x='75.50' y='22.78' width='605.63' height='534.75' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<path d='M 397.54 533.23 L 103.02 317.47 L 181.05 47.09 L 538.21 70.30 L 625.03 256.02 L 653.60 354.34 L 397.54 533.23 Z' style='fill-rule: evenodd; fill: #E5E5E5; stroke-width: 0.43; stroke: #595959; stroke-linecap: butt;' />
+<path d='M 397.54 533.23 L 103.02 317.47 L 181.05 47.09 L 538.21 70.30 L 625.03 256.02 L 653.60 354.34 L 397.54 533.23 Z' style='fill-rule: evenodd; fill: #E5E5E5; stroke-width: 0.43; stroke: #595959; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
 <rect x='75.50' y='22.78' width='605.63' height='534.75' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -180,7 +180,7 @@ test_that("geom_sf draws correctly", {
   expect_error(regexp = NA, ggplot_build(plot))
 
   expect_doppelganger("North Carolina county boundaries",
-    ggplot() + geom_sf(data = nc) + coord_sf(datum = 4326)
+    ggplot() + geom_sf(data = nc, linetype = 2) + coord_sf(datum = 4326)
   )
 
   pts <- sf::st_sf(a = 1:2, geometry = sf::st_sfc(sf::st_point(0:1), sf::st_point(1:2)))


### PR DESCRIPTION
This PR fixes https://github.com/tidyverse/ggplot2/pull/5904#issuecomment-2403851670.

Briefly, `linetype` never ended up in the grob's graphical parameters. This PR fixes that.