### PR TITLE
Don't link {interp} and {akima} packages

### DIFF
--- a/R/geom-contour.R
+++ b/R/geom-contour.R
@@ -9,7 +9,7 @@
 #' once. Missing values of `z` are allowed, but contouring will only work for
 #' grid points where all four corners are non-missing. If you have irregular
 #' data, you'll need to first interpolate on to a grid before visualising,
-#' using [interp::interp()], [akima::bilinear()], or similar.
+#' using `interp::interp()`, `akima::bilinear()`, or similar.
 #'
 #' @eval rd_aesthetics("geom", "contour")
 #' @eval rd_aesthetics("geom", "contour_filled")

--- a/man/geom_contour.Rd
+++ b/man/geom_contour.Rd
@@ -200,7 +200,7 @@ form an equally spaced grid, and each combination of \code{x} and \code{y} appea
 once. Missing values of \code{z} are allowed, but contouring will only work for
 grid points where all four corners are non-missing. If you have irregular
 data, you'll need to first interpolate on to a grid before visualising,
-using \code{\link[interp:interp]{interp::interp()}}, \code{\link[akima:bilinear]{akima::bilinear()}}, or similar.
+using \code{interp::interp()}, \code{akima::bilinear()}, or similar.
 }
 \section{Aesthetics}{
 


### PR DESCRIPTION
While switching to R 4.5.0, I hadn't installed {interp} and {akima} yet. I noticed roxygen complains when these aren't present due to some links in the doc pages. I don't think it is worth it to place them in suggested packages just for the purpose of linking docs. So instead I propose to remove the links.