### PR TITLE
Polish #6070

### DIFF
--- a/R/coord-.R
+++ b/R/coord-.R
@@ -159,11 +159,13 @@ Coord <- ggproto("Coord",
     empty  <- vapply(guides, inherits, logical(1), "GuideNone")
     guide_params <- panel_params$guides$get_params(aesthetics)
     aesthetics <- aesthetics[!empty]
+    # Guides are not subject to reverse logic
+    temp_params <- modify_list(panel_params, list(reverse = "none"))
 
     guide_params[!empty] <- Map(
       function(guide, guide_param, scale) {
         guide_param <- guide$train(guide_param, scale)
-        guide_param <- guide$transform(guide_param, self, panel_params)
+        guide_param <- guide$transform(guide_param, self, temp_params)
         guide_param <- guide$get_layer_key(guide_param, layers)
         guide_param
       },

--- a/R/coord-cartesian-.R
+++ b/R/coord-cartesian-.R
@@ -102,8 +102,8 @@ CoordCartesian <- ggproto("CoordCartesian", Coord,
     self$range(panel_params)
   },
 
-  transform = function(self, data, panel_params) {
-    reverse <- self$reverse %||% "none"
+  transform = function(data, panel_params) {
+    reverse <- panel_params$reverse %||% "none"
     x <- panel_params$x[[switch(reverse, xy = , x = "reverse", "rescale")]]
     y <- panel_params$y[[switch(reverse, xy = , y = "reverse", "rescale")]]
     data <- transform_position(data, x, y)
@@ -113,7 +113,8 @@ CoordCartesian <- ggproto("CoordCartesian", Coord,
   setup_panel_params = function(self, scale_x, scale_y, params = list()) {
     c(
       view_scales_from_scale(scale_x, self$limits$x, params$expand[c(4, 2)]),
-      view_scales_from_scale(scale_y, self$limits$y, params$expand[c(3, 1)])
+      view_scales_from_scale(scale_y, self$limits$y, params$expand[c(3, 1)]),
+      reverse = self$reverse %||% "none"
     )
   },
 

--- a/R/coord-radial.R
+++ b/R/coord-radial.R
@@ -491,6 +491,7 @@ polar_bbox <- function(arc, margin = c(0.05, 0.05, 0.05, 0.05),
     return(list(x = c(0, 1), y = c(0, 1)))
   }
   arc <- sort(arc)
+  inner_radius <- sort(inner_radius)
 
   # X and Y position of the sector arc ends
   xmax <- 0.5 * sin(arc) + 0.5

--- a/R/coord-sf.R
+++ b/R/coord-sf.R
@@ -86,7 +86,7 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
     target_crs <- panel_params$crs
 
     # CoordSf doesn't use the viewscale rescaling, so we just flip ranges
-    reverse <- self$reverse %||% "none"
+    reverse <- panel_params$reverse %||% "none"
     x_range <- switch(reverse, xy = , x = rev, identity)(panel_params$x_range)
     y_range <- switch(reverse, xy = , y = rev, identity)(panel_params$y_range)
 
@@ -268,7 +268,8 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
       y_range = y_range,
       crs = params$crs,
       default_crs = params$default_crs,
-      !!!viewscales
+      !!!viewscales,
+      reverse = self$reverse %||% "none"
     )
 
     # Rescale graticule for panel grid

--- a/R/coord-transform.R
+++ b/R/coord-transform.R
@@ -134,7 +134,7 @@ CoordTrans <- ggproto("CoordTrans", Coord,
   transform = function(self, data, panel_params) {
     # trans_x() and trans_y() needs to keep Inf values because this can be called
     # in guide_transform.axis()
-    reverse <- self$reverse %||% "none"
+    reverse <- panel_params$reverse %||% "none"
     x_range <- switch(reverse, xy = , x = rev, identity)(panel_params$x.range)
     y_range <- switch(reverse, xy = , y = rev, identity)(panel_params$y.range)
     trans_x <- function(data) {
@@ -159,7 +159,8 @@ CoordTrans <- ggproto("CoordTrans", Coord,
   setup_panel_params = function(self, scale_x, scale_y, params = list()) {
     c(
       view_scales_from_scale_with_coord_trans(scale_x, self$limits$x, self$trans$x, params$expand[c(4, 2)]),
-      view_scales_from_scale_with_coord_trans(scale_y, self$limits$y, self$trans$y, params$expand[c(3, 1)])
+      view_scales_from_scale_with_coord_trans(scale_y, self$limits$y, self$trans$y, params$expand[c(3, 1)]),
+      reverse = self$reverse
     )
   },
 


### PR DESCRIPTION
This PR fixes #6211.

Briefly, a few mistakes crept into #6070, which this PR rectifies.
The `reverse` parameter is now passed along in panel parameters so that we can opt-out for guide calculations.

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

p <- ggplot(mpg, aes(displ, hwy)) +
  geom_point() +
  theme(axis.line = element_line())

p + coord_cartesian(reverse = "xy")
```

![](https://i.imgur.com/1VfBig3.png)<!-- -->

For https://github.com/tidyverse/ggplot2/issues/6211#issuecomment-2517218127, note that plot is now correctly centered and 'hwy' title is placed reasonably.

``` r
p + coord_radial(
  start = 0.25 * pi, end = 0.75 * pi,
  reverse = "thetar", inner.radius = 0.3
)
```

![](https://i.imgur.com/9VzwjxN.png)<!-- -->

<sup>Created on 2024-12-04 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
