### PR TITLE
Explain how to fix fill guide for points with filled shapes

### DIFF
--- a/R/geom-point.R
+++ b/R/geom-point.R
@@ -85,9 +85,9 @@
 #' ggplot(mtcars, aes(wt, mpg)) +
 #'   geom_point(shape = 21, colour = "black", fill = "white", size = 5, stroke = 5)
 #'
-#' # The default shape used in legends is not filled, so you will need to
-#' # override it in the guide in order to see the fill reflected in the legend
-#' ggplot(mtcars, aes(wt, mpg, fill = factor(carb), shape = factor(cyl), colour = factor(vs))) +
+#' # The default shape in legends is not filled, but you can override the shape
+#' # in the guide to reflect the fill in the legend
+#' ggplot(mtcars, aes(wt, mpg, fill = factor(carb), shape = factor(cyl))) +
 #'   geom_point(size = 5, stroke = 1) +
 #'   scale_shape_manual(values = 21:25) +
 #'   scale_fill_ordinal(guide = guide_legend(override.aes = list(shape = 21)))

--- a/R/geom-point.R
+++ b/R/geom-point.R
@@ -85,6 +85,13 @@
 #' ggplot(mtcars, aes(wt, mpg)) +
 #'   geom_point(shape = 21, colour = "black", fill = "white", size = 5, stroke = 5)
 #'
+#' # The default shape used in legends is not filled, so you will need to
+#' # override it in the guide in order to see the fill reflected in the legend
+#' ggplot(mtcars, aes(wt, mpg, fill = factor(carb), shape = factor(cyl), colour = factor(vs))) +
+#'   geom_point(size = 5, stroke = 1) +
+#'   scale_shape_manual(values = 21:25) +
+#'   scale_fill_ordinal(guide = guide_legend(override.aes = list(shape = 21)))
+#'
 #' \donttest{
 #' # You can create interesting shapes by layering multiple points of
 #' # different sizes

--- a/man/geom_point.Rd
+++ b/man/geom_point.Rd
@@ -182,9 +182,9 @@ d + geom_point(alpha = 1/100)
 ggplot(mtcars, aes(wt, mpg)) +
   geom_point(shape = 21, colour = "black", fill = "white", size = 5, stroke = 5)
 
-# The default shape used in legends is not filled, so you will need to
-# override it in the guide in order to see the fill reflected in the legend
-ggplot(mtcars, aes(wt, mpg, fill = factor(carb), shape = factor(cyl), colour = factor(vs))) +
+# The default shape in legends is not filled, but you can override the shape
+# in the guide to reflect the fill in the legend
+ggplot(mtcars, aes(wt, mpg, fill = factor(carb), shape = factor(cyl))) +
   geom_point(size = 5, stroke = 1) +
   scale_shape_manual(values = 21:25) +
   scale_fill_ordinal(guide = guide_legend(override.aes = list(shape = 21)))

--- a/man/geom_point.Rd
+++ b/man/geom_point.Rd
@@ -182,6 +182,13 @@ d + geom_point(alpha = 1/100)
 ggplot(mtcars, aes(wt, mpg)) +
   geom_point(shape = 21, colour = "black", fill = "white", size = 5, stroke = 5)
 
+# The default shape used in legends is not filled, so you will need to
+# override it in the guide in order to see the fill reflected in the legend
+ggplot(mtcars, aes(wt, mpg, fill = factor(carb), shape = factor(cyl), colour = factor(vs))) +
+  geom_point(size = 5, stroke = 1) +
+  scale_shape_manual(values = 21:25) +
+  scale_fill_ordinal(guide = guide_legend(override.aes = list(shape = 21)))
+
 \donttest{
 # You can create interesting shapes by layering multiple points of
 # different sizes

--- a/vignettes/ggplot2-specs.Rmd
+++ b/vignettes/ggplot2-specs.Rmd
@@ -251,7 +251,7 @@ ggplot(sizes, aes(size, stroke, size = size, stroke = stroke)) +
   scale_size_identity()
 ```
 
-Because most shapes are not filled, mapping the `fill` aesthetic of points is considered an advanced feature. Additional steps may be required to produce sensible results, such as overriding the shape used in the `fill` guide (refer to `geom_point()` for an example of this).
+Because points are not typically filled, you may need to change some default settings when using these shapes and mapping `fill`. In particular, discrete `fill` guides will be drawn with an unfilled shape unless overridden (refer to `geom_point()` for an example of this).
 
 ## Text
 

--- a/vignettes/ggplot2-specs.Rmd
+++ b/vignettes/ggplot2-specs.Rmd
@@ -251,6 +251,8 @@ ggplot(sizes, aes(size, stroke, size = size, stroke = stroke)) +
   scale_size_identity()
 ```
 
+Because most shapes are not filled, mapping the `fill` aesthetic of points is considered an advanced feature. Additional steps may be required to produce sensible results, such as overriding the shape used in the `fill` guide (refer to `geom_point()` for an example of this).
+
 ## Text
 
 ### Font family


### PR DESCRIPTION
Adds an example for `geom_point` and a small note to the relevant part of the specs vignette so there's a better chance of people finding out how to deal with guides for filled shapes. Closes #6177.