### PR TITLE
`geom_raster()` fallback for non-linear Cartesian coordinates

### DIFF
--- a/R/geom-raster.R
+++ b/R/geom-raster.R
@@ -90,7 +90,7 @@ GeomRaster <- ggproto("GeomRaster", Geom,
 
   draw_panel = function(self, data, panel_params, coord, interpolate = FALSE,
                         hjust = 0.5, vjust = 0.5) {
-    if (!inherits(coord, "CoordCartesian")) {
+    if (!inherits(coord, "CoordCartesian") || !coord$is_linear()) {
       cli::cli_inform(c(
         "{.fn {snake_class(self)}} only works with {.fn coord_cartesian}.",
         i = "Falling back to drawing as {.fn {snake_class(GeomRect)}}."


### PR DESCRIPTION
This PR aims to fix #6382 and amends #5627.

It kicks off the fallback mechanism too if the coord is non-linear. I hadn't foreseen at the time that `coord_sf()` is technically a non-linear child-coordinate of `coord_cartesian()`.

Reprex from the issue:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2
library(sf)
#> Linking to GEOS 3.12.1, GDAL 3.8.4, PROJ 9.3.1; sf_use_s2() is TRUE

file <- file.choose()
data <- read.csv(file, row.names = 1)

targetcrs <- paste(
  "+proj=lcc", 
  "+lat_1=25", 
  "+lat_2=47", 
  "+lon_0=105", 
  "+datum=WGS84", 
  "+units=m", 
  sep = " "
)

ggplot(data = data, aes(x = x, y = y))+
  geom_raster(aes(fill = value))+
  facet_wrap(~class)+
  coord_sf(
    crs = st_crs('epsg:32649'),
    default_crs = st_crs('epsg:4326')
  )
#> `geom_raster()` only works with `coord_cartesian()`.
#> ℹ Falling back to drawing as `geom_rect()`.
#> `geom_raster()` only works with `coord_cartesian()`.
#> ℹ Falling back to drawing as `geom_rect()`.
#> `geom_raster()` only works with `coord_cartesian()`.
#> ℹ Falling back to drawing as `geom_rect()`.
```

![](https://i.imgur.com/2n3VPvj.png)<!-- -->

<sup>Created on 2025-03-27 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
