### PR TITLE
Optionally skip test requiring maptools

### DIFF
--- a/tests/testthat/test-coord-map.R
+++ b/tests/testthat/test-coord-map.R
@@ -52,6 +52,7 @@ test_that("coord map throws error when limits are badly specified", {
 })
 
 test_that("coord_map throws informative warning about guides", {
+  skip_if_not_installed("mapproj")
   expect_snapshot_warning(
    ggplot_build(ggplot() + coord_map() + guides(x = guide_axis()))
   )


### PR DESCRIPTION
The dependency of the test on {maptools} is not very transparent; here's the failure if {maptools} is not installed:

```
<rlib_error_package_not_found/rlang_error/error/condition> ('test-coord-map.R:55:3')
--------------------------------------------------------------------------------
<rlib_error_package_not_found/rlang_error/error/condition>
Error in `mproject(self, grid$x, grid$y, orientation)`: The package "mapproj" is required for `coord_map()`.
Backtrace:
     x
  1. +-testthat::expect_snapshot_warning(...) at test-coord-map.R:55:3
  2. | \-testthat:::expect_snapshot_condition(...)
  3. |   +-testthat:::with_is_snapshotting(...)
  4. |   \-testthat:::capture_matching_condition(x, cnd_matcher(class))
  5. |     \-base::withCallingHandlers(...)
  6. +-ggplot2::ggplot_build(ggplot() + coord_map() + guides(x = guide_axis()))
  7. \-ggplot2:::ggplot_build.ggplot(ggplot() + coord_map() + guides(x = guide_axis()))
  8.   \-layout$setup_panel_params()
  9.     \-ggplot2 (local) setup_panel_params(..., self = self)
 10.       \-base::Map(setup_panel_params, scales_x, scales_y)
 11.         \-base::mapply(FUN = f, ..., SIMPLIFY = FALSE)
 12.           \-ggplot2 (local) `<fn>`(dots[[1L]][[1L]], dots[[2L]][[1L]])
 13.             \-self$coord$setup_panel_params(scale_x, scale_y, params = self$coord_params)
 14.               \-ggplot2 (local) setup_panel_params(..., self = self)
 15.                 \-ggplot2:::mproject(self, grid$x, grid$y, orientation)
 16.                   \-rlang::check_installed("mapproj", reason = "for `coord_map()`.")
```

Somewhat scary unless you're all-too-accustomed to seeing such errors :)