### PR TITLE
Density uses `line*` instead of `border*` geom element

### DIFF
--- a/R/geom-density.R
+++ b/R/geom-density.R
@@ -10,8 +10,8 @@ GeomDensity <- ggproto(
     fill   = from_theme(fill %||% NA),
     weight = 1,
     alpha  = NA,
-    linewidth = from_theme(borderwidth),
-    linetype  = from_theme(bordertype)
+    linewidth = from_theme(linewidth),
+    linetype  = from_theme(linetype)
   )
 )
 


### PR DESCRIPTION
This PR fixes #6512.

It doesn't solve David's issue at large, which we've expressed reluctance about, but it does fix the example pointed out.
From https://github.com/tidyverse/ggplot2/issues/6512#issuecomment-2979027023:

> Now for geom_density in particular this is a bit surprising because it is a polygon under the hood so it present itself as a line but is in fact a polygon. Maybe we can do something there.

This changes the border parametrisation to line parametrisation. 