### PR TITLE
`Facet`: new method `setup_panel_params` to interact panel_params

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # ggplot2 (development version)
 
+* Facet gains a new method `setup_panel_params` to interact with the panel_params setted by Coord object (@Yunuuuu, #6397, #6380)
 * `position_fill()` avoids stacking observations of zero (@teunbrand, #6338)
 * New `layer(layout)` argument to interact with facets (@teunbrand, #3062)
 * New `stat_connect()` to connect points via steps or other shapes 

--- a/R/facet-.R
+++ b/R/facet-.R
@@ -94,7 +94,7 @@ Facet <- ggproto("Facet", NULL,
   map_data = function(data, layout, params) {
     cli::cli_abort("Not implemented.")
   },
-  setup_panel_params = function(self, panel_params, coord) panel_params,
+  setup_panel_params = function(self, panel_params, coord, ...) panel_params,
   init_scales = function(layout, x_scale = NULL, y_scale = NULL, params) {
     scales <- list()
     if (!is.null(x_scale)) {

--- a/R/facet-.R
+++ b/R/facet-.R
@@ -46,6 +46,10 @@ NULL
 #' the default behaviour of one or more of the following methods:
 #'
 #'   - `setup_params`:
+#'
+#'   - `setup_panel_params`: modifies the x and y ranges for each panel. This is
+#'     used to allow the `Facet` to interact with the `panel_params`.
+#' 
 #'   - `init_scales`: Given a master scale for x and y, create panel
 #'   specific scales for each panel defined in the layout. The default is to
 #'   simply clone the master scale.
@@ -90,6 +94,7 @@ Facet <- ggproto("Facet", NULL,
   map_data = function(data, layout, params) {
     cli::cli_abort("Not implemented.")
   },
+  setup_panel_params = function(self, panel_params, coord) panel_params,
   init_scales = function(layout, x_scale = NULL, y_scale = NULL, params) {
     scales <- list()
     if (!is.null(x_scale)) {

--- a/R/layout.R
+++ b/R/layout.R
@@ -210,11 +210,14 @@ Layout <- ggproto("Layout", NULL,
     scales_x <- self$panel_scales_x[self$layout$SCALE_X[index]]
     scales_y <- self$panel_scales_y[self$layout$SCALE_Y[index]]
 
-    self$panel_params <- Map(
+    panel_params <- Map(
       self$coord$setup_panel_params,
       scales_x, scales_y,
       MoreArgs = list(params = self$coord_params)
     )[order] # `[order]` does the repeating
+
+    # Let Facet modify `panel_params` for each panel
+    self$panel_params <- self$facet$setup_panel_params(panel_params, self$coord)
 
     invisible()
   },

--- a/man/ggplot2-ggproto.Rd
+++ b/man/ggplot2-ggproto.Rd
@@ -309,6 +309,8 @@ In addition to the methods described above, it is also possible to override
 the default behaviour of one or more of the following methods:
 \itemize{
 \item \code{setup_params}:
+\item \code{setup_panel_params}: modifies the x and y ranges for each panel. This is
+used to allow the \code{Facet} to interact with the \code{panel_params}.
 \item \code{init_scales}: Given a master scale for x and y, create panel
 specific scales for each panel defined in the layout. The default is to
 simply clone the master scale.


### PR DESCRIPTION
fix https://github.com/tidyverse/ggplot2/issues/6380

This commit just add new method `setup_panel_params` in `Facet` object, and let `Facet` can act with the `panel_params` setted by `Coord` object before drawing.