### PR TITLE
ci: Add Tweak for Windows R 4.1

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -66,10 +66,9 @@ jobs:
           cache-version: 3
           extra-packages: >
             any::rcmdcheck,
+            ragg@1.4.0,
             Hmisc=?ignore-before-r=4.2.0,
             quantreg=?ignore-before-r=4.3.0
-          packages: >
-            ragg@1.4.0
           needs: check
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -58,6 +58,15 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      # TODO: remove this when R 4.6 is released
+      - name: Tweak for old Windows (R 4.1)
+        uses: r-lib/actions/setup-r-dependencies@v2
+        if: ${{ matrix.config.os == 'windows-latest' && matrix.config.r = 'oldrel-4' }}
+        with:
+          cache-version: 3
+          packages: >
+            ragg@1.4.0
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           cache-version: 3

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -61,7 +61,7 @@ jobs:
       # TODO: remove this when R 4.6 is released
       - name: Tweak for old Windows (R 4.1)
         uses: r-lib/actions/setup-r-dependencies@v2
-        if: ${{ matrix.config.os == 'windows-latest' && matrix.config.r = 'oldrel-4' }}
+        if: ${{ matrix.config.os == 'windows-latest' && matrix.config.r == 'oldrel-4' }}
         with:
           cache-version: 3
           packages: >

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -64,10 +64,16 @@ jobs:
         if: ${{ matrix.config.os == 'windows-latest' && matrix.config.r == 'oldrel-4' }}
         with:
           cache-version: 3
+          extra-packages: >
+            any::rcmdcheck,
+            Hmisc=?ignore-before-r=4.2.0,
+            quantreg=?ignore-before-r=4.3.0
           packages: >
             ragg@1.4.0
+          needs: check
 
       - uses: r-lib/actions/setup-r-dependencies@v2
+        if: ${{ matrix.config.os != 'windows-latest' || matrix.config.r != 'oldrel-4' }}
         with:
           cache-version: 3
           extra-packages: >


### PR DESCRIPTION
Close #6620 

As ragg 1.5.0 cannot be installed on Windows with R 4.1, use 1.4.0.