### PR TITLE
Missing `contour` parameter defaults to `TRUE`

### DIFF
--- a/R/stat-density-2d.R
+++ b/R/stat-density-2d.R
@@ -143,7 +143,7 @@ StatDensity2d <- ggproto("StatDensity2d", Stat,
     data <- ggproto_parent(Stat, self)$compute_layer(data, params, layout)
 
     # if we're not contouring we're done
-    if (!isTRUE(params$contour)) return(data)
+    if (!isTRUE(params$contour %||% TRUE)) return(data)
 
     # set up data and parameters for contouring
     contour_var <- params$contour_var %||% "density"


### PR DESCRIPTION
This PR aims to fix #5571.

It is a simple fix that just does what the title indicates.

Example from linked issue:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

ggplot() +
  layer(
    geom = GeomDensity2d,
    stat = StatDensity2d,
    data = faithful,
    mapping = aes(x = eruptions, y = waiting),
    position = PositionIdentity,
  )
```

![](https://i.imgur.com/iQax4la.png)<!-- -->

<sup>Created on 2024-12-09 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
