### PR TITLE
suggested small tweaks to README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -64,7 +64,9 @@ ggplot(mpg, aes(displ, hwy, colour = class)) +
 
 [![lifecycle](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html)
 
-ggplot2 is now over 10 years old and is used by hundreds of thousands of people to make millions of plots. That means, by-and-large, ggplot2 itself changes relatively little. When we do make changes, they will be generally to add new functions or arguments rather than changing the behaviour of existing functions, and if we do make changes to existing behaviour we will do them for compelling reasons.
+ggplot2 is now 18 years old and is used by hundreds of thousands of people to make millions of plots. That means, by-and-large, ggplot2 itself changes relatively little. When we do make changes, they will be generally to add new functions or arguments rather than changing the behaviour of existing functions, and if we do make changes to existing behaviour we will do them for compelling reasons.
+
+For information about the major new 4.0.0 version, see the tidyverse blog post [ggplot2 4.0.0](https://www.tidyverse.org/blog/2025/09/ggplot2-4-0-0/)
 
 If you are looking for innovation, look to ggplot2's rich ecosystem of extensions. See a community maintained list at <https://exts.ggplot2.tidyverse.org/gallery/>.
 


### PR DESCRIPTION
ggplot2 is now a lot older than 10 years, so suggest updating that. In addition, maybe README should reference the major new 4.0 version after saying 'ggplot2 itself changes relatively little', since there's been a significant change?