### PR TITLE
Fix reverse dependency issue with scale `na.value`

### DIFF
--- a/R/scale-.R
+++ b/R/scale-.R
@@ -1311,7 +1311,7 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
       pal <- vec_set_names(pal, NULL)
       limits <- pal_names
     }
-    pal <- vec_c(pal, na_value)
+    pal <- c(pal, na_value)
     pal_match <-
       vec_slice(pal, match(as.character(x), limits, nomatch = vec_size(pal)))
 

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -1311,7 +1311,10 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
       pal <- vec_set_names(pal, NULL)
       limits <- pal_names
     }
-    pal <- c(pal, na_value)
+
+    # vec_c is too strict in some cases, but we do want to allow 2D structures
+    pal <- if (is.null(dim(pal))) c(pal, na_value) else vec_c(pal, na_value)
+
     pal_match <-
       vec_slice(pal, match(as.character(x), limits, nomatch = vec_size(pal)))
 


### PR DESCRIPTION
This aims to fix a problem identified in #6469.

Briefly, using `vec_c()`  to concatenate the palette with `na.value` is  too strict in some cases. It was introduced in #6118.
Herein, we use regular `c()`, relying on `vctrs:::c.vctrs_vctr` to handle to vctrs case correctly.