### PR TITLE
Checks for bandwidth in `stat_density_2d()`

### DIFF
--- a/R/stat-density-2d.R
+++ b/R/stat-density-2d.R
@@ -141,6 +141,9 @@ StatDensity2d <- ggproto("StatDensity2d", Stat,
     check_installed("MASS", reason = "for calculating 2D density.")
     # first run the regular layer calculation to infer densities
     data <- ggproto_parent(Stat, self)$compute_layer(data, params, layout)
+    if (empty(data)) {
+      return(data_frame0())
+    }
 
     # if we're not contouring we're done
     if (!isTRUE(params$contour %||% TRUE)) return(data)

--- a/R/stat-density-2d.R
+++ b/R/stat-density-2d.R
@@ -182,24 +182,7 @@ StatDensity2d <- ggproto("StatDensity2d", Stat,
   compute_group = function(data, scales, na.rm = FALSE, h = NULL, adjust = c(1, 1),
                            n = 100, ...) {
 
-    if (is.null(h)) {
-      # Note: MASS::bandwidth.nrd is equivalent to stats::bw.nrd * 4
-      h <- c(MASS::bandwidth.nrd(data$x), MASS::bandwidth.nrd(data$y))
-      # Handle case when when IQR == 0 and thus regular nrd bandwidth fails
-      if (h[1] == 0) {
-        h[1] <- bw.nrd0(data$x) * 4
-      }
-      if (h[2] == 0) {
-        h[2] <- bw.nrd0(data$y) * 4
-      }
-      h <- h * adjust
-    }
-    if (any(is.na(h) | h <= 0)) {
-      cli::cli_abort(c(
-        "The bandwidth argument {.arg h} must contain numbers larger than 0.",
-        i = "Please set the {.arg h} argument to stricly positive numbers manually."
-      ))
-    }
+    h <- precompute_2d_bw(data$x, data$y, h = h, adjust = adjust)
 
     # calculate density
     dens <- MASS::kde2d(
@@ -231,4 +214,28 @@ StatDensity2dFilled <- ggproto("StatDensity2dFilled", StatDensity2d,
   default_aes = aes(colour = NA, fill = after_stat(level)),
   contour_type = "bands"
 )
+
+precompute_2d_bw <- function(x, y, h = NULL, adjust = 1) {
+
+  if (is.null(h)) {
+    # Note: MASS::bandwidth.nrd is equivalent to stats::bw.nrd * 4
+    h <- c(MASS::bandwidth.nrd(x), MASS::bandwidth.nrd(y))
+    # Handle case when when IQR == 0 and thus regular nrd bandwidth fails
+    if (h[1] == 0 && length(x) > 1) h[1] <- bw.nrd0(x) * 4
+    if (h[2] == 0 && length(y) > 1) h[2] <- bw.nrd0(y) * 4
+    h <- h * adjust
+  }
+
+  check_numeric(h)
+  check_length(h, 2L)
+
+  if (any(is.na(h) | h <= 0)) {
+    cli::cli_abort(c(
+      "The bandwidth argument {.arg h} must contain numbers larger than 0.",
+      i = "Please set the {.arg h} argument to stricly positive numbers manually."
+    ))
+  }
+
+  h
+}
 

--- a/R/stat-density-2d.R
+++ b/R/stat-density-2d.R
@@ -181,8 +181,17 @@ StatDensity2d <- ggproto("StatDensity2d", Stat,
 
   compute_group = function(data, scales, na.rm = FALSE, h = NULL, adjust = c(1, 1),
                            n = 100, ...) {
+
     if (is.null(h)) {
+      # Note: MASS::bandwidth.nrd is equivalent to stats::bw.nrd * 4
       h <- c(MASS::bandwidth.nrd(data$x), MASS::bandwidth.nrd(data$y))
+      # Handle case when when IQR == 0 and thus regular nrd bandwidth fails
+      if (h[1] == 0) {
+        h[1] <- bw.nrd0(data$x) * 4
+      }
+      if (h[2] == 0) {
+        h[2] <- bw.nrd0(data$y) * 4
+      }
       h <- h * adjust
     }
     if (any(is.na(h) | h <= 0)) {

--- a/R/stat-density-2d.R
+++ b/R/stat-density-2d.R
@@ -182,6 +182,12 @@ StatDensity2d <- ggproto("StatDensity2d", Stat,
       h <- c(MASS::bandwidth.nrd(data$x), MASS::bandwidth.nrd(data$y))
       h <- h * adjust
     }
+    if (any(is.na(h) | h <= 0)) {
+      cli::cli_abort(c(
+        "The bandwidth argument {.arg h} must contain numbers larger than 0.",
+        i = "Please set the {.arg h} argument to stricly positive numbers manually."
+      ))
+    }
 
     # calculate density
     dens <- MASS::kde2d(

--- a/tests/testthat/_snaps/stat-density2d.md
+++ b/tests/testthat/_snaps/stat-density2d.md
@@ -5,3 +5,10 @@
     Caused by error in `compute_layer()`:
     ! `contour_var` must be one of "density", "ndensity", or "count", not "abcd".
 
+# stat_density_2d handles faulty bandwidth
+
+    Computation failed in `stat_density2d()`.
+    Caused by error in `precompute_2d_bw()`:
+    ! The bandwidth argument `h` must contain numbers larger than 0.
+    i Please set the `h` argument to stricly positive numbers manually.
+

--- a/tests/testthat/test-stat-density2d.R
+++ b/tests/testthat/test-stat-density2d.R
@@ -95,3 +95,10 @@ test_that("stat_density2d can produce contour and raster data", {
   # error on incorrect contouring variable
   expect_snapshot_error(ggplot_build(p + stat_density_2d(contour_var = "abcd")))
 })
+
+test_that("stat_density_2d handles faulty bandwidth", {
+  p <- ggplot(faithful, aes(eruptions, waiting)) +
+    stat_density_2d(h = c(0, NA))
+  expect_snapshot_warning(b <- ggplot_build(p))
+  expect_s3_class(layer_grob(b)[[1]], "zeroGrob")
+})


### PR DESCRIPTION
This PR aims to fix #6374

Briefly, it introduces some fallbacks and more informative error messages for calculating the bandwidth in `stat_density_2d()`.

The reprex from the issue now runs without errors, due to fallbacks when `h = 0` to use `stats::bw.nrd0()` instead of `MASS::bandwidth.nrd()`.

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2
set.seed(42)
df <- data.frame(
  x = sample(0:10, 100, replace = T), 
  y = c(rep(5, 80), sample(0:10, 20, replace = T))
)
ggplot(df, aes(x, y)) + stat_density_2d()
```

![](https://i.imgur.com/7dG98j4.png)<!-- -->

Moreover, if the bandwidth is nonsense it will throw an error (demoted to warning by stats).

``` r
ggplot(df, aes(x, y)) + stat_density_2d(h = c(0, NA))
#> Warning: Computation failed in `stat_density2d()`.
#> Caused by error in `precompute_2d_bw()` at ggplot2/R/stat-density-2d.R:185:5:
#> ! The bandwidth argument `h` must contain numbers larger than 0.
#> ℹ Please set the `h` argument to stricly positive numbers manually.
```

![](https://i.imgur.com/OyneDXL.png)<!-- -->

<sup>Created on 2025-03-21 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
