### PR TITLE
:bug: Avoid mapping AsIs variables to mapped_discrete class in discrete scales

### DIFF
--- a/R/scale-discrete-.R
+++ b/R/scale-discrete-.R
@@ -153,6 +153,9 @@ ScaleDiscretePosition <- ggproto("ScaleDiscretePosition", ScaleDiscrete,
   },
 
   map = function(self, x, limits = self$get_limits()) {
+    if (inherits(x, "AsIs")) {
+      return(x)
+    }
     if (is.discrete(x)) {
       values <- self$palette(length(limits))
       if (!is.numeric(values)) {


### PR DESCRIPTION
This PR aims to fix #6308.

From https://github.com/tidyverse/ggplot2/issues/6308#issuecomment-2621535954:

> Where the scale maps AsIs variables to the <mapped_discrete> class, thereby skipping the rescale.AsIs method.

This PR no longer maps AsIs variables to the `<mapped_discrete>` class.