### PR TITLE
Deprecate the `optional_aes` field in Geom/Stat

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggplot2 (development version)
 
+* The `optional_aes` field in `Geom` and `Stat` classes is now deprecated in
+  favour of using `default_aes = aes(foo = NULL)` to mark the 'foo' aesthetic
+  as optional (@teunbrand, #6393).
 * `position_fill()` avoids stacking observations of zero (@teunbrand, #6338)
 * New `layer(layout)` argument to interact with facets (@teunbrand, #3062)
 * New `stat_connect()` to connect points via steps or other shapes 

--- a/R/geom-.R
+++ b/R/geom-.R
@@ -227,7 +227,7 @@ Geom <- ggproto("Geom",
       required_aes <- unlist(strsplit(self$required_aes, '|', fixed = TRUE))
     }
     optional_aes <- self$optional_aes
-    if (length(optional_aes) > 1) {
+    if (length(optional_aes) > 0) {
       deprecate_soft0(
         "4.0.0",
         I("The `optional_aes` field"),

--- a/R/geom-.R
+++ b/R/geom-.R
@@ -222,12 +222,19 @@ Geom <- ggproto("Geom",
   },
 
   aesthetics = function(self) {
-    if (is.null(self$required_aes)) {
-      required_aes <- NULL
-    } else {
+    required_aes <- self$required_aes
+    if (!is.null(required_aes)) {
       required_aes <- unlist(strsplit(self$required_aes, '|', fixed = TRUE))
     }
-    c(union(required_aes, names(self$default_aes)), self$optional_aes, "group")
+    optional_aes <- self$optional_aes
+    if (length(optional_aes) > 1) {
+      deprecate_soft0(
+        "4.0.0",
+        I("The `optional_aes` field"),
+        I("NULL-aesthetics in `default_aes`")
+      )
+    }
+    c(union(required_aes, names(self$default_aes)), optional_aes, "group")
   },
 
   # Should the geom rename size to linewidth?

--- a/R/geom-rug.R
+++ b/R/geom-rug.R
@@ -86,7 +86,6 @@ geom_rug <- function(mapping = NULL, data = NULL,
 #' @usage NULL
 #' @export
 GeomRug <- ggproto("GeomRug", Geom,
-  optional_aes = c("x", "y"),
 
   draw_panel = function(self, data, panel_params, coord, lineend = "butt",
                         sides = "bl", outside = FALSE, length = unit(0.03, "npc")) {
@@ -153,7 +152,7 @@ GeomRug <- ggproto("GeomRug", Geom,
     gTree(children = inject(gList(!!!rugs)))
   },
 
-  default_aes = GeomPath$default_aes,
+  default_aes = aes(x = NULL, y = NULL, !!!GeomPath$default_aes),
 
   draw_key = draw_key_path,
 

--- a/R/geom-smooth.R
+++ b/R/geom-smooth.R
@@ -166,9 +166,9 @@ GeomSmooth <- ggproto("GeomSmooth", Geom,
   draw_key = draw_key_smooth,
 
   required_aes = c("x", "y"),
-  optional_aes = c("ymin", "ymax"),
 
   default_aes = aes(
+    ymin = NULL, ymax = NULL,
     colour = from_theme(colour %||% accent),
     fill = from_theme(fill %||% col_mix(ink, paper, 0.6)),
     linewidth = from_theme(2 * linewidth),

--- a/R/stat-.R
+++ b/R/stat-.R
@@ -209,12 +209,19 @@ Stat <- ggproto("Stat",
   },
 
   aesthetics = function(self) {
-    if (is.null(self$required_aes)) {
-      required_aes <- NULL
-    } else {
+    required_aes <- self$required_aes
+    if (!is.null(self$required_aes)) {
       required_aes <- unlist(strsplit(self$required_aes, '|', fixed = TRUE))
     }
-    c(union(required_aes, names(self$default_aes)), self$optional_aes, "group")
+    optional_aes <- self$optional_aes
+    if (length(optional_aes) > 1) {
+      deprecate_soft0(
+        "4.0.0",
+        I("The `optional_aes` field"),
+        I("NULL-aesthetics in `default_aes`")
+      )
+    }
+    c(union(required_aes, names(self$default_aes)), optional_aes, "group")
   }
 
 )

--- a/R/stat-.R
+++ b/R/stat-.R
@@ -214,7 +214,7 @@ Stat <- ggproto("Stat",
       required_aes <- unlist(strsplit(self$required_aes, '|', fixed = TRUE))
     }
     optional_aes <- self$optional_aes
-    if (length(optional_aes) > 1) {
+    if (length(optional_aes) > 0) {
       deprecate_soft0(
         "4.0.0",
         I("The `optional_aes` field"),

--- a/R/stat-ellipse.R
+++ b/R/stat-ellipse.R
@@ -77,7 +77,7 @@ stat_ellipse <- function(mapping = NULL, data = NULL,
 #' @export
 StatEllipse <- ggproto("StatEllipse", Stat,
   required_aes = c("x", "y"),
-  optional_aes = "weight",
+  default_aes = aes(weight = NULL),
   dropped_aes = "weight",
 
   setup_params = function(data, params) {

--- a/tests/testthat/test-geom-.R
+++ b/tests/testthat/test-geom-.R
@@ -64,9 +64,6 @@ test_that("updating geom aesthetic defaults preserves class and order", {
 
 })
 
-
-
-
 test_that("updating stat aesthetic defaults preserves class and order", {
 
   original_defaults <- StatBin$default_aes
@@ -85,4 +82,9 @@ test_that("updating stat aesthetic defaults preserves class and order", {
 
   update_stat_defaults("bin", NULL)
 
+})
+
+test_that("Geom throws lifecycle signals", {
+  test <- ggproto(NULL, GeomPoint, optional_aes = "foo")
+  lifecycle::expect_deprecated(stat_identity(geom = test))
 })


### PR DESCRIPTION
This PR aims to fix #6393.

It takes the 'violent' path of deprecating the field. 
We can also choose to delay deprecating the field.