### PR TITLE
Tweaks to `map_data()`/fortify.map()`

### DIFF
--- a/R/fortify-map.R
+++ b/R/fortify-map.R
@@ -1,5 +1,8 @@
 #' Fortify method for map objects
 #'
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' This function turns a map into a data frame that can more easily be
 #' plotted with ggplot2.
 #'

--- a/R/fortify-map.R
+++ b/R/fortify-map.R
@@ -24,6 +24,9 @@
 #'   geom_polygon(aes(group = group), colour = "white")
 #' }
 fortify.map <- function(model, data, ...) {
+  lifecycle::deprecate_warn(
+    "3.6.0", I("`fortify(<map>)`"), "map_data()"
+  )
   df <- data_frame0(
     long = model$x,
     lat = model$y,

--- a/R/fortify-map.R
+++ b/R/fortify-map.R
@@ -46,10 +46,10 @@ fortify.map <- function(model, data, ...) {
 #' for plotting with ggplot2.
 #'
 #' @param map name of map provided by the \pkg{maps} package. These
-#'   include [maps::county()], [maps::france()],
-#'   [maps::italy()], [maps::nz()],
-#'   [maps::state()], [maps::usa()],
-#'   [maps::world()], [maps::world2()].
+#'   include [`"county"`][maps::county], [`"france"`][maps::france],
+#'   [`"italy"`][maps::italy], [`"nz"`][maps::nz],
+#'   [`"state"`][maps::state], [`"usa"`][maps::usa],
+#'   [`"world"`][maps::world], or [`"world2"`][maps::world2].
 #' @param region name(s) of subregion(s) to include. Defaults to `.` which
 #'   includes all subregions. See documentation for [maps::map()]
 #'   for more details.

--- a/R/fortify-map.R
+++ b/R/fortify-map.R
@@ -88,7 +88,11 @@ map_data <- function(map, region = ".", exact = FALSE, ...) {
   map_obj <- maps::map(map, region, exact = exact, plot = FALSE, fill = TRUE, ...)
 
   if (!inherits(map_obj, "map")) {
-    return(fortify(map_obj))
+    cli::cli_abort(c(
+      "{.fn maps::map} must return an object of type {.cls map}, not \\
+      {obj_type_friendly(map_obj)}.",
+      i = "Did you pass the right arguments?"
+    ))
   }
 
   df <- data_frame0(

--- a/R/fortify-spatial.R
+++ b/R/fortify-spatial.R
@@ -1,5 +1,8 @@
 #' Fortify method for classes from the sp package.
 #'
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' To figure out the correct variable name for region, inspect
 #' `as.data.frame(model)`.
 #'

--- a/man/fortify.map.Rd
+++ b/man/fortify.map.Rd
@@ -14,6 +14,8 @@
 \item{...}{not used by this method}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
 This function turns a map into a data frame that can more easily be
 plotted with ggplot2.
 }

--- a/man/fortify.sp.Rd
+++ b/man/fortify.sp.Rd
@@ -35,6 +35,8 @@
 \item{...}{not used by this method}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
 To figure out the correct variable name for region, inspect
 \code{as.data.frame(model)}.
 }

--- a/man/map_data.Rd
+++ b/man/map_data.Rd
@@ -8,10 +8,10 @@ map_data(map, region = ".", exact = FALSE, ...)
 }
 \arguments{
 \item{map}{name of map provided by the \pkg{maps} package. These
-include \code{\link[maps:county]{maps::county()}}, \code{\link[maps:france]{maps::france()}},
-\code{\link[maps:italy]{maps::italy()}}, \code{\link[maps:nz]{maps::nz()}},
-\code{\link[maps:state]{maps::state()}}, \code{\link[maps:usa]{maps::usa()}},
-\code{\link[maps:world]{maps::world()}}, \code{\link[maps:world2]{maps::world2()}}.}
+include \code{\link[maps:county]{"county"}}, \code{\link[maps:france]{"france"}},
+\code{\link[maps:italy]{"italy"}}, \code{\link[maps:nz]{"nz"}},
+\code{\link[maps:state]{"state"}}, \code{\link[maps:usa]{"usa"}},
+\code{\link[maps:world]{"world"}}, or \code{\link[maps:world2]{"world2"}}.}
 
 \item{region}{name(s) of subregion(s) to include. Defaults to \code{.} which
 includes all subregions. See documentation for \code{\link[maps:map]{maps::map()}}

--- a/tests/testthat/_snaps/geom-map.md
+++ b/tests/testthat/_snaps/geom-map.md
@@ -6,3 +6,12 @@
 
     `map` must have the columns `x`, `y`, and `id`.
 
+# map_data() checks it input
+
+    Code
+      map_data("world", namesonly = TRUE)
+    Condition
+      Error in `map_data()`:
+      ! `maps::map()` must return an object of type <map>, not a character vector.
+      i Did you pass the right arguments?
+

--- a/tests/testthat/test-geom-map.R
+++ b/tests/testthat/test-geom-map.R
@@ -2,3 +2,8 @@ test_that("geom_map() checks its input", {
   expect_snapshot_error(geom_map(map = letters))
   expect_snapshot_error(geom_map(map = mtcars))
 })
+
+test_that("map_data() checks it input", {
+  skip_if_not_installed("maps")
+  expect_snapshot(map_data("world", namesonly = TRUE), error = TRUE)
+})


### PR DESCRIPTION
This PR aims to fix #3816, close #5469 and fix #3717.

With regards to #3816, this PR checks off the last bullet that `fortify.map()` is deprecated.
WIth regards to #5469, this PR makes the issue obsolete, since we have deprecated all the functions we were considering putting up for adoption.
With regards to #3717 this PR fixes the mislinked `map_data(map)` argument.