### PR TITLE
Prevent instantiating NULL palettes

### DIFF
--- a/R/theme.R
+++ b/R/theme.R
@@ -545,13 +545,14 @@ validate_theme_palettes <- function(elements) {
   }
 
   # Standardise spelling
-  elements <- replace_null(
-    elements,
-    palette.colour.discrete   = elements$palette.color.discrete,
-    palette.colour.continuous = elements$palette.color.continuous
-  )
-  elements$palette.color.discrete   <- NULL
-  elements$palette.color.continuous <- NULL
+  if ("palette.color.continuous" %in% names(elements)) {
+    elements["palette.colour.continuous"]  <- elements["palette.color.continuous"]
+    elements[["palette.color.continuous"]] <- NULL
+  }
+  if ("palette.color.discrete" %in% names(elements)) {
+    elements["palette.colour.discrete"]  <- elements["palette.color.discrete"]
+    elements[["palette.color.discrete"]] <- NULL
+  }
 
   # Check for incompatible options
   pals <- c("palette.colour.discrete", "palette.colour.continuous",


### PR DESCRIPTION
This PR aims to fix #6447.

Briefly, using the `replace_null()` function will set `NULL` elements when replacements are not present. Such `NULL` elements would then override proper palettes causing the bug. This PR prevents those palettes from being initiated to `NULL` elements. This still allows an explicit `theme(palette.colour.continuous = NULL)` to replace an older palette.