### PR TITLE
Fixes Delete code for old versions of R

### DIFF
--- a/R/backports.R
+++ b/R/backports.R
@@ -1,25 +1,6 @@
-# Backport fix from R 3.3:
-# https://github.com/wch/r-source/commit/4efc81c98d262f93de9e7911aaa910f5c63cd00f
-if (getRversion() < "3.3") {
-  absolute.units <- utils::getFromNamespace("absolute.units", "grid")
-  absolute.units.unit <- utils::getFromNamespace("absolute.units.unit", "grid")
-  absolute.units.unit.list <- utils::getFromNamespace("absolute.units.unit.list", "grid")
-  absolute.units.unit.arithmetic <- utils::getFromNamespace("absolute.units.unit.arithmetic", "grid")
-
-  backport_unit_methods <- function() {
-    registerS3method("absolute.units", "unit", absolute.units.unit)
-    registerS3method("absolute.units", "unit.list", absolute.units.unit.list)
-    registerS3method("absolute.units", "unit.arithmetic", absolute.units.unit.arithmetic)
-  }
-} else {
-  backport_unit_methods <- function() {}
-}
-
 # enable usage of <S7_object>@name in package code
 #' @rawNamespace if (getRversion() < "4.3.0") importFrom("S7", "@")
 NULL
-
-on_load(backport_unit_methods())
 
 unitType <- function(x) {
   unit <- attr(x, "unit")

--- a/R/geom-polygon.R
+++ b/R/geom-polygon.R
@@ -41,9 +41,6 @@ GeomPolygon <- ggproto("GeomPolygon", Geom,
         )
       )
     } else {
-      if (getRversion() < "3.6") {
-        cli::cli_abort("Polygons with holes requires R 3.6 or above.")
-      }
       # Sort by group to make sure that colors, fill, etc. come in same order
       munched <- munched[order(munched$group, munched$subgroup), ]
       id <- match(munched$subgroup, unique0(munched$subgroup))
@@ -177,16 +174,3 @@ GeomPolygon <- ggproto("GeomPolygon", Geom,
 #'   p
 #' }
 geom_polygon <- make_constructor(GeomPolygon)
-
-# Assigning pathGrob in .onLoad ensures that packages that subclass GeomPolygon
-# do not install with error `possible error in 'pathGrob(munched$x, munched$y, ':
-# unused argument (pathId = munched$group)` despite the fact that this is correct
-# usage
-pathGrob <- NULL
-on_load(
-  if (getRversion() < as.numeric_version("3.6")) {
-    pathGrob <- function(..., pathId.lengths) {
-      grid::pathGrob(...)
-    }
-  }
-)


### PR DESCRIPTION
Deleted all code snippets that call `getRversion() <= "4.1"`. Fixes #6589