### PR TITLE
Compatibility with upcoming testthat version

### DIFF
--- a/tests/testthat/_snaps/aes.md
+++ b/tests/testthat/_snaps/aes.md
@@ -1,4 +1,4 @@
-# accessing an undefined variable results in an error
+# aes evaluated in environment where plot created
 
     Code
       get_layer_data(p)

--- a/tests/testthat/_snaps/empty-data.md
+++ b/tests/testthat/_snaps/empty-data.md
@@ -14,7 +14,7 @@
       Error in `combine_vars()`:
       ! Faceting variables must have at least one value.
 
-# Should error when totally empty data frame because there's no x and y
+# empty data overrides plot defaults
 
     Code
       get_layer_data(d)

--- a/tests/testthat/test-aes.R
+++ b/tests/testthat/test-aes.R
@@ -48,14 +48,10 @@ test_that("aes evaluated in environment where plot created", {
   df <- data_frame(x = 1, y = 1)
   p <- ggplot(df, aes(foo, y)) + geom_point()
 
-  test_that("accessing an undefined variable results in an error", {
-    skip_if(getRversion() <= "4.4.0")
-    expect_snapshot(get_layer_data(p), error = TRUE)
-  })
-
   # Once it's defined we should get it back
   foo <- 0
   expect_equal(get_layer_data(p)$x, 0)
+  rm(foo)
 
   # And regular variable shadowing should work
   f <- function() {
@@ -63,6 +59,9 @@ test_that("aes evaluated in environment where plot created", {
     ggplot(df, aes(foo, y)) + geom_point()
   }
   expect_equal(get_layer_data(f())$x, 10)
+
+  skip_if(getRversion() <= "4.4.0")
+  expect_snapshot(get_layer_data(p), error = TRUE)
 })
 
 test_that("constants are not wrapped in quosures", {

--- a/tests/testthat/test-empty-data.R
+++ b/tests/testthat/test-empty-data.R
@@ -53,14 +53,6 @@ test_that("layers with empty data are silently omitted with facet_grid", {
 })
 
 test_that("empty data overrides plot defaults", {
-  test_that("Should error when totally empty data frame because there's no x and y", {
-    skip_if(getRversion() <= "4.4.0")
-    d <- ggplot(mtcars, aes(mpg, wt)) +
-      geom_point() +
-      geom_point(data = data_frame())
-    expect_snapshot(get_layer_data(d), error = TRUE)
-  })
-
   # No extra points when x and y vars don't exist but are set
   d <- ggplot(mtcars, aes(mpg, wt)) +
     geom_point() +
@@ -74,6 +66,12 @@ test_that("empty data overrides plot defaults", {
     geom_point(data = df0, x = 20, y = 3)
   expect_equal(nrow(get_layer_data(d, 1)), nrow(mtcars))
   expect_equal(nrow(get_layer_data(d, 2)), 0)
+
+  skip_if(getRversion() <= "4.4.0")
+  d <- ggplot(mtcars, aes(mpg, wt)) +
+    geom_point() +
+    geom_point(data = data_frame())
+  expect_snapshot(get_layer_data(d), error = TRUE)
 })
 
 test_that("layer inherits data from plot when data = NULL", {


### PR DESCRIPTION
This PR is upkeep.

It moves skipped expectations to the end of the test, rather than using nested tests.
