### PR TITLE
`annotation_raster()/_custom()` respond to scale transformations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # ggplot2 (development version)
 
-* Custom and raster annotation now respond to scale transformations 
-  (@teunbrand based on @yutannihilation's prior work, #3120)
+* Custom and raster annotation now respond to scale transformations, and can
+  use AsIs variables for relative placement (@teunbrand based on 
+  @yutannihilation's prior work, #3120)
 * When discrete breaks have names, they'll be used as labels by default 
   (@teunbrand, #6147).
 * The helper function `is.waiver()` is now exported to help extensions to work

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* Custom and raster annotation now respond to scale transformations 
+  (@teunbrand based on @yutannihilation's prior work, #3120)
 * When discrete breaks have names, they'll be used as labels by default 
   (@teunbrand, #6147).
 * The helper function `is.waiver()` is now exported to help extensions to work

--- a/R/annotation-custom.R
+++ b/R/annotation-custom.R
@@ -70,21 +70,12 @@ GeomCustomAnn <- ggproto("GeomCustomAnn", Geom,
 
   draw_panel = function(data, panel_params, coord, grob, xmin, xmax,
                         ymin, ymax) {
-    if (!inherits(coord, "CoordCartesian")) {
-      cli::cli_abort("{.fn annotation_custom} only works with {.fn coord_cartesian}.")
-    }
-    corners <- data_frame0(
-      x = c(xmin, xmax),
-      y = c(ymin, ymax),
-      .size = 2
+    range <- ranges_annotation(
+      coord, panel_params, c(xmin, xmax), c(ymin, ymax),
+      fun = "annotation_custom"
     )
-    data <- coord$transform(corners, panel_params)
-
-    x_rng <- range(data$x, na.rm = TRUE)
-    y_rng <- range(data$y, na.rm = TRUE)
-
-    vp <- viewport(x = mean(x_rng), y = mean(y_rng),
-                   width = diff(x_rng), height = diff(y_rng),
+    vp <- viewport(x = mean(range$x), y = mean(range$y),
+                   width = diff(range$x), height = diff(range$y),
                    just = c("center","center"))
     editGrob(grob, vp = vp, name = paste(grob$name, annotation_id()))
   },

--- a/R/annotation-custom.R
+++ b/R/annotation-custom.R
@@ -99,3 +99,17 @@ annotation_id <- local({
     i
   }
 })
+
+ranges_annotation <- function(coord, panel_params, x, y, fun) {
+  if (!inherits(coord, "CoordCartesian")) {
+    cli::cli_abort("{.fn {fun}} only works with {.fn coord_cartesian}.")
+  }
+  if (!inherits(x, "AsIs")) {
+    x <- panel_params$x$scale$transform(x)
+  }
+  if (!inherits(y, "AsIs")) {
+    y <- panel_params$y$scale$transform(y)
+  }
+  data <- coord$transform(data_frame0(x = x, y = y, .size = 2), panel_params)
+  list(x = range(data$x, na.rm = TRUE), y = range(data$y, na.rm = TRUE))
+}

--- a/R/annotation-custom.R
+++ b/R/annotation-custom.R
@@ -71,7 +71,7 @@ GeomCustomAnn <- ggproto("GeomCustomAnn", Geom,
   draw_panel = function(data, panel_params, coord, grob, xmin, xmax,
                         ymin, ymax) {
     range <- ranges_annotation(
-      coord, panel_params, c(xmin, xmax), c(ymin, ymax),
+      coord, panel_params, vec_c(xmin, xmax), vec_c(ymin, ymax),
       fun = "annotation_custom"
     )
     vp <- viewport(x = mean(range$x), y = mean(range$y),

--- a/R/annotation-raster.R
+++ b/R/annotation-raster.R
@@ -73,21 +73,13 @@ GeomRasterAnn <- ggproto("GeomRasterAnn", Geom,
 
   draw_panel = function(data, panel_params, coord, raster, xmin, xmax,
                         ymin, ymax, interpolate = FALSE) {
-    if (!inherits(coord, "CoordCartesian")) {
-      cli::cli_abort("{.fn annotation_raster} only works with {.fn coord_cartesian}.")
-    }
-    corners <- data_frame0(
-      x = c(xmin, xmax),
-      y = c(ymin, ymax),
-      .size = 2
+    range <- ranges_annotation(
+      coord, panel_params, c(xmin, xmax), c(ymin, ymax),
+      fun = "annotation_raster"
     )
-    data <- coord$transform(corners, panel_params)
-
-    x_rng <- range(data$x, na.rm = TRUE)
-    y_rng <- range(data$y, na.rm = TRUE)
-
-    rasterGrob(raster, x_rng[1], y_rng[1],
-      diff(x_rng), diff(y_rng), default.units = "native",
-      just = c("left","bottom"), interpolate = interpolate)
+    rasterGrob(raster, range$x[1], range$y[1],
+      diff(range$x), diff(range$y), default.units = "native",
+      just = c("left","bottom"), interpolate = interpolate
+    )
   }
 )

--- a/R/annotation-raster.R
+++ b/R/annotation-raster.R
@@ -74,7 +74,7 @@ GeomRasterAnn <- ggproto("GeomRasterAnn", Geom,
   draw_panel = function(data, panel_params, coord, raster, xmin, xmax,
                         ymin, ymax, interpolate = FALSE) {
     range <- ranges_annotation(
-      coord, panel_params, c(xmin, xmax), c(ymin, ymax),
+      coord, panel_params, vec_c(xmin, xmax), vec_c(ymin, ymax),
       fun = "annotation_raster"
     )
     rasterGrob(raster, range$x[1], range$y[1],

--- a/R/annotation-raster.R
+++ b/R/annotation-raster.R
@@ -74,7 +74,7 @@ GeomRasterAnn <- ggproto("GeomRasterAnn", Geom,
   draw_panel = function(data, panel_params, coord, raster, xmin, xmax,
                         ymin, ymax, interpolate = FALSE) {
     range <- ranges_annotation(
-      coord, panel_params, vec_c(xmin, xmax), vec_c(ymin, ymax),
+      coord, panel_params, xmin, xmax, ymin, ymax,
       fun = "annotation_raster"
     )
     rasterGrob(raster, range$x[1], range$y[1],

--- a/tests/testthat/_snaps/annotate.md
+++ b/tests/testthat/_snaps/annotate.md
@@ -2,14 +2,14 @@
 
     Problem while converting geom to grob.
     i Error occurred in the 1st layer.
-    Caused by error in `draw_panel()`:
+    Caused by error in `ranges_annotation()`:
     ! `annotation_raster()` only works with `coord_cartesian()`.
 
 ---
 
     Problem while converting geom to grob.
     i Error occurred in the 1st layer.
-    Caused by error in `draw_panel()`:
+    Caused by error in `ranges_annotation()`:
     ! `annotation_custom()` only works with `coord_cartesian()`.
 
 # annotation_map() checks the input data

--- a/tests/testthat/test-annotate.R
+++ b/tests/testthat/test-annotate.R
@@ -86,3 +86,32 @@ test_that("annotate() warns about `stat` or `position` arguments", {
     annotate("point", 1:3, 1:3, stat = "density", position = "dodge")
   )
 })
+
+test_that("annotation_custom() and annotation_raster() adhere to scale transforms", {
+  rast <- matrix(rainbow(10), nrow = 1)
+
+  p <- ggplot() +
+    annotation_raster(rast, 1, 10, 1, 9) +
+    scale_x_continuous(transform = "log10", limits = c(0.1, 100), expand = FALSE) +
+    scale_y_continuous(limits = c(0, 10), expand = FALSE)
+  ann <- get_layer_grob(p)[[1]]
+
+  expect_equal(as.numeric(ann$x), 1/3)
+  expect_equal(as.numeric(ann$y), 1/10)
+  expect_equal(as.numeric(ann$width), 1/3)
+  expect_equal(as.numeric(ann$height), 8/10)
+
+  rast <- rasterGrob(rast, width = 1, height = 1)
+
+  p <- ggplot() +
+    annotation_custom(rast, 1, 10, 1, 9) +
+    scale_x_continuous(transform = "log10", limits = c(0.1, 100), expand = FALSE) +
+    scale_y_continuous(limits = c(0, 10), expand = FALSE)
+  ann <- get_layer_grob(p)[[1]]$vp
+
+  expect_equal(as.numeric(ann$x), 1/2)
+  expect_equal(as.numeric(ann$y), 1/2)
+  expect_equal(as.numeric(ann$width), 1/3)
+  expect_equal(as.numeric(ann$height), 8/10)
+
+})


### PR DESCRIPTION
This PR aims to fix #3120 and is incompatible with #3121.

Briefly, it uses the panel parameters to transform the corners of the rectangle used for annotation placement.

To recap some discussion in #3121. The scales should affect the annotation, but not vice versa (i.e., we don't want to train scales on annotations) https://github.com/tidyverse/ggplot2/pull/3121#issuecomment-465171258. The approach of encoding the corners coordinates as aesthetics did affect the scales, so that approach was unsuitable. Instead it was proposed to keep them as parameters and transform them in the drawing stage https://github.com/tidyverse/ggplot2/pull/3121#issuecomment-466220128. In addition, it was proposed to have data agnostic placement as well https://github.com/tidyverse/ggplot2/pull/3121#issuecomment-466221111. #3121 was waiting for #3116 to get implemented, but as this hasn't happened in 5 years, I felt it was time to forge ahead.

This PR implements transformed parameters, so scales are not trained by annotations. In addition, the `I()` mechanism (#5477) is used for data agnostic placement of annotations.

Some examples; plain annotation:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2
rainbow <- matrix(pal_hue()(100), nrow = 1)
p <- ggplot(mtcars, aes(mpg, wt)) +
  geom_point() +
  annotation_raster(rainbow, 15, 20, 3, 4)
p
```

![](https://i.imgur.com/reXzf48.png)<!-- -->

Reversed x:

``` r
p + scale_x_reverse()
```

![](https://i.imgur.com/XaoKDwu.png)<!-- -->

AsIs coordinates:

``` r
ggplot(mtcars, aes(mpg, wt)) +
  geom_point() +
  annotation_raster(rainbow, I(0.3), I(0.7), I(0.1), I(0.9))
```

![](https://i.imgur.com/pEVcvuo.png)<!-- -->

<sup>Created on 2024-11-12 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
