### PR TITLE
Fix regression in `geom_sf()`

### DIFF
--- a/R/geom-sf.R
+++ b/R/geom-sf.R
@@ -231,7 +231,7 @@ GeomSf <- ggproto("GeomSf", Geom,
     point_size[!(is_point | is_collection)] <-
       data$linewidth[!(is_point | is_collection)]
 
-    stroke <- data$stroke * .stroke / 2
+    stroke <- (data$stroke %||% rep(0.5, nrow(data))) * .stroke / 2
     font_size <- point_size * .pt + stroke
 
     linewidth <- data$linewidth * .pt


### PR DESCRIPTION
This PR aims to fix #6189.

Briefly, `ggraph::GeomEdgeSf` did not have a `stroke` aesthetic in `GeomEdgeSf$default_aes`.
That causes some calculations to go awry in `GeomSf$draw_panel()`.
This PR makes a fallback for when `stroke` is missing.

``` r
devtools::load_all("~/packages/ggplot2/")
library(ggraph)

gr <- sfnetworks::as_sfnetwork(sfnetworks::roxel)
ggraph(gr, 'sf') + geom_edge_sf()
```

![](https://i.imgur.com/9ncsoTv.png)<!-- -->

<sup>Created on 2024-11-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
