### PR TITLE
Non-orthogonal coords preserve AsIs x/y variables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* In non-orthogonal coordinate systems (`coord_sf()`, `coord_polar()` and 
+  `coord_radial()`), using 'AsIs' variables escape transformation when
+  both `x` and `y` is an 'AsIs' variable (@teunbrand, #6205).
 * Custom and raster annotation now respond to scale transformations, and can
   use AsIs variables for relative placement (@teunbrand based on 
   @yutannihilation's prior work, #3120)

--- a/R/coord-polar.R
+++ b/R/coord-polar.R
@@ -180,6 +180,10 @@ CoordPolar <- ggproto("CoordPolar", Coord,
   },
 
   transform = function(self, data, panel_params) {
+    if (inherits(data$x, "AsIs") && inherits(data$y, "AsIs")) {
+      return(data)
+    }
+
     arc  <- self$start + c(0, 2 * pi)
     dir  <- self$direction
     data <- rename_data(self, data)

--- a/R/coord-radial.R
+++ b/R/coord-radial.R
@@ -275,6 +275,10 @@ CoordRadial <- ggproto("CoordRadial", Coord,
   },
 
   transform = function(self, data, panel_params) {
+    if (inherits(data$x, "AsIs") && inherits(data$y, "AsIs")) {
+      return(data)
+    }
+
     data <- rename_data(self, data)
     bbox <- panel_params$bbox %||% list(x = c(0, 1), y = c(0, 1))
     arc  <- panel_params$arc  %||% c(0, 2 * pi)

--- a/R/coord-sf.R
+++ b/R/coord-sf.R
@@ -77,6 +77,10 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
   },
 
   transform = function(self, data, panel_params) {
+    if (inherits(data$x, "AsIs") && inherits(data$y, "AsIs")) {
+      return(data)
+    }
+
     # we need to transform all non-sf data into the correct coordinate system
     source_crs <- panel_params$default_crs
     target_crs <- panel_params$crs

--- a/tests/testthat/test-coord-polar.R
+++ b/tests/testthat/test-coord-polar.R
@@ -155,6 +155,22 @@ test_that("bounding box calculations are sensible", {
   )
 })
 
+test_that("when both x and y are AsIs, they are not transformed", {
+
+  p <- ggplot() +
+    annotate("text", x = I(0.75), y = I(0.25), label = "foo") +
+    scale_x_continuous(limits = c(0, 10)) +
+    scale_y_continuous(limits = c(0, 10))
+
+  grob <- get_layer_grob(p + coord_polar())[[1]]
+  location <- c(as.numeric(grob$x), as.numeric(grob$y))
+  expect_equal(location, c(0.75, 0.25))
+
+  grob <- get_layer_grob(p + coord_radial())[[1]]
+  location <- c(as.numeric(grob$x), as.numeric(grob$y))
+  expect_equal(location, c(0.75, 0.25))
+
+})
 
 # Visual tests ------------------------------------------------------------
 

--- a/tests/testthat/test-coord_sf.R
+++ b/tests/testthat/test-coord_sf.R
@@ -314,6 +314,22 @@ test_that("sf_transform_xy() works", {
 
 })
 
+test_that("when both x and y are AsIs, they are not transformed", {
+
+  skip_if_not_installed("sf")
+
+  p <- ggplot() +
+    annotate("text", x = I(0.75), y = I(0.25), label = "foo") +
+    scale_x_continuous(limits = c(-180, 180)) +
+    scale_y_continuous(limits = c(-80, 80)) +
+    coord_sf(default_crs = 4326, crs = 3857)
+
+  grob <- get_layer_grob(p)[[1]]
+  location <- c(as.numeric(grob$x), as.numeric(grob$y))
+  expect_equal(location, c(0.75, 0.25))
+
+})
+
 test_that("coord_sf() can use function breaks and n.breaks", {
 
   polygon <- sf::st_sfc(


### PR DESCRIPTION
This PR aims to fix #6205.

Briefly in `coord_sf()`,  `coord_polar/radial()`, the x/y variables are preserved if they both have the 'AsIs' type. I don't think there is a reasonable interpretation if just one of the variables is 'AsIs' and the other is a plain numeric.