### PR TITLE
Fix a minor deprecated warning about `trans` arg

### DIFF
--- a/tests/testthat/test-scale-binned.R
+++ b/tests/testthat/test-scale-binned.R
@@ -47,7 +47,7 @@ test_that("binned limits should not compute out-of-bounds breaks", {
 test_that("binned scales can use limits and transformations simultaneously (#6144)", {
   s <- scale_x_binned(
     limits = function(x) x + 1,
-    trans = transform_log10()
+    transform = transform_log10()
   )
   s$train(c(0, 1)) # c(1, 10) in untransformed space
   out <- s$get_limits()


### PR DESCRIPTION
I see this warning.

```
> devtools::test(filter = "binned")
ℹ Testing ggplot2
✔ | F W  S  OK | Context
✔ |   1     15 | scale-binned                                                                                
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Warning (test-scale-binned.R:48:3): binned scales can use limits and transformations simultaneously (#6144)
The `trans` argument of `binned_scale()` is deprecated as of ggplot2 3.5.0.
i Please use the `transform` argument instead.
Backtrace:
    ▆
 1. └─ggplot2::scale_x_binned(limits = function(x) x + 1, trans = transform_log10()) at test-scale-binned.R:48:3
 2.   └─ggplot2::binned_scale(...) at ggplot2/R/scale-binned.R:34:3
 3.     └─ggplot2:::deprecate_soft0("3.5.0", "binned_scale(trans)", "binned_scale(transform)") at ggplot2/R/scale-.R:307:5
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

══ Results ══════════════════════════════════════════════════════════════════════════════════════════════════
[ FAIL 0 | WARN 1 | SKIP 0 | PASS 15 ]
```