### PR TITLE
🚑 Fix for revdep problem with adding `NULL` to theme

### DIFF
--- a/R/guides-.R
+++ b/R/guides-.R
@@ -546,7 +546,8 @@ Guides <- ggproto(
           legend.justification.inside = groups$key$justs[[i]]
         )
       }
-      grobs[[i]] <- self$package_box(grobs[[i]], position, theme + adjust)
+      adjust <- add_theme(theme, adjust, "internal theme settings")
+      grobs[[i]] <- self$package_box(grobs[[i]], position, adjust)
     }
 
     # merge inside grobs into single gtable

--- a/R/guides-.R
+++ b/R/guides-.R
@@ -479,7 +479,7 @@ Guides <- ggproto(
     if (length(default_position) == 2) {
       default_position <- "inside"
     }
-    if (default_position == "none") {
+    if (!default_position %in% c(.trbl, "inside")) {
       return(zeroGrob())
     }
 
@@ -598,11 +598,7 @@ Guides <- ggproto(
     }
 
     # Determine default direction
-    direction <- switch(
-      position,
-      inside = , left = , right = "vertical",
-      top = , bottom = "horizontal"
-    )
+    direction <- switch(position, top = , bottom = "horizontal", "vertical")
 
     # Populate missing theme arguments
     theme$legend.box       <- theme$legend.box       %||% direction


### PR DESCRIPTION
This PR aims to fix #6291.

Briefly it circumvents the `+` dispatch by using `add_theme()` directly.
In addition, contains a small failsafe for when `theme(legend.position)` is not recognised.