### PR TITLE
POC: Position guides have acces to layer data

### DIFF
--- a/R/coord-.R
+++ b/R/coord-.R
@@ -163,8 +163,8 @@ Coord <- ggproto("Coord",
     guide_params[!empty] <- Map(
       function(guide, guide_param, scale) {
         guide_param <- guide$train(guide_param, scale)
+        guide_param <- guide$get_layer_key(guide_param, layers, data)
         guide_param <- guide$transform(guide_param, self, panel_params)
-        guide_param <- guide$get_layer_key(guide_param, layers)
         guide_param
       },
       guide = guides[!empty],

--- a/R/coord-.R
+++ b/R/coord-.R
@@ -147,7 +147,7 @@ Coord <- ggproto("Coord",
     panel_params
   },
 
-  train_panel_guides = function(self, panel_params, layers, params = list()) {
+  train_panel_guides = function(self, panel_params, layers, params = list(), data = NULL) {
 
     aesthetics <- c("x", "y", "x.sec", "y.sec")
 

--- a/R/coord-map.R
+++ b/R/coord-map.R
@@ -249,7 +249,7 @@ CoordMap <- ggproto("CoordMap", Coord,
     panel_params
   },
 
-  train_panel_guides = function(self, panel_params, layers, params = list()) {
+  train_panel_guides = function(self, panel_params, layers, params = list(), data = NULL) {
     panel_params
   },
 

--- a/R/coord-polar.R
+++ b/R/coord-polar.R
@@ -175,7 +175,7 @@ CoordPolar <- ggproto("CoordPolar", Coord,
     panel_params
   },
 
-  train_panel_guides = function(self, panel_params, layers, default_mapping, params = list()) {
+  train_panel_guides = function(self, panel_params, ...) {
     panel_params
   },
 

--- a/R/coord-radial.R
+++ b/R/coord-radial.R
@@ -237,7 +237,7 @@ CoordRadial <- ggproto("CoordRadial", Coord,
     panel_params
   },
 
-  train_panel_guides = function(self, panel_params, layers, params = list()) {
+  train_panel_guides = function(self, panel_params, layers, params = list(), data = NULL) {
 
     aesthetics <- c("r", "theta", "r.sec", "theta.sec")
     aesthetics <- intersect(aesthetics, names(panel_params$guides$aesthetics))

--- a/R/coord-sf.R
+++ b/R/coord-sf.R
@@ -276,7 +276,7 @@ CoordSf <- ggproto("CoordSf", CoordCartesian,
     panel_params
   },
 
-  train_panel_guides = function(self, panel_params, layers, params = list()) {
+  train_panel_guides = function(self, panel_params, layers, params = list(), data = NULL) {
     # The guide positions are already in the target CRS, so we mask the default
     # CRS to prevent a double transformation.
     panel_params$guides <- ggproto_parent(Coord, self)$train_panel_guides(

--- a/R/layout.R
+++ b/R/layout.R
@@ -219,26 +219,24 @@ Layout <- ggproto("Layout", NULL,
     invisible()
   },
 
-  setup_panel_guides = function(self, guides, layers) {
-
-    # Like in `setup_panel_params`, we only need to setup guides for unique
-    # combinations of x/y scales.
-    index <- vec_unique_loc(self$layout$COORD)
-    order <- vec_match(self$layout$COORD, self$layout$COORD[index])
+  setup_panel_guides = function(self, guides, layers, data = NULL) {
 
     self$panel_params <- lapply(
-      self$panel_params[index],
+      self$panel_params,
       self$coord$setup_panel_guides,
       guides,
       self$coord_params
     )
 
-    self$panel_params <- lapply(
-      self$panel_params,
-      self$coord$train_panel_guides,
-      layers,
-      self$coord_params
-    )[order]
+    self$panel_params <- Map(
+      function(params, data) {
+        self$coord$train_panel_guides(params, layers, self$coord_params, data = data)
+      },
+      params = self$panel_params,
+      data = lapply(levels(self$layout$PANEL), function(i) {
+        lapply(data, function(x) vec_slice(x, x$PANEL == i))
+      })
+    )
 
     invisible()
   },

--- a/R/plot-build.R
+++ b/R/plot-build.R
@@ -98,7 +98,7 @@ ggplot_build.ggplot <- function(plot) {
   data <- layout$map_position(data)
 
   # Hand off position guides to layout
-  layout$setup_panel_guides(plot$guides, plot$layers)
+  layout$setup_panel_guides(plot$guides, plot$layers, data = data)
 
   # Complete the plot's theme
   plot$theme <- plot_theme(plot)


### PR DESCRIPTION
This PR aims to fix #6247.

Briefly, it adds the plumbing to let panel data reach the `get_layer_key()` method of position guides.

I've put this in as a draft, because I'm not entirely sure that we should take this approach.
It has some overhead because it needs to split up data by panel, making code slower.
We can illustrate with this benchmark:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

p <- ggplot(mpg, aes(displ, hwy, colour = drv)) +
  geom_point() +
  facet_grid(year ~ cyl)

bench::mark(ggplotGrob(p), min_iterations = 10)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression         min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 ggplotGrob(p)    101ms    105ms      6.51    10.8MB     11.7
```

<sup>Created on 2025-02-21 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

The exact same code on the main branch gives this result:

```r
#> # A tibble: 1 × 6
#>   expression         min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 ggplotGrob(p)   81.3ms   82.3ms      7.71    10.5MB     12.3
```

To illustrate that it works, we can assemble a quick-and-dirty guide extension that displays a density line for the data it sees, instead of the actual axis line.

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

GuideDensity <- ggproto(
  "GuideDensity", GuideAxis,
  get_layer_key = function(params, layers, data = NULL, theme = NULL) {
    vals <- unlist(lapply(data, function(d) d[[params$aesthetic]]))
    dens <- density(vals, from = min(vals), to = max(vals))
    params$decor <- data.frame(x = dens$x, z = dens$y / max(dens$y))
    params
  },
  build_decor = function(decor, grobs, elements, params) {
    element_grob(
      elements$line,
      x = unit(decor$x, "npc"),
      y = unit(1 - decor$z, "npc")
    )
  }
)

ggplot(mpg, aes(displ, hwy)) +
  geom_point() +
  guides(x = new_guide(super = GuideDensity, available_aes = "x")) +
  theme(axis.line = element_line())
```

![](https://i.imgur.com/Pc0Ey5s.png)<!-- -->

<sup>Created on 2025-02-21 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
