### PR TITLE
Support saving objects from `grDevices::recordPlot()`

### DIFF
--- a/R/save.R
+++ b/R/save.R
@@ -329,6 +329,10 @@ validate_device <- function(device, filename = NULL, dpi = 300, call = caller_en
 grid.draw.ggplot <- function(x, recording = TRUE) {
   print(x)
 }
+#' @export
+grid.draw.recordedplot <- function(x) {
+  grDevices::replayPlot(x)
+}
 
 absorb_grdevice_args <- function(f) {
   function(..., type, antialias) {


### PR DESCRIPTION
Add support for saving plot objects created by the `recordPlot` function from the base-R-bundled `grDevices` package. The dedicated function `replayPlot` is used in a new `grid.draw` method to display a `recordedplot` in a device.

 This enables `ggsave` to be used more flexibly with base R code.