### PR TITLE
Fix label formatting bug in warning

### DIFF
--- a/R/labels.R
+++ b/R/labels.R
@@ -80,10 +80,17 @@ setup_plot_labels <- function(plot, layers, data) {
   extra_labels <- setdiff(names(plot_labels), known_labels)
 
   if (length(extra_labels) > 0) {
-    extra_labels <- paste0(
-      "{.code ", extra_labels, " = \"", plot_labels[extra_labels], "\"}"
+
+    warn_labels <- plot_labels[extra_labels]
+    warn_labels <- ifelse(
+      vapply(warn_labels, is.function, logical(1)),
+      "{.cls function}",
+      paste0("{.val ", warn_labels, "}")
     )
+
+    extra_labels <- paste0("{.field ", extra_labels, "} : ", warn_labels)
     names(extra_labels) <- rep("*", length(extra_labels))
+
     cli::cli_warn(c(
       "Ignoring unknown labels:",
       extra_labels

--- a/tests/testthat/_snaps/labels.md
+++ b/tests/testthat/_snaps/labels.md
@@ -15,7 +15,9 @@
 # warnings are thrown for unknown labels
 
     Ignoring unknown labels:
-    * `foo = "bar"`
+    * foo : "i don't exist"
+    * bar : <function>
+    * qux : "expression(me * neither)"
 
 # plot.tag.position rejects invalid input
 

--- a/tests/testthat/test-labels.R
+++ b/tests/testthat/test-labels.R
@@ -110,7 +110,13 @@ test_that("get_alt_text checks dots", {
 })
 
 test_that("warnings are thrown for unknown labels", {
-  p <- ggplot(mtcars, aes(mpg, disp)) + geom_point() + labs(foo = 'bar')
+  p <- ggplot(mtcars, aes(mpg, disp)) +
+    geom_point() +
+    labs(
+      foo = "i don't exist",
+      bar = function(x) "i don't exist either",
+      qux = expression(me * neither)
+    )
   expect_snapshot_warning(ggplot_build(p))
 })
 


### PR DESCRIPTION
This PR aims to fix #6463.

Briefly, function-labels are formatted as `<function>` so they don't mess with text formatting.
Example from reprex, note the warning about unknown labels:

``` r
library(palmerpenguins)
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

penguins |> 
  ggplot() +
  geom_histogram(aes(x = flipper_length_mm)) +
  labs(
    x = snakecase::to_sentence_case,
    y = snakecase::to_sentence_case,
    fill = snakecase::to_sentence_case,
  )
#> Warning: Ignoring unknown labels:
#> • fill : <function>
#> `stat_bin()` using `bins = 30`. Pick better value `binwidth`.
#> Warning: Removed 2 rows containing non-finite outside the scale range
#> (`stat_bin()`).
```

![](https://i.imgur.com/UXPYalE.png)<!-- -->

<sup>Created on 2025-05-28 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
