### PR TITLE
Additional notes on legend.ticks.length

### DIFF
--- a/R/theme.R
+++ b/R/theme.R
@@ -92,10 +92,7 @@
 #'   or `"top"`, or a two-element numeric vector.
 #' @param legend.frame frame drawn around the bar ([element_rect()]).
 #' @param legend.ticks tick marks shown along bars or axes ([element_line()])
-#' @param legend.ticks.length length of tick marks in legend
-#'   ([`unit()`][grid::unit]); By default, tick marks are positioned symmetrically.  
-#'   One-sided tick lengths can be controlled using absolute (`unit()`) or relative (`rel()`) values.  
-#'   For example, `unit(c(-0.15, 0), "cm")` or `rel(c(0.175, 0))` produces ticks on one side only. inherits from `legend.key.size`.
+#' @param legend.ticks.length length of tick marks in legend ([`unit()`][grid::unit]); By default, tick marks are positioned symmetrically. One-sided tick lengths can be controlled using absolute (`unit()`) or relative (`rel()`) values. For example, `unit(c(-0.15, 0), "cm")` or `rel(c(0.175, 0))` produces ticks on one side only. inherits from `legend.key.size`.
 #' @param legend.axis.line lines along axes in legends ([element_line()])
 #' @param legend.text legend item labels ([element_text()]; inherits from
 #'   `text`)

--- a/R/theme.R
+++ b/R/theme.R
@@ -95,7 +95,7 @@
 #' @param legend.ticks.length length of tick marks in legend
 #'   ([`unit()`][grid::unit]); By default, tick marks are positioned symmetrically.  
 #'   One-sided tick lengths can be controlled using absolute (`unit()`) or relative (`rel()`) values.  
-#'   For example, `unit(c(-0.15, 0), "cm")` or `rel(c(0.175, 0))` produces ticks on one side only.inherits from `legend.key.size`.
+#'   For example, `unit(c(-0.15, 0), "cm")` or `rel(c(0.175, 0))` produces ticks on one side only.    inherits from `legend.key.size`.
 #' @param legend.axis.line lines along axes in legends ([element_line()])
 #' @param legend.text legend item labels ([element_text()]; inherits from
 #'   `text`)

--- a/R/theme.R
+++ b/R/theme.R
@@ -95,7 +95,7 @@
 #' @param legend.ticks.length length of tick marks in legend
 #'   ([`unit()`][grid::unit]); By default, tick marks are positioned symmetrically.  
 #'   One-sided tick lengths can be controlled using absolute (`unit()`) or relative (`rel()`) values.  
-#'   For example, `unit(c(-0.15, 0), "cm")` or `rel(c(0.175, 0))` produces ticks on one side only.    inherits from `legend.key.size`.
+#'   For example, `unit(c(-0.15, 0), "cm")` or `rel(c(0.175, 0))` produces ticks on one side only. inherits from `legend.key.size`.
 #' @param legend.axis.line lines along axes in legends ([element_line()])
 #' @param legend.text legend item labels ([element_text()]; inherits from
 #'   `text`)

--- a/R/theme.R
+++ b/R/theme.R
@@ -93,7 +93,9 @@
 #' @param legend.frame frame drawn around the bar ([element_rect()]).
 #' @param legend.ticks tick marks shown along bars or axes ([element_line()])
 #' @param legend.ticks.length length of tick marks in legend
-#'   ([`unit()`][grid::unit]); inherits from `legend.key.size`.
+#'   ([`unit()`][grid::unit]); By default, tick marks are positioned symmetrically.  
+#'   One-sided tick lengths can be controlled using absolute (`unit()`) or relative (`rel()`) values.  
+#'   For example, `unit(c(-0.15, 0), "cm")` or `rel(c(0.175, 0))` produces ticks on one side only.inherits from `legend.key.size`.
 #' @param legend.axis.line lines along axes in legends ([element_line()])
 #' @param legend.text legend item labels ([element_text()]; inherits from
 #'   `text`)


### PR DESCRIPTION
Hi, Teun and Thomas!

When adjusting the length of ticks in the legend of ggplot2, many users are not aware of adjusting the length of a single side, e.g. to generate a legend with only one side of ticks. I would like to add to the documentation accordingly.
If you all think it's not appropriate, clear feel free to close this PR.

(This is my first PR, if there are problems please help to modify or close it.🤣)