### PR TITLE
:zap: Skip replacing NAs during mapping when appropriate

### DIFF
--- a/R/scale-.R
+++ b/R/scale-.R
@@ -714,7 +714,11 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
     pal <- self$palette(uniq)
     scaled <- pal[match(x, uniq)]
 
-    ifelse(!is.na(scaled), scaled, self$na.value)
+    if (!anyNA(scaled)) {
+      return(scaled)
+    }
+
+    vec_assign(scaled, is.na(scaled), self$na.value)
   },
 
   rescale = function(self, x, limits = self$get_limits(), range = limits) {

--- a/R/scale-continuous.R
+++ b/R/scale-continuous.R
@@ -142,7 +142,10 @@ ScaleContinuousPosition <- ggproto("ScaleContinuousPosition", ScaleContinuous,
   # can tell the difference between continuous and discrete data.
   map = function(self, x, limits = self$get_limits()) {
     scaled <- as.numeric(self$oob(x, limits))
-    ifelse(!is.na(scaled), scaled, self$na.value)
+    if (!anyNA(scaled)) {
+      return(scaled)
+    }
+    vec_assign(scaled, is.na(scaled), self$na.value)
   },
   break_info = function(self, range = NULL) {
     breaks <- ggproto_parent(ScaleContinuous, self)$break_info(range)


### PR DESCRIPTION
This PR replaces #5032.

Briefly, it skips the NA replacment step if there are no NAs present.
Moreover `vec_assign()` is faster (and I presume more type stable) than `ifelse()`.
I think it is more of an 'empirical' determination than relying on some palette attribute as is proposed in the linked PR.

Benchmarking this PR, note 4 continuous scales (x, y, size, colour):

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

p <- ggplot(diamonds, aes(carat, price, colour = depth, size = table)) +
  geom_point()

bench::mark(ggplot_build(p), min_iterations = 10)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 ggplot_build(p)   31.4ms   34.1ms      15.3    50.4MB     24.5
```

<sup>Created on 2025-02-24 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

The same code on the main branch gives me:

``` r
#> # A tibble: 1 × 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 ggplot_build(p)   39.9ms   41.1ms      15.4    66.5MB     32.4
```

<sup>Created on 2025-02-24 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

