### PR TITLE
Only RHS-formula accepted as lambda function

### DIFF
--- a/R/scale-.R
+++ b/R/scale-.R
@@ -1454,5 +1454,5 @@ trans_support_nbreaks <- function(trans) {
 }
 
 allow_lambda <- function(x) {
-  if (is_formula(x)) as_function(x) else x
+  if (is_formula(x, lhs = FALSE)) as_function(x) else x
 }

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -1454,5 +1454,6 @@ trans_support_nbreaks <- function(trans) {
 }
 
 allow_lambda <- function(x) {
-  if (is_formula(x, lhs = FALSE)) as_function(x) else x
+  # we check the 'call' class to prevent interpreting `bquote()` calls as a function
+  if (is_formula(x, lhs = FALSE) && !inherits(x, "call")) as_function(x) else x
 }

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -188,6 +188,24 @@ test_that("expose/ignore_data() can round-trip a data.frame", {
 
 })
 
+test_that("allow_lambda converts the correct cases", {
+
+  f <- allow_lambda(function(x) x + 1)
+  expect_equal(f(1), 2)
+
+  f <- allow_lambda(~ .x + 1)
+  expect_equal(f(1), 2)
+
+  f <- allow_lambda("A")
+  expect_equal(f, "A")
+
+  f <- allow_lambda(expression(A))
+  expect_equal(f, expression(A))
+
+  f <- allow_lambda(bquote("foo"~"bar"))
+  expect_equal(f, call("~", "foo", "bar"))
+})
+
 test_that("summary method gives a nice summary", {
   # This test isn't important enough to break anything on CRAN
   skip_on_cran()


### PR DESCRIPTION
Thsi PR aims to fix #6384 and amends #6200.

Briefly, the reason `bquote()` input for scale names wasn't accepted is because it was interpreted as a two-sided formula.
This PR only attempts to cast a RHS-only formula as a function.

Reprex from issue:

``` r
devtools::load_all("~/packages/ggplot2")
#> ℹ Loading ggplot2

eff <- "Efficiency"
ggplot(mtcars, aes(factor(cyl), mpg)) + 
  geom_boxplot() + 
  scale_y_continuous(name = bquote(.(eff)~(mi~gl^{-1})))
```

![](https://i.imgur.com/rZrPAXm.png)<!-- -->

<sup>Created on 2025-03-28 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
