### PR TITLE
:memo: Tweak docs for `lims()`

### DIFF
--- a/R/limits.R
+++ b/R/limits.R
@@ -4,7 +4,9 @@
 #' scales. By default, any values outside the limits specified are replaced with
 #' `NA`. Be warned that this will remove data outside the limits and this can
 #' produce unintended results. For changing x or y axis limits \strong{without}
-#' dropping data observations, see [coord_cartesian()].
+#' dropping data observations, see
+#' [`coord_cartesian(xlim, ylim)`][coord_cartesian], or use a full scale with
+#' [`oob = scales::oob_keep`][scales::oob_keep].
 #'
 #' @param ... For `xlim()` and `ylim()`: Two numeric values, specifying the left/lower
 #'  limit and the right/upper limit of the scale. If the larger value is given first,

--- a/man/lims.Rd
+++ b/man/lims.Rd
@@ -31,7 +31,9 @@ This is a shortcut for supplying the \code{limits} argument to the individual
 scales. By default, any values outside the limits specified are replaced with
 \code{NA}. Be warned that this will remove data outside the limits and this can
 produce unintended results. For changing x or y axis limits \strong{without}
-dropping data observations, see \code{\link[=coord_cartesian]{coord_cartesian()}}.
+dropping data observations, see
+\code{\link[=coord_cartesian]{coord_cartesian(xlim, ylim)}}, or use a full scale with
+\code{\link[scales:oob]{oob = scales::oob_keep}}.
 }
 \examples{
 # Zoom into a specified area


### PR DESCRIPTION
This PR aims to fix #5148.
It more clearly points out out-of-bounds handling options.