### PR TITLE
Expand on docs/example for cases with non-equal-width bins in `stat_bin()`

### DIFF
--- a/R/geom-histogram.R
+++ b/R/geom-histogram.R
@@ -64,7 +64,7 @@
 #'   geom_freqpoly(binwidth = 500)
 #'
 #'
-#' # When using the non-equal-width bins, we need to set the area of the bars to
+#' # When using the non-equal-width bins, we should set the area of the bars to
 #' # represent the counts (not the height).
 #' # Here we're using 10 equi-probable bins:
 #' price_bins <- quantile(diamonds$price, probs = seq(0, 1, length = 11))

--- a/R/geom-histogram.R
+++ b/R/geom-histogram.R
@@ -63,6 +63,18 @@
 #' ggplot(diamonds, aes(price, after_stat(density), colour = cut)) +
 #'   geom_freqpoly(binwidth = 500)
 #'
+#'
+#' # When using the non-equal-width bins, we need to set the area of the bars to
+#' # represent the counts (not the height).
+#' # Here we're using 10 equi-probable bins:
+#' price_bins <- quantile(diamonds$price, probs = seq(0, 1, length = 11))
+#'
+#' ggplot(diamonds, aes(price)) +
+#'   geom_histogram(breaks = price_bins, color = "black") # wrong (height = count)
+#'
+#' ggplot(diamonds, aes(price, after_stat(count / width))) +
+#'   geom_histogram(breaks = price_bins, color = "black") # area = count
+#'
 #' if (require("ggplot2movies")) {
 #' # Often we don't want the height of the bar to represent the
 #' # count of observations, but the sum of some other variable.

--- a/R/geom-histogram.R
+++ b/R/geom-histogram.R
@@ -70,7 +70,7 @@
 #' price_bins <- quantile(diamonds$price, probs = seq(0, 1, length = 11))
 #'
 #' ggplot(diamonds, aes(price)) +
-#'   geom_histogram(breaks = price_bins, color = "black") # wrong (height = count)
+#'   geom_histogram(breaks = price_bins, color = "black") # misleading (height = count)
 #'
 #' ggplot(diamonds, aes(price, after_stat(count / width))) +
 #'   geom_histogram(breaks = price_bins, color = "black") # area = count

--- a/R/geom-histogram.R
+++ b/R/geom-histogram.R
@@ -17,6 +17,12 @@
 #' one change at a time. You may need to look at a few options to uncover
 #' the full story behind your data.
 #'
+#' By default, the _height_ of the bars represent the counts within each bin.
+#' However, there are situations where this behavior might produce misleading
+#' plots (e.g., when non-equal-width bins are used), in which case it might be
+#' preferable to have the _area_ of the bars represent the counts (by setting
+#' `aes(y = after_stat(count / width))`). See example below.
+#'
 #' In addition to `geom_histogram()`, you can create a histogram plot by using
 #' `scale_x_binned()` with [geom_bar()]. This method by default plots tick marks
 #' in between each bar.

--- a/R/stat-bin.R
+++ b/R/stat-bin.R
@@ -31,7 +31,7 @@
 #'   density  = "density of points in bin, scaled to integrate to 1.",
 #'   ncount   = "count, scaled to a maximum of 1.",
 #'   ndensity = "density, scaled to a maximum of 1.",
-#'   width    = "widths of bins."
+#'   width    = "widths of bins. Use with `after_stat(count / width)` to obtain bars with _areas_ representing counts (e.g., with non-equal-width bins). See example."
 #' )
 #'
 #' @section Dropped variables:

--- a/R/stat-bin.R
+++ b/R/stat-bin.R
@@ -31,7 +31,7 @@
 #'   density  = "density of points in bin, scaled to integrate to 1.",
 #'   ncount   = "count, scaled to a maximum of 1.",
 #'   ndensity = "density, scaled to a maximum of 1.",
-#'   width    = "widths of bins. Use with `after_stat(count / width)` to obtain bars with _areas_ representing counts (e.g., with non-equal-width bins). See example."
+#'   width    = "widths of bins."
 #' )
 #'
 #' @section Dropped variables:

--- a/man/geom_histogram.Rd
+++ b/man/geom_histogram.Rd
@@ -215,7 +215,7 @@ These are calculated by the 'stat' part of layers and can be accessed with \link
 \item \code{after_stat(density)}\cr density of points in bin, scaled to integrate to 1.
 \item \code{after_stat(ncount)}\cr count, scaled to a maximum of 1.
 \item \code{after_stat(ndensity)}\cr density, scaled to a maximum of 1.
-\item \code{after_stat(width)}\cr widths of bins.
+\item \code{after_stat(width)}\cr widths of bins. Use with \code{after_stat(count / width)} to obtain bars with \emph{areas} representing counts (e.g., with non-equal-width bins). See example.
 }
 }
 
