### PR TITLE
🚑 Give default value to `Guides$build(theme)`

### DIFF
--- a/R/guides-.R
+++ b/R/guides-.R
@@ -274,7 +274,7 @@ Guides <- ggproto(
   #
   # The resulting guide is then drawn in ggplot_gtable
 
-  build = function(self, scales, layers, labels, layer_data, theme) {
+  build = function(self, scales, layers, labels, layer_data, theme = theme()) {
 
     # Empty guides list
     custom <- self$get_custom()


### PR DESCRIPTION
This PR aims to fix an issue identified in #6287.

Briefly, some packages implement `ggplot_build()` methods. We added a `theme` argument to `Guides$build()`, which is now causing complaints about missing arguments in reverse dependencies. This PR provides a fallback for when the extension's `ggplot_build()` method does not support the new guide building yet.