### PR TITLE
Fix typo in coord_radial documentation

### DIFF
--- a/R/coord-radial.R
+++ b/R/coord-radial.R
@@ -4,7 +4,7 @@
 #' @param end Position from 12 o'clock in radians where plot ends, to allow
 #'   for partial polar coordinates. The default, `NULL`, is set to
 #'   `start + 2 * pi`.
-#' @param expand If `TRUE`, the default, adds a small expansion factor the
+#' @param expand If `TRUE`, the default, adds a small expansion factor to
 #'   the limits to prevent overlap between data and axes. If `FALSE`, limits
 #'   are taken directly from the scale.
 #' @param r.axis.inside One of the following:

--- a/man/coord_polar.Rd
+++ b/man/coord_polar.Rd
@@ -38,7 +38,7 @@ means no. For details, please see \code{\link[=coord_cartesian]{coord_cartesian(
 for partial polar coordinates. The default, \code{NULL}, is set to
 \code{start + 2 * pi}.}
 
-\item{expand}{If \code{TRUE}, the default, adds a small expansion factor the
+\item{expand}{If \code{TRUE}, the default, adds a small expansion factor to
 the limits to prevent overlap between data and axes. If \code{FALSE}, limits
 are taken directly from the scale.}
 


### PR DESCRIPTION
Fix minor typo in coord_radial documentation. Closes #6276.