### PR TITLE
🚑 Repair layer names that might have become lost

### DIFF
--- a/R/plot-construction.R
+++ b/R/plot-construction.R
@@ -195,13 +195,20 @@ ggplot_add.by <- function(object, plot, object_name) {
 
 #' @export
 ggplot_add.Layer <- function(object, plot, object_name) {
-  layers_names <- new_layer_names(object, names(plot$layers))
+  layers_names <- new_layer_names(object, names2(plot$layers))
   plot$layers <- append(plot$layers, object)
   names(plot$layers) <- layers_names
   plot
 }
 
 new_layer_names <- function(layer, existing) {
+
+  empty <- !nzchar(existing)
+  if (any(empty)) {
+    existing[empty] <- "unknown"
+    existing <- vec_as_names(existing, repair = "unique", quiet = TRUE)
+  }
+
   new_name <- layer$name
   if (is.null(new_name)) {
     # Construct a name from the layer's call


### PR DESCRIPTION
This PR aims to fix #6295.

It bequeaths the 'unknown' name upon layers that have lost their names.
Reprex from issue:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

p <- ggplot(mpg, aes(displ, hwy)) +
  geom_point()

# To wipe out names
p$layers <- list(geom_path(), geom_path())
p <- p + geom_point() + geom_point()
names(p$layers)
#> [1] "unknown...1"    "unknown...2"    "geom_point"     "geom_point...4"
```

<sup>Created on 2025-01-22 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
