### PR TITLE
Document vector passing to nudge_y/nudge_x/position_nudge

### DIFF
--- a/R/position-nudge.R
+++ b/R/position-nudge.R
@@ -31,7 +31,7 @@
 #' # For each text individually
 #' ggplot(df, aes(x, y)) +
 #'   geom_point() +
-#'   geom_text(aes(label = y), nudge_y = c(-0.1, 0.1, -0.1, 0.1))
+#'   geom_text(aes(label = y, nudge_y = c(-0.1, 0.1, -0.1, 0.1)))
 position_nudge <- function(x = NULL, y = NULL) {
   ggproto(NULL, PositionNudge,
     x = x,

--- a/R/position-nudge.R
+++ b/R/position-nudge.R
@@ -27,6 +27,11 @@
 #' ggplot(df, aes(x, y)) +
 #'   geom_point() +
 #'   geom_text(aes(label = y), nudge_y = -0.1)
+#'
+#' # For each text individually
+#' ggplot(df, aes(x, y)) +
+#'   geom_point() +
+#'   geom_text(aes(label = y), nudge_y = c(-0.1, 0.1, -0.1, 0.1))
 position_nudge <- function(x = NULL, y = NULL) {
   ggproto(NULL, PositionNudge,
     x = x,

--- a/man/hmisc.Rd
+++ b/man/hmisc.Rd
@@ -29,10 +29,10 @@ These are wrappers around functions from \pkg{Hmisc} designed to make them
 easier to use with \code{\link[=stat_summary]{stat_summary()}}. See the Hmisc documentation
 for more details:
 \itemize{
-\item \code{\link[Hmisc:smean.sd]{Hmisc::smean.cl.boot()}}
-\item \code{\link[Hmisc:smean.sd]{Hmisc::smean.cl.normal()}}
-\item \code{\link[Hmisc:smean.sd]{Hmisc::smean.sdl()}}
-\item \code{\link[Hmisc:smean.sd]{Hmisc::smedian.hilow()}}
+\item \code{\link[Hmisc:smean.cl.boot]{Hmisc::smean.cl.boot()}}
+\item \code{\link[Hmisc:smean.cl.normal]{Hmisc::smean.cl.normal()}}
+\item \code{\link[Hmisc:smean.sdl]{Hmisc::smean.sdl()}}
+\item \code{\link[Hmisc:smedian.hilow]{Hmisc::smedian.hilow()}}
 }
 }
 \examples{

--- a/man/hmisc.Rd
+++ b/man/hmisc.Rd
@@ -29,10 +29,10 @@ These are wrappers around functions from \pkg{Hmisc} designed to make them
 easier to use with \code{\link[=stat_summary]{stat_summary()}}. See the Hmisc documentation
 for more details:
 \itemize{
-\item \code{\link[Hmisc:smean.cl.boot]{Hmisc::smean.cl.boot()}}
-\item \code{\link[Hmisc:smean.cl.normal]{Hmisc::smean.cl.normal()}}
-\item \code{\link[Hmisc:smean.sdl]{Hmisc::smean.sdl()}}
-\item \code{\link[Hmisc:smedian.hilow]{Hmisc::smedian.hilow()}}
+\item \code{\link[Hmisc:smean.sd]{Hmisc::smean.cl.boot()}}
+\item \code{\link[Hmisc:smean.sd]{Hmisc::smean.cl.normal()}}
+\item \code{\link[Hmisc:smean.sd]{Hmisc::smean.sdl()}}
+\item \code{\link[Hmisc:smean.sd]{Hmisc::smedian.hilow()}}
 }
 }
 \examples{

--- a/man/position_nudge.Rd
+++ b/man/position_nudge.Rd
@@ -43,6 +43,11 @@ ggplot(df, aes(x, y)) +
 ggplot(df, aes(x, y)) +
   geom_point() +
   geom_text(aes(label = y), nudge_y = -0.1)
+
+# For each text individually
+ggplot(df, aes(x, y)) +
+  geom_point() +
+  geom_text(aes(label = y, nudge_y = c(-0.1, 0.1, -0.1, 0.1)))
 }
 \seealso{
 Other position adjustments: 


### PR DESCRIPTION
Recently, when creating plots with `ggstatsplot` (using the `ggbetweenstats` function), I wanted to move the centrality labels for each distribution individually. It took me quite some time to figure out that I can pass a vector to `nudge_y` (or `position_nudge` for that matter).

Therefore, I propose to document this functionality.