### PR TITLE
Fix regression in colour/fill scale name redirection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # ggplot2 (development version)
 
-### Bug fixes
-
+* Fixed regression where the first (unnamed) argument to colour/fill scales was 
+  not passed as the `name` argument (@teunbrand, #6623)
 * Fixed regression where `draw_key_rect()` stopped using `fill` colours 
   (@mitchelloharawild, #6609).
 * Fixed regression where `scale_{x,y}_*()` threw an error when an expression

--- a/R/scale-colour.R
+++ b/R/scale-colour.R
@@ -93,7 +93,8 @@ scale_colour_continuous <- function(..., palette = NULL, aesthetics = "colour",
   }
   palette <- if (!is.null(palette)) as_continuous_pal(palette)
   continuous_scale(
-    aesthetics, palette = palette, guide = guide, na.value = na.value,
+    aesthetics = aesthetics, palette = palette, guide = guide,
+    na.value = na.value, scale_name = deprecated(),
     ...
   )
 }
@@ -115,7 +116,8 @@ scale_fill_continuous <- function(..., palette = NULL, aesthetics = "fill", guid
   }
   palette <- if (!is.null(palette)) as_continuous_pal(palette)
   continuous_scale(
-    aesthetics, palette = palette, guide = guide, na.value = na.value,
+    aesthetics = aesthetics, palette = palette, guide = guide,
+    na.value = na.value, scale_name = deprecated(),
     ...
   )
 }
@@ -137,7 +139,8 @@ scale_colour_binned <- function(..., palette = NULL, aesthetics = "colour", guid
   }
   palette <- if (!is.null(palette)) pal_binned(as_discrete_pal(palette))
   binned_scale(
-    aesthetics, palette = palette, guide = guide, na.value = na.value,
+    aesthetics = aesthetics, palette = palette, guide = guide,
+    na.value = na.value, scale_name = deprecated(),
     ...
   )
 }
@@ -158,7 +161,8 @@ scale_fill_binned <- function(..., palette = NULL, aesthetics = "fill", guide = 
   }
   palette <- if (!is.null(palette)) pal_binned(as_discrete_pal(palette))
   binned_scale(
-    aesthetics, palette = palette, guide = guide, na.value = na.value,
+    aesthetics = aesthetics, palette = palette, guide = guide,
+    na.value = na.value, scale_name = deprecated(),
     ...
   )
 }
@@ -225,7 +229,8 @@ scale_colour_discrete <- function(..., palette = NULL, aesthetics = "colour", na
   }
   palette <- if (!is.null(palette)) as_discrete_pal(palette)
   discrete_scale(
-    aesthetics, palette = palette, na.value = na.value,
+    aesthetics = aesthetics, palette = palette, na.value = na.value,
+    scale_name = deprecated(),
     ...
   )
 }
@@ -246,7 +251,8 @@ scale_fill_discrete <- function(..., palette = NULL, aesthetics = "fill", na.val
   }
   palette <- if (!is.null(palette)) as_discrete_pal(palette)
   discrete_scale(
-    aesthetics, palette = palette, na.value = na.value,
+    aesthetics = aesthetics, palette = palette, na.value = na.value,
+    scale_name = deprecated(),
     ...
   )
 }

--- a/tests/testthat/test-scale-colour.R
+++ b/tests/testthat/test-scale-colour.R
@@ -49,3 +49,22 @@ test_that("palette arguments can take alternative input", {
   expect_equal(alpha(test, 1), hex)
 
 })
+
+test_that("`name` is directed correctly (#6623)", {
+  # The desired behaviour is that the first argument passed to scales is the
+  # 'name' argument.
+
+  scales <- list(
+    scale_colour_continuous,
+    scale_colour_discrete,
+    scale_colour_binned,
+    scale_fill_continuous,
+    scale_fill_discrete,
+    scale_fill_binned
+  )
+
+  for (scale in scales) {
+    p <- scale("foobar")
+    expect_equal(p$name, "foobar")
+  }
+})


### PR DESCRIPTION
This PR aims to fix #6623.

Briefly, it populates named parameters to the scale constructors such that `name` is once again populated by the first unnamed argument (or the argument named 'name', of course).

Reprex from issue, note that all legends have the given names, rather than default labels:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

ggplot(mtcars, aes(x = disp, y = hp, size = gear, colour = wt, fill = factor(cyl))) +
  geom_point(shape = 21) +
  scale_fill_discrete("Cylinders") + 
  scale_colour_continuous("Weight") + 
  scale_size_continuous("Gears")  
```

![](https://i.imgur.com/AO7gMwM.png)<!-- -->

<sup>Created on 2025-09-24 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
