### PR TITLE
Background for `theme_void()` and `theme_minimal()`

### DIFF
--- a/R/theme-defaults.R
+++ b/R/theme-defaults.R
@@ -559,7 +559,10 @@ theme_void <- function(base_size = 11, base_family = "",
   # Only keep indispensable text: legend and plot titles
   t <- theme(
     line =               element_blank(),
-    rect =               element_blank(),
+    rect =               element_rect(
+                           fill = paper, colour = NA, linewidth = 0, linetype = 1,
+                           inherit.blank = FALSE
+                         ),
     polygon =            element_blank(),
     point =              element_blank(),
     text =               element_text(
@@ -591,12 +594,18 @@ theme_void <- function(base_size = 11, base_family = "",
     legend.box.margin =  rel(0),
     legend.box.spacing = unit(0.2, "cm"),
     legend.ticks.length = rel(0.2),
+    legend.background =  element_blank(),
+    legend.frame =       element_blank(),
+    legend.box.background = element_blank(),
     strip.clip =         "on",
     strip.text =         element_text(size = rel(0.8)),
     strip.switch.pad.grid = rel(0.5),
     strip.switch.pad.wrap = rel(0.5),
+    strip.background =   element_blank(),
     panel.ontop =        FALSE,
     panel.spacing =      NULL,
+    panel.background =   element_blank(),
+    panel.border =       element_blank(),
     plot.margin =        rel(0),
     plot.title =         element_text(
                            size = rel(1.2),
@@ -619,15 +628,9 @@ theme_void <- function(base_size = 11, base_family = "",
                            hjust = 0.5, vjust = 0.5
                          ),
     plot.tag.position =  'topleft',
+    plot.background =    element_rect(),
 
     complete = TRUE
-  ) + theme(
-    # Contrary to default behaviour, we do not want to inherit the plot
-    # background from a blank root element
-    plot.background = element_rect(
-      fill = paper, colour = NA, linewidth = 0, linetype = 1,
-      inherit.blank = FALSE
-    )
   )
 
   # make sure all elements are set to NULL if not explicitly defined

--- a/R/theme-defaults.R
+++ b/R/theme-defaults.R
@@ -472,7 +472,7 @@ theme_minimal <- function(base_size = 11, base_family = "",
       panel.background  = element_blank(),
       panel.border      = element_blank(),
       strip.background  = element_blank(),
-      plot.background   = element_blank(),
+      plot.background   = element_rect(fill = paper, colour = NA),
 
       complete = TRUE
     )
@@ -553,7 +553,7 @@ theme_void <- function(base_size = 11, base_family = "",
                        header_family = NULL,
                        base_line_size = base_size / 22,
                        base_rect_size = base_size / 22,
-                       ink = "black", paper = "white") {
+                       ink = "black", paper = alpha(ink, 0)) {
   half_line <- base_size / 2
 
   # Only keep indispensable text: legend and plot titles
@@ -621,6 +621,13 @@ theme_void <- function(base_size = 11, base_family = "",
     plot.tag.position =  'topleft',
 
     complete = TRUE
+  ) + theme(
+    # Contrary to default behaviour, we do not want to inherit the plot
+    # background from a blank root element
+    plot.background = element_rect(
+      fill = paper, colour = NA, linewidth = 0, linetype = 1,
+      inherit.blank = FALSE
+    )
   )
 
   # make sure all elements are set to NULL if not explicitly defined

--- a/man/ggtheme.Rd
+++ b/man/ggtheme.Rd
@@ -111,7 +111,7 @@ theme_void(
   base_line_size = base_size/22,
   base_rect_size = base_size/22,
   ink = "black",
-  paper = "white"
+  paper = alpha(ink, 0)
 )
 
 theme_test(

--- a/tests/testthat/_snaps/geom-polygon/open-and-closed-munched-polygons.svg
+++ b/tests/testthat/_snaps/geom-polygon/open-and-closed-munched-polygons.svg
@@ -18,6 +18,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <defs>
   <clipPath id='cpMC4wMHw2NjYuMTN8MTcuMzB8NTc2LjAw'>

--- a/tests/testthat/_snaps/guides/guide-custom-with-void-theme.svg
+++ b/tests/testthat/_snaps/guides/guide-custom-with-void-theme.svg
@@ -18,6 +18,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <defs>
   <clipPath id='cpMC4wMHw2NDguODl8MTcuMzB8NTc2LjAw'>

--- a/tests/testthat/_snaps/theme/theme-minimal-large.svg
+++ b/tests/testthat/_snaps/theme/theme-minimal-large.svg
@@ -18,6 +18,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='-0.000000000000064' y='0.00' width='720.00' height='576.00' style='stroke-width: 3.20; stroke: none; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMTA1LjcxfDU4OS40MXwxMTguMzB8NDgzLjM0'>

--- a/tests/testthat/_snaps/theme/theme-minimal.svg
+++ b/tests/testthat/_snaps/theme/theme-minimal.svg
@@ -18,6 +18,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 </g>
 <defs>
   <clipPath id='cpMzUuMjR8NjY0Ljk1fDM5LjQzfDU0NS4xMQ=='>

--- a/tests/testthat/_snaps/theme/theme-void-large.svg
+++ b/tests/testthat/_snaps/theme/theme-void-large.svg
@@ -18,6 +18,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <defs>
   <clipPath id='cpMC4wMHw2NjUuOTN8NzUuNTZ8NTc2LjAw'>

--- a/tests/testthat/_snaps/theme/theme-void.svg
+++ b/tests/testthat/_snaps/theme/theme-void.svg
@@ -18,6 +18,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <defs>
   <clipPath id='cpMC4wMHw2ODYuNjh8MjUuMTl8NTc2LjAw'>


### PR DESCRIPTION
This PR aims to fix #6251.

Briefly, some themes had `plot.background = element_blank()` (explicitly or implicitly), which led to counterintuitive colouring.
By providing this element we surprise less.

Examples:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

p <- ggplot(mpg, aes(displ, hwy)) +
  geom_point()

p + theme_minimal(paper = "cornsilk")
```

![](https://i.imgur.com/75iTE3R.png)<!-- -->

``` r
p + theme_void(paper = "cornsilk")
```

![](https://i.imgur.com/XmzwNcb.png)<!-- -->

<sup>Created on 2025-02-24 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
