### PR TITLE
Fix binned scaled not accepting function-limits if there are transformations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* Fixed bug where binned scales wouldn't simultaneously accept transformations
+  and function-limits (@teunbrand, #6144).
 * Fixed bug where the `ggplot2::`-prefix did not work with `stage()` 
   (@teunbrand, #6104).
 * New `get_labs()` function for retrieving completed plot labels 

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -319,7 +319,7 @@ binned_scale <- function(aesthetics, scale_name = deprecated(), palette, name = 
   }
 
   transform <- as.transform(transform)
-  if (!is.null(limits)) {
+  if (!is.null(limits) && !is.function(limits)) {
     limits <- transform$transform(limits)
   }
 

--- a/tests/testthat/test-scale-binned.R
+++ b/tests/testthat/test-scale-binned.R
@@ -44,6 +44,16 @@ test_that("binned limits should not compute out-of-bounds breaks", {
   ))
 })
 
+test_that("binned scales can use limits and transformations simultaneously (#6144)", {
+  s <- scale_x_binned(
+    limits = function(x) x + 1,
+    trans = transform_log10()
+  )
+  s$train(c(0, 1)) # c(1, 10) in untransformed space
+  out <- s$get_limits()
+  expect_equal(s$get_limits(), log10(c(2, 11)))
+})
+
 test_that("binned scales can use NAs in limits", {
   scale <- scale_x_binned(limits = c(NA, 10))
   scale$train(c(-20, 20))


### PR DESCRIPTION
This PR aims to fix #6144.

It simply doesn't attempt to pre-transform the limits when the limits is a function.

Reprex from issue:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

df <- data.frame(x = seq(as.Date("2024-01-01"), as.Date("2024-06-30"), "day"))

ggplot(df) +
  geom_bar(aes(x)) +
  scale_x_binned(
    breaks = scales::breaks_width("1 month"),
    transform = scales::transform_date(),
    limits = function(x) { x }
  )
#> Warning in scale_x_binned(breaks = scales::breaks_width("1 month"), transform = scales::transform_date(), : Ignoring `n.breaks`. Use a breaks function that supports setting number of
#> breaks.
```

![](https://i.imgur.com/cKQyldy.png)<!-- -->

<sup>Created on 2024-10-18 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

The spurious warning the scale throws is commented upon [here](https://github.com/tidyverse/ggplot2/pull/5974#issue-2389249603) as well and better fixed in that PR than this PR.
