### PR TITLE
Use `knitr::convert_chunk_header(type = "yaml")`

### DIFF
--- a/vignettes/articles/faq-annotation.Rmd
+++ b/vignettes/articles/faq-annotation.Rmd
@@ -13,7 +13,8 @@ title: "FAQ: Annotation"
   }
 </style>
 ```
-```{r, include = FALSE}
+```{r}
+#| include: false
 library(ggplot2)
 library(dplyr)
 knitr::opts_chunk$set(

--- a/vignettes/articles/faq-axes.Rmd
+++ b/vignettes/articles/faq-axes.Rmd
@@ -13,7 +13,8 @@ title: "FAQ: Axes"
   }
 </style>
 ```
-```{r, include = FALSE}
+```{r}
+#| include: false
 library(ggplot2)
 knitr::opts_chunk$set(
   fig.dpi = 300, 
@@ -36,7 +37,8 @@ Set the angle of the text in the `axis.text.x` or `axis.text.y` components of th
 
 In the following plot the labels on the x-axis are overlapping.
 
-```{r msleep-order-sleep-total}
+```{r}
+#| label: msleep-order-sleep-total
 #| fig.alt: "A boxplot showing the total amount of sleep on the y-axis for 19 
 #|  taxonomical orders of mammals on the x-axis. The horizontal labels on the 
 #|  x-axis for the orders overlap and are unreadable."
@@ -46,7 +48,8 @@ ggplot(msleep, aes(x = order, y = sleep_total)) +
 
 -   Rotate axis labels: We can do this by components of the `theme()`, specifically the `axis.text.x` component. Applying some vertical and horizontal justification to the labels centers them at the axis ticks. The `angle` can be set as desired within the 0 to 360 degree range, here we set it to 90 degrees.
 
-```{r msleep-order-sleep-total-rotate}
+```{r}
+#| label: msleep-order-sleep-total-rotate
 #| fig.alt: "A boxplot showing the total amount of sleep on the y-axis for 19 
 #|  taxonomical orders of mammals on the x-axis. The x-axis labels are oriented
 #|  vertically and are readable."
@@ -57,7 +60,8 @@ ggplot(msleep, aes(x = order, y = sleep_total)) +
 
 -   Flip the axes: Use the y-axis for long labels.
 
-```{r msleep-order-sleep-total-flip}
+```{r}
+#| label: msleep-order-sleep-total-flip
 #| fig.alt: "A boxplot showing the total amount of sleep on the x-axis for 19
 #|  taxonomical orders of mammals on the y-axis. The y-axis labels are oriented
 #|  horizontally and are readable."
@@ -67,7 +71,8 @@ ggplot(msleep, aes(y = order, x = sleep_total)) +
 
 -   Dodge axis labels: Add a `scale_*()` layer, e.g. `scale_x_continuous()`, `scale_y_discrete()`, etc., and customise the `guide` argument with the `guide_axis()` function. In this case we want to customise the x-axis, and the variable on the x-axis is discrete, so we'll use `scale_x_continuous()`. In the `guide` argument we use the `guide_axis()` and specify how many rows to dodge the labels into with `n.dodge`. This is likely a trial-and-error exercise, depending on the lengths of your labels and the width of your plot. In this case we've settled on 3 rows to render the labels.
 
-```{r msleep-order-sleep-total-dodge}
+```{r}
+#| label: msleep-order-sleep-total-dodge
 #| fig.alt: "A boxplot showing the total amount of sleep on the y-axis for 19 
 #|  taxonomical orders of mammals on the x-axis. The horizontal labels on the 
 #|  x-axis are dodged to three levels so that they remain readable."
@@ -78,7 +83,8 @@ ggplot(msleep, aes(x = order, y = sleep_total)) +
 
 -   Omit overlapping labels: Alternatively, you can set `guide_axis(check.overlap = TRUE)` to omit axis labels that overlap. ggplot2 will prioritize the first, last, and middle labels. Note that this option might be more preferable for axes representing variables that have an inherent ordering that is obvious to the audience of the plot, so that it's trivial to guess what the missing labels are. (This is not the case for the following plot.)
 
-```{r msleep-order-sleep-total-check-overlap}
+```{r}
+#| label: msleep-order-sleep-total-check-overlap
 #| fig.alt: "A boxplot showing the total amount of sleep on the y-axis for 19 
 #|  taxonomical orders of mammals on the x-axis. Several of the x-axis labels
 #|  have been omitted, but the one that remain are readable and don't overlap."
@@ -99,7 +105,8 @@ Add a `theme()` layer and set relevant arguments, e.g. `axis.title.x`, `axis.tex
 
 Suppose we want to remove the axis labels entirely.
 
-```{r ref.label="msleep-order-sleep-total"}
+```{r}
+#| ref-label: msleep-order-sleep-total
 #| fig.alt: "A boxplot showing the total amount of sleep on the y-axis for 19 
 #|  taxonomical orders of mammals on the x-axis. The horizontal labels on the 
 #|  x-axis for the orders overlap and are unreadable."

--- a/vignettes/articles/faq-bars.Rmd
+++ b/vignettes/articles/faq-bars.Rmd
@@ -13,7 +13,8 @@ title: "FAQ: Barplots"
   }
 </style>
 ```
-```{r, include = FALSE}
+```{r}
+#| include: false
 library(ggplot2)
 library(dplyr)
 library(tidyr)

--- a/vignettes/articles/faq-customising.Rmd
+++ b/vignettes/articles/faq-customising.Rmd
@@ -13,7 +13,8 @@ title: "FAQ: Customising"
   }
 </style>
 ```
-```{r, include = FALSE}
+```{r}
+#| include: false
 library(ggplot2)
 library(tibble)
 knitr::opts_chunk$set(
@@ -370,7 +371,8 @@ ggplot(mpg, aes(x = hwy, y = cty, color = class)) +
 If you would like all plots within a session/document to use a particular base size, you can set it with `set_theme()`.
 Run the following at the beginning of your session or include on top of your R Markdown document.
 
-```{r eval = FALSE}
+```{r}
+#| eval: false
 set_theme(theme_gray(base_size = 18))
 ```
 

