### PR TITLE
Fix legend key sizes

### DIFF
--- a/R/guide-colorbar.R
+++ b/R/guide-colorbar.R
@@ -291,10 +291,10 @@ GuideColourbar <- ggproto(
     # We set the defaults in `theme` so that the `params$theme` can still
     # overrule defaults given here
     if (params$direction == "horizontal") {
-      theme$legend.key.width <- rel(5)
+      theme$legend.key.width <- (theme$legend.key.width %||% rel(1)) * 5
       valid_position <- c("bottom", "top")
     } else {
-      theme$legend.key.height <- rel(5)
+      theme$legend.key.height <- (theme$legend.key.height %||% rel(1)) * 5
       valid_position <- c("right", "left")
     }
 

--- a/R/guides-.R
+++ b/R/guides-.R
@@ -941,7 +941,11 @@ redistribute_null_units <- function(units, spacing, margin, type = "width") {
 
   # Get spacing between guides and margins in absolute units
   size    <- switch(type, width = width_cm, height = height_cm)
-  spacing <- sum(rep(spacing, length.out = length(units) - 1))
+  if (length(units) < 2) {
+    spacing <- unit(0, "cm")
+  } else {
+    spacing <- sum(rep(spacing, length.out = length(units) - 1))
+  }
   margin  <- switch(type, width = margin[c(2, 4)], height = margin[c(1, 3)])
   margin  <- sum(size(margin))
 


### PR DESCRIPTION
This PR aims to fix #6484

Briefly, in #6340 we override user input in colour bars and descendants. We should've edited it, not override it.

``` r
library(ggplot2)

p <- ggplot(mpg) +
  geom_point(aes(x = factor(cyl), y = displ, color = hwy)) +
  scale_color_fermenter(palette = "RdYlBu", direction = 1) +
  theme(legend.key.width = unit(0.25, "lines"))

plots <- list(
  p + ggtitle("default"),
  p + ggtitle("0.5 lines") + theme(legend.key.height = unit(0.5, "lines")),
  p + ggtitle("2.5 lines") + theme(legend.key.height = unit(2.5, "lines")),
  p + ggtitle("null") + theme(legend.key.height = unit(1, "null"))
)

cowplot::plot_grid(plotlist = plots)
```

![](https://i.imgur.com/gUhfXGJ.png)<!-- -->

<sup>Created on 2025-05-29 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
