### PR TITLE
Use snapshot expectations for transformation breaks

### DIFF
--- a/tests/testthat/_snaps/scales.md
+++ b/tests/testthat/_snaps/scales.md
@@ -73,9 +73,128 @@
 # numeric scale transforms can produce breaks
 
     Code
+      test_breaks("asn", limits = c(0, 1))
+    Output
+      [1] 0.00 0.25 0.50 0.75 1.00
+
+---
+
+    Code
+      test_breaks("sqrt", limits = c(0, 10))
+    Output
+      [1]  0.0  2.5  5.0  7.5 10.0
+
+---
+
+    Code
+      test_breaks("atanh", limits = c(-0.9, 0.9))
+    Output
+      [1]   NA -0.5  0.0  0.5   NA
+
+---
+
+    Code
+      test_breaks(transform_boxcox(0), limits = c(1, 10))
+    Output
+      [1]   NA  2.5  5.0  7.5 10.0
+
+---
+
+    Code
+      test_breaks(transform_modulus(0), c(-10, 10))
+    Output
+      [1] -10  -5   0   5  10
+
+---
+
+    Code
+      test_breaks(transform_yj(0), c(-10, 10))
+    Output
+      [1] -10  -5   0   5  10
+
+---
+
+    Code
+      test_breaks("exp", c(-10, 10))
+    Output
+      [1] -10  -5   0   5  10
+
+---
+
+    Code
+      test_breaks("identity", limits = c(-10, 10))
+    Output
+      [1] -10  -5   0   5  10
+
+---
+
+    Code
       test_breaks("log", limits = c(0.1, 1000))
     Output
       [1]        NA   1.00000  20.08554 403.42879
+
+---
+
+    Code
+      test_breaks("log10", limits = c(0.1, 1000))
+    Output
+      [1] 1e-01 1e+00 1e+01 1e+02 1e+03
+
+---
+
+    Code
+      test_breaks("log2", limits = c(0.5, 32))
+    Output
+      [1]  0.5  2.0  8.0 32.0
+
+---
+
+    Code
+      test_breaks("log1p", limits = c(0, 10))
+    Output
+      [1]  0.0  2.5  5.0  7.5 10.0
+
+---
+
+    Code
+      test_breaks("pseudo_log", limits = c(-10, 10))
+    Output
+      [1] -10  -5   0   5  10
+
+---
+
+    Code
+      test_breaks("logit", limits = c(0.001, 0.999))
+    Output
+      [1]   NA 0.25 0.50 0.75   NA
+
+---
+
+    Code
+      test_breaks("probit", limits = c(0.001, 0.999))
+    Output
+      [1]   NA 0.25 0.50 0.75   NA
+
+---
+
+    Code
+      test_breaks("reciprocal", limits = c(1, 10))
+    Output
+      [1]   NA  2.5  5.0  7.5 10.0
+
+---
+
+    Code
+      test_breaks("reverse", limits = c(-10, 10))
+    Output
+      [1] -10  -5   0   5  10
+
+---
+
+    Code
+      test_breaks("sqrt", limits = c(0, 10))
+    Output
+      [1]  0.0  2.5  5.0  7.5 10.0
 
 # training incorrectly appropriately communicates the offenders
 

--- a/tests/testthat/test-scales.R
+++ b/tests/testthat/test-scales.R
@@ -469,59 +469,24 @@ test_that("numeric scale transforms can produce breaks", {
     scale$get_transformation()$inverse(view$get_breaks())
   }
 
-  expect_equal(test_breaks("asn", limits = c(0, 1)),
-               seq(0, 1, by = 0.25))
-
-  expect_equal(test_breaks("sqrt", limits = c(0, 10)),
-               seq(0, 10, by = 2.5))
-
-  expect_equal(test_breaks("atanh", limits = c(-0.9, 0.9)),
-               c(NA, -0.5, 0, 0.5, NA))
-
-  expect_equal(test_breaks(transform_boxcox(0), limits = c(1, 10)),
-               c(NA, 2.5, 5.0, 7.5, 10))
-
-  expect_equal(test_breaks(transform_modulus(0), c(-10, 10)),
-               seq(-10, 10, by = 5))
-
-  expect_equal(test_breaks(transform_yj(0), c(-10, 10)),
-               seq(-10, 10, by = 5))
-
-  expect_equal(test_breaks("exp", c(-10, 10)),
-               seq(-10, 10, by = 5))
-
-  expect_equal(test_breaks("identity", limits = c(-10, 10)),
-               seq(-10, 10, by = 5))
-
-  # irrational numbers, so snapshot values
+  expect_snapshot(test_breaks("asn", limits = c(0, 1)))
+  expect_snapshot(test_breaks("sqrt", limits = c(0, 10)))
+  expect_snapshot(test_breaks("atanh", limits = c(-0.9, 0.9)))
+  expect_snapshot(test_breaks(transform_boxcox(0), limits = c(1, 10)))
+  expect_snapshot(test_breaks(transform_modulus(0), c(-10, 10)))
+  expect_snapshot(test_breaks(transform_yj(0), c(-10, 10)))
+  expect_snapshot(test_breaks("exp", c(-10, 10)))
+  expect_snapshot(test_breaks("identity", limits = c(-10, 10)))
   expect_snapshot(test_breaks("log", limits = c(0.1, 1000)))
-
-  expect_equal(test_breaks("log10", limits = c(0.1, 1000)),
-               10 ^ seq(-1, 3))
-
-  expect_equal(test_breaks("log2", limits = c(0.5, 32)),
-               c(0.5, 2, 8, 32))
-
-  expect_equal(test_breaks("log1p", limits = c(0, 10)),
-               seq(0, 10, by = 2.5))
-
-  expect_equal(test_breaks("pseudo_log", limits = c(-10, 10)),
-               seq(-10, 10, by = 5))
-
-  expect_equal(test_breaks("logit", limits = c(0.001, 0.999)),
-               c(NA, 0.25, 0.5, 0.75, NA))
-
-  expect_equal(test_breaks("probit", limits = c(0.001, 0.999)),
-               c(NA, 0.25, 0.5, 0.75, NA))
-
-  expect_equal(test_breaks("reciprocal", limits = c(1, 10)),
-               c(NA, 2.5, 5, 7.5, 10))
-
-  expect_equal(test_breaks("reverse", limits = c(-10, 10)),
-               seq(-10, 10, by = 5))
-
-  expect_equal(test_breaks("sqrt", limits = c(0, 10)),
-               seq(0, 10, by = 2.5))
+  expect_snapshot(test_breaks("log10", limits = c(0.1, 1000)))
+  expect_snapshot(test_breaks("log2", limits = c(0.5, 32)))
+  expect_snapshot(test_breaks("log1p", limits = c(0, 10)))
+  expect_snapshot(test_breaks("pseudo_log", limits = c(-10, 10)))
+  expect_snapshot(test_breaks("logit", limits = c(0.001, 0.999)))
+  expect_snapshot(test_breaks("probit", limits = c(0.001, 0.999)))
+  expect_snapshot(test_breaks("reciprocal", limits = c(1, 10)))
+  expect_snapshot(test_breaks("reverse", limits = c(-10, 10)))
+  expect_snapshot(test_breaks("sqrt", limits = c(0, 10)))
 })
 
 test_that("scale functions accurately report their calls", {


### PR DESCRIPTION
This PR fixes an issue discussed off-github.

Briefly, scales 1.4.0 was poised to break ggplot2 because `transform_exp()`'s breaks were improved and broke a test.
This PR makes all the transformation break tests snapshots, which means ggplot2 will not break on CRAN in the future if breaks are further improved.