### PR TITLE
🩹 Don't warn when fatten is absent

### DIFF
--- a/R/geom-crossbar.R
+++ b/R/geom-crossbar.R
@@ -60,7 +60,7 @@ geom_crossbar <- function(mapping = NULL, data = NULL,
 #' @export
 GeomCrossbar <- ggproto("GeomCrossbar", Geom,
   setup_params = function(data, params) {
-    if (lifecycle::is_present(params$fatten)) {
+    if (lifecycle::is_present(params$fatten %||% deprecated())) {
       deprecate_soft0(
         "3.6.0", "geom_crossbar(fatten)",
         "geom_crossbar(middle.linewidth)"

--- a/R/geom-pointrange.R
+++ b/R/geom-pointrange.R
@@ -42,7 +42,7 @@ GeomPointrange <- ggproto("GeomPointrange", Geom,
   required_aes = c("x", "y", "ymin|xmin", "ymax|xmax"),
 
   setup_params = function(data, params) {
-    if (lifecycle::is_present(params$fatten)) {
+    if (lifecycle::is_present(params$fatten %||% deprecated())) {
       deprecate_soft0("3.6.0", "geom_pointrange(fatten)", I("the `size` aesthetic"))
     } else {
       # For backward compatibility reasons


### PR DESCRIPTION
This PR amends #6238.

Briefly: it prevents a bunch of false positive warnings about the `fatten` parameters.

In some details; `lifecycle::is_present(params$fatten)` was evaluated as `TRUE` when fatten was absent and `params$fatten` returns `NULL`. This caused a bunch of false-positive deprecation warnings in stats that has `geom = "crossbar"` or `geom = "pointrange"`, like `stat_summary_bin()`.