### PR TITLE
Implement `geom_linerange(arrow)` and `geom_pointrange(arrow)`

### DIFF
--- a/R/geom-linerange.R
+++ b/R/geom-linerange.R
@@ -27,11 +27,18 @@ GeomLinerange <- ggproto(
     data
   },
 
-  draw_panel = function(data, panel_params, coord, lineend = "butt", flipped_aes = FALSE, na.rm = FALSE) {
+  draw_panel = function(data, panel_params, coord, lineend = "butt",
+                        flipped_aes = FALSE, na.rm = FALSE,
+                        arrow = NULL, arrow.fill = NULL) {
     data <- flip_data(data, flipped_aes)
     data <- transform(data, xend = x, y = ymin, yend = ymax)
     data <- flip_data(data, flipped_aes)
-    ggname("geom_linerange", GeomSegment$draw_panel(data, panel_params, coord, lineend = lineend, na.rm = na.rm))
+    grob <- GeomSegment$draw_panel(
+      data, panel_params, coord,
+      lineend = lineend, na.rm = na.rm,
+      arrow = arrow, arrow.fill = arrow.fill
+    )
+    ggname("geom_linerange", grob)
   },
 
   rename_size = TRUE

--- a/R/geom-linerange.R
+++ b/R/geom-linerange.R
@@ -62,6 +62,7 @@ GeomLinerange <- ggproto(
 #' @export
 #' @inheritParams layer
 #' @inheritParams geom_bar
+#' @inheritParams geom_segment
 #' @examples
 #' # Create a simple example dataset
 #' df <- data.frame(

--- a/R/geom-pointrange.R
+++ b/R/geom-pointrange.R
@@ -31,23 +31,24 @@ GeomPointrange <- ggproto("GeomPointrange", Geom,
   },
 
   draw_panel = function(data, panel_params, coord, lineend = "butt", fatten = 4,
-                        flipped_aes = FALSE, na.rm = FALSE) {
+                        flipped_aes = FALSE, na.rm = FALSE,
+                        arrow = NULL, arrow.fill = NULL) {
     line_grob <- GeomLinerange$draw_panel(
       data, panel_params, coord, lineend = lineend, flipped_aes = flipped_aes,
-      na.rm = na.rm
+      na.rm = na.rm, arrow = arrow, arrow.fill = arrow.fill
     )
-    if (is.null(data[[flipped_names(flipped_aes)$y]]))
-      return(line_grob)
 
-    ggname("geom_pointrange",
-      gTree(children = gList(
-        line_grob,
-        GeomPoint$draw_panel(
-          transform(data, size = size * fatten),
-          panel_params, coord, na.rm = na.rm
-        )
-      ))
+    skip_point <- is.null(data[[flipped_names(flipped_aes)$y]])
+    if (skip_point) {
+      return(line_grob)
+    }
+
+    point_grob <- GeomPoint$draw_panel(
+      transform(data, size = size * fatten),
+      panel_params, coord, na.rm = na.rm
     )
+    grob <- gTree(children = gList(line_grob, point_grob))
+    ggname("geom_pointrange", grob)
   }
 )
 

--- a/man/geom_linerange.Rd
+++ b/man/geom_linerange.Rd
@@ -53,6 +53,8 @@ geom_linerange(
   ...,
   orientation = NA,
   lineend = "butt",
+  arrow = NULL,
+  arrow.fill = NULL,
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE
@@ -67,6 +69,8 @@ geom_pointrange(
   orientation = NA,
   fatten = deprecated(),
   lineend = "butt",
+  arrow = NULL,
+  arrow.fill = NULL,
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE
@@ -179,6 +183,11 @@ that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[=annotation_borders]{annotation_borders()}}.}
 
 \item{lineend}{Line end style (round, butt, square).}
+
+\item{arrow}{specification for arrow heads, as created by \code{\link[grid:arrow]{grid::arrow()}}.}
+
+\item{arrow.fill}{fill colour to use for the arrow head (if closed). \code{NULL}
+means use \code{colour} aesthetic.}
 }
 \description{
 Various ways of representing a vertical interval defined by \code{x},


### PR DESCRIPTION
This PR aims to fix #6481.

Briefly, it adds the `arrow` and `arrow.fill` arguments to the geoms mentioned in the title.
Examples:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

df <- data.frame(
  trt = c("A", "A", "B", "B"),
  resp = c(1, 5, 3, 4),
  group = factor(c(1, 2, 1, 2)),
  upper = c(1.1, 5.3, 3.3, 4.2),
  lower = c(0.8, 4.6, 2.4, 3.6)
)

staple <- arrow(angle = 90, length = unit(2, "mm"), ends = "both")

p <- ggplot(df, aes(trt, resp, colour = group, ymin = lower, ymax = upper))
p + geom_linerange(arrow = staple)
```

![](https://i.imgur.com/xJ7rd63.png)<!-- -->

``` r
p + geom_pointrange(arrow = staple)
```

![](https://i.imgur.com/0qZHmB0.png)<!-- -->

<sup>Created on 2025-05-27 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
