### PR TITLE
Allow expression labels in `scale_{x,y}_*()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Fixed regression where `draw_key_rect()` stopped using `fill` colours 
   (@mitchelloharawild, #6609).
+* Fixed regression where `scale_{x,y}_*()` threw an error when an expression
+  object is set to `labels` argument (@yutannihilation, #6617).
 
 # ggplot2 4.0.0
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -803,7 +803,7 @@ as_unordered_factor <- function(x) {
 size0 <- function(x) {
   if (obj_is_vector(x)) {
     vec_size(x)
-  } else if (is.vector(x)) {
+  } else if (is.vector(x) || is.expression(x)) {
     length(x)
   } else {
     NULL

--- a/tests/testthat/test-scales-breaks-labels.R
+++ b/tests/testthat/test-scales-breaks-labels.R
@@ -16,6 +16,14 @@ test_that("labels don't have to match null breaks", {
   expect_silent(check_breaks_labels(breaks = NULL, labels = 1:2))
 })
 
+test_that("labels accept expressions", {
+  labels <- parse(text = paste0(1:4, "^degree"))
+  sc <- scale_y_continuous(breaks = 1:4, labels = labels, limits = c(1, 3))
+
+  expect_equal(sc$get_breaks(), 1:4)
+  expect_equal(sc$get_labels(), as.list(labels))
+})
+
 test_that("labels don't have extra spaces", {
   labels <- c("a", "abc", "abcdef")
 


### PR DESCRIPTION
Fix #6617 

This function `size0` was introduced in https://github.com/tidyverse/ggplot2/pull/6076 and I guess the expression labels don't work since then. Reading #6076, I found there's no intention to drop support for expression labels, so I think this fixes the problem. (As I don't actively follow the recent development of ggplot2, sorry if I'm missing some discussion)

``` r
library(tibble)
devtools::load_all("~/GitHub/ggplot2/")
#> ℹ Loading ggplot2
#> Overwriting method +(<ggplot2::ggplot>, <ANY>)
#> 
#> Overwriting method +(<ggplot2::theme>, <ANY>)
#> 
#> Overwriting method convert(<ggplot2::ggplot>, <list>)

ggplot(tibble(x = -10:10, y = x^2)) +
  geom_point(aes(x, y)) +
  scale_x_continuous(
    breaks = seq(-10, 10, 2),
    labels = parse(text = paste0(seq(-10, 10, 2), "^degree"))
  )
```

![](https://i.imgur.com/ti6YYnB.png)<!-- -->

<sup>Created on 2025-09-21 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
