### PR TITLE
Remove duplicate `\cr`

### DIFF
--- a/R/utilities-help.R
+++ b/R/utilities-help.R
@@ -34,7 +34,7 @@ rd_aesthetics_item <- function(x) {
     paste0("\\strong{\\code{", docs, "}}"),
     paste0("\\code{", docs, "}")
   )
-  paste0(" \u2022 \\tab ", item, " \\tab ", defaults, " \\cr\\cr")
+  paste0(" \u2022 \\tab ", item, " \\tab ", defaults, " \\cr")
 }
 
 rd_defaults <- function(layer, aesthetics) {

--- a/man/geom_bar.Rd
+++ b/man/geom_bar.Rd
@@ -243,35 +243,35 @@ number of cases at each \code{x} position (without binning into ranges).
 
 \code{geom_bar()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
- • \tab \code{width} \tab → \code{0.9} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
+ • \tab \code{width} \tab → \code{0.9} \cr
 }
 
 \code{geom_col()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
- • \tab \code{width} \tab → \code{0.9} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
+ • \tab \code{width} \tab → \code{0.9} \cr
 }
 
 \code{stat_count()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}} \emph{or} \code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{weight} \tab → \code{1} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}} \emph{or} \code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{weight} \tab → \code{1} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_bin_2d.Rd
+++ b/man/geom_bin_2d.Rd
@@ -204,16 +204,16 @@ d + geom_bin_2d(binwidth = c(0.1, 0.1))
 
 \code{geom_bin2d()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{height} \tab → \code{1} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
- • \tab \code{width} \tab → \code{1} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{height} \tab → \code{1} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
+ • \tab \code{width} \tab → \code{1} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_boxplot.Rd
+++ b/man/geom_boxplot.Rd
@@ -297,22 +297,22 @@ box plots. The American Statistician 32, 12-16.
 
 \code{geom_boxplot()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}} \emph{or} \code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \strong{\code{lower} \emph{or} \code{xlower}} \tab   \cr\cr
