### PR TITLE
Default coords do not replace user coords

### DIFF
--- a/R/plot-construction.R
+++ b/R/plot-construction.R
@@ -200,6 +200,12 @@ S7::method(update_ggplot, list(class_theme, class_ggplot)) <-
 S7::method(update_ggplot, list(class_coord, class_ggplot)) <-
   function(object, plot, ...) {
     if (!isTRUE(plot@coordinates$default)) {
+
+      if (isTRUE(object$default)) {
+        # We don't let default coords override non-default coords (#6572)
+        return(plot)
+      }
+
       cli::cli_inform(c(
         "Coordinate system already present.",
         i = "Adding new coordinate system, which will replace the existing one."

--- a/tests/testthat/_snaps/coord-.md
+++ b/tests/testthat/_snaps/coord-.md
@@ -34,3 +34,11 @@
       Error:
       ! `1:3` must be a vector of length 2, not length 3.
 
+# adding default coords works correctly
+
+    Code
+      test <- test + coord_cartesian(xlim = c(-2, 2))
+    Message
+      Coordinate system already present.
+      i Adding new coordinate system, which will replace the existing one.
+

--- a/tests/testthat/test-coord-.R
+++ b/tests/testthat/test-coord-.R
@@ -108,3 +108,31 @@ test_that("coord expand takes a vector", {
 
 })
 
+test_that("adding default coords works correctly", {
+
+  base <- ggplot() + coord_cartesian(default = TRUE, xlim = c(0, 1))
+
+  # default + user = user
+  expect_no_message(
+    test <- base + coord_cartesian(xlim = c(-1, 1))
+  )
+  expect_equal(test@coordinates$limits$x, c(-1, 1))
+
+  # user1 + user2 = user2 + message
+  expect_snapshot(
+    test <- test + coord_cartesian(xlim = c(-2, 2))
+  )
+  expect_equal(test@coordinates$limits$x, c(-2, 2))
+
+  # user + default = user
+  expect_no_message(
+    test <- test + coord_cartesian(xlim = c(-3, 3), default = TRUE)
+  )
+  expect_equal(test@coordinates$limits$x, c(-2, 2))
+
+  # default1 + default2 = default2 (silent)
+  expect_no_message(
+    test <- base + coord_cartesian(xlim = c(-4, 4), default = TRUE)
+  )
+  expect_equal(test@coordinates$limits$x, c(-4, 4))
+})


### PR DESCRIPTION
This PR aims to fix #6572.

It does what is says in the title. Reprex from the linked issue:

``` r
devtools::load_all("~/packages/ggplot2/")

world <- rnaturalearth::ne_countries()

ggplot(world) +
  coord_sf(crs = "+proj=moll") +
  geom_sf()
```

![](https://i.imgur.com/ApBeRWL.png)<!-- -->

<sup>Created on 2025-08-22 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
