### PR TITLE
set_theme() resets theme if called with no arguments.

### DIFF
--- a/R/theme-current.R
+++ b/R/theme-current.R
@@ -91,12 +91,10 @@ get_theme <- function() {
 theme_get <- get_theme
 
 #' @rdname get_theme
-#' @param new new theme (a list of theme elements). Sets theme to the default (theme_grey) if `new` isn't supplied.
+#' @param new new theme (a list of theme elements). Sets theme to the default ([theme_grey()]) if `new` isn't supplied.
 #' @export
 set_theme <- function(new) {
-  if (missing(new)) {
-    new <- ggplot_global$theme_default
-  }
+  new <- new %||% ggplot_global$theme_default
   check_object(new, is_theme, "a {.cls theme} object")
   old <- ggplot_global$theme_current
   ggplot_global$theme_current <- new

--- a/R/theme-current.R
+++ b/R/theme-current.R
@@ -93,7 +93,7 @@ theme_get <- get_theme
 #' @rdname get_theme
 #' @param new new theme (a list of theme elements). Sets theme to the default ([theme_grey()]) if `new` isn't supplied.
 #' @export
-set_theme <- function(new) {
+set_theme <- function(new = null) {
   new <- new %||% ggplot_global$theme_default
   check_object(new, is_theme, "a {.cls theme} object")
   old <- ggplot_global$theme_current

--- a/R/theme-current.R
+++ b/R/theme-current.R
@@ -91,9 +91,12 @@ get_theme <- function() {
 theme_get <- get_theme
 
 #' @rdname get_theme
-#' @param new new theme (a list of theme elements)
+#' @param new new theme (a list of theme elements). Sets theme to the default (theme_grey) if `new` isn't supplied.
 #' @export
 set_theme <- function(new) {
+  if (missing(new)) {
+    new <- ggplot_global$theme_default
+  }
   check_object(new, is_theme, "a {.cls theme} object")
   old <- ggplot_global$theme_current
   ggplot_global$theme_current <- new
@@ -141,4 +144,3 @@ theme_replace <- replace_theme
 
   e1
 }
-

--- a/R/theme-current.R
+++ b/R/theme-current.R
@@ -93,7 +93,7 @@ theme_get <- get_theme
 #' @rdname get_theme
 #' @param new new theme (a list of theme elements). Sets theme to the default ([theme_grey()]) if `new` isn't supplied.
 #' @export
-set_theme <- function(new = null) {
+set_theme <- function(new = NULL) {
   new <- new %||% ggplot_global$theme_default
   check_object(new, is_theme, "a {.cls theme} object")
   old <- ggplot_global$theme_current

--- a/man/get_theme.Rd
+++ b/man/get_theme.Rd
@@ -16,9 +16,9 @@ get_theme()
 
 theme_get()
 
-set_theme(new = null)
+set_theme(new = NULL)
 
-theme_set(new = null)
+theme_set(new = NULL)
 
 update_theme(...)
 

--- a/man/get_theme.Rd
+++ b/man/get_theme.Rd
@@ -31,7 +31,7 @@ theme_replace(...)
 e1 \%+replace\% e2
 }
 \arguments{
-\item{new}{new theme (a list of theme elements)}
+\item{new}{new theme (a list of theme elements). Sets theme to the default (theme_grey) if \code{new} isn't supplied.}
 
 \item{...}{named list of theme settings}
 

--- a/man/get_theme.Rd
+++ b/man/get_theme.Rd
@@ -31,7 +31,7 @@ theme_replace(...)
 e1 \%+replace\% e2
 }
 \arguments{
-\item{new}{new theme (a list of theme elements). Sets theme to the default (theme_grey) if \code{new} isn't supplied.}
+\item{new}{new theme (a list of theme elements). Sets theme to the default (\code{\link[=theme_grey]{theme_grey()}}) if \code{new} isn't supplied.}
 
 \item{...}{named list of theme settings}
 

--- a/man/get_theme.Rd
+++ b/man/get_theme.Rd
@@ -16,9 +16,9 @@ get_theme()
 
 theme_get()
 
-set_theme(new)
+set_theme(new = null)
 
-theme_set(new)
+theme_set(new = null)
 
 update_theme(...)
 

--- a/tests/testthat/test-theme.R
+++ b/tests/testthat/test-theme.R
@@ -56,6 +56,12 @@ test_that("modifying theme element properties with + operator works", {
   )
 })
 
+test_that("set_theme() resets theme to default when called with no arguments", {
+  theme_set(theme_void())
+  set_theme()
+  expect_identical(theme_get(), theme_grey())
+})
+
 test_that("adding theme object to ggplot object with + operator works", {
   ## test with complete theme
   p <- ggplot(data.frame(x = 1:3), aes(x, x)) + geom_point() + theme_grey()


### PR DESCRIPTION
`set_theme()` called without any arguments resets the theme to the default theme.

Fixes #6598.