### PR TITLE
Skip annotation labels

### DIFF
--- a/R/aes.R
+++ b/R/aes.R
@@ -360,7 +360,7 @@ aes_all <- function(vars) {
   # refer to the data mask
   structure(
     lapply(vars, function(x) new_quosure(as.name(x), emptyenv())),
-    class = "uneval"
+    class = c("unlabelled_uneval", "uneval")
   )
 }
 

--- a/R/labels.R
+++ b/R/labels.R
@@ -24,10 +24,16 @@ setup_plot_labels <- function(plot, layers, data) {
   # Find labels from every layer
   for (i in seq_along(layers)) {
     layer <- layers[[i]]
-    exclude <- names(layer$aes_params)
+
     mapping <- layer$computed_mapping
+    if (inherits(mapping, "unlabelled_uneval")) {
+      next
+    }
+
     mapping <- strip_stage(mapping)
     mapping <- strip_dots(mapping, strip_pronoun = TRUE)
+
+    exclude <- names(layer$aes_params)
     mapping <- mapping[setdiff(names(mapping), exclude)]
 
     # Acquire default labels

--- a/R/layer.R
+++ b/R/layer.R
@@ -210,6 +210,8 @@ validate_mapping <- function(mapping, call = caller_env()) {
     }
 
     cli::cli_abort(msg, call = call)
+  } else {
+    return(mapping)
   }
 
   # For backward compatibility with pre-tidy-eval layers

--- a/tests/testthat/test-labels.R
+++ b/tests/testthat/test-labels.R
@@ -83,6 +83,13 @@ test_that("Labels from static aesthetics are ignored (#6003)", {
   expect_null(get_labs(p)$colour)
 })
 
+test_that("Labels from annotations are ignored (#6316)", {
+  df <- data.frame(a = 1, b = 2)
+  p <- ggplot(df, aes(a, b)) + annotate("point", x = 1, y = 2) + geom_point()
+  labs <- get_labs(p)
+  expect_equal(labs[c("x", "y")], list(x = "a", y = "b"))
+})
+
 test_that("alt text is returned", {
   p <- ggplot(mtcars, aes(mpg, disp)) +
     geom_point()


### PR DESCRIPTION
This PR aims to fix #6316.

Briefly, it skips label extraction when the mapping was constructed using the `aes_all()` function. This is communicated through a subclass. The layers from `annotation()` and `expand_limits()` functions are thereby not contributing to labels.