### PR TITLE
Strip `srcref` from the `$constructor` expression

### DIFF
--- a/R/layer.R
+++ b/R/layer.R
@@ -181,6 +181,7 @@ layer <- function(geom = NULL, stat = NULL,
   geom <- set_draw_key(geom, key_glyph %||% params$key_glyph)
 
   fr_call <- layer_class$constructor %||% frame_call(call_env) %||% current_call()
+  attr(fr_call, "srcref") <- NULL
 
   ggproto("LayerInstance", layer_class,
     constructor = fr_call,


### PR DESCRIPTION
Fixes #6467 - layer expression shows up correctly on print

```r
p_expr <- parse(text = "
  p <- ggplot() +
    geom_point(size = 5)
")
eval(p_expr)

p$layers[[1]]$constructor
#> geom_point(size = 5)
```

I don't think I see existing tests for `$constructor` and this is only a minor display change, but if we were to add a test for the PR it'd be something like:

```r
expect_identical(
  capture.output(p$layers[[1]]$constructor),
  "geom_point(size = 5)"
)
```