### PR TITLE
Document guide theme argument

### DIFF
--- a/R/guide-axis.R
+++ b/R/guide-axis.R
@@ -6,6 +6,9 @@
 #' [scale_(x|y)_discrete()][scale_x_discrete()].
 #'
 #' @inheritParams guide_legend
+#' @param theme A [`theme`][theme()] object to style the guide individually or
+#'   differently from the plot's theme settings. The `theme` argument in the
+#'   guide partially overrides, and is combined with, the plot's theme.
 #' @param check.overlap silently remove overlapping labels,
 #'   (recursively) prioritizing the first, last, and middle labels.
 #' @param angle Compared to setting the angle in [theme()] / [element_text()],

--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -15,7 +15,11 @@
 #'   specified in [labs()] is used for the title.
 #' @param theme A [`theme`][theme()] object to style the guide individually or
 #'   differently from the plot's theme settings. The `theme` argument in the
-#'   guide overrides, and is combined with, the plot's theme.
+#'   guide partially overrides, and is combined with, the plot's theme.
+#'   Arguments that apply to a single legend are respected, most of which have
+#'   the `legend`-prefix. Arguments that apply to combined legends
+#'   (the legend box) are ignored, including `legend.position`,
+#'   `legend.justification.*`, `legend.location` and `legend.box.*`.
 #' @param position A character string indicating where the legend should be
 #'   placed relative to the plot panels.
 #' @param direction  A character string indicating the direction of the guide.

--- a/man/guide_axis.Rd
+++ b/man/guide_axis.Rd
@@ -24,7 +24,7 @@ specified in \code{\link[=labs]{labs()}} is used for the title.}
 
 \item{theme}{A \code{\link[=theme]{theme}} object to style the guide individually or
 differently from the plot's theme settings. The \code{theme} argument in the
-guide overrides, and is combined with, the plot's theme.}
+guide partially overrides, and is combined with, the plot's theme.}
 
 \item{check.overlap}{silently remove overlapping labels,
 (recursively) prioritizing the first, last, and middle labels.}

--- a/man/guide_axis_logticks.Rd
+++ b/man/guide_axis_logticks.Rd
@@ -51,7 +51,7 @@ and \code{FALSE} are shorthand for \code{"both"} and \code{"none"} respectively.
 
 \item{theme}{A \code{\link[=theme]{theme}} object to style the guide individually or
 differently from the plot's theme settings. The \code{theme} argument in the
-guide overrides, and is combined with, the plot's theme.}
+guide partially overrides, and is combined with, the plot's theme.}
 
 \item{prescale_base, negative_small, short_theme}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}}
 