- • \tab \strong{\code{upper} \emph{or} \code{xupper}} \tab   \cr\cr
- • \tab \strong{\code{middle} \emph{or} \code{xmiddle}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{ymin}} \emph{or} \code{\link[=aes_position]{xmin}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{ymax}} \emph{or} \code{\link[=aes_position]{xmax}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{shape}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{size}} \tab → via \code{theme()} \cr\cr
- • \tab \code{weight} \tab → \code{1} \cr\cr
- • \tab \code{width} \tab → \code{0.9} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}} \emph{or} \code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \strong{\code{lower} \emph{or} \code{xlower}} \tab   \cr
+ • \tab \strong{\code{upper} \emph{or} \code{xupper}} \tab   \cr
+ • \tab \strong{\code{middle} \emph{or} \code{xmiddle}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{ymin}} \emph{or} \code{\link[=aes_position]{xmin}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{ymax}} \emph{or} \code{\link[=aes_position]{xmax}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{shape}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{size}} \tab → via \code{theme()} \cr
+ • \tab \code{weight} \tab → \code{1} \cr
+ • \tab \code{width} \tab → \code{0.9} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_contour.Rd
+++ b/man/geom_contour.Rd
@@ -272,46 +272,46 @@ v + geom_raster(aes(fill = density)) +
 
 \code{geom_contour()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
- • \tab \code{weight} \tab → \code{1} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
+ • \tab \code{weight} \tab → \code{1} \cr
 }
 
 \code{geom_contour_filled()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
- • \tab \code{subgroup} \tab → \code{NULL} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
+ • \tab \code{subgroup} \tab → \code{NULL} \cr
 }
 
 \code{stat_contour()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \strong{\code{z}} \tab   \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{order} \tab → \code{after_stat(level)} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \strong{\code{z}} \tab   \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{order} \tab → \code{after_stat(level)} \cr
 }
 
 \code{stat_contour_filled()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \strong{\code{z}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → \code{after_stat(level)} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{order} \tab → \code{after_stat(level)} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \strong{\code{z}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → \code{after_stat(level)} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{order} \tab → \code{after_stat(level)} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_count.Rd
+++ b/man/geom_count.Rd
@@ -162,15 +162,15 @@ For continuous \code{x} and \code{y}, use \code{\link[=geom_bin_2d]{geom_bin_2d(
 
 \code{geom_point()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{shape}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{size}} \tab → via \code{theme()} \cr\cr
- • \tab \code{stroke} \tab → via \code{theme()} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{shape}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{size}} \tab → via \code{theme()} \cr
+ • \tab \code{stroke} \tab → via \code{theme()} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_density.Rd
+++ b/man/geom_density.Rd
@@ -239,15 +239,15 @@ See \code{\link[=geom_violin]{geom_violin()}} for a compact density display.
 
 \code{geom_density()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
- • \tab \code{weight} \tab → \code{1} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
+ • \tab \code{weight} \tab → \code{1} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_density_2d.Rd
+++ b/man/geom_density_2d.Rd
@@ -255,26 +255,26 @@ overplotting.
 
 \code{geom_density2d()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
 }
 
 \code{geom_density2d_filled()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
- • \tab \code{subgroup} \tab → \code{NULL} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
+ • \tab \code{subgroup} \tab → \code{NULL} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_dotplot.Rd
+++ b/man/geom_dotplot.Rd
@@ -243,16 +243,16 @@ Wilkinson, L. (1999) Dot plots. The American Statistician,
 
 \code{geom_dotplot()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{stroke} \tab → via \code{theme()} \cr\cr
- • \tab \code{weight} \tab → \code{1} \cr\cr
- • \tab \code{width} \tab → \code{0.9} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{stroke} \tab → via \code{theme()} \cr
+ • \tab \code{weight} \tab → \code{1} \cr
+ • \tab \code{width} \tab → \code{0.9} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_function.Rd
+++ b/man/geom_function.Rd
@@ -222,13 +222,13 @@ geom_function(fun = dnorm, colour = "red", xlim=c(-7, 7))
 
 \code{geom_function()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_hex.Rd
+++ b/man/geom_hex.Rd
@@ -184,23 +184,23 @@ d + geom_hex(binwidth = c(.1, 500))
 
 \code{geom_hex()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
 }
 
 \code{stat_binhex()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → \code{after_stat(count)} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{weight} \tab → \code{1} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → \code{after_stat(count)} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{weight} \tab → \code{1} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_jitter.Rd
+++ b/man/geom_jitter.Rd
@@ -152,15 +152,15 @@ distribution of a variable
 
 \code{geom_point()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{shape}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{size}} \tab → via \code{theme()} \cr\cr
- • \tab \code{stroke} \tab → via \code{theme()} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{shape}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{size}} \tab → via \code{theme()} \cr
+ • \tab \code{stroke} \tab → via \code{theme()} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_linerange.Rd
+++ b/man/geom_linerange.Rd
@@ -249,14 +249,14 @@ geom_errorbar(
 
 \code{geom_linerange()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}} \emph{or} \code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{ymin}} \emph{or} \code{\link[=aes_position]{xmin}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{ymax}} \emph{or} \code{\link[=aes_position]{xmax}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}} \emph{or} \code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{ymin}} \emph{or} \code{\link[=aes_position]{xmin}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{ymax}} \emph{or} \code{\link[=aes_position]{xmax}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
 }
 Note that \code{geom_pointrange()} also understands \code{size} for the size of the points.
 

--- a/man/geom_map.Rd
+++ b/man/geom_map.Rd
@@ -182,14 +182,14 @@ if (require(maps)) {
 
 \code{geom_map()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{map_id}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
- • \tab \code{subgroup} \tab → \code{NULL} \cr\cr
+ • \tab \strong{\code{map_id}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
+ • \tab \code{subgroup} \tab → \code{NULL} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_path.Rd
+++ b/man/geom_path.Rd
@@ -270,13 +270,13 @@ should_stop(p + geom_line(aes(colour = x), linetype=2))
 
 \code{geom_path()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_point.Rd
+++ b/man/geom_point.Rd
@@ -196,15 +196,15 @@ ggplot(mtcars2, aes(wt, mpg)) +
 
 \code{geom_point()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{shape}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{size}} \tab → via \code{theme()} \cr\cr
- • \tab \code{stroke} \tab → via \code{theme()} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{shape}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{size}} \tab → via \code{theme()} \cr
+ • \tab \code{stroke} \tab → via \code{theme()} \cr
 }
 The \code{fill} aesthetic only applies to shapes 21-25.
 

--- a/man/geom_polygon.Rd
+++ b/man/geom_polygon.Rd
@@ -198,15 +198,15 @@ if (packageVersion("grid") >= "3.6") {
 
 \code{geom_polygon()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
- • \tab \code{subgroup} \tab → \code{NULL} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
+ • \tab \code{subgroup} \tab → \code{NULL} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_qq.Rd
+++ b/man/geom_qq.Rd
@@ -217,18 +217,18 @@ ggplot(mtcars, aes(sample = mpg, colour = factor(cyl))) +
 
 \code{stat_qq()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{sample}} \tab   \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_position]{x}} \tab → \code{after_stat(theoretical)} \cr\cr
- • \tab \code{\link[=aes_position]{y}} \tab → \code{after_stat(sample)} \cr\cr
+ • \tab \strong{\code{sample}} \tab   \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_position]{x}} \tab → \code{after_stat(theoretical)} \cr
+ • \tab \code{\link[=aes_position]{y}} \tab → \code{after_stat(sample)} \cr
 }
 
 \code{stat_qq_line()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{sample}} \tab   \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_position]{x}} \tab → \code{after_stat(x)} \cr\cr
- • \tab \code{\link[=aes_position]{y}} \tab → \code{after_stat(y)} \cr\cr
+ • \tab \strong{\code{sample}} \tab   \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_position]{x}} \tab → \code{after_stat(x)} \cr
+ • \tab \code{\link[=aes_position]{y}} \tab → \code{after_stat(y)} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_quantile.Rd
+++ b/man/geom_quantile.Rd
@@ -174,14 +174,14 @@ m + geom_quantile(colour = "red", linewidth = 2, alpha = 0.5)
 
 \code{geom_quantile()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
- • \tab \code{weight} \tab → \code{1} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
+ • \tab \code{weight} \tab → \code{1} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_ribbon.Rd
+++ b/man/geom_ribbon.Rd
@@ -237,15 +237,15 @@ ggplot(df, aes(x, y, fill = g)) +
 
 \code{geom_ribbon()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}} \emph{or} \code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{ymin}} \emph{or} \code{\link[=aes_position]{xmin}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{ymax}} \emph{or} \code{\link[=aes_position]{xmax}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}} \emph{or} \code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{ymin}} \emph{or} \code{\link[=aes_position]{xmin}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{ymax}} \emph{or} \code{\link[=aes_position]{xmax}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_rug.Rd
+++ b/man/geom_rug.Rd
@@ -170,13 +170,13 @@ p +
 
 \code{geom_rug()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_position]{x}} \tab   \cr\cr
