### PR TITLE
Guide custom order

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # ggplot2 (development version)
 
+* Fixed a bug where the `guide_custom(order)` wasn't working (@teunbrand, #6195)
 * Custom and raster annotation now respond to scale transformations, and can
   use AsIs variables for relative placement (@teunbrand based on 
   @yutannihilation's prior work, #3120)

--- a/R/guides-.R
+++ b/R/guides-.R
@@ -308,8 +308,9 @@ Guides <- ggproto(
       return(no_guides)
     }
 
-    guides$guides <- c(guides$guides, custom$guides)
-    guides$params <- c(guides$params, custom$params)
+    ord <- order(c(names(guides$guides), names(custom$guides)))
+    guides$guides <- c(guides$guides, custom$guides)[ord]
+    guides$params <- c(guides$params, custom$params)[ord]
 
     guides
   },


### PR DESCRIPTION
This PR aims to fix #6195.

Briefly, it applies the `order` argument, which is encoded into the names of guides after the merge step.

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

df <- tibble::tribble(
  ~x, ~y, ~color, ~shape, 
  1, 2, "grey", 1,
  2, 2, "red", 2
) |>
  dplyr::mutate(shape = as.factor(shape))
circle <- grid::circleGrob()
custom <- guide_custom(circle, title = "My circle", order = 1,
                       width = unit(2, "cm"), height = unit(2, "cm"))
color_legend <- guide_legend(order = 3)
shape_legend <- guide_legend(order = 2)

ggplot(df, aes(x, y, color = color, shape = shape)) +
  geom_point() + 
  guides(color = color_legend, 
         shape = shape_legend,
         custom = custom)
```

![](https://i.imgur.com/35Z48TC.png)<!-- -->

<sup>Created on 2024-11-25 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
