### PR TITLE
Polygon/timeseries legend keys reflect `outline.type` setting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
 
 
 * Allow `stat` in `geom_hline`, `geom_vline`, and `geom_abline`. (@sierrajohnson, #6559)
+* `draw_key_polygon()` and `draw_key_timeseries()` now reflect the 
+  `outline.type` parameter (@teunbrand, #6649).
 
 # ggplot2 4.0.0
 

--- a/tests/testthat/_snaps/stat-align/align-two-areas-with-cliff.svg
+++ b/tests/testthat/_snaps/stat-align/align-two-areas-with-cliff.svg
@@ -53,9 +53,11 @@
 <rect x='686.87' y='259.00' width='27.65' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='686.87' y='267.71' style='font-size: 11.00px; font-family: sans;' textLength='6.12px' lengthAdjust='spacingAndGlyphs'>g</text>
 <rect x='686.87' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='687.58' y='275.04' width='15.86' height='15.86' style='stroke-width: 1.07; stroke-linecap: butt; fill: #F8766D;' />
+<rect x='687.58' y='275.04' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #F8766D;' />
+<line x1='687.58' y1='275.04' x2='703.44' y2='275.04' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <rect x='686.87' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='687.58' y='292.32' width='15.86' height='15.86' style='stroke-width: 1.07; stroke-linecap: butt; fill: #00BFC4;' />
+<rect x='687.58' y='292.32' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #00BFC4;' />
+<line x1='687.58' y1='292.32' x2='703.44' y2='292.32' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <text x='709.63' y='286.00' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>a</text>
 <text x='709.63' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text>
 <text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='139.40px' lengthAdjust='spacingAndGlyphs'>align two areas with cliff</text>

--- a/tests/testthat/_snaps/stat-align/align-two-areas-with-pos-neg-y.svg
+++ b/tests/testthat/_snaps/stat-align/align-two-areas-with-pos-neg-y.svg
@@ -53,9 +53,11 @@
 <rect x='686.87' y='259.00' width='27.65' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='686.87' y='267.71' style='font-size: 11.00px; font-family: sans;' textLength='6.12px' lengthAdjust='spacingAndGlyphs'>g</text>
 <rect x='686.87' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='687.58' y='275.04' width='15.86' height='15.86' style='stroke-width: 1.07; stroke-linecap: butt; fill: #F8766D;' />
+<rect x='687.58' y='275.04' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #F8766D;' />
+<line x1='687.58' y1='275.04' x2='703.44' y2='275.04' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <rect x='686.87' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='687.58' y='292.32' width='15.86' height='15.86' style='stroke-width: 1.07; stroke-linecap: butt; fill: #00BFC4;' />
+<rect x='687.58' y='292.32' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #00BFC4;' />
+<line x1='687.58' y1='292.32' x2='703.44' y2='292.32' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <text x='709.63' y='286.00' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>a</text>
 <text x='709.63' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text>
 <text x='30.83' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='176.85px' lengthAdjust='spacingAndGlyphs'>align two areas with pos/neg y</text>

--- a/tests/testthat/_snaps/stat-align/align-two-areas.svg
+++ b/tests/testthat/_snaps/stat-align/align-two-areas.svg
@@ -53,9 +53,11 @@
 <rect x='686.87' y='259.00' width='27.65' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='686.87' y='267.71' style='font-size: 11.00px; font-family: sans;' textLength='6.12px' lengthAdjust='spacingAndGlyphs'>g</text>
 <rect x='686.87' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='687.58' y='275.04' width='15.86' height='15.86' style='stroke-width: 1.07; stroke-linecap: butt; fill: #F8766D;' />
+<rect x='687.58' y='275.04' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #F8766D;' />
+<line x1='687.58' y1='275.04' x2='703.44' y2='275.04' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <rect x='686.87' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='687.58' y='292.32' width='15.86' height='15.86' style='stroke-width: 1.07; stroke-linecap: butt; fill: #00BFC4;' />
+<rect x='687.58' y='292.32' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #00BFC4;' />
+<line x1='687.58' y1='292.32' x2='703.44' y2='292.32' style='stroke-width: 1.07; stroke-linecap: butt;' />
 <text x='709.63' y='286.00' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>a</text>
 <text x='709.63' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text>
 <text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='88.79px' lengthAdjust='spacingAndGlyphs'>align two areas</text>


### PR DESCRIPTION
This PR aims to fix #6649.

This PR adds additional lines to the key glyphs when the `outline.type` is not full.
Arguably `draw_key_timeseries()` could also be made to support the `fill` aesthetic under all circumstances, but that is not enforced in this PR.

Demonstrations, notice the legend keys:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

ggplot(economics, aes(date)) +
  geom_area(
    aes(y = unemploy, fill = "Unemployment"),
    alpha = 0.5, colour = "black", outline.type = "upper"
  ) +
  geom_area(
    aes(y = pce, fill = "PCE"),
    alpha = 0.5, colour = "black", outline.type = "both"
  ) +
  geom_area(
    aes(y = pop / 30, fill = "Population"),
    alpha = 0.5, colour = "black", outline.type = "lower"
  ) +
  theme(
    legend.key.spacing.y = unit(5.5, "pt")
  )
```

![](https://i.imgur.com/m6L1MrC.png)<!-- -->

And for `draw_key_timeseries()`:

``` r
ggplot(economics, aes(date)) +
  geom_area(
    aes(y = unemploy, fill = "Unemployment"),
    alpha = 0.5, colour = "black", outline.type = "upper",
    key_glyph = draw_key_timeseries
  ) +
  geom_area(
    aes(y = pce, fill = "PCE"),
    alpha = 0.5, colour = "black", outline.type = "both",
    key_glyph = draw_key_timeseries
  ) +
  geom_area(
    aes(y = pop / 30, fill = "Population"),
    alpha = 0.5, colour = "black", outline.type = "lower",
    key_glyph = draw_key_timeseries
  ) +
  theme(
    legend.key.spacing.y = unit(5.5, "pt")
  )
```

![](https://i.imgur.com/15Y9cEl.png)<!-- -->

<sup>Created on 2025-09-25 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
