### PR TITLE
A really minor document tweak

### DIFF
--- a/R/theme-elements.R
+++ b/R/theme-elements.R
@@ -33,7 +33,7 @@
 #'   a blank element among its parents will cause this element to be blank as
 #'   well. If `FALSE` any blank parent element will be ignored when
 #'   calculating final element state.
-#' @return An S3 object of class `element`, `rel`, or `margin`.
+#' @return An object of class `element`, `rel`, or `margin`.
 #' @details
 #' The `element_polygon()` and `element_point()` functions are not rendered
 #' in standard plots and just serve as extension points.

--- a/man/element.Rd
+++ b/man/element.Rd
@@ -176,7 +176,7 @@ is anchored.}
 \item{x}{A single number specifying size relative to parent element.}
 }
 \value{
-An S3 object of class \code{element}, \code{rel}, or \code{margin}.
+An object of class \code{element}, \code{rel}, or \code{margin}.
 }
 \description{
 In conjunction with the \link{theme} system, the \code{element_} functions


### PR DESCRIPTION
The document of `element` says the return value is "S3", but `element` and `margin` are already S7. `rel` is still S3, so this pull request just removes `S3` for accuracy.