### PR TITLE
Tiptoe around `na.value`

### DIFF
--- a/R/scale-.R
+++ b/R/scale-.R
@@ -1315,7 +1315,11 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
     if (!is_null(pal_names)) {
       # if pal is named, limit the pal by the names first,
       # then limit the values by the pal
-      vec_slice(pal, is.na(match(pal_names, limits))) <- na_value
+      if (is.null(dim(pal))) {
+        pal[is.na(match(pal_names, limits))] <- na_value
+      } else {
+        vec_slice(pal, is.na(match(pal_names, limits))) <- na_value
+      }
       pal <- vec_set_names(pal, NULL)
       limits <- pal_names
     }

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -1315,7 +1315,7 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
     if (!is_null(pal_names)) {
       # if pal is named, limit the pal by the names first,
       # then limit the values by the pal
-      if (is.null(dim(pal))) {
+      if (is_null(dim(pal))) {
         pal[is.na(match(pal_names, limits))] <- na_value
       } else {
         vec_slice(pal, is.na(match(pal_names, limits))) <- na_value


### PR DESCRIPTION
This PR aims to fix #6499.

The solution is the same as in #6474.
Reprex from the issue:

``` r
devtools::load_all("~/packages/ggplot2/")

ggplot(mpg, aes(displ, hwy, colour = drv)) +
  geom_point() +
  scale_colour_manual(
    values = structure(c(`4` = "blue", f = "red", r = "green"), class = "foobar"),
    na.value = "gray"
  )
```

![](https://i.imgur.com/FRRipGX.png)<!-- -->

<sup>Created on 2025-06-11 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
