### PR TITLE
Abort when ggproto definition is circular

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
 
 
 * Allow `stat` in `geom_hline`, `geom_vline`, and `geom_abline`. (@sierrajohnson, #6559)
+* Circularly defined `ggproto()` classes will throw more informative warning 
+  (@teunbrand, #6583).
 
 # ggplot2 4.0.0
 

--- a/R/ggproto.R
+++ b/R/ggproto.R
@@ -131,7 +131,14 @@ fetch_ggproto <- function(x, name) {
     if (is.null(super)) {
       # no super class
     } else if (is.function(super)) {
-      res <- fetch_ggproto(super(), name)
+      parent <- super()
+      if (!identical(parent, x)) {
+        # happy path
+        return(fetch_ggproto(parent, name))
+      }
+      cli::cli_abort(
+        "{.cls {class(x)[1]}} cannot have a circular definition."
+      )
     } else {
       cli::cli_abort(c(
         "{class(x)[[1]]} was built with an incompatible version of ggproto.",

--- a/tests/testthat/_snaps/ggproto.md
+++ b/tests/testthat/_snaps/ggproto.md
@@ -10,3 +10,7 @@
 
     `_inherit` must be a <ggproto> object, not a <data.frame> object.
 
+# circular definitions are protested
+
+    <Circular> cannot have a circular definition.
+

--- a/tests/testthat/test-ggproto.R
+++ b/tests/testthat/test-ggproto.R
@@ -11,6 +11,12 @@ test_that("construction checks input", {
   expect_snapshot_error(ggproto("Test", mtcars, a = function(self, a) a))
 })
 
+test_that("circular definitions are protested", {
+  circular <- ggproto("Circular")
+  circular <- ggproto(NULL, circular)
+  expect_snapshot_error(print(circular))
+})
+
 test_that("all ggproto methods start with `{` (#6459)", {
 
   ggprotos <- Filter(


### PR DESCRIPTION
This PR aims to fix #6583.

AFAICT, we cannot detect this during object construction.
The second best way to detect this is in `fetch_ggproto()`, as it is such a widely used accessor.
Reprex from issue:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

A <- ggproto("A")
A <- ggproto(NULL, A)
A
#> Error in `fetch_ggproto()` at ggplot2/R/ggproto.R:172:3:
#> ! <A> cannot have a circular definition.
```

<sup>Created on 2025-09-25 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
