### PR TITLE
Fix bug in fallback of `grid::linearGradient()`

### DIFF
--- a/R/backports.R
+++ b/R/backports.R
@@ -67,6 +67,6 @@ on_load({
     as.mask <- grid::as.mask
   }
   if ("linearGradient" %in% getNamespaceExports("grid")) {
-    linearGradient <- grid::linearGradient()
+    linearGradient <- grid::linearGradient
   }
 })


### PR DESCRIPTION
This PR does not fix an active issue. Instead it fixes a bug that should have been an issue, but isn't.

Briefly, when `linearGradient` is found in {grid}'s namespace, we want to declare that the `linearGradient()` function that ggplot2 uses is the one from {grid} and not the one we define here:

https://github.com/tidyverse/ggplot2/blob/ddd207e926cc1c1847dc661d9a099b8ec19c4010/R/backports.R#L55-L56

However, we're assigning the *result* of `linearGradient()`, *not* the function itself. This PR rectifies this mistake.
This doesn't really affect anybody as when we use `linearGradient()` as a function, the {grid} version is used anyway because `ggplot2::linearGradient` is not a function.