@@ -254,6 +254,18 @@ ggplot(diamonds, aes(price, colour = cut)) +
 # put density on the y axis instead of the default count
 ggplot(diamonds, aes(price, after_stat(density), colour = cut)) +
   geom_freqpoly(binwidth = 500)
+
+
+# When using the non-equal-width bins, we need to set the area of the bars to
+# represent the counts (not the height).
+# Here we're using 10 equi-probable bins:
+price_bins <- quantile(diamonds$price, probs = seq(0, 1, length = 11))
+
+ggplot(diamonds, aes(price)) +
+  geom_histogram(breaks = price_bins, color = "black") # wrong (height = count)
+
+ggplot(diamonds, aes(price, after_stat(count / width))) +
+  geom_histogram(breaks = price_bins, color = "black") # area = count
 
 if (require("ggplot2movies")) {
 # Often we don't want the height of the bar to represent the

--- a/man/geom_histogram.Rd
+++ b/man/geom_histogram.Rd
@@ -192,6 +192,12 @@ different number of bins. You can also experiment modifying the \code{binwidth} 
 one change at a time. You may need to look at a few options to uncover
 the full story behind your data.
 
+By default, the \emph{height} of the bars represent the counts within each bin.
+However, there are situations where this behavior might produce misleading
+plots (e.g., when non-equal-width bins are used), in which case it might be
+preferable to have the \emph{area} of the bars represent the counts (by setting
+\code{aes(y = after_stat(count / width))}). See example below.
+
 In addition to \code{geom_histogram()}, you can create a histogram plot by using
 \code{scale_x_binned()} with \code{\link[=geom_bar]{geom_bar()}}. This method by default plots tick marks
 in between each bar.
@@ -215,7 +221,7 @@ These are calculated by the 'stat' part of layers and can be accessed with \link
 \item \code{after_stat(density)}\cr density of points in bin, scaled to integrate to 1.
 \item \code{after_stat(ncount)}\cr count, scaled to a maximum of 1.
 \item \code{after_stat(ndensity)}\cr density, scaled to a maximum of 1.
-\item \code{after_stat(width)}\cr widths of bins. Use with \code{after_stat(count / width)} to obtain bars with \emph{areas} representing counts (e.g., with non-equal-width bins). See example.
+\item \code{after_stat(width)}\cr widths of bins.
 }
 }
 
@@ -256,13 +262,13 @@ ggplot(diamonds, aes(price, after_stat(density), colour = cut)) +
   geom_freqpoly(binwidth = 500)
 
 
-# When using the non-equal-width bins, we need to set the area of the bars to
+# When using the non-equal-width bins, we should set the area of the bars to
 # represent the counts (not the height).
 # Here we're using 10 equi-probable bins:
 price_bins <- quantile(diamonds$price, probs = seq(0, 1, length = 11))
 
 ggplot(diamonds, aes(price)) +
-  geom_histogram(breaks = price_bins, color = "black") # wrong (height = count)
+  geom_histogram(breaks = price_bins, color = "black") # misleading (height = count)
 
 ggplot(diamonds, aes(price, after_stat(count / width))) +
   geom_histogram(breaks = price_bins, color = "black") # area = count


### PR DESCRIPTION
This PR addresses the points brought up in #5895: 
- The default behavior of `stat_bin()` of mapping counts to _height_ instead of _area_ is suitable for most common applications.
- This is because most common applications use equal-width bins.
- When non-equal-width bins are used, this behavior produces histograms that are hard to interpret and violate the [proportional ink](https://clauswilke.com/dataviz/proportional-ink.html) principle. 
- Therefore, I suggested adding to the docs/examples something that discusses this / shows how to do it properly.

Which is what I did 


## The Changes

### 1. Slightly expanded the _Computed variables_ bullet for `width`.

Previously was:

> - `after_stat(width)`
widths of bins.

Now is:

> - `after_stat(width)`
widths of bins. Use with `after_stat(count / width)` to obtain bars with _areas_ representing counts (e.g., with non-equal-width bins). See example.


### 2. Added an example

``` r
# When using the non-equal-width bins, we need to set the area of the bars to
# represent the counts (not the height).
# Here we're using 10 equi-probable bins:
price_bins <- quantile(diamonds$price, probs = seq(0, 1, length = 11))

ggplot(diamonds, aes(price)) +
  geom_histogram(breaks = price_bins, color = "black") # wrong (height = count)
```

![](https://i.imgur.com/kjnjbb7.png)<!-- -->

``` r

ggplot(diamonds, aes(price, after_stat(count / width))) +
  geom_histogram(breaks = price_bins, color = "black") # area = count
```

![](https://i.imgur.com/mw3K1Na.png)<!-- -->

<sup>Created on 2024-10-21 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

