### PR TITLE
Consider `PANEL` for handling NAs in line geoms

### DIFF
--- a/R/geom-path.R
+++ b/R/geom-path.R
@@ -19,7 +19,7 @@ GeomPath <- ggproto("GeomPath", Geom,
     # middle since you expect those to be shown by a break in the line
     aesthetics <- c(self$required_aes, self$non_missing_aes)
     complete <- stats::complete.cases(data[names(data) %in% aesthetics])
-    kept <- stats::ave(complete, data$group, FUN = keep_mid_true)
+    kept <- stats::ave(complete, data$group, data$PANEL, FUN = keep_mid_true)
     data <- data[kept, ]
 
     if (!all(kept) && !params$na.rm) {


### PR DESCRIPTION
This PR aims to fix #6533.

Briefly, line geoms require special NA-handling methods because we want to exclude terminal vertices but not internal vertices from a path. We use `group` to determine these, but we should consider `PANEL` as well.

Reprex from issue:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

d2 <- data.frame(x = 1:3, col = c("blue", "green", NA)) |> 
  tidyr::crossing(group = c("A", "B"))

ggplot(d2, aes(x, x, color = I(col), group = 1)) +
  facet_wrap(~ group) + 
  geom_line(lwd = 2)
#> Warning: Removed 2 rows containing missing values or values outside the scale range
#> (`geom_line()`).
```

![](https://i.imgur.com/oGtij7Z.png)<!-- -->

<sup>Created on 2025-07-03 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
