### PR TITLE
Fix reverse dependency issue with `scale_backward_compatibility()`

### DIFF
--- a/R/scale-colour.R
+++ b/R/scale-colour.R
@@ -298,18 +298,14 @@ scale_backward_compatibility <- function(..., scale, aesthetic, type) {
     scale <- scale %||% fallback
   }
 
-  if (is_bare_string(scale)) {
-    if (scale == "continuous") {
-      scale <- "gradient"
-    }
-    if (scale == "discrete") {
-      scale <- "hue"
-    }
-    if (scale == "viridis") {
-      scale <- switch(
-        type, discrete = "viridis_d", binned = "viridis_b", "viridis_c"
-      )
-    }
+  if (is_bare_string(scale) || is.null(scale)) {
+    scale <- switch(
+      scale %||% type,
+      discrete = "hue",
+      viridis = switch(type, discrete = "viridis_d", binned = "viridis_b", "viridis_c"),
+      continuous = "gradient",
+      scale
+    )
 
     candidates <- paste("scale", aesthetic, scale, sep = "_")
     for (candi in candidates) {


### PR DESCRIPTION
This PR aims to fix a problem identified in #6469.

Briefly, the `scale_backward_compatibility()` fallback we used sometimes got handed `scale = NULL`, which I didn't anticipate. That change was introduced in #5946. Here, we inspect `type` to inform us what to do in that case.