### PR TITLE
coord_radial: add xlim and ylim arguments

### DIFF
--- a/R/coord-radial.R
+++ b/R/coord-radial.R
@@ -42,7 +42,7 @@
 #'   geom_point() +
 #'   coord_radial(start = -0.4 * pi, end = 0.4 * pi, inner.radius = 0.3)
 #' 
-#' # Similar with coord_cartesian(), you can set limtis, but note the `clip` 
+#' # Similar with coord_cartesian(), you can set limits, but note the `clip` 
 #' # area is not the same with the circle track area.
 #' ggplot(mtcars, aes(disp, mpg)) +
 #'     geom_point() +

--- a/R/coord-radial.R
+++ b/R/coord-radial.R
@@ -161,12 +161,18 @@ CoordRadial <- ggproto("CoordRadial", Coord,
   },
 
   setup_panel_params = function(self, scale_x, scale_y, params = list()) {
-
+    if (self$theta == "x") {
+      xlimits <- self$limits$theta
+      ylimits <- self$limits$r
+    } else {
+      xlimits <- self$limits$r
+      ylimits <- self$limits$theta
+    }
     params <- c(
-      view_scales_polar(scale_x, self$theta, self$limits$theta,
+      view_scales_polar(scale_x, self$theta, xlimits,
         expand = params$expand[c(4, 2)]
       ),
-      view_scales_polar(scale_y, self$theta, self$limits$r, 
+      view_scales_polar(scale_y, self$theta, ylimits,
         expand = params$expand[c(3, 1)]
       ),
       list(bbox = polar_bbox(self$arc, inner_radius = self$inner_radius),

--- a/R/coord-radial.R
+++ b/R/coord-radial.R
@@ -41,9 +41,8 @@
 #' ggplot(mtcars, aes(disp, mpg)) +
 #'   geom_point() +
 #'   coord_radial(start = -0.4 * pi, end = 0.4 * pi, inner.radius = 0.3)
-#' 
-#' # Similar with coord_cartesian(), you can set limits, but note the `clip` 
-#' # area is not the same with the circle track area.
+#'
+#' # Similar with coord_cartesian(), you can set limits.
 #' ggplot(mtcars, aes(disp, mpg)) +
 #'     geom_point() +
 #'     coord_radial(

--- a/R/coord-radial.R
+++ b/R/coord-radial.R
@@ -4,7 +4,7 @@
 #' @param end Position from 12 o'clock in radians where plot ends, to allow
 #'   for partial polar coordinates. The default, `NULL`, is set to
 #'   `start + 2 * pi`.
-#' @inheritParams coord_cartesian
+#' @param thetalim,rlim Limits for the theta and r axes.
 #' @param expand If `TRUE`, the default, adds a small expansion factor to
 #'   the limits to prevent overlap between data and axes. If `FALSE`, limits
 #'   are taken directly from the scale.
@@ -49,13 +49,13 @@
 #'     coord_radial(
 #'         start = -0.4 * pi,
 #'         end = 0.4 * pi, inner.radius = 0.3,
-#'         xlim = c(200, 300),
-#'         ylim = c(15, 30),
+#'         thetalim = c(200, 300),
+#'         rlim = c(15, 30),
 #'         clip = "on"
 #'     )
 coord_radial <- function(theta = "x",
                          start = 0, end = NULL,
-                         xlim = NULL, ylim = NULL, expand = TRUE,
+                         thetalim = NULL, rlim = NULL, expand = TRUE,
                          direction = deprecated(),
                          clip = "off",
                          r.axis.inside = NULL,
@@ -109,7 +109,7 @@ coord_radial <- function(theta = "x",
   inner.radius <- switch(reverse, thetar = , r = rev, identity)(inner.radius)
 
   ggproto(NULL, CoordRadial,
-    limits = list(x = xlim, y = ylim),
+    limits = list(theta = thetalim, r = rlim),
     theta = theta,
     r = r,
     arc = arc,
@@ -163,10 +163,10 @@ CoordRadial <- ggproto("CoordRadial", Coord,
   setup_panel_params = function(self, scale_x, scale_y, params = list()) {
 
     params <- c(
-      view_scales_polar(scale_x, self$theta, self$limits$x,
+      view_scales_polar(scale_x, self$theta, self$limits$theta,
         expand = params$expand[c(4, 2)]
       ),
-      view_scales_polar(scale_y, self$theta, self$limits$y, 
+      view_scales_polar(scale_y, self$theta, self$limits$r, 
         expand = params$expand[c(3, 1)]
       ),
       list(bbox = polar_bbox(self$arc, inner_radius = self$inner_radius),

--- a/R/coord-radial.R
+++ b/R/coord-radial.R
@@ -44,14 +44,13 @@
 #'
 #' # Similar with coord_cartesian(), you can set limits.
 #' ggplot(mtcars, aes(disp, mpg)) +
-#'     geom_point() +
-#'     coord_radial(
-#'         start = -0.4 * pi,
-#'         end = 0.4 * pi, inner.radius = 0.3,
-#'         thetalim = c(200, 300),
-#'         rlim = c(15, 30),
-#'         clip = "on"
-#'     )
+#'   geom_point() +
+#'   coord_radial(
+#'     start = -0.4 * pi,
+#'     end = 0.4 * pi, inner.radius = 0.3,
+#'     thetalim = c(200, 300),
+#'     rlim = c(15, 30),
+#'   )
 coord_radial <- function(theta = "x",
                          start = 0, end = NULL,
                          thetalim = NULL, rlim = NULL, expand = TRUE,

--- a/man/coord_polar.Rd
+++ b/man/coord_polar.Rd
@@ -11,8 +11,8 @@ coord_radial(
   theta = "x",
   start = 0,
   end = NULL,
-  xlim = NULL,
-  ylim = NULL,
+  thetalim = NULL,
+  rlim = NULL,
   expand = TRUE,
   direction = deprecated(),
   clip = "off",
@@ -40,7 +40,7 @@ means no. For details, please see \code{\link[=coord_cartesian]{coord_cartesian(
 for partial polar coordinates. The default, \code{NULL}, is set to
 \code{start + 2 * pi}.}
 
-\item{xlim, ylim}{Limits for the x and y axes.}
+\item{thetalim, rlim}{Limits for the theta and r axes.}
 
 \item{expand}{If \code{TRUE}, the default, adds a small expansion factor to
 the limits to prevent overlap between data and axes. If \code{FALSE}, limits
@@ -143,8 +143,8 @@ ggplot(mtcars, aes(disp, mpg)) +
     coord_radial(
         start = -0.4 * pi,
         end = 0.4 * pi, inner.radius = 0.3,
-        xlim = c(200, 300),
-        ylim = c(15, 30),
+        thetalim = c(200, 300),
+        rlim = c(15, 30),
         clip = "on"
     )
 }

--- a/man/coord_polar.Rd
+++ b/man/coord_polar.Rd
@@ -136,8 +136,7 @@ ggplot(mtcars, aes(disp, mpg)) +
   geom_point() +
   coord_radial(start = -0.4 * pi, end = 0.4 * pi, inner.radius = 0.3)
 
-# Similar with coord_cartesian(), you can set limtis, but note the `clip` 
-# area is not the same with the circle track area.
+# Similar with coord_cartesian(), you can set limits.
 ggplot(mtcars, aes(disp, mpg)) +
     geom_point() +
     coord_radial(

--- a/man/coord_polar.Rd
+++ b/man/coord_polar.Rd
@@ -11,6 +11,8 @@ coord_radial(
   theta = "x",
   start = 0,
   end = NULL,
+  xlim = NULL,
+  ylim = NULL,
   expand = TRUE,
   direction = deprecated(),
   clip = "off",
@@ -37,6 +39,8 @@ means no. For details, please see \code{\link[=coord_cartesian]{coord_cartesian(
 \item{end}{Position from 12 o'clock in radians where plot ends, to allow
 for partial polar coordinates. The default, \code{NULL}, is set to
 \code{start + 2 * pi}.}
+
+\item{xlim, ylim}{Limits for the x and y axes.}
 
 \item{expand}{If \code{TRUE}, the default, adds a small expansion factor to
 the limits to prevent overlap between data and axes. If \code{FALSE}, limits
@@ -131,6 +135,18 @@ doh + geom_bar(width = 0.9, position = "fill") + coord_polar(theta = "y")
 ggplot(mtcars, aes(disp, mpg)) +
   geom_point() +
   coord_radial(start = -0.4 * pi, end = 0.4 * pi, inner.radius = 0.3)
+
+# Similar with coord_cartesian(), you can set limtis, but note the `clip` 
+# area is not the same with the circle track area.
+ggplot(mtcars, aes(disp, mpg)) +
+    geom_point() +
+    coord_radial(
+        start = -0.4 * pi,
+        end = 0.4 * pi, inner.radius = 0.3,
+        xlim = c(200, 300),
+        ylim = c(15, 30),
+        clip = "on"
+    )
 }
 \seealso{
 The \href{https://ggplot2-book.org/coord#polar-coordinates-with-coord_polar}{polar coordinates section} of the online ggplot2 book.


### PR DESCRIPTION
Partial of https://github.com/tidyverse/ggplot2/issues/6259 (The feature request has been changed from set limits for `coord_radial()`).

Since `coord_polar()` does not have an `expand` argument, I have not implemented this for `coord_polar()`.

```r
ggplot(mtcars, aes(disp, mpg)) +
        geom_point() +
        coord_radial(
            start = -0.4 * pi,
            end = 0.4 * pi, inner.radius = 0.3
        )
```
![image](https://github.com/user-attachments/assets/d65464b8-25d7-4db4-858a-c8f93c1d54ae)

```r
ggplot(mtcars, aes(disp, mpg)) +
        geom_point() +
        coord_radial(
            start = -0.4 * pi,
            end = 0.4 * pi, inner.radius = 0.3,
            xlim = c(200, 300),
            ylim = c(15, 30),
            clip = "on"
        )
```
![image](https://github.com/user-attachments/assets/e901e0f9-a1c8-426d-9e65-a841713ebc1c)
