### PR TITLE
Silently drop out-of-bounds padding in `stat_align()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ### Bug fixes
 
+* Out-of-bounds datapoints used as padding by `stat_align()` now get removed
+  silently rather than verbosely (@teunbrand, #6667)
 * Fixed regression where `draw_key_rect()` stopped using `fill` colours 
   (@mitchelloharawild, #6609).
 * Fixed regression where `scale_{x,y}_*()` threw an error when an expression

--- a/R/stat-align.R
+++ b/R/stat-align.R
@@ -73,6 +73,13 @@ StatAlign <- ggproto(
       flipped_aes = flipped_aes
     )
     flip_data(data_aligned, flipped_aes)
+  },
+
+  finish_layer = function(data, params) {
+    # Silently remove out-of-bounds padding vertices
+    var <- flipped_names(params$flipped_aes)$x
+    remove <- is.na(data[[var]]) & (data$align_padding %||% FALSE)
+    vec_slice(data, !remove)
   }
 )
 

--- a/tests/testthat/test-stat-align.R
+++ b/tests/testthat/test-stat-align.R
@@ -50,3 +50,24 @@ test_that("alignment adjusts per panel", {
   expect_equal(diff(ld$x[1:2]), 1e-3, tolerance = 1e-4)
 
 })
+
+test_that("out-of-bounds padding is removed (#6667)", {
+  df <- data_frame0(
+    g = rep(c("a", "b"), each = 3L),
+    x = c(1, 3, 5, 2, 4, 6),
+    y = c(2, 5, 1, 3, 6, 7)
+  )
+  p <- ggplot(df, aes(x, y, fill = g)) + geom_area()
+  ld <- layer_data(p)
+  expect_equal(sum(ld$align_padding), 4)
+  # The first and last datapoints should be padding
+  expect_equal(ld$align_padding[c(1, nrow(ld))], c(TRUE, TRUE))
+
+
+  ld <- layer_data(
+    p + scale_x_continuous(limits = range(df$x), expand = c(0, 0))
+  )
+  expect_equal(sum(ld$align_padding), 2)
+  # The first and last datapoints should not be padding
+  expect_equal(ld$align_padding[c(1, nrow(ld))], c(FALSE, FALSE))
+})


### PR DESCRIPTION
This PR aims to fix #6667.

Since the padding values are not user error, we should just silently drop them.