- • \tab \code{\link[=aes_position]{y}} \tab   \cr\cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_position]{x}} \tab   \cr
+ • \tab \code{\link[=aes_position]{y}} \tab   \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_segment.Rd
+++ b/man/geom_segment.Rd
@@ -219,14 +219,14 @@ segment lines and paths.
 
 \code{geom_segment()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{xend}} \emph{or} \code{\link[=aes_position]{yend}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{xend}} \emph{or} \code{\link[=aes_position]{yend}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_smooth.Rd
+++ b/man/geom_smooth.Rd
@@ -274,17 +274,17 @@ See individual modelling functions for more details:
 
 \code{geom_smooth()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{0.4} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
- • \tab \code{weight} \tab → \code{1} \cr\cr
- • \tab \code{\link[=aes_position]{ymax}} \tab   \cr\cr
- • \tab \code{\link[=aes_position]{ymin}} \tab   \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{0.4} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
+ • \tab \code{weight} \tab → \code{1} \cr
+ • \tab \code{\link[=aes_position]{ymax}} \tab   \cr
+ • \tab \code{\link[=aes_position]{ymin}} \tab   \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_spoke.Rd
+++ b/man/geom_spoke.Rd
@@ -144,15 +144,15 @@ ggplot(df, aes(x, y)) +
 
 \code{geom_spoke()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \strong{\code{angle}} \tab   \cr\cr
- • \tab \strong{\code{radius}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \strong{\code{angle}} \tab   \cr
+ • \tab \strong{\code{radius}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_text.Rd
+++ b/man/geom_text.Rd
@@ -308,19 +308,19 @@ The \href{https://ggplot2-book.org/annotations#sec-text-labels}{text labels sect
 
 \code{geom_text()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \strong{\code{label}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{angle} \tab → \code{0} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{family} \tab → via \code{theme()} \cr\cr
- • \tab \code{fontface} \tab → \code{1} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{hjust} \tab → \code{0.5} \cr\cr
- • \tab \code{lineheight} \tab → \code{1.2} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{size}} \tab → via \code{theme()} \cr\cr
- • \tab \code{vjust} \tab → \code{0.5} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \strong{\code{label}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{angle} \tab → \code{0} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{family} \tab → via \code{theme()} \cr
+ • \tab \code{fontface} \tab → \code{1} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{hjust} \tab → \code{0.5} \cr
+ • \tab \code{lineheight} \tab → \code{1.2} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{size}} \tab → via \code{theme()} \cr
+ • \tab \code{vjust} \tab → \code{0.5} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/geom_tile.Rd
+++ b/man/geom_tile.Rd
@@ -222,14 +222,14 @@ cars +
 
 \code{geom_rect()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}} \emph{or} \code{width} \emph{or} \code{\link[=aes_position]{xmin}} \emph{or} \code{\link[=aes_position]{xmax}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}} \emph{or} \code{height} \emph{or} \code{\link[=aes_position]{ymin}} \emph{or} \code{\link[=aes_position]{ymax}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}} \emph{or} \code{width} \emph{or} \code{\link[=aes_position]{xmin}} \emph{or} \code{\link[=aes_position]{xmax}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}} \emph{or} \code{height} \emph{or} \code{\link[=aes_position]{ymin}} \emph{or} \code{\link[=aes_position]{ymax}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
 }
 \code{geom_tile()} understands only the \code{x}/\code{width} and \code{y}/\code{height} combinations.
 Note that \code{geom_raster()} ignores \code{colour}.

--- a/man/geom_violin.Rd
+++ b/man/geom_violin.Rd
@@ -272,16 +272,16 @@ for examples with data along the x axis.
 
 \code{geom_violin()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr\cr
- • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr\cr
- • \tab \code{weight} \tab → \code{1} \cr\cr
- • \tab \code{width} \tab → \code{0.9} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{alpha}} \tab → \code{NA} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{colour}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_colour_fill_alpha]{fill}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linetype}} \tab → via \code{theme()} \cr
+ • \tab \code{\link[=aes_linetype_size_shape]{linewidth}} \tab → via \code{theme()} \cr
+ • \tab \code{weight} \tab → \code{1} \cr
+ • \tab \code{width} \tab → \code{0.9} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/position_dodge.Rd
+++ b/man/position_dodge.Rd
@@ -124,7 +124,7 @@ Other position adjustments:
 
 \code{position_dodge()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \code{order} \tab → \code{NULL} \cr\cr
+ • \tab \code{order} \tab → \code{NULL} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/position_nudge.Rd
+++ b/man/position_nudge.Rd
@@ -52,8 +52,8 @@ Other position adjustments:
 
 \code{position_nudge()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \code{nudge_x} \tab → \code{0} \cr\cr
- • \tab \code{nudge_y} \tab → \code{0} \cr\cr
+ • \tab \code{nudge_x} \tab → \code{0} \cr
+ • \tab \code{nudge_y} \tab → \code{0} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/stat_connect.Rd
+++ b/man/stat_connect.Rd
@@ -144,9 +144,9 @@ ggplot(head(economics, 10), aes(date, unemploy)) +
 
 \code{stat_connect()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}} \emph{or} \code{\link[=aes_position]{xmin}} \emph{or} \code{\link[=aes_position]{xmax}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}} \emph{or} \code{\link[=aes_position]{ymin}} \emph{or} \code{\link[=aes_position]{ymax}}} \tab   \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}} \emph{or} \code{\link[=aes_position]{xmin}} \emph{or} \code{\link[=aes_position]{xmax}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}} \emph{or} \code{\link[=aes_position]{ymin}} \emph{or} \code{\link[=aes_position]{ymax}}} \tab   \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/stat_ecdf.Rd
