### PR TITLE
Make the input panels for `Facet$draw_panesl` predicatable

### DIFF
--- a/R/coord-.R
+++ b/R/coord-.R
@@ -211,17 +211,14 @@ Coord <- ggproto("Coord",
   },
 
   draw_panel = function(self, panel, params, theme) {
-    fg <- self$render_fg(params, theme)
-    bg <- self$render_bg(params, theme)
+    fg <- ensure_grob(self$render_fg(params, theme))
+    bg <- ensure_grob(self$render_bg(params, theme))
     if (isTRUE(theme$panel.ontop)) {
-      panel <- list2(!!!panel, bg, fg)
+      panel <- gList(panel, bg, fg)
     } else {
-      panel <- list2(bg, !!!panel, fg)
+      panel <- gList(bg, panel, fg)
     }
-    gTree(
-      children = inject(gList(!!!panel)),
-      vp = viewport(clip = self$clip)
-    )
+    gTree(children = panel, vp = viewport(clip = self$clip))
   }
 )
 

--- a/R/coord-radial.R
+++ b/R/coord-radial.R
@@ -405,10 +405,7 @@ CoordRadial <- ggproto("CoordRadial", Coord,
       # Note that clipping path is applied to panel without coord
       # foreground/background (added in parent method).
       # These may contain decorations that needn't be clipped
-      panel <- list(gTree(
-        children = inject(gList(!!!panel)),
-        vp = viewport(clip = clip_path)
-      ))
+      panel <- editGrob(panel, vp = viewport(clip = clip_path))
     }
     ggproto_parent(Coord, self)$draw_panel(panel, params, theme)
   },

--- a/R/layer.R
+++ b/R/layer.R
@@ -452,7 +452,11 @@ Layer <- ggproto("Layer", NULL,
     }
 
     data <- self$geom$handle_na(data, self$computed_geom_params)
-    self$geom$draw_layer(data, self$computed_geom_params, layout, layout$coord)
+    grobs <- self$geom$draw_layer(data, 
+      self$computed_geom_params, 
+      layout, layout$coord
+    )
+    lapply(grobs, ensure_grob)
   }
 )
 

--- a/R/layout.R
+++ b/R/layout.R
@@ -78,8 +78,12 @@ Layout <- ggproto("Layout", NULL,
 
     # Draw individual panels, then assemble into gtable
     panels <- lapply(seq_along(panels[[1]]), function(i) {
-      panel <- lapply(panels, `[[`, i)
-      panel <- c(facet_bg[i], panel, facet_fg[i])
+      panel <- gTree(children = inject(gList(!!!lapply(panels, `[[`, i))))
+      panel <- gTree(children = gList(
+        ensure_grob(facet_bg[[i]]),
+        panel,
+        ensure_grob(facet_fg[[i]])
+      ))
       panel <- self$coord$draw_panel(panel, self$panel_params[[i]], theme)
       ggname(paste("panel", i, sep = "-"), panel)
     })

--- a/R/utilities-grid.R
+++ b/R/utilities-grid.R
@@ -4,6 +4,13 @@ grid::unit
 #' @export
 grid::arrow
 
+# helper function to ensure the object is a grob
+# This will simply return a `zeroGrob()` for non-grob object
+ensure_grob <- function(x) {
+  if (inherits(x, "gList")) x <- gTree(children = x)
+  if (is.grob(x)) x else zeroGrob()
+}
+
 # Name ggplot grid object
 # Convenience function to name grid objects
 #

--- a/tests/testthat/test-geom-sf.R
+++ b/tests/testthat/test-geom-sf.R
@@ -120,11 +120,13 @@ test_that("geom_sf() handles alpha properly", {
   g <- get_layer_grob(p)[[1]]
 
   # alpha affects the colour of points and lines
-  expect_equal(g[[1]]$gp$col, alpha(red, 0.5))
-  expect_equal(g[[2]]$gp$col, alpha(red, 0.5))
+  # geom_sf() will use `gList()` which is not a grob
+  # and will be wrapped into a `gTree()`.
+  expect_equal(g$children[[1]]$gp$col, alpha(red, 0.5))
+  expect_equal(g$children[[2]]$gp$col, alpha(red, 0.5))
   # alpha doesn't affect the colour of polygons, but the fill
-  expect_equal(g[[3]]$gp$col, alpha(red, 1.0))
-  expect_equal(g[[3]]$gp$fill, alpha(red, 0.5))
+  expect_equal(g$children[[3]]$gp$col, alpha(red, 1.0))
+  expect_equal(g$children[[3]]$gp$fill, alpha(red, 0.5))
 })
 
 test_that("errors are correctly triggered", {


### PR DESCRIPTION
fix https://github.com/tidyverse/ggplot2/issues/6406

This PR just make sure the `panels` input for `Facet$draw_panel` follows the shape:

It'll be a list of gTree object for each panel: each gTree object contains 3 children for Coord$render_fg, Coord$render_bg and another gTree of Facet$draw_back, all layer grobs, and Facet$draw_front