### PR TITLE
Bump level of panel grid blanknness in `theme_classic()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -270,8 +270,11 @@
   is setup once in total instead of once per group (@teunbrand, #5971)
 * `facet_grid(space = "free")` can now be combined with `coord_fixed()` 
   (@teunbrand, #4584).
-* `theme_classic()` now has black ticks and text instead of dark gray. In 
-  addition, `theme_classic()`'s axis line end is `"square"` (@teunbrand, #5978).
+* `theme_classic()` has the following changes (@teunbrand, #5978 & #6320):
+    * Axis ticks are now black (`ink`-coloured) instead of dark gray.
+    * Axis line ends are now `"square"`.
+    * The panel grid is now blank at the `panel.grid` hierarchy level instead of 
+    the `panel.grid.major` and `panel.grid.minor` levels.
 * {tibble} is now suggested instead of imported (@teunbrand, #5986)
 * The ellipsis argument is now checked in `fortify()`, `get_alt_text()`, 
   `labs()` and several guides (@teunbrand, #3196).

--- a/R/theme-defaults.R
+++ b/R/theme-defaults.R
@@ -495,9 +495,8 @@ theme_classic <- function(base_size = 11, base_family = "",
   ) %+replace%
     theme(
       # no background and no grid
-      panel.border     = element_blank(),
-      panel.grid.major = element_blank(),
-      panel.grid.minor = element_blank(),
+      panel.border = element_blank(),
+      panel.grid   = element_blank(),
 
       # show axes
       axis.text  = element_text(size = rel(0.8)),


### PR DESCRIPTION
This PR aims to fix #6320.

Instead of setting `panel.grid.major` and `panel.grid.minor` to blank, we set the parent `panel.grid` to blank.

Reprex from issue:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

p <- ggplot(mpg, aes(displ, hwy)) +
  geom_point() +
  theme_classic()

p + theme(panel.grid = element_line(colour = "limegreen"))
```

![](https://i.imgur.com/d6NNS0g.png)<!-- -->

<sup>Created on 2025-02-05 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