--- a/vignettes/articles/faq-faceting.Rmd
+++ b/vignettes/articles/faq-faceting.Rmd
@@ -13,7 +13,8 @@ title: "FAQ: Faceting"
   }
 </style>
 ```
-```{r, include = FALSE}
+```{r}
+#| include: false
 library(ggplot2)
 knitr::opts_chunk$set(
   fig.dpi = 300, 
@@ -77,7 +78,8 @@ In `facet_grid()` these values are determined by the number of levels of the var
 Similarly, you can also use `facet_grid()` to facet by a single categorical variable as well.
 In the formula notation, you use a `.` to indicate that no faceting should be done along that axis, i.e. `cyl ~ .` facets across the y-axis (within a column) while `. ~ cyl` facets across the x-axis (within a row).
 
-```{r out.width = "50%"}
+```{r}
+#| out-width: 50%
 #| fig.alt:
 #| - "A histogram showing the city miles per gallon distribution. The plot has 
 #|  four panels in a 4-row, 1-column layout, showing four numbers of cylinders."
@@ -303,7 +305,8 @@ df
 
 You can plot `price` versus `time` and facet by `country`, but the resulting plot can be a bit difficult to read due to the shared y-axis label.
 
-```{r warning = FALSE}
+```{r}
+#| warning: false
 #| fig.alt: "A timeseries plot showing price over time for two countries, Japan
 #|  and the US, in two panels in a 2-row, 1-column layout. The countries are
 #|  indicated at the top of each panel. The two y-axes have different ranges."

--- a/vignettes/articles/faq-reordering.Rmd
+++ b/vignettes/articles/faq-reordering.Rmd
@@ -13,7 +13,8 @@ title: "FAQ: Reordering"
   }
 </style>
 ```
-```{r, include = FALSE}
+```{r}
+#| include: false
 library(ggplot2)
 library(dplyr)
 library(tibble)

--- a/vignettes/extending-ggplot2.Rmd
+++ b/vignettes/extending-ggplot2.Rmd
@@ -9,7 +9,8 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r, include = FALSE}
+```{r}
+#| include: false
 knitr::opts_chunk$set(collapse = TRUE, comment = "#>", fig.width = 7, fig.height = 7, fig.align = "center")
 library(ggplot2)
 ```
@@ -28,7 +29,8 @@ It's strange to say, but this is a case where inventing a new OO system was actu
 
 Here's a quick demo of ggproto in action:
 
