### PR TITLE
Add missing theme sub args

### DIFF
--- a/R/theme-sub.R
+++ b/R/theme-sub.R
@@ -96,10 +96,24 @@ theme_sub_axis_right <- function(title, text, ticks, ticks.length, line, minor.t
 
 #' @export
 #' @describeIn subtheme Theme specification for the legend.
-theme_sub_legend <- function(background, margin, spacing, spacing.x, spacing.y,
-                             key, key.size, key.height, key.width, text, title,
-                             position, direction, justification, box, box.just,
-                             box.margin, box.background, box.spacing) {
+theme_sub_legend <- function(
+  # Text stuff
+  text, text.position, title, title.position,
+  # Drawn elements
+  background, frame, ticks, ticks.length, axis.line,
+  # Spacings
+  spacing, spacing.x, spacing.y,   margin,
+  # Seys
+  key, key.size, key.height, key.width, key.spacing, key.spacing.x,
+  key.spacing.y, key.justification,
+  # Settings
+  byrow, position, direction, location, position.inside,
+  # Justification
+  justification, justification.top, justification.bottom, justification.left,
+  justification.right, justification.inside,
+  # Box
+  box, box.just, box.margin, box.background, box.spacing
+) {
   subtheme(find_args(), "legend.")
 }
 

--- a/R/theme-sub.R
+++ b/R/theme-sub.R
@@ -54,43 +54,43 @@ subtheme <- function(elements, prefix = "", suffix = "", call = caller_env()) {
 
 #' @export
 #' @describeIn subtheme Theme specification for all axes.
-theme_sub_axis <- function(title, text, ticks, ticks.length, line) {
+theme_sub_axis <- function(title, text, ticks, ticks.length, line, minor.ticks.length) {
   subtheme(find_args(), "axis.")
 }
 
 #' @export
 #' @describeIn subtheme Theme specification for both x axes.
-theme_sub_axis_x <- function(title, text, ticks, ticks.length, line) {
+theme_sub_axis_x <- function(title, text, ticks, ticks.length, line, minor.ticks.length) {
   subtheme(find_args(), "axis.", ".x")
 }
 
 #' @export
 #' @describeIn subtheme Theme specification for both y axes.
-theme_sub_axis_y <- function(title, text, ticks, ticks.length, line) {
+theme_sub_axis_y <- function(title, text, ticks, ticks.length, line, minor.ticks.length) {
   subtheme(find_args(), "axis.", ".y")
 }
 
 #' @export
 #' @describeIn subtheme Theme specification for the bottom x axis.
-theme_sub_axis_bottom <- function(title, text, ticks, ticks.length, line) {
+theme_sub_axis_bottom <- function(title, text, ticks, ticks.length, line, minor.ticks, minor.ticks.length) {
   subtheme(find_args(), "axis.", ".x.bottom")
 }
 
 #' @export
 #' @describeIn subtheme Theme specification for the top x axis.
-theme_sub_axis_top <- function(title, text, ticks, ticks.length, line) {
+theme_sub_axis_top <- function(title, text, ticks, ticks.length, line, minor.ticks, minor.ticks.length) {
   subtheme(find_args(), "axis.", ".x.top")
 }
 
 #' @export
 #' @describeIn subtheme Theme specification for the left y axis.
-theme_sub_axis_left <- function(title, text, ticks, ticks.length, line) {
+theme_sub_axis_left <- function(title, text, ticks, ticks.length, line, minor.ticks, minor.ticks.length) {
   subtheme(find_args(), "axis.", ".y.left")
 }
 
 #' @export
 #' @describeIn subtheme Theme specification for the right y axis.
-theme_sub_axis_right <- function(title, text, ticks, ticks.length, line) {
+theme_sub_axis_right <- function(title, text, ticks, ticks.length, line, minor.ticks, minor.ticks.length) {
   subtheme(find_args(), "axis.", ".y.right")
 }
 

--- a/R/theme-sub.R
+++ b/R/theme-sub.R
@@ -105,7 +105,8 @@ theme_sub_legend <- function(background, margin, spacing, spacing.x, spacing.y,
 
 #' @export
 #' @describeIn subtheme Theme specification for the panels.
-theme_sub_panel <- function(background, border, spacing, spacing.x, spacing.y,
+theme_sub_panel <- function(background, border,
+                            widths, heights, spacing, spacing.x, spacing.y,
                             grid, grid.major, grid.minor, grid.major.x,
                             grid.major.y, grid.minor.x, grid.minor.y, ontop) {
   subtheme(find_args(), "panel.")

--- a/man/subtheme.Rd
+++ b/man/subtheme.Rd
@@ -54,6 +54,8 @@ theme_sub_legend(
 theme_sub_panel(
   background,
   border,
+  widths,
+  heights,
   spacing,
   spacing.x,
   spacing.y,

--- a/man/subtheme.Rd
+++ b/man/subtheme.Rd
@@ -62,20 +62,38 @@ theme_sub_axis_right(
 )
 
 theme_sub_legend(
+  text,
+  text.position,
+  title,
+  title.position,
   background,
-  margin,
+  frame,
+  ticks,
+  ticks.length,
+  axis.line,
   spacing,
   spacing.x,
   spacing.y,
+  margin,
   key,
   key.size,
   key.height,
   key.width,
-  text,
-  title,
+  key.spacing,
+  key.spacing.x,
+  key.spacing.y,
+  key.justification,
+  byrow,
   position,
   direction,
+  location,
+  position.inside,
   justification,
+  justification.top,
+  justification.bottom,
+  justification.left,
+  justification.right,
+  justification.inside,
   box,
   box.just,
   box.margin,
@@ -132,7 +150,7 @@ theme_sub_strip(
 )
 }
 \arguments{
-\item{background, background.x, background.y, border, box, box.background, box.just, box.margin, box.spacing, caption, caption.position, clip, direction, grid, grid.major, grid.major.x, grid.major.y, grid.minor, grid.minor.x, grid.minor.y, heights, justification, key, key.height, key.size, key.width, line, margin, minor.ticks, minor.ticks.length, ontop, placement, position, spacing, spacing.x, spacing.y, subtitle, switch.pad.grid, switch.pad.wrap, tag, tag.location, tag.position, text, text.x, text.x.bottom, text.x.top, text.y, text.y.left, text.y.right, ticks, ticks.length, title, title.position, widths}{Arguments that are renamed and passed on to \code{\link[=theme]{theme()}}.}
+\item{axis.line, background, background.x, background.y, border, box, box.background, box.just, box.margin, box.spacing, byrow, caption, caption.position, clip, direction, frame, grid, grid.major, grid.major.x, grid.major.y, grid.minor, grid.minor.x, grid.minor.y, heights, justification, justification.bottom, justification.inside, justification.left, justification.right, justification.top, key, key.height, key.justification, key.size, key.spacing, key.spacing.x, key.spacing.y, key.width, line, location, margin, minor.ticks, minor.ticks.length, ontop, placement, position, position.inside, spacing, spacing.x, spacing.y, subtitle, switch.pad.grid, switch.pad.wrap, tag, tag.location, tag.position, text, text.position, text.x, text.x.bottom, text.x.top, text.y, text.y.left, text.y.right, ticks, ticks.length, title, title.position, widths}{Arguments that are renamed and passed on to \code{\link[=theme]{theme()}}.}
 }
 \value{
 A \code{theme}-class object that can be added to a plot.

--- a/man/subtheme.Rd
+++ b/man/subtheme.Rd
@@ -15,19 +15,51 @@
 \alias{theme_sub_strip}
 \title{Shortcuts for theme settings}
 \usage{
-theme_sub_axis(title, text, ticks, ticks.length, line)
+theme_sub_axis(title, text, ticks, ticks.length, line, minor.ticks.length)
 
-theme_sub_axis_x(title, text, ticks, ticks.length, line)
+theme_sub_axis_x(title, text, ticks, ticks.length, line, minor.ticks.length)
 
-theme_sub_axis_y(title, text, ticks, ticks.length, line)
+theme_sub_axis_y(title, text, ticks, ticks.length, line, minor.ticks.length)
 
-theme_sub_axis_bottom(title, text, ticks, ticks.length, line)
+theme_sub_axis_bottom(
+  title,
+  text,
+  ticks,
+  ticks.length,
+  line,
+  minor.ticks,
+  minor.ticks.length
+)
 
-theme_sub_axis_top(title, text, ticks, ticks.length, line)
+theme_sub_axis_top(
+  title,
+  text,
+  ticks,
+  ticks.length,
+  line,
+  minor.ticks,
+  minor.ticks.length
+)
 
-theme_sub_axis_left(title, text, ticks, ticks.length, line)
+theme_sub_axis_left(
+  title,
+  text,
+  ticks,
+  ticks.length,
+  line,
+  minor.ticks,
+  minor.ticks.length
+)
 
-theme_sub_axis_right(title, text, ticks, ticks.length, line)
+theme_sub_axis_right(
+  title,
+  text,
+  ticks,
+  ticks.length,
+  line,
+  minor.ticks,
+  minor.ticks.length
+)
 
 theme_sub_legend(
   background,
@@ -100,7 +132,7 @@ theme_sub_strip(
 )
 }
 \arguments{
-\item{background, background.x, background.y, border, box, box.background, box.just, box.margin, box.spacing, caption, caption.position, clip, direction, grid, grid.major, grid.major.x, grid.major.y, grid.minor, grid.minor.x, grid.minor.y, justification, key, key.height, key.size, key.width, line, margin, ontop, placement, position, spacing, spacing.x, spacing.y, subtitle, switch.pad.grid, switch.pad.wrap, tag, tag.location, tag.position, text, text.x, text.x.bottom, text.x.top, text.y, text.y.left, text.y.right, ticks, ticks.length, title, title.position}{Arguments that are renamed and passed on to \code{\link[=theme]{theme()}}.}
+\item{background, background.x, background.y, border, box, box.background, box.just, box.margin, box.spacing, caption, caption.position, clip, direction, grid, grid.major, grid.major.x, grid.major.y, grid.minor, grid.minor.x, grid.minor.y, heights, justification, key, key.height, key.size, key.width, line, margin, minor.ticks, minor.ticks.length, ontop, placement, position, spacing, spacing.x, spacing.y, subtitle, switch.pad.grid, switch.pad.wrap, tag, tag.location, tag.position, text, text.x, text.x.bottom, text.x.top, text.y, text.y.left, text.y.right, ticks, ticks.length, title, title.position, widths}{Arguments that are renamed and passed on to \code{\link[=theme]{theme()}}.}
 }
 \value{
 A \code{theme}-class object that can be added to a plot.

--- a/tests/testthat/_snaps/theme.md
+++ b/tests/testthat/_snaps/theme.md
@@ -103,3 +103,22 @@
     The `options('ggplot2.discrete.colour')` setting is incompatible with the `palette.colour.discrete` theme setting.
     i You can set `options(ggplot2.discrete.colour = NULL)`.
 
+# theme elements are covered in `theme_sub_*()` functions
+
+    Code
+      extra_elements
+    Output
+       [1] "..."                           "line"                         
+       [3] "rect"                          "text"                         
+       [5] "title"                         "point"                        
+       [7] "polygon"                       "geom"                         
+       [9] "spacing"                       "margins"                      
+      [11] "aspect.ratio"                  "axis.text.theta"              
+      [13] "axis.text.r"                   "axis.ticks.theta"             
+      [15] "axis.ticks.r"                  "axis.minor.ticks.theta"       
+      [17] "axis.minor.ticks.r"            "axis.ticks.length.theta"      
+      [19] "axis.ticks.length.r"           "axis.minor.ticks.length.theta"
+      [21] "axis.minor.ticks.length.r"     "axis.line.theta"              
+      [23] "axis.line.r"                   "complete"                     
+      [25] "validate"                     
+

--- a/tests/testthat/test-theme.R
+++ b/tests/testthat/test-theme.R
@@ -748,7 +748,7 @@ test_that("theme elements are covered in `theme_sub_*()` functions", {
   fmls <- c(fmls, paste0("axis.",   fn_fmls_names(theme_sub_axis_top), ".x.top"))
   fmls <- c(fmls, paste0("axis.",   fn_fmls_names(theme_sub_axis_bottom), ".x.bottom"))
   fmls <- c(fmls, paste0("axis.",   fn_fmls_names(theme_sub_axis_left), ".y.left"))
-  fmls <- c(fmls, paste0("axis.",   fn_fmls_names(theme_sub_axis_right), ".y.right")  )
+  fmls <- c(fmls, paste0("axis.",   fn_fmls_names(theme_sub_axis_right), ".y.right"))
   fmls <- c(fmls, paste0("legend.", fn_fmls_names(theme_sub_legend)))
   fmls <- c(fmls, paste0("plot.",   fn_fmls_names(theme_sub_plot)))
   fmls <- c(fmls, paste0("panel.",  fn_fmls_names(theme_sub_panel)))

--- a/tests/testthat/test-theme.R
+++ b/tests/testthat/test-theme.R
@@ -736,6 +736,28 @@ test_that("geom elements are inherited correctly", {
   expect_equal(p$colour, "red")
 })
 
+test_that("theme elements are covered in `theme_sub_*()` functions", {
+  # We use a snapshot test here to trigger when a new theme element is added
+  # or removed.
+  # A failure of this test should be taken as a prompt to see if the new
+  # theme element should be included in one of the `theme_sub_*` functions.
+
+  fmls <- paste0("axis.", fn_fmls_names(theme_sub_axis))
+  fmls <- c(fmls, paste0("axis.",   fn_fmls_names(theme_sub_axis_x), ".x"))
+  fmls <- c(fmls, paste0("axis.",   fn_fmls_names(theme_sub_axis_y), ".y"))
+  fmls <- c(fmls, paste0("axis.",   fn_fmls_names(theme_sub_axis_top), ".x.top"))
+  fmls <- c(fmls, paste0("axis.",   fn_fmls_names(theme_sub_axis_bottom), ".x.bottom"))
+  fmls <- c(fmls, paste0("axis.",   fn_fmls_names(theme_sub_axis_left), ".y.left"))
+  fmls <- c(fmls, paste0("axis.",   fn_fmls_names(theme_sub_axis_right), ".y.right")  )
+  fmls <- c(fmls, paste0("legend.", fn_fmls_names(theme_sub_legend)))
+  fmls <- c(fmls, paste0("plot.",   fn_fmls_names(theme_sub_plot)))
+  fmls <- c(fmls, paste0("panel.",  fn_fmls_names(theme_sub_panel)))
+  fmls <- c(fmls, paste0("strip.",  fn_fmls_names(theme_sub_strip)))
+
+  extra_elements <- setdiff(fn_fmls_names(theme), fmls)
+  expect_snapshot(extra_elements)
+})
+
 # Visual tests ------------------------------------------------------------
 
 test_that("element_polygon() can render a grob", {


### PR DESCRIPTION
This PR aims to fix #6491.

It integrates the `panel.widths`, `panel.heights`, `axis.minor.ticks.length.{...}` and `axis.minor.ticks.{...}` settings in the `theme_sub_axis_*()` family and `theme_sub_panel()` function.

A demo:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

minor <- guide_axis(minor.ticks = TRUE)

ggplot(mpg, aes(displ, hwy)) +
  geom_point() +
  # Panel settings
  theme_sub_panel(
    widths = unit(5, "cm"),
    heights = unit(5, "cm")
  ) +
  # Minor ticks settings
  guides(x = minor, y = minor, x.sec = minor, y.sec = minor) +
  theme_sub_axis(minor.ticks.length = unit(5, "mm")) +
  theme_sub_axis_bottom(minor.ticks = element_line(colour = "red")) +
  theme_sub_axis_left(minor.ticks = element_line(colour = "limegreen")) +
  theme_sub_axis_right(minor.ticks = element_blank()) +
  theme_sub_axis_top(minor.ticks.length = unit(1, "mm"))
```

![](https://i.imgur.com/5n53qFj.png)<!-- -->

<sup>Created on 2025-06-02 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
