### PR TITLE
Unclass expression labels to allow `latex2exp::Tex()` to be axis labels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * Fixed regression where `draw_key_rect()` stopped using `fill` colours 
   (@mitchelloharawild, #6609).
 * Fixed regression where `scale_{x,y}_*()` threw an error when an expression
-  object is set to `labels` argument (@yutannihilation, #6617).
+  object is set to `labels` argument (@yutannihilation, #6617, #6638).
 
 
 * Allow `stat` in `geom_hline`, `geom_vline`, and `geom_abline`. (@sierrajohnson, #6559)

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -1190,7 +1190,7 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
       labels <- lapply(labels, `[`, 1)
     }
     if (is.expression(labels)) {
-      labels <- as.list(labels)
+      labels <- as.list(unclass(labels))
     }
 
     labels
@@ -1438,7 +1438,7 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
     }
 
     if (is.expression(labels)) {
-      labels <- as.list(labels)
+      labels <- as.list(unclass(labels))
     }
     labels
   },
@@ -1689,7 +1689,7 @@ ScaleBinned <- ggproto("ScaleBinned", Scale,
       )
     }
     if (is.expression(labels)) {
-      labels <- as.list(labels)
+      labels <- as.list(unclass(labels))
     }
     labels
   },

--- a/tests/testthat/test-scales-breaks-labels.R
+++ b/tests/testthat/test-scales-breaks-labels.R
@@ -18,10 +18,14 @@ test_that("labels don't have to match null breaks", {
 
 test_that("labels accept expressions", {
   labels <- parse(text = paste0(1:4, "^degree"))
-  sc <- scale_y_continuous(breaks = 1:4, labels = labels, limits = c(1, 3))
+  sc1 <- scale_y_continuous(breaks = 1:4, labels = labels, limits = c(1, 3))
 
-  expect_equal(sc$get_breaks(), 1:4)
-  expect_equal(sc$get_labels(), as.list(labels))
+  # classed labels should also work (#6638)
+  labels <- structure(labels, class = "foo")
+  sc2 <- scale_y_continuous(breaks = 1:4, labels = labels, limits = c(1, 3))
+
+  expect_equal(sc1$get_labels(), as.list(labels))
+  expect_equal(sc2$get_labels(), as.list(labels))
 })
 
 test_that("labels don't have extra spaces", {

--- a/tests/testthat/test-scales-breaks-labels.R
+++ b/tests/testthat/test-scales-breaks-labels.R
@@ -21,8 +21,8 @@ test_that("labels accept expressions", {
   sc1 <- scale_y_continuous(breaks = 1:4, labels = labels, limits = c(1, 3))
 
   # classed labels should also work (#6638)
-  labels <- structure(labels, class = "foo")
-  sc2 <- scale_y_continuous(breaks = 1:4, labels = labels, limits = c(1, 3))
+  classed_labels <- structure(labels, class = "foo")
+  sc2 <- scale_y_continuous(breaks = 1:4, labels = classed_labels, limits = c(1, 3))
 
   expect_equal(sc1$get_labels(), as.list(labels))
   expect_equal(sc2$get_labels(), as.list(labels))


### PR DESCRIPTION
Fix #6638

Quote myself in https://github.com/tidyverse/ggplot2/issues/6622#issuecomment-3321896346:

The error happens here. `key` is a data frame containing a `latexexpression` object in `.label` column.

https://github.com/tidyverse/ggplot2/blob/af6f4e8841f9af25a9706e7ee4d6e1ff0172c982/R/guide-.R#L287

The problem is, the `latexexpression` object cannot be subset by `vec_slice()` because

``` r
x <- as.list(latex2exp::TeX("$\\alpha$"))
vctrs::obj_is_vector(x)
#> [1] FALSE
```

However, it works if the object doesn't have S3 classes.

``` r
vctrs::obj_is_vector(unclass(x))
#> [1] TRUE
```

This pull request fixes the error by simply removing the class. Honestly, I'm not fully sure if this doesn't break any existing usage that actually requires the class information in labels. But, I believe this does the right thing.

---

``` r
devtools::load_all("~/GitHub/ggplot2/")
#> ℹ Loading ggplot2
#> Overwriting method +(<ggplot2::ggplot>, <ANY>)
#> 
#> Overwriting method +(<ggplot2::theme>, <ANY>)
#> 
#> Overwriting method convert(<ggplot2::ggplot>, <list>)
library(latex2exp)
ggplot(mtcars, aes(x = wt, y = mpg)) +
  geom_point() +
  scale_x_continuous(breaks = 3, labels = TeX("$\\alpha$"))
```

![](https://i.imgur.com/OE84wAG.png)<!-- -->

<sup>Created on 2025-09-24 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