-```{r ggproto-intro}
+```{r}
+#| label: ggproto-intro
 A <- ggproto("A", NULL,
   x = 1,
   inc = function(self) {
@@ -53,7 +55,8 @@ To create a new geom or stat, you will just create a new ggproto that inherits f
 
 We'll start by creating a very simple stat: one that gives the convex hull (the _c_ hull) of a set of points. First we create a new ggproto object that inherits from `Stat`:
 
-```{r chull}
+```{r}
+#| label: chull
 StatChull <- ggproto("StatChull", Stat,
   compute_group = function(data, scales) {
     data[chull(data$x, data$y), , drop = FALSE]
@@ -374,7 +377,8 @@ It's harder to create a new geom than a new stat because you also need to know s
 
 It's easiest to start with a simple example. The code below is a simplified version of `geom_point()`:
 
-```{r GeomSimplePoint}
+```{r}
+#| label: GeomSimplePoint
 #| fig.alt: "Scatterplot of engine displacement versus highway miles per
 #|  gallon, for 234 cars. The points are larger than the default."
 GeomSimplePoint <- ggproto("GeomSimplePoint", Geom,
@@ -625,7 +629,8 @@ title        | `element_text()`  | all text in title elements (plot, axes & lege
 
 These set default properties that are inherited by more specific settings. These are most useful for setting an overall "background" colour and overall font settings (e.g. family and size).
 
-```{r axis-line-ex}
+```{r}
+#| label: axis-line-ex
 #| fig.alt:
 #| - "Scatterplot of three observations arranged diagonally. The axis titles 'x' 
 #|  and 'y' are coloured in black"
@@ -1150,7 +1155,8 @@ guide_key <- function(
 
 Our new guide can now be used inside the `guides()` function or as the `guide` argument in a position scale.
 
-```{r key_example}
+```{r}
+#| label: key_example
 #| fig.alt: >
 #|  Scatterplot of engine displacement versus highway miles per 
 #|  gallon. The x-axis axis ticks are at 2.5, 3.5, 4.5, 5.5 and 6.5.
@@ -1174,7 +1180,8 @@ We'll edit the method so that the labels are drawn with a `colour` set in the ke
 In addition to the `key` and `params` variable we've seen before, we now also have an `elements` variable, which is a list of precomputed theme elements. We can use the `elements$text` element to draw a graphical object (grob) in the style of axis text.
 Perhaps the most finicky thing about drawing guides is that a lot of settings depend on the guide's `position` parameter.
 
-```{r key_ggproto_edit}
+```{r}
+#| label: key_ggproto_edit
 # Same as before
 GuideKey <- ggproto(
   "Guide", GuideAxis,
@@ -1205,7 +1212,8 @@ GuideKey <- ggproto(
 Because we are incorporating the `...` argument to `guide_key()` in the key, adding a `colour` column to the key is straightforward.
 We can check that are guide looks correct in the different positions around the panel.
 
-```{r key_example_2}
+```{r}
+#| label: key_example_2
 #| fig.alt: >
 #|  Scatterplot of engine displacement versus highway miles per 
 #|  gallon. There are two x-axes at the bottom and top of the plot. The bottom

--- a/vignettes/ggplot2-in-packages.Rmd
+++ b/vignettes/ggplot2-in-packages.Rmd
@@ -9,7 +9,8 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r, include = FALSE}
+```{r}
+#| include: false
 knitr::opts_chunk$set(collapse = TRUE, comment = "#>", fig.show = "hide")
 library(ggplot2)
 ```
@@ -28,7 +29,8 @@ mpg_drv_summary <- function() {
 }
 ```
 
-```{r, include=FALSE}
+```{r}
+#| include: false
 # make sure this function runs!
 mpg_drv_summary()
 ```
@@ -44,7 +46,8 @@ mpg_drv_summary <- function() {
 }
 ```
 
-```{r, include=FALSE}
+```{r}
+#| include: false
 # make sure this function runs!
 mpg_drv_summary()
 ```
@@ -100,7 +103,8 @@ col_summary(mpg, "drv", "year")
 
 If the column name or expression is supplied by the user, you can also pass it to `aes()` or `vars()` using `{{ col }}`. This tidy eval operator captures the expression supplied by the user and forwards it to another tidy eval-enabled function such as `aes()` or `vars()`.
 
-```{r, eval = (packageVersion("rlang") >= "0.3.4.9003")}
+```{r}
+#| eval: !expr (packageVersion("rlang") >= "0.3.4.9003")
 col_summary <- function(df, col, by) {
   ggplot(df) + 
     geom_bar(aes(y = {{ col }})) + 
@@ -225,14 +229,16 @@ theme_custom <- function(...) {
 }
 ```
 
-```{r, include=FALSE}
+```{r}
+#| include: false
 # make sure this function runs!
 mpg_drv_summary() + theme_custom()
 ```
 
 Generally, if you add a method for a ggplot2 generic like `autoplot()`, ggplot2 should be in `Imports`. If for some reason you would like to keep ggplot2 in `Suggests`, it is possible to register your generics only if ggplot2 is installed using `vctrs::s3_register()`. If you do this, you should copy and paste the source of `vctrs::s3_register()` into your own package to avoid adding a [vctrs](https://vctrs.r-lib.org/) dependency.
 
-```{r, eval=FALSE}
+```{r}
+#| eval: false
 .onLoad <- function(...) {
   if (requireNamespace("ggplot2", quietly = TRUE)) {
     vctrs::s3_register("ggplot2::autoplot", "discrete_distr")

--- a/vignettes/ggplot2-specs.Rmd
+++ b/vignettes/ggplot2-specs.Rmd
@@ -9,7 +9,8 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r, include = FALSE}
+```{r}
+#| include: false
 library(ggplot2)
 knitr::opts_chunk$set(fig.dpi = 96, collapse = TRUE, comment = "#>")
 ```
@@ -106,7 +107,9 @@ with this mistake.
 *   The appearance of the line end is controlled by the `lineend` paramter,
     and can be one of "round", "butt" (the default), or "square".
 
-    ```{r, out.width = "30%", fig.show = "hold"}
+    ```{r}
+    #| out-width: 30%
+    #| fig-show: hold
     #| fig.alt:
     #| - "A plot showing a line with an angle. A thinner red line is placed over
     #|  a thicker black line. The black line ends where the red line ends."
@@ -134,7 +137,9 @@ with this mistake.
 *   The appearance of line joins is controlled by `linejoin` and can be one of 
     "round" (the default), "mitre", or "bevel".
 
-    ```{r, out.width = "30%", fig.show = "hold"}
+    ```{r}
+    #| out-width: 30%
+    #| fig-show: hold
     #| fig.alt:
     #| - "A plot showing a thin red line on top of a thick black line shaped like 
     #|  the letter 'V'. The corner in the black V-shape is rounded."
@@ -192,7 +197,10 @@ Shapes take five types of values:
    
 *   The __name__ of the shape:
      
-    ```{r out.width = "90%", fig.asp = 0.4, fig.width = 8}
+    ```{r}
+    #| out-width: 90%
+    #| fig-asp: 0.4
+    #| fig-width: 8
     #| fig.alt: "An irregular 6-by-7 grid of point symbols annotated by the 
     #|  names that can be used to represent the symbols. Broadly, from top to 
     #|  bottom, the symbols are circles, squares, diamonds, triangles and 

--- a/vignettes/ggplot2.Rmd
+++ b/vignettes/ggplot2.Rmd
@@ -9,7 +9,8 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r, include = FALSE}
+```{r}
+#| include: false
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
@@ -22,7 +23,9 @@ This allows you to 'speak' a graph from composable elements, instead of being li
 
 More complete information about how to use ggplot2 can be found in the [book](https://ggplot2-book.org/), but here you'll find a brief overview of the plot components and some terse examples to build a plot like this: 
 
-```{r cake, echo = FALSE}
+```{r}
+#| label: cake
+#| echo: false
 #| fig.alt: "Scatterplot of city versus highway miles per gallon, for many cars
 #|  coloured by engine displacement. The plot has six panels in a 2-row, 
 #|  3-column layout, showing the combinations of three types of drive train and
@@ -40,7 +43,9 @@ ggplot(mpg, aes(cty, hwy)) +
 
 For structure, we go over the 7 composable parts that come together as a set of instructions on how to draw a chart.
 
-```{r overview_graphic, echo=FALSE}
+```{r}
+#| label: overview_graphic
+#| echo: false
 #| fig.alt: "A schematic displaying seven overlaying rhombuses indicating the
 #|  different composable parts. From bottom to top, the labels read 'Data', 
 #|  'Mapping', 'Layers', 'Scales', 'Facets', 'Coordinates' and 'Theme'."
@@ -81,7 +86,9 @@ The system works best if the data is provided in a [tidy](https://tidyr.tidyvers
 
 As the first step in many plots, you would pass the data to the `ggplot()` function, which stores the data to be used later by other parts of the plotting system. For example, if we intend to make a graphic about the `mpg` dataset, we would start as follows:
 
-```{r example_data, fig.show='hide'}
+```{r}
+#| label: example_data
+#| fig-show: hide
 ggplot(data = mpg)
 ```
 
@@ -92,7 +99,9 @@ The [mapping](https://ggplot2-book.org/getting-started.html#aesthetics) of a plo
 A mapping can be made by using the `aes()` function to make pairs of graphical attributes and parts of the data.
 If we want the `cty` and `hwy` columns to map to the x- and y-coordinates in the plot, we can do that as follows:
 
-```{r example_mapping, fig.show='hide'}
+```{r}
+#| label: example_mapping
+#| fig-show: hide
 ggplot(mpg, mapping = aes(x = cty, y = hwy))
 ```
 
@@ -107,7 +116,9 @@ Every layer consists of three important parts:
 
 A layer can be constructed using the `geom_*()` and `stat_*()` functions. These functions often determine one of the three parts of a layer, while the other two can still be specified. Here is how we can use two layers to display the `cty` and `hwy` columns of the `mpg` dataset as points and stack a trend line on top.
 
-```{r example_layer, fig.show='hold'}
+```{r}
+#| label: example_layer
+#| fig-show: hold
 #| fig.alt: "A scatterplot showing city versus highway miles per gallon for 
 #|  many cars. The plot has a blue trendline with a positive slope."
 ggplot(mpg, aes(cty, hwy)) +
@@ -124,7 +135,8 @@ Scales are responsible for updating the limits of a plot, setting the breaks, fo
 
 To use scales, one can use one of the scale functions that are patterned as `scale_{aesthetic}_{type}()` functions, where `{aesthetic}` is one of the pairings made in the mapping part of a plot. To map the `class` column in the `mpg` dataset to the viridis colour palette, we can write the following:
 
-```{r example_scales}
+```{r}
+#| label: example_scales
 #| fig.alt: "A scatterplot showing city versus highway miles per gallon for 
 #|  many cars. The points are coloured according to seven classes of cars."
 ggplot(mpg, aes(cty, hwy, colour = class)) +
@@ -140,7 +152,8 @@ It is a powerful tool to quickly split up the data into smaller panels, based on
 The facets have their own mapping that can be given as a formula. 
 To plot subsets of the `mpg` dataset based on levels of the `drv` and `year` variables, we can use `facet_grid()` as follows:
 
-```{r example_facets}
+```{r}
+#| label: example_facets
 #| fig.alt: "Scatterplot of city versus highway miles per gallon, for many cars.
 #|  The plot has six panels in a 2-row, 3-column layout, showing the 
 #|  combinations of three types of drive train and year of manifacture."
@@ -156,7 +169,8 @@ While typically Cartesian coordinates are used, the coordinate system powers the
 
 We can also use coordinates to display a plot with a fixed aspect ratio so that one unit has the same length in both the x and y directions. The `coord_fixed()` function sets this ratio automatically.
 
-```{r example_coords}
+```{r}
+#| label: example_coords
 #| fig.alt: "A scatterplot showing city versus highway miles per gallon for 
 #|  many cars. The aspect ratio of the plot is such that units on the x-axis
 #|  have the same length as units on the y-axis."
@@ -171,7 +185,8 @@ The [theme](https://ggplot2-book.org/themes) system controls almost any visuals 
 
 To tweak the look of the plot, one can use many of the built-in `theme_*()` functions and/or detail specific aspects with the `theme()` function. The `element_*()` functions control the graphical attributes of theme components.
 
-```{r example_theme}
+```{r}
+#| label: example_theme
 #| fig.alt: "A scatterplot showing city versus highway miles per gallon for 
 #|  many cars. The points are coloured according to seven classes of cars. The
 #|  legend of the colour is displayed on top of the plot. The plot has thick
@@ -190,7 +205,8 @@ ggplot(mpg, aes(cty, hwy, colour = class)) +
 
 As mentioned at the start, you can layer all of the pieces to build a customized plot of your data, like the one shown at the beginning of this vignette:
 
-```{r outro}
+```{r}
+#| label: outro
 #| fig.alt: "Scatterplot of city versus highway miles per gallon, for many cars
 #|  coloured by engine displacement. The plot has six panels in a 2-row, 
 #|  3-column layout, showing the combinations of three types of drive train and

--- a/vignettes/profiling.Rmd
+++ b/vignettes/profiling.Rmd
@@ -10,7 +10,9 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r setup, include = FALSE}
+```{r}
+#| label: setup
+#| include: false
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
@@ -33,7 +35,9 @@ profile <- profvis(for (i in seq_len(100)) ggplotGrob(p))
 profile
 ```
 
-```{r, eval=FALSE, include=FALSE}
+```{r}
+#| eval: false
+#| include: false
 saveRDS(profile, file.path('profilings', paste0(packageVersion('ggplot2'), '.rds')))
 ```
 


### PR DESCRIPTION
This PR follows #6083 and is in anticipation of spring cleaning 2024.
It applies YAML syntax of chunk options (quarto chunk style) everywhere.