### PR TITLE
Improve quantile docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ### Bug fixes
 
+* Logical values for the linetype aesthetic will be interpreted numerically,
+  so that `linetype = FALSE` becomes 0/'blank' and `linetype = TRUE` becomes 
+  1/'solid' (@teunbrand, #6641)
 * Fixed regression where `draw_key_rect()` stopped using `fill` colours 
   (@mitchelloharawild, #6609).
 * Fixed regression where `scale_{x,y}_*()` threw an error when an expression

--- a/R/geom-violin.R
+++ b/R/geom-violin.R
@@ -24,7 +24,8 @@
 #' @param quantile.colour,quantile.color,quantile.linewidth,quantile.linetype
 #'   Default aesthetics for the quantile lines. Set to `NULL` to inherit from
 #'   the data's aesthetics. By default, quantile lines are hidden and can be
-#'   turned on by changing `quantile.linetype`.
+#'   turned on by changing `quantile.linetype`. Quantile values can be set
+#'   using the `quantiles` argument when using `stat = "ydensity"` (default).
 #' @param draw_quantiles `r lifecycle::badge("deprecated")` Previous
 #'   specification of drawing quantiles.
 #' @export

--- a/R/stat-ydensity.R
+++ b/R/stat-ydensity.R
@@ -137,8 +137,11 @@ StatYdensity <- ggproto(
 #' @param drop Whether to discard groups with less than 2 observations
 #'   (`TRUE`, default) or keep such groups for position adjustment purposes
 #'   (`FALSE`).
-#' @param quantiles If not `NULL` (default), compute the `quantile` variable
-#'   and draw horizontal lines at the given quantiles in `geom_violin()`.
+#' @param quantiles A numeric vector with numbers between 0 and 1 to indicate
+#'   quantiles marked by the `quantile` computed variable. The default marks the
+#'   25th, 50th and 75th percentiles. The display of quantiles can be
+#'   turned on by setting `quantile.linetype` to non-blank when using
+#'   `geom = "violin"` (default).
 #'
 #' @eval rd_computed_vars(
 #'   density = "Density estimate.",

--- a/R/utilities-grid.R
+++ b/R/utilities-grid.R
@@ -41,8 +41,13 @@ gg_par <- function(..., stroke = NULL, pointsize = NULL) {
     stroke[is.na(stroke)] <- 0
     args$fontsize <- pointsize * .pt + stroke * .stroke / 2
   }
-  if (!is.null(args$lty) && anyNA(args$lty)) {
-    args$lty[is.na(args$lty)] <- if (is.character(args$lty)) "blank" else 0
+  if (!is.null(args$lty)) {
+    if (is.logical(args$lty)) {
+      args$lty <- as.integer(args$lty)
+    }
+    if (anyNA(args$lty)) {
+      args$lty[is.na(args$lty)] <- if (is.character(args$lty)) "blank" else 0
+    }
   }
 
   inject(gpar(!!!args))

--- a/man/geom_violin.Rd
+++ b/man/geom_violin.Rd
@@ -118,7 +118,8 @@ outside of bounds are removed with a warning.}
 
 \item{quantile.colour, quantile.color, quantile.linewidth, quantile.linetype}{Default aesthetics for the quantile lines. Set to \code{NULL} to inherit from
 the data's aesthetics. By default, quantile lines are hidden and can be
-turned on by changing \code{quantile.linetype}.}
+turned on by changing \code{quantile.linetype}. Quantile values can be set
+using the \code{quantiles} argument when using \code{stat = "ydensity"} (default).}
 
 \item{draw_quantiles}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Previous
 specification of drawing quantiles.}
@@ -169,8 +170,11 @@ For example, \code{adjust = 1/2} means use half of the default bandwidth.}
 (\code{TRUE}, default) or keep such groups for position adjustment purposes
 (\code{FALSE}).}
 
-\item{quantiles}{If not \code{NULL} (default), compute the \code{quantile} variable
-and draw horizontal lines at the given quantiles in \code{geom_violin()}.}
+\item{quantiles}{A numeric vector with numbers between 0 and 1 to indicate
+quantiles marked by the \code{quantile} computed variable. The default marks the
+25th, 50th and 75th percentiles. The display of quantiles can be
+turned on by setting \code{quantile.linetype} to non-blank when using
+\code{geom = "violin"} (default).}
 }
 \description{
 A violin plot is a compact display of a continuous distribution. It is a


### PR DESCRIPTION
This PR aims to fix #6641.

In addition to improving the docs around quantiles, it also interprests logical `linetype` values as numeric.
From this follows that `linetype = TRUE` becomes solid and `linetype = FALSE` becomes blank.
It is convenient if you want a logical switch for linetypes, like so:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

ggplot(mpg, aes(drv, displ)) +
  geom_violin(quantile.linetype = TRUE)
```

![](https://i.imgur.com/F6G8J1h.png)<!-- -->

<sup>Created on 2025-09-26 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
