### PR TITLE
Adapt to scales 1.4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Imports:
     isoband,
     lifecycle (> 1.0.1),
     rlang (>= 1.1.0),
-    scales (>= 1.3.0),
+    scales (>= 1.4.0),
     stats,
     vctrs (>= 0.6.0),
     withr (>= 2.5.0)

--- a/R/geom-sf.R
+++ b/R/geom-sf.R
@@ -171,7 +171,7 @@ GeomSf <- ggproto("GeomSf", Geom,
     other_default <- modify_list(
       GeomPolygon$default_aes,
       aes(
-        fill   = from_theme(fill %||% col_mix(ink, paper, 0.9)),
+        fill   = from_theme(fill %||% col_mix(ink, paper, 0.899)),
         colour = from_theme(colour %||% col_mix(ink, paper, 0.35)),
         linewidth = from_theme(0.4 * borderwidth)
       )

--- a/R/theme-defaults.R
+++ b/R/theme-defaults.R
@@ -167,7 +167,7 @@ theme_grey <- function(base_size = 11, base_family = "",
     axis.line =          element_blank(),
     axis.line.x =        NULL,
     axis.line.y =        NULL,
-    axis.text =          element_text(size = rel(0.8), colour = col_mix(ink, paper, 0.305)),
+    axis.text =          element_text(size = rel(0.8), colour = col_mix(ink, paper, 0.302)),
     axis.text.x =        element_text(margin = margin(t = 0.8 * half_line / 2), vjust = 1),
     axis.text.x.top =    element_text(margin = margin(b = 0.8 * half_line / 2), vjust = 0),
     axis.text.y =        element_text(margin = margin(r = 0.8 * half_line / 2), hjust = 1),
@@ -223,7 +223,7 @@ theme_grey <- function(base_size = 11, base_family = "",
     legend.box.background = element_blank(),
     legend.box.spacing = rel(2),
 
-    panel.background =   element_rect(fill = col_mix(ink, paper, 0.925), colour = NA),
+    panel.background =   element_rect(fill = col_mix(ink, paper, 0.92), colour = NA),
     panel.border =       element_blank(),
     panel.grid =         element_line(colour = paper),
     panel.grid.minor =   element_line(linewidth = rel(0.5)),
@@ -232,10 +232,10 @@ theme_grey <- function(base_size = 11, base_family = "",
     panel.spacing.y =    NULL,
     panel.ontop    =     FALSE,
 
-    strip.background =   element_rect(fill = col_mix(ink, paper, 0.854), colour = NA),
+    strip.background =   element_rect(fill = col_mix(ink, paper, 0.85), colour = NA),
     strip.clip =         "on",
     strip.text =         element_text(
-                           colour = col_mix(ink, paper, 0.105),
+                           colour = col_mix(ink, paper, 0.1),
                            size = rel(0.8),
                            margin = margin_auto(0.8 * half_line)
                          ),
@@ -303,7 +303,7 @@ theme_bw <- function(base_size = 11, base_family = "",
       panel.background = element_rect(fill = paper, colour = NA),
       panel.border     = element_rect(colour = col_mix(ink, paper, 0.2)),
       # make gridlines dark, same contrast with white as in theme_grey
-      panel.grid = element_line(colour = col_mix(ink, paper, 0.925)),
+      panel.grid = element_line(colour = col_mix(ink, paper, 0.92)),
       panel.grid.minor = element_line(linewidth = rel(0.5)),
       # contour strips to match panel contour
       strip.background = element_rect(
@@ -380,7 +380,7 @@ theme_light <- function(base_size = 11, base_family = "",
     theme(
       # white panel with light grey border
       panel.background = element_rect(fill = paper, colour = NA),
-      panel.border     = element_rect(colour = col_mix(ink, paper, 0.705), linewidth = rel(1)),
+      panel.border     = element_rect(colour = col_mix(ink, paper, 0.702), linewidth = rel(1)),
       # light grey, thinner gridlines
       # => make them slightly darker to keep acceptable contrast
       panel.grid       = element_line(colour = col_mix(ink, paper, 0.871)),
@@ -388,10 +388,10 @@ theme_light <- function(base_size = 11, base_family = "",
       panel.grid.minor = element_line(linewidth = rel(0.25)),
 
       # match axes ticks thickness to gridlines and colour to panel border
-      axis.ticks       = element_line(colour = col_mix(ink, paper, 0.705), linewidth = rel(0.5)),
+      axis.ticks       = element_line(colour = col_mix(ink, paper, 0.702), linewidth = rel(0.5)),
 
       # dark strips with light text (inverse contrast compared to theme_grey)
-      strip.background = element_rect(fill = col_mix(ink, paper, 0.705), colour = NA),
+      strip.background = element_rect(fill = col_mix(ink, paper, 0.702), colour = NA),
       strip.text       = element_text(
                            colour = paper,
                            size = rel(0.8),
@@ -423,7 +423,7 @@ theme_dark <- function(base_size = 11, base_family = "",
   ) %+replace%
     theme(
       # dark panel
-      panel.background = element_rect(fill = col_mix(ink, paper, 0.5), colour = NA),
+      panel.background = element_rect(fill = col_mix(ink, paper, 0.499), colour = NA),
       # inverse grid lines contrast compared to theme_grey
       # make them thinner and try to keep the same visual contrast as in theme_light
       panel.grid       = element_line(colour = col_mix(ink, paper, 0.42)),
@@ -436,7 +436,7 @@ theme_dark <- function(base_size = 11, base_family = "",
       # dark strips with light text (inverse contrast compared to theme_grey)
       strip.background = element_rect(fill = col_mix(ink, paper, 0.15), colour = NA),
       strip.text       = element_text(
-                           colour = col_mix(ink, paper, 0.9),
+                           colour = col_mix(ink, paper, 0.899),
                            size = rel(0.8),
                            margin = margin_auto(0.8 * half_line)
                          ),
@@ -649,7 +649,7 @@ theme_test <- function(base_size = 11, base_family = "",
     axis.line =          element_blank(),
     axis.line.x =        NULL,
     axis.line.y =        NULL,
-    axis.text =          element_text(size = rel(0.8), colour = col_mix(ink, paper, 0.305)),
+    axis.text =          element_text(size = rel(0.8), colour = col_mix(ink, paper, 0.302)),
     axis.text.x =        element_text(margin = margin(t = 0.8 * half_line / 2), vjust = 1),
     axis.text.x.top =    element_text(margin = margin(b = 0.8 * half_line / 2), vjust = 0),
     axis.text.y =        element_text(margin = margin(r = 0.8 * half_line / 2), hjust = 1),
@@ -715,12 +715,12 @@ theme_test <- function(base_size = 11, base_family = "",
     panel.ontop    =     FALSE,
 
     strip.background =   element_rect(
-                           fill   = col_mix(ink, paper, 0.851),
+                           fill   = col_mix(ink, paper, 0.85),
                            colour = col_mix(ink, paper, 0.2)
                          ),
     strip.clip =         "on",
     strip.text =         element_text(
-                           colour = col_mix(ink, paper, 0.105),
+                           colour = col_mix(ink, paper, 0.1),
                            size = rel(0.8),
                            margin = margin_auto(0.8 * half_line)
                          ),

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -852,56 +852,6 @@ warn_dots_used <- function(env = caller_env(), call = caller_env()) {
   )
 }
 
-# TODO: delete shims when {scales} releases >1.3.0.9000
-# and bump {scales} version requirements
-# Shim for scales/#424
-col_mix <- function(a, b, amount = 0.5) {
-  input <- vec_recycle_common(a = a, b = b, amount = amount)
-  a <- grDevices::col2rgb(input$a, TRUE)
-  b <- grDevices::col2rgb(input$b, TRUE)
-  new <- (a * (1 - input$amount) + b * input$amount)
-  grDevices::rgb(
-    new["red", ], new["green", ], new["blue", ],
-    alpha = new["alpha", ], maxColorValue = 255
-  )
-}
-
-# Shim for scales/#427
-as_discrete_pal <- function(x, ...) {
-  if (is.function(x)) {
-    return(x)
-  }
-  pal_manual(x)
-}
-
-# Shim for scales/#427
-as_continuous_pal <- function(x, ...) {
-  if (is.function(x)) {
-    return(x)
-  }
-  is_color <- grepl("^#(([[:xdigit:]]{2}){3,4}|([[:xdigit:]]){3,4})$", x) |
-    x %in% grDevices::colours()
-  if (all(is_color)) {
-    colour_ramp(x)
-  } else {
-    stats::approxfun(seq(0, 1, length.out = length(x)), x)
-  }
-}
-
-# Replace shims by actual scales function when available
-on_load({
-  nse <- getNamespaceExports("scales")
-  if ("col_mix" %in% nse) {
-    col_mix <- scales::col_mix
-  }
-  if ("as_discrete_pal" %in% nse) {
-    as_discrete_pal <- scales::as_discrete_pal
-  }
-  if ("as_continuous_pal" %in% nse) {
-    as_continuous_pal <- scales::as_continuous_pal
-  }
-})
-
 # TODO: Replace me if rlang/#1730 gets implemented
 # Similar to `rlang::check_installed()` but returns boolean and misses
 # features such as versions, comparisons and using {pak}.

--- a/tests/testthat/_snaps/scale-date.md
+++ b/tests/testthat/_snaps/scale-date.md
@@ -6,7 +6,7 @@
 ---
 
     A <numeric> value was passed to a Datetime scale.
-    i The value was converted to a <POSIXt> object.
+    i The value was converted to a <POSIXct> object.
 
 ---
 

--- a/tests/testthat/_snaps/theme/theme-with-inverted-colours.svg
+++ b/tests/testthat/_snaps/theme/theme-with-inverted-colours.svg
@@ -26,7 +26,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpNDEuNjB8NjY0Ljk1fDY2LjU5fDUzMS43NQ==)'>
-<rect x='41.60' y='66.59' width='623.35' height='465.16' style='stroke-width: 1.07; stroke: none; fill: #131313;' />
+<rect x='41.60' y='66.59' width='623.35' height='465.16' style='stroke-width: 1.07; stroke: none; fill: #141414;' />
 <polyline points='41.60,470.96 664.95,470.96 ' style='stroke-width: 0.53; stroke-linecap: butt;' />
 <polyline points='41.60,338.81 664.95,338.81 ' style='stroke-width: 0.53; stroke-linecap: butt;' />
 <polyline points='41.60,206.67 664.95,206.67 ' style='stroke-width: 0.53; stroke-linecap: butt;' />
@@ -289,8 +289,8 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpNDEuNjB8NjY0Ljk1fDQ5Ljk0fDY2LjU5)'>
-<rect x='41.60' y='49.94' width='623.35' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #252525;' />
-<text x='353.27' y='61.29' text-anchor='middle' style='font-size: 8.80px; fill: #E4E4E4; font-family: sans;' textLength='34.23px' lengthAdjust='spacingAndGlyphs'>Strip title</text>
+<rect x='41.60' y='49.94' width='623.35' height='16.65' style='stroke-width: 1.07; stroke: none; fill: #262626;' />
+<text x='353.27' y='61.29' text-anchor='middle' style='font-size: 8.80px; fill: #E6E6E6; font-family: sans;' textLength='34.23px' lengthAdjust='spacingAndGlyphs'>Strip title</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <polyline points='111.91,534.49 111.91,531.75 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
@@ -299,15 +299,15 @@
 <polyline points='426.73,534.49 426.73,531.75 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
 <polyline points='531.67,534.49 531.67,531.75 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
 <polyline points='636.61,534.49 636.61,531.75 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
-<text x='111.91' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #B1B1B1; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='216.85' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #B1B1B1; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='321.79' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #B1B1B1; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='426.73' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #B1B1B1; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
-<text x='531.67' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #B1B1B1; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
-<text x='636.61' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #B1B1B1; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>7</text>
-<text x='36.67' y='407.92' text-anchor='end' style='font-size: 8.80px; fill: #B1B1B1; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='36.67' y='275.77' text-anchor='end' style='font-size: 8.80px; fill: #B1B1B1; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
-<text x='36.67' y='143.62' text-anchor='end' style='font-size: 8.80px; fill: #B1B1B1; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='111.91' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #B2B2B2; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='216.85' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #B2B2B2; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='321.79' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #B2B2B2; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='426.73' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #B2B2B2; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='531.67' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #B2B2B2; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='636.61' y='542.74' text-anchor='middle' style='font-size: 8.80px; fill: #B2B2B2; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>7</text>
+<text x='36.67' y='407.92' text-anchor='end' style='font-size: 8.80px; fill: #B2B2B2; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='36.67' y='275.77' text-anchor='end' style='font-size: 8.80px; fill: #B2B2B2; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
+<text x='36.67' y='143.62' text-anchor='end' style='font-size: 8.80px; fill: #B2B2B2; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>40</text>
 <polyline points='38.86,404.89 41.60,404.89 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
 <polyline points='38.86,272.74 41.60,272.74 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
 <polyline points='38.86,140.59 41.60,140.59 ' style='stroke-width: 1.07; stroke: #CCCCCC; stroke-linecap: butt;' />
@@ -315,11 +315,11 @@
 <text transform='translate(21.86,299.17) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; fill: #FFFFFF; font-family: sans;' textLength='19.57px' lengthAdjust='spacingAndGlyphs'>hwy</text>
 <rect x='675.91' y='260.10' width='38.61' height='78.13' style='stroke-width: 1.07; stroke: none; fill: #000000;' />
 <text x='681.39' y='274.30' style='font-size: 11.00px; fill: #FFFFFF; font-family: sans;' textLength='15.29px' lengthAdjust='spacingAndGlyphs'>drv</text>
-<rect x='681.39' y='280.92' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #131313;' />
+<rect x='681.39' y='280.92' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #141414;' />
 <circle cx='690.03' cy='289.56' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<rect x='681.39' y='298.20' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #131313;' />
+<rect x='681.39' y='298.20' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #141414;' />
 <circle cx='690.03' cy='306.84' r='1.95' style='stroke-width: 0.71; stroke: #00BA38; fill: #00BA38;' />
-<rect x='681.39' y='315.48' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #131313;' />
+<rect x='681.39' y='315.48' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #141414;' />
 <circle cx='690.03' cy='324.12' r='1.95' style='stroke-width: 0.71; stroke: #619CFF; fill: #619CFF;' />
 <text x='704.15' y='292.59' style='font-size: 8.80px; fill: #FFFFFF; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
 <text x='704.15' y='309.87' style='font-size: 8.80px; fill: #FFFFFF; font-family: sans;' textLength='2.44px' lengthAdjust='spacingAndGlyphs'>f</text>


### PR DESCRIPTION
This PR aims to fix #6172.

It implements the two remaining items on the list in the issue.
Most of this PR are just tiny changes in colour mixing proportions to preserve the hex code.
One visual test changed, but that is fine as that theme option wasn't available in previous versions, so there isn't anything to preserve really.