### PR TITLE
bug(S7): Use `local()` to avoid `rm()` call

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -281,5 +281,8 @@ S7::method(convert, list(from = class_ggplot, to = S7::class_list)) <-
     S7::props(from)
   }
 
-S7::method(as.list, class_ggplot) <- function(x, ...) convert(x, S7::class_list)
-rm(`as.list`)
+# S7 currently attaches the S3 method to the calling environment which gives `ggplot2:::as.list`
+# Wrap in `local()` to provide a temp environment which throws away the attachment
+local({
+  S7::method(as.list, class_ggplot) <- function(x, ...) convert(x, S7::class_list)
+})


### PR DESCRIPTION
If/when S7 decides to fix the bug, `rm("non-existant")` will produce a warning message.

By using `local()`, it will work for the current version and if/when S7 fixes it.