### PR TITLE
Add `format()` method for `class_gg`

### DIFF
--- a/R/plot-construction.R
+++ b/R/plot-construction.R
@@ -268,3 +268,12 @@ new_layer_names <- function(layer, existing) {
   names <- c(existing, new_name)
   vec_as_names(names, repair = "check_unique")
 }
+
+local({
+  S7::method(format, class_gg) <- function(x, ...) {
+    x <- S7::S7_class(x)
+    # Similar to S7:::S7_class_name
+    x <- paste(c(x@package, x@name), collapse = "::")
+    format(paste0("<", x, ">"), ...)
+  }
+})


### PR DESCRIPTION
This PR aims to fix #6526.

This is a fix for R-devel, as it relies on https://github.com/r-devel/r-svn/commit/940b5c2992dc606fdcf5146afc8ed27404d49754.
I don't think it is possible to also fix this for release/old versions.

Quick demonstration:

``` r
getRversion()
#> [1] '4.6.0'
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

z <- iris
z$gg <- list(ggplot())
print(head(z))
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species                gg
#> 1          5.1         3.5          1.4         0.2  setosa <ggplot2::ggplot>
#> 2          4.9         3.0          1.4         0.2  setosa <ggplot2::ggplot>
#> 3          4.7         3.2          1.3         0.2  setosa <ggplot2::ggplot>
#> 4          4.6         3.1          1.5         0.2  setosa <ggplot2::ggplot>
#> 5          5.0         3.6          1.4         0.2  setosa <ggplot2::ggplot>
#> 6          5.4         3.9          1.7         0.4  setosa <ggplot2::ggplot>
```

<sup>Created on 2025-09-26 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
