### PR TITLE
Pull GeomSf `linetype` from GeomPolygon/GeomLine

### DIFF
--- a/R/geom-sf.R
+++ b/R/geom-sf.R
@@ -126,7 +126,7 @@ GeomSf <- ggproto("GeomSf", Geom,
     fill = NULL,
     size = NULL,
     linewidth = NULL,
-    linetype = from_theme(linetype),
+    linetype = NULL,
     alpha = NA,
     stroke = 0.5
   ),
@@ -161,6 +161,7 @@ GeomSf <- ggproto("GeomSf", Geom,
         vec_slice(data, index$point),
         params, modifiers, theme = theme
       )
+      points$linetype <- 1L # Avoids NA linetype, which is invalid input
     }
     if (length(index$line) > 0) {
       lines <- GeomLine$use_defaults(


### PR DESCRIPTION
This PR aims to fix #6543.

Briefly, the default `linetype` aesthetic is now retrieved from `GeomPolygon` for `sf::st_polygon()` and from `GeomLine` for `sf::st_(multi)linestring()`.
The `sf::st_geometrycollection()` doesn't pull from a specific default.

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

# Bit contrived example to include all types
t <- seq(0, 2 *pi, length.out = 10)
data <- sf::st_sf(sf::st_sfc(
  sf::st_multipoint(cbind(1:2, 3:4)),
  sf::st_multilinestring(list(
    cbind(c(1, 1.8), c(3.8, 3)),
    cbind(c(1.2, 2), c(4, 3.2))
  )),
  sf::st_polygon(list(
    cbind(cos(t), zapsmall(sin(t))),
    cbind(cos(t), zapsmall(sin(t))) + 5
  )),
  sf::st_geometrycollection(x = list(
    sf::st_point(x = c(3, 2)),
    sf::st_linestring(cbind(c(2, 4, 4), c(1, 1, 3)))
  )),
  sf::st_linestring(x = cbind(c(2, 6), c(-1, 3))),
  sf::st_point(c(5, 0))
))

ggplot(data) + 
  geom_sf() +
  theme(
    geom.polygon = element_geom(colour = "red", bordertype = 2),
    geom.line    = element_geom(colour = "blue", linetype = 3),
    geom.point   = element_geom(colour = "orchid"),
    geom         = element_geom(colour = "orange", bordertype = 4) # collection
  )
```

![](https://i.imgur.com/N9YktNH.png)<!-- -->

<sup>Created on 2025-09-29 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
