### PR TITLE
Align `stat_bin(drop)` with meaning

### DIFF
--- a/R/stat-bin.R
+++ b/R/stat-bin.R
@@ -133,7 +133,7 @@ StatBin <- ggproto("StatBin", Stat,
   compute_group = function(data, scales, binwidth = NULL, bins = NULL,
                            center = NULL, boundary = NULL,
                            closed = c("right", "left"), pad = FALSE,
-                           breaks = NULL, flipped_aes = FALSE, drop = "all",
+                           breaks = NULL, flipped_aes = FALSE, drop = "none",
                            # The following arguments are not used, but must
                            # be listed so parameters are computed correctly
                            origin = NULL, right = NULL) {

--- a/R/stat-bin.R
+++ b/R/stat-bin.R
@@ -26,10 +26,10 @@
 #'   or left edges of bins are included in the bin.
 #' @param pad If `TRUE`, adds empty bins at either end of x. This ensures
 #'   frequency polygons touch 0. Defaults to `FALSE`.
-#' @param drop Treatment of zero count bins. If `"all"` (default), such
-#'   bins are kept as-is. If `"none"`, all zero count bins are filtered out.
-#'   If `"inner"` only zero count bins at the flanks are filtered out, but not
-#'   in the middle. `TRUE` is shorthand for `"all"` and `FALSE` is shorthand
+#' @param drop Treatment of zero count bins. If `"none"` (default), such
+#'   bins are kept as-is. If `"all"`, all zero count bins are filtered out.
+#'   If `"extremes"` only zero count bins at the flanks are filtered out, but
+#'   not in the middle. `TRUE` is shorthand for `"all"` and `FALSE` is shorthand
 #'   for `"none"`.
 #' @eval rd_computed_vars(
 #'   count    = "number of points in bin.",
@@ -100,9 +100,10 @@ StatBin <- ggproto("StatBin", Stat,
     if (is.logical(params$drop)) {
       params$drop <- if (isTRUE(params$drop)) "all" else "none"
     }
+    drop <- params$drop
     params$drop <- arg_match0(
-      params$drop %||% "all",
-      c("all", "none", "inner"), arg_nm = "drop"
+      params$drop %||% "none",
+      c("all", "none", "extremes"), arg_nm = "drop"
     )
 
     has_x <- !(is.null(data$x) && is.null(params$x))
@@ -146,8 +147,8 @@ StatBin <- ggproto("StatBin", Stat,
 
     keep <- switch(
       drop,
-      none  = bins$count != 0,
-      inner = inner_runs(bins$count != 0),
+      all = bins$count != 0,
+      extremes = inner_runs(bins$count != 0),
       TRUE
     )
     bins <- vec_slice(bins, keep)

--- a/R/stat-bin.R
+++ b/R/stat-bin.R
@@ -60,7 +60,7 @@ stat_bin <- function(mapping = NULL, data = NULL,
                      closed = c("right", "left"),
                      pad = FALSE,
                      na.rm = FALSE,
-                     drop = "all",
+                     drop = "none",
                      orientation = NA,
                      show.legend = NA,
                      inherit.aes = TRUE) {

--- a/man/geom_histogram.Rd
+++ b/man/geom_histogram.Rd
@@ -46,7 +46,7 @@ stat_bin(
   closed = c("right", "left"),
   pad = FALSE,
   na.rm = FALSE,
-  drop = "all",
+  drop = "none",
   orientation = NA,
   show.legend = NA,
   inherit.aes = TRUE

--- a/man/geom_histogram.Rd
+++ b/man/geom_histogram.Rd
@@ -174,10 +174,10 @@ or left edges of bins are included in the bin.}
 \item{pad}{If \code{TRUE}, adds empty bins at either end of x. This ensures
 frequency polygons touch 0. Defaults to \code{FALSE}.}
 
-\item{drop}{Treatment of zero count bins. If \code{"all"} (default), such
-bins are kept as-is. If \code{"none"}, all zero count bins are filtered out.
-If \code{"inner"} only zero count bins at the flanks are filtered out, but not
-in the middle. \code{TRUE} is shorthand for \code{"all"} and \code{FALSE} is shorthand
+\item{drop}{Treatment of zero count bins. If \code{"none"} (default), such
+bins are kept as-is. If \code{"all"}, all zero count bins are filtered out.
+If \code{"extremes"} only zero count bins at the flanks are filtered out, but
+not in the middle. \code{TRUE} is shorthand for \code{"all"} and \code{FALSE} is shorthand
 for \code{"none"}.}
 }
 \description{

--- a/tests/testthat/test-stat-bin.R
+++ b/tests/testthat/test-stat-bin.R
@@ -122,13 +122,13 @@ test_that("stat_bin(drop) options work as intended", {
   p <- ggplot(data.frame(x = c(1, 2, 2, 3, 5, 6, 6, 7)), aes(x)) +
     scale_x_continuous(limits = c(-1, 9))
 
-  ld <- layer_data(p + geom_histogram(binwidth = 1, drop = "all"))
+  ld <- layer_data(p + geom_histogram(binwidth = 1, drop = "none"))
   expect_equal(ld$x, -1:9)
 
-  ld <- layer_data(p + geom_histogram(binwidth = 1, drop = "inner"))
+  ld <- layer_data(p + geom_histogram(binwidth = 1, drop = "extremes"))
   expect_equal(ld$x, c(1:7))
 
-  ld <- layer_data(p + geom_histogram(binwidth = 1, drop = "none"))
+  ld <- layer_data(p + geom_histogram(binwidth = 1, drop = "all"))
   expect_equal(ld$x, c(1:3, 5:7))
 })
 


### PR DESCRIPTION
This PR amends #6212 and also fixes #5118.

Briefly, #6212 repurposed the `keep.zeroes` argument to `drop`, but I forgot to invert the logic as well. This PR ensures that the interpretation is consistent and that `drop = TRUE` removes empty bins and `drop = FALSE` keeps them.
The fix for #5118 comes from being able to control the warning at the root of the issue. 