--- a/man/guide_axis_stack.Rd
+++ b/man/guide_axis_stack.Rd
@@ -30,7 +30,7 @@ specified in \code{\link[=labs]{labs()}} is used for the title.}
 
 \item{theme}{A \code{\link[=theme]{theme}} object to style the guide individually or
 differently from the plot's theme settings. The \code{theme} argument in the
-guide overrides, and is combined with, the plot's theme.}
+guide partially overrides, and is combined with, the plot's theme.}
 
 \item{spacing}{A \code{\link[=unit]{unit()}} objects that determines how far separate guides are
 spaced apart.}

--- a/man/guide_axis_theta.Rd
+++ b/man/guide_axis_theta.Rd
@@ -22,7 +22,7 @@ specified in \code{\link[=labs]{labs()}} is used for the title.}
 
 \item{theme}{A \code{\link[=theme]{theme}} object to style the guide individually or
 differently from the plot's theme settings. The \code{theme} argument in the
-guide overrides, and is combined with, the plot's theme.}
+guide partially overrides, and is combined with, the plot's theme.}
 
 \item{angle}{Compared to setting the angle in \code{\link[=theme]{theme()}} / \code{\link[=element_text]{element_text()}},
 this also uses some heuristics to automatically pick the \code{hjust} and \code{vjust} that

--- a/man/guide_bins.Rd
+++ b/man/guide_bins.Rd
@@ -25,7 +25,11 @@ specified in \code{\link[=labs]{labs()}} is used for the title.}
 
 \item{theme}{A \code{\link[=theme]{theme}} object to style the guide individually or
 differently from the plot's theme settings. The \code{theme} argument in the
-guide overrides, and is combined with, the plot's theme.}
+guide partially overrides, and is combined with, the plot's theme.
+Arguments that apply to a single legend are respected, most of which have
+the \code{legend}-prefix. Arguments that apply to combined legends
+(the legend box) are ignored, including \code{legend.position},
+\verb{legend.justification.*}, \code{legend.location} and \verb{legend.box.*}.}
 
 \item{angle}{Overrules the theme settings to automatically apply appropriate
 \code{hjust} and \code{vjust} for angled legend text. Can be a single number

--- a/man/guide_colourbar.Rd
+++ b/man/guide_colourbar.Rd
@@ -49,7 +49,11 @@ specified in \code{\link[=labs]{labs()}} is used for the title.}
 
 \item{theme}{A \code{\link[=theme]{theme}} object to style the guide individually or
 differently from the plot's theme settings. The \code{theme} argument in the
-guide overrides, and is combined with, the plot's theme.}
+guide partially overrides, and is combined with, the plot's theme.
+Arguments that apply to a single legend are respected, most of which have
+the \code{legend}-prefix. Arguments that apply to combined legends
+(the legend box) are ignored, including \code{legend.position},
+\verb{legend.justification.*}, \code{legend.location} and \verb{legend.box.*}.}
 
 \item{nbin}{A numeric specifying the number of bins for drawing the
 colourbar. A smoother colourbar results from a larger value.}

--- a/man/guide_coloursteps.Rd
+++ b/man/guide_coloursteps.Rd
@@ -43,7 +43,11 @@ specified in \code{\link[=labs]{labs()}} is used for the title.}
 
 \item{theme}{A \code{\link[=theme]{theme}} object to style the guide individually or
 differently from the plot's theme settings. The \code{theme} argument in the
-guide overrides, and is combined with, the plot's theme.}
+guide partially overrides, and is combined with, the plot's theme.
+Arguments that apply to a single legend are respected, most of which have
+the \code{legend}-prefix. Arguments that apply to combined legends
+(the legend box) are ignored, including \code{legend.position},
+\verb{legend.justification.*}, \code{legend.location} and \verb{legend.box.*}.}
 
 \item{alpha}{A numeric between 0 and 1 setting the colour transparency of
 the bar. Use \code{NA} to preserve the alpha encoded in the colour itself

--- a/man/guide_custom.Rd
+++ b/man/guide_custom.Rd
@@ -25,7 +25,11 @@ If \code{NULL} (default), no title is shown.}
 
 \item{theme}{A \code{\link[=theme]{theme}} object to style the guide individually or
 differently from the plot's theme settings. The \code{theme} argument in the
-guide overrides, and is combined with, the plot's theme.}
+guide partially overrides, and is combined with, the plot's theme.
+Arguments that apply to a single legend are respected, most of which have
+the \code{legend}-prefix. Arguments that apply to combined legends
+(the legend box) are ignored, including \code{legend.position},
+\verb{legend.justification.*}, \code{legend.location} and \verb{legend.box.*}.}
 
 \item{position}{A character string indicating where the legend should be
 placed relative to the plot panels.}

--- a/man/guide_legend.Rd
+++ b/man/guide_legend.Rd
@@ -25,7 +25,11 @@ specified in \code{\link[=labs]{labs()}} is used for the title.}
 
 \item{theme}{A \code{\link[=theme]{theme}} object to style the guide individually or
 differently from the plot's theme settings. The \code{theme} argument in the
-guide overrides, and is combined with, the plot's theme.}
+guide partially overrides, and is combined with, the plot's theme.
+Arguments that apply to a single legend are respected, most of which have
+the \code{legend}-prefix. Arguments that apply to combined legends
+(the legend box) are ignored, including \code{legend.position},
+\verb{legend.justification.*}, \code{legend.location} and \verb{legend.box.*}.}
 
 \item{position}{A character string indicating where the legend should be
 placed relative to the plot panels.}


### PR DESCRIPTION
This PR aims to fix #6263.

Briefly, it states which theme arguments are ignored by individual (non-position) guides.