### PR TITLE
Fix `geom_ribbon(na.rm)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* `geom_ribbon()` now appropriately warns about, and removes, missing values 
+  (@teunbrand, #6243).
 * `guide_*()` can now accept two inside legend theme elements:
   `legend.position.inside` and `legend.justification.inside`, allowing inside
   legends to be placed at different positions. Only inside legends with the same

--- a/tests/testthat/_snaps/geom-ribbon.md
+++ b/tests/testthat/_snaps/geom-ribbon.md
@@ -23,3 +23,7 @@
 
     `outline.type` must be one of "both", "upper", "lower", or "full", not "test".
 
+# NAs are dropped from the data
+
+    Removed 1 row containing missing values or values outside the scale range (`geom_ribbon()`).
+

--- a/tests/testthat/test-geom-ribbon.R
+++ b/tests/testthat/test-geom-ribbon.R
@@ -13,13 +13,19 @@ test_that("geom_ribbon() checks the aesthetics", {
   expect_snapshot_error(geom_ribbon(aes(year, ymin = level - 5, ymax = level + 5), outline.type = "test"))
 })
 
-test_that("NAs are not dropped from the data", {
+test_that("NAs are dropped from the data", {
   df <- data_frame(x = 1:5, y = c(1, 1, NA, 1, 1))
 
   p <- ggplot(df, aes(x))+
     geom_ribbon(aes(ymin = y - 1, ymax = y + 1))
+  p <- ggplot_build(p)
 
   expect_equal(get_layer_data(p)$ymin, c(0, 0, NA, 0, 0))
+  expect_snapshot_warning(
+    grob <- get_layer_grob(p)[[1]]
+  )
+  # We expect the ribbon to be broken up into 2 parts
+  expect_length(grob$children, 2)
 })
 
 test_that("geom_ribbon works in both directions", {


### PR DESCRIPTION
This PR aims to fix #6243.

Briefly, missing values are thrown out and warn about when `na.rm = FALSE`.
The warning is skipped when `na.rm = TRUE` but missing values are thrown out.
When throwing out missing values, the `group` aesthetic is reformed so that groups with NA values break up into new uninterrupted groups.

Reprex from issue, note gradient is uniform now:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

df <- data.frame(
  x = c(1:3, 1:3),
  ymin = c(1, 1, 1, NA, 2, 2),
  ymax = c(1.5, 2, 1.5, 2.5, 3, 2.5),
  group = c(1,1,1,2,2,2)
)

ggplot(df, aes(x, ymin = ymin, ymax = ymax, group = group, fill = x)) +
  geom_ribbon() +
  scale_fill_viridis_c()
#> Warning: Removed 1 row containing missing values or values outside the scale range
#> (`geom_ribbon()`).
```

![](https://i.imgur.com/cJHVSf8.png)<!-- -->

<sup>Created on 2024-12-17 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