+++ b/man/stat_ecdf.Rd
@@ -181,9 +181,9 @@ ggplot(plain, aes(x)) +
 
 \code{stat_ecdf()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}} \emph{or} \code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{weight} \tab → \code{NULL} \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}} \emph{or} \code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{weight} \tab → \code{NULL} \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/stat_ellipse.Rd
+++ b/man/stat_ellipse.Rd
@@ -160,10 +160,10 @@ Statist. Sci. 28 (1) 1 - 39, February 2013. URL: \url{https://projecteuclid.org/
 
 \code{stat_ellipse()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
- • \tab \code{weight} \tab   \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
+ • \tab \code{weight} \tab   \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/stat_manual.Rd
+++ b/man/stat_manual.Rd
@@ -194,7 +194,7 @@ if (requireNamespace("dplyr", quietly = TRUE)) {
 
 \code{stat_manual()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/stat_summary.Rd
+++ b/man/stat_summary.Rd
@@ -301,9 +301,9 @@ display summarised data
 
 \code{stat_summary()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr\cr
- • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr\cr
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
+ • \tab \strong{\code{\link[=aes_position]{x}}} \tab   \cr
+ • \tab \strong{\code{\link[=aes_position]{y}}} \tab   \cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.

--- a/man/stat_unique.Rd
+++ b/man/stat_unique.Rd
@@ -119,7 +119,7 @@ ggplot(mtcars, aes(vs, am)) +
 
 \code{stat_unique()} understands the following aesthetics. Required aesthetics are displayed in bold and defaults are displayed for optional aesthetics:
 \tabular{rll}{
- • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr\cr
+ • \tab \code{\link[=aes_group_order]{group}} \tab → inferred \cr
 }
 
 Learn more about setting these aesthetics in \code{vignette("ggplot2-specs")}.


### PR DESCRIPTION
Close #6509 

Currently, the generated `\tabular` for "Aesthetics" section uses double `\cr`. But, guessing from what is described in [WRE](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Lists-and-tables), it's unnecessary.

> ... The second argument consists of an arbitrary number of lines separated by `\cr`, and with fields separated by `\tab`. For example:
> ```tex
>   \tabular{rlll}{
>     [,1] \tab Ozone   \tab numeric \tab Ozone (ppb)\cr
>     [,2] \tab Solar.R \tab numeric \tab Solar R (lang)\cr
>     [,3] \tab Wind    \tab numeric \tab Wind (mph)\cr
>     [,4] \tab Temp    \tab numeric \tab Temperature (degrees F)\cr
>     [,5] \tab Month   \tab numeric \tab Month (1--12)\cr
>     [,6] \tab Day     \tab numeric \tab Day of month (1--31)
>   }
> ```

This was added in #6285, but I found no particular reason. So, I guess we can just remove this.