### PR TITLE
🚑 Amend clause in #6244

### DIFF
--- a/R/geom-ribbon.R
+++ b/R/geom-ribbon.R
@@ -132,7 +132,7 @@ GeomRibbon <- ggproto("GeomRibbon", Geom,
       strsplit(self$required_aes, "|", fixed = TRUE),
       `[[`, i = 1, character(1)
     )
-    if (params$flipped_aes || any(data$flipped_aes) %||% FALSE) {
+    if (isTRUE(params$flipped_aes || any(data$flipped_aes) %||% FALSE)) {
       vars <- switch_orientation(vars)
     }
     vars <- c(vars, self$non_missing_aes)


### PR DESCRIPTION
This PR aims to fix an issue uncovered in #6287.

Briefly, in some extension packages an if-statement might have length other than 1. This PR asks for exactly length 1.