### PR TITLE
Improve palette fallback

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ### Bug fixes
 
+* Improved palette fallback mechanism in scales (@teunbrand, #6669).
 * Fixed regression where `draw_key_rect()` stopped using `fill` colours 
   (@mitchelloharawild, #6609).
 * Fixed regression where `scale_{x,y}_*()` threw an error when an expression

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -92,6 +92,8 @@
 #'   to generate the values for the `expand` argument. The defaults are to
 #'   expand the scale by 5% on each side for continuous variables, and by
 #'   0.6 units on each side for discrete variables.
+#' @param fallback.palette Function to use when `palette = NULL` and the
+#'   palette is not represented in the theme.
 #' @param position For position scales, The position of the axis.
 #' `left` or `right` for y axes, `top` or `bottom` for x axes.
 #' @param call The `call` used to construct the scale for reporting messages.

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -107,6 +107,7 @@ continuous_scale <- function(aesthetics, scale_name = deprecated(), palette, nam
                              oob = censor, expand = waiver(), na.value = NA,
                              transform = "identity", trans = deprecated(),
                              guide = "legend", position = "left",
+                             fallback.palette = NULL,
                              call = caller_call(),
                              super = ScaleContinuous) {
   call <- call %||% current_call()
@@ -121,6 +122,7 @@ continuous_scale <- function(aesthetics, scale_name = deprecated(), palette, nam
   aesthetics <- standardise_aes_names(aesthetics)
 
   check_breaks_labels(breaks, labels, call = call)
+  check_fallback_palette(palette, fallback.palette, call = call)
 
   position <- arg_match0(position, c("left", "right", "top", "bottom"))
 
@@ -152,6 +154,7 @@ continuous_scale <- function(aesthetics, scale_name = deprecated(), palette, nam
 
     aesthetics = aesthetics,
     palette = palette,
+    fallback_palette = fallback.palette,
 
     range = ContinuousRange$new(),
     limits = limits,
@@ -211,6 +214,7 @@ discrete_scale <- function(aesthetics, scale_name = deprecated(), palette, name 
                            labels = waiver(), limits = NULL, expand = waiver(),
                            na.translate = TRUE, na.value = NA, drop = TRUE,
                            guide = "legend", position = "left",
+                           fallback.palette = NULL,
                            call = caller_call(),
                            super = ScaleDiscrete) {
   call <- call %||% current_call()
@@ -221,6 +225,7 @@ discrete_scale <- function(aesthetics, scale_name = deprecated(), palette, name 
   aesthetics <- standardise_aes_names(aesthetics)
 
   check_breaks_labels(breaks, labels, call = call)
+  check_fallback_palette(palette, fallback.palette, call = call)
 
   # Convert formula input to function if appropriate
   limits <- allow_lambda(limits)
@@ -251,6 +256,7 @@ discrete_scale <- function(aesthetics, scale_name = deprecated(), palette, name 
 
     aesthetics = aesthetics,
     palette = palette,
+    fallback_palette = fallback.palette,
 
     range = DiscreteRange$new(),
     limits = limits,
@@ -303,6 +309,7 @@ binned_scale <- function(aesthetics, scale_name = deprecated(), palette, name = 
                          right = TRUE, transform = "identity",
                          trans = deprecated(), show.limits = FALSE,
                          guide = "bins", position = "left",
+                         fallback.palette = NULL,
                          call = caller_call(),
                          super = ScaleBinned) {
   if (lifecycle::is_present(scale_name)) {
@@ -318,6 +325,7 @@ binned_scale <- function(aesthetics, scale_name = deprecated(), palette, name = 
   aesthetics <- standardise_aes_names(aesthetics)
 
   check_breaks_labels(breaks, labels, call = call)
+  check_fallback_palette(palette, fallback.palette, call = call)
 
   position <- arg_match0(position, c("left", "right", "top", "bottom"))
 
@@ -346,6 +354,7 @@ binned_scale <- function(aesthetics, scale_name = deprecated(), palette, name = 
 
     aesthetics = aesthetics,
     palette = palette,
+    fallback_palette = fallback.palette,
 
     range = ContinuousRange$new(),
     limits = limits,
@@ -1791,6 +1800,15 @@ check_continuous_limits <- function(limits, ...,
   }
   check_numeric(limits, arg = arg, call = call, allow_na = TRUE)
   check_length(limits, 2L, arg = arg, call = call)
+}
+
+check_fallback_palette <- function(pal, fallback, call = caller_env()) {
+  if (!is.null(pal) || is.function(fallback)) {
+    return(invisible)
+  }
+  cli::cli_abort(
+    "When {.code palette = NULL}, the {.arg fallback.palette} must be defined."
+  )
 }
 
 allow_lambda <- function(x) {

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -598,7 +598,7 @@ Scale <- ggproto("Scale", NULL,
     if (empty(df)) {
       return()
     }
-    self$palette <- self$palette %||% fallback_palette(self)
+    self$palette <- self$palette %||% fetch_ggproto(self, "fallback_palette")
 
     aesthetics <- intersect(self$aesthetics, names(df))
     names(aesthetics) <- aesthetics

--- a/R/scale-alpha.R
+++ b/R/scale-alpha.R
@@ -33,7 +33,11 @@
 #' p + scale_alpha("cylinders")
 scale_alpha <- function(name = waiver(), ..., range = NULL, aesthetics = "alpha") {
   palette <- if (!is.null(range)) pal_rescale(range) else NULL
-  continuous_scale(aesthetics, name = name, palette = palette, ...)
+  continuous_scale(
+    aesthetics, name = name, palette = palette,
+    fallback.palette = pal_rescale(c(0.1, 1)),
+    ...
+  )
 }
 
 #' @rdname scale_alpha
@@ -44,7 +48,11 @@ scale_alpha_continuous <- scale_alpha
 #' @export
 scale_alpha_binned <- function(name = waiver(), ..., range = NULL, aesthetics = "alpha") {
   palette <- if (!is.null(range)) pal_rescale(range) else NULL
-  binned_scale(aesthetics, name = name, palette = palette, ...)
+  binned_scale(
+    aesthetics, name = name, palette = palette,
+    fallback.palette = pal_rescale(c(0.1, 1)),
+    ...
+  )
 }
 
 #' @rdname scale_alpha
@@ -64,7 +72,11 @@ scale_alpha_ordinal <- function(name = waiver(), ..., range = NULL, aesthetics =
   } else {
     NULL
   }
-  discrete_scale(aesthetics, name = name, palette = palette, ...)
+  discrete_scale(
+    aesthetics, name = name, palette = palette,
+    fallback.palette = function(n) seq(0.1, 1, length.out = n),
+    ...
+  )
 }
 
 #' @rdname scale_alpha
@@ -74,7 +86,8 @@ scale_alpha_datetime <- function(name = waiver(), ..., range = NULL, aesthetics 
   palette <- if (!is.null(range)) pal_rescale(range) else NULL
   datetime_scale(
     aesthetics = aesthetics, transform = "time", name = name,
-    palette = palette, ...
+    palette = palette, fallback.palette = pal_rescale(c(0.1, 1)),
+    ...
   )
 }
 
@@ -85,6 +98,7 @@ scale_alpha_date <- function(name = waiver(), ..., range = NULL, aesthetics = "a
   palette <- if (!is.null(range)) pal_rescale(range) else NULL
   datetime_scale(
     aesthetics = aesthetics, transform = "date", name = name,
-    palette = palette, ...
+    palette = palette, fallback.palette = pal_rescale(c(0.1, 1)),
+    ...
   )
 }

--- a/R/scale-colour.R
+++ b/R/scale-colour.R
@@ -94,6 +94,7 @@ scale_colour_continuous <- function(..., palette = NULL, aesthetics = "colour",
   palette <- if (!is.null(palette)) as_continuous_pal(palette)
   continuous_scale(
     aesthetics, palette = palette, guide = guide, na.value = na.value,
+    fallback.palette = pal_seq_gradient("#132B43", "#56B1F7"),
     ...
   )
 }
@@ -116,6 +117,7 @@ scale_fill_continuous <- function(..., palette = NULL, aesthetics = "fill", guid
   palette <- if (!is.null(palette)) as_continuous_pal(palette)
   continuous_scale(
     aesthetics, palette = palette, guide = guide, na.value = na.value,
+    fallback.palette = pal_seq_gradient("#132B43", "#56B1F7"),
     ...
   )
 }
@@ -138,6 +140,7 @@ scale_colour_binned <- function(..., palette = NULL, aesthetics = "colour", guid
   palette <- if (!is.null(palette)) pal_binned(as_discrete_pal(palette))
   binned_scale(
     aesthetics, palette = palette, guide = guide, na.value = na.value,
+    fallback.palette = pal_seq_gradient("#132B43", "#56B1F7"),
     ...
   )
 }
@@ -159,6 +162,7 @@ scale_fill_binned <- function(..., palette = NULL, aesthetics = "fill", guide = 
   palette <- if (!is.null(palette)) pal_binned(as_discrete_pal(palette))
   binned_scale(
     aesthetics, palette = palette, guide = guide, na.value = na.value,
+    fallback.palette = pal_seq_gradient("#132B43", "#56B1F7"),
     ...
   )
 }
@@ -226,6 +230,7 @@ scale_colour_discrete <- function(..., palette = NULL, aesthetics = "colour", na
   palette <- if (!is.null(palette)) as_discrete_pal(palette)
   discrete_scale(
     aesthetics, palette = palette, na.value = na.value,
+    fallback.palette = pal_hue(),
     ...
   )
 }
@@ -247,6 +252,7 @@ scale_fill_discrete <- function(..., palette = NULL, aesthetics = "fill", na.val
   palette <- if (!is.null(palette)) as_discrete_pal(palette)
   discrete_scale(
     aesthetics, palette = palette, na.value = na.value,
+    fallback.palette = pal_hue(),
     ...
   )
 }

--- a/R/scale-discrete-.R
+++ b/R/scale-discrete-.R
@@ -10,7 +10,7 @@
 #' level, and increasing by one for each level (i.e. the labels are placed
 #' at integer positions).  This is what allows jittering to work.
 #'
-#' @inheritDotParams discrete_scale -scale_name
+#' @inheritDotParams discrete_scale -scale_name -fallback.palette
 #' @inheritParams discrete_scale
 #' @param palette A palette function that when called with a single integer
 #'   argument (the number of levels in the scale) returns the numerical values

--- a/R/scale-gradient.R
+++ b/R/scale-gradient.R
@@ -16,7 +16,7 @@
 #' @param low,high Colours for low and high ends of the gradient.
 #' @param guide Type of legend. Use `"colourbar"` for continuous
 #'   colour bar, or `"legend"` for discrete colour legend.
-#' @inheritDotParams continuous_scale -na.value -guide -aesthetics -expand -position -palette
+#' @inheritDotParams continuous_scale -na.value -guide -aesthetics -expand -position -palette -fallback.palette
 #' @seealso [scales::pal_seq_gradient()] for details on underlying
 #'   palette, [scale_colour_steps()] for binned variants of these scales.
 #'

--- a/R/scale-grey.R
+++ b/R/scale-grey.R
@@ -5,7 +5,7 @@
 #'
 #' @inheritParams scales::pal_grey
 #' @inheritParams scale_colour_hue
-#' @inheritDotParams discrete_scale -expand -position -scale_name -palette
+#' @inheritDotParams discrete_scale -expand -position -scale_name -palette -fallback.palette
 #' @family colour scales
 #' @seealso
 #' The documentation on [colour aesthetics][aes_colour_fill_alpha].

--- a/R/scale-hue.R
+++ b/R/scale-hue.R
@@ -4,7 +4,7 @@
 #' It does not generate colour-blind safe palettes.
 #'
 #' @param na.value Colour to use for missing values
-#' @inheritDotParams discrete_scale -aesthetics -expand -position -scale_name -palette
+#' @inheritDotParams discrete_scale -aesthetics -expand -position -scale_name -palette -fallback.palette
 #' @param aesthetics Character string or vector of character strings listing the
 #'   name(s) of the aesthetic(s) that this scale works with. This can be useful, for
 #'   example, to apply colour settings to the `colour` and `fill` aesthetics at the

--- a/R/scale-linetype.R
+++ b/R/scale-linetype.R
@@ -6,7 +6,7 @@
 #' no inherent order, this use is not advised.
 #'
 #' @inheritParams discrete_scale
-#' @inheritDotParams discrete_scale -expand -position -na.value -scale_name -palette
+#' @inheritDotParams discrete_scale -expand -position -na.value -scale_name -palette -fallback.palette
 #' @rdname scale_linetype
 #' @details
 #' Lines can be referred to by number, name or hex code. Contrary to base R

--- a/R/scale-linetype.R
+++ b/R/scale-linetype.R
@@ -45,7 +45,7 @@
 scale_linetype <- function(name = waiver(), ..., aesthetics = "linetype") {
   discrete_scale(
     aesthetics, name = name,
-    palette = NULL,
+    palette = NULL, fallback.palette = pal_linetype(),
     ...
   )
 }
@@ -55,7 +55,7 @@ scale_linetype <- function(name = waiver(), ..., aesthetics = "linetype") {
 scale_linetype_binned <- function(name = waiver(), ..., aesthetics = "linetype") {
   binned_scale(
     aesthetics, name = name,
-    palette = NULL,
+    palette = NULL, fallback.palette = pal_binned(pal_linetype()),
     ...
   )
 }

--- a/R/scale-linewidth.R
+++ b/R/scale-linewidth.R
@@ -36,9 +36,12 @@ scale_linewidth_continuous <- function(name = waiver(), breaks = waiver(),
                                        guide = "legend",
                                        aesthetics = "linewidth") {
   palette <- if (!is.null(range)) pal_rescale(range) else NULL
-  continuous_scale(aesthetics, palette = palette, name = name,
-                   breaks = breaks, labels = labels, limits = limits,
-                   transform = transform, trans = trans, guide = guide)
+  continuous_scale(
+    aesthetics, palette = palette, name = name,
+    breaks = breaks, labels = labels, limits = limits,
+    transform = transform, trans = trans, guide = guide,
+    fallback.palette = pal_rescale(c(1, 6))
+  )
 }
 
 #' @rdname scale_linewidth
@@ -52,10 +55,13 @@ scale_linewidth_binned <- function(name = waiver(), breaks = waiver(), labels = 
                               nice.breaks = TRUE, transform = "identity",
                               trans = deprecated(), guide = "bins", aesthetics = "linewidth") {
   palette <- if (!is.null(range)) pal_rescale(range) else NULL
-  binned_scale(aesthetics, palette = palette, name = name,
-               breaks = breaks, labels = labels, limits = limits,
-               transform = transform, trans = trans, n.breaks = n.breaks,
-               nice.breaks = nice.breaks, guide = guide)
+  binned_scale(
+    aesthetics, palette = palette, name = name,
+    breaks = breaks, labels = labels, limits = limits,
+    transform = transform, trans = trans, n.breaks = n.breaks,
+    nice.breaks = nice.breaks, guide = guide,
+    fallback.palette = pal_rescale(c(1, 6))
+  )
 }
 
 #' @rdname scale_linewidth
@@ -77,7 +83,11 @@ scale_linewidth_ordinal <- function(name = waiver(), ..., range = NULL, aestheti
   } else {
     NULL
   }
-  discrete_scale(aesthetics, name = name, palette = palette, ...)
+  discrete_scale(
+    aesthetics, name = name, palette = palette,
+    fallback.palette = function(n) seq(2, 6, length.out = n),
+    ...
+  )
 }
 
 #' @rdname scale_linewidth
@@ -87,7 +97,8 @@ scale_linewidth_datetime <- function(name = waiver(), ..., range = NULL, aesthet
   palette <- if (!is.null(range)) pal_rescale(range) else NULL
   datetime_scale(
     aesthetics, transform = "time", name = name,
-    palette = palette, ...
+    palette = palette, fallback.palette = pal_rescale(c(1, 6)),
+    ...
   )
 }
 
@@ -98,6 +109,7 @@ scale_linewidth_date <- function(name = waiver(), ..., range = NULL, aesthetics 
   palette <- if (!is.null(range)) pal_rescale(range) else NULL
   datetime_scale(
     aesthetics, transform = "date", name = name,
-    palette = palette, ...
+    palette = palette, fallback.palette = pal_rescale(c(1, 6)),
+    ...
   )
 }

--- a/R/scale-manual.R
+++ b/R/scale-manual.R
@@ -12,7 +12,7 @@
 #' of aesthetics provided via the `aesthetics` argument.
 #'
 #' @inheritParams discrete_scale
-#' @inheritDotParams discrete_scale -expand -position -aesthetics -palette -scale_name
+#' @inheritDotParams discrete_scale -expand -position -aesthetics -palette -scale_name -fallback.palette
 #' @param aesthetics Character string or vector of character strings listing the
 #'   name(s) of the aesthetic(s) that this scale works with. This can be useful, for
 #'   example, to apply colour settings to the `colour` and `fill` aesthetics at the

--- a/R/scale-shape.R
+++ b/R/scale-shape.R
@@ -10,7 +10,7 @@
 #' @param solid Should the shapes be solid, `TRUE`, or hollow,
 #'   `FALSE`?
 #' @inheritParams discrete_scale
-#' @inheritDotParams discrete_scale -expand -position -scale_name -palette
+#' @inheritDotParams discrete_scale -expand -position -scale_name -palette -fallback.palette
 #' @rdname scale_shape
 #' @details
 #' Shapes can be referred to by number or name. Shapes in \[0, 20\] do not

--- a/R/scale-shape.R
+++ b/R/scale-shape.R
@@ -51,14 +51,22 @@
 #'   theme_void()
 scale_shape <- function(name = waiver(), ..., solid = NULL, aesthetics = "shape") {
   palette <- if (!is.null(solid)) pal_shape(solid) else NULL
-  discrete_scale(aesthetics, name = name, palette = palette, ...)
+  discrete_scale(
+    aesthetics, name = name, palette = palette,
+    fallback.palette = pal_shape(),
+    ...
+  )
 }
 
 #' @rdname scale_shape
 #' @export
 scale_shape_binned <- function(name = waiver(), ..., solid = TRUE, aesthetics = "shape") {
   palette <- if (!is.null(solid)) pal_binned(pal_shape(solid)) else NULL
-  binned_scale(aesthetics, name = name, palette = palette, ...)
+  binned_scale(
+    aesthetics, name = name, palette = palette,
+    fallback.palette = pal_binned(pal_shape(solid)),
+    ...
+  )
 }
 
 #' @rdname scale_shape

--- a/R/scale-size.R
+++ b/R/scale-size.R
@@ -58,9 +58,12 @@ scale_size_continuous <- function(name = waiver(), breaks = waiver(), labels = w
                                   guide = "legend",
                                   aesthetics = "size") {
   palette <- if (!is.null(range)) pal_area(range) else NULL
-  continuous_scale(aesthetics, palette = palette, name = name,
+  continuous_scale(
+    aesthetics, palette = palette, name = name,
     breaks = breaks, labels = labels, limits = limits,
-    transform = transform, trans = trans, guide = guide)
+    transform = transform, trans = trans, guide = guide,
+    fallback.palette = pal_area()
+  )
 }
 
 #' @rdname scale_size
@@ -86,10 +89,13 @@ scale_size_binned <- function(name = waiver(), breaks = waiver(), labels = waive
                               trans = deprecated(), guide = "bins",
                               aesthetics = "size") {
   palette <- if (!is.null(range)) pal_area(range) else NULL
-  binned_scale(aesthetics, palette = palette, name = name,
-               breaks = breaks, labels = labels, limits = limits,
-               transform = transform, trans = trans, n.breaks = n.breaks,
-               nice.breaks = nice.breaks, guide = guide)
+  binned_scale(
+    aesthetics, palette = palette, name = name,
+    breaks = breaks, labels = labels, limits = limits,
+    transform = transform, trans = trans, n.breaks = n.breaks,
+    nice.breaks = nice.breaks, guide = guide,
+    fallback.palette = pal_area()
+  )
 }
 
 #' @rdname scale_size
@@ -111,7 +117,11 @@ scale_size_ordinal <- function(name = waiver(), ..., range = NULL, aesthetics = 
   } else {
     NULL
   }
-  discrete_scale(aesthetics, name = name, palette = palette, ...)
+  discrete_scale(
+    aesthetics, name = name, palette = palette,
+    fallback.palette = function(n) sqrt(seq(4, 36, length.out = n)),
+    ...
+  )
 }
 
 #' @inheritDotParams continuous_scale -aesthetics -scale_name -palette -rescaler -expand -position
@@ -141,7 +151,11 @@ scale_size_binned_area <- function(name = waiver(), ..., max_size = 6, aesthetic
 #' @usage NULL
 scale_size_datetime <- function(name = waiver(), ..., range = NULL, aesthetics = "size") {
   palette <- if (!is.null(range)) pal_area(range) else NULL
-  datetime_scale(aesthetics, "time", name = name, palette = palette, ...)
+  datetime_scale(
+    aesthetics, "time", name = name, palette = palette,
+    fallback.palette = pal_area(),
+    ...
+  )
 }
 
 #' @rdname scale_size
@@ -149,5 +163,9 @@ scale_size_datetime <- function(name = waiver(), ..., range = NULL, aesthetics =
 #' @usage NULL
 scale_size_date <- function(name = waiver(), ..., range = NULL, aesthetics = "size") {
   palette <- if (!is.null(range)) pal_area(range) else NULL
-  datetime_scale(aesthetics, "date", name = name, palette = palette, ...)
+  datetime_scale(
+    aesthetics, "date", name = name, palette = palette,
+    fallback.palette = pal_area(),
+    ...
+  )
 }

--- a/R/scale-size.R
+++ b/R/scale-size.R
@@ -124,7 +124,7 @@ scale_size_ordinal <- function(name = waiver(), ..., range = NULL, aesthetics = 
   )
 }
 
-#' @inheritDotParams continuous_scale -aesthetics -scale_name -palette -rescaler -expand -position
+#' @inheritDotParams continuous_scale -aesthetics -scale_name -palette -rescaler -expand -position -fallback.palette
 #' @param max_size Size of largest points.
 #' @export
 #' @rdname scale_size

--- a/R/scale-steps.R
+++ b/R/scale-steps.R
@@ -13,7 +13,7 @@
 #' Munsell colour system.
 #'
 #' @inheritParams scale_colour_gradient
-#' @inheritDotParams binned_scale -aesthetics -scale_name -palette -na.value -guide -rescaler -expand -position
+#' @inheritDotParams binned_scale -aesthetics -scale_name -palette -na.value -guide -rescaler -expand -position -fallback.palette
 #'
 #' @seealso
 #' [scales::pal_seq_gradient()] for details on underlying palette,

--- a/R/scales-.R
+++ b/R/scales-.R
@@ -183,7 +183,7 @@ ScalesList <- ggproto("ScalesList", NULL,
       elem <- compact(lapply(elem, calc_element, theme))[1][[1]]
 
       # Resolve the palette itself
-      elem <- elem %||% fallback_palette(scale)
+      elem <- elem %||% fetch_ggproto(scale, "fallback_palette")
       palette <- switch(
         type,
         discrete   = as_discrete_pal(elem),

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -810,34 +810,6 @@ size0 <- function(x) {
   }
 }
 
-fallback_palette <- function(scale) {
-  aes <- scale$aesthetics[1]
-  discrete <- scale$is_discrete()
-  if (discrete) {
-    pal <- switch(
-      aes,
-      colour = , fill = pal_hue(),
-      alpha = function(n) seq(0.1, 1, length.out = n),
-      linewidth = function(n) seq(2, 6, length.out = n),
-      linetype = pal_linetype(),
-      shape = pal_shape(),
-      size = function(n) sqrt(seq(4, 36, length.out = n)),
-      ggplot_global$theme_default[[paste0("palette.", aes, ".discrete")]]
-    )
-    return(pal)
-  }
-  switch(
-    aes,
-    colour = , fill = pal_seq_gradient("#132B43", "#56B1F7"),
-    alpha = pal_rescale(c(0.1, 1)),
-    linewidth = pal_rescale(c(1, 6)),
-    linetype = pal_binned(pal_linetype()),
-    shape = pal_binned(pal_shape()),
-    size = pal_area(),
-    ggplot_global$theme_default[[paste0("palette.", aes, ".continuous")]]
-  )
-}
-
 warn_dots_used <- function(env = caller_env(), call = caller_env()) {
   check_dots_used(
     env = env, call = call,

--- a/man/binned_scale.Rd
+++ b/man/binned_scale.Rd
@@ -24,6 +24,7 @@ binned_scale(
   show.limits = FALSE,
   guide = "bins",
   position = "left",
+  fallback.palette = NULL,
   call = caller_call(),
   super = ScaleBinned
 )
@@ -147,6 +148,9 @@ You can create your own transformation with \code{\link[scales:new_transform]{sc
 
 \item{position}{For position scales, The position of the axis.
 \code{left} or \code{right} for y axes, \code{top} or \code{bottom} for x axes.}
+
+\item{fallback.palette}{Function to use when \code{palette = NULL} and the
+palette is not represented in the theme.}
 
 \item{call}{The \code{call} used to construct the scale for reporting messages.}
 

--- a/man/continuous_scale.Rd
+++ b/man/continuous_scale.Rd
@@ -22,6 +22,7 @@ continuous_scale(
   trans = deprecated(),
   guide = "legend",
   position = "left",
+  fallback.palette = NULL,
   call = caller_call(),
   super = ScaleContinuous
 )
@@ -145,6 +146,9 @@ You can create your own transformation with \code{\link[scales:new_transform]{sc
 
 \item{position}{For position scales, The position of the axis.
 \code{left} or \code{right} for y axes, \code{top} or \code{bottom} for x axes.}
+
+\item{fallback.palette}{Function to use when \code{palette = NULL} and the
+palette is not represented in the theme.}
 
 \item{call}{The \code{call} used to construct the scale for reporting messages.}
 

--- a/man/datetime_scale.Rd
+++ b/man/datetime_scale.Rd
@@ -146,6 +146,8 @@ away from the axes. Use the convenience function \code{\link[=expansion]{expansi
 to generate the values for the \code{expand} argument. The defaults are to
 expand the scale by 5\% on each side for continuous variables, and by
 0.6 units on each side for discrete variables.}
+    \item{\code{fallback.palette}}{Function to use when \code{palette = NULL} and the
+palette is not represented in the theme.}
     \item{\code{position}}{For position scales, The position of the axis.
 \code{left} or \code{right} for y axes, \code{top} or \code{bottom} for x axes.}
     \item{\code{super}}{The super class to use for the constructed scale}

--- a/man/discrete_scale.Rd
+++ b/man/discrete_scale.Rd
@@ -19,6 +19,7 @@ discrete_scale(
   drop = TRUE,
   guide = "legend",
   position = "left",
+  fallback.palette = NULL,
   call = caller_call(),
   super = ScaleDiscrete
 )
@@ -109,6 +110,9 @@ every level in a legend, the layer should use \code{show.legend = TRUE}.}
 
 \item{position}{For position scales, The position of the axis.
 \code{left} or \code{right} for y axes, \code{top} or \code{bottom} for x axes.}
+
+\item{fallback.palette}{Function to use when \code{palette = NULL} and the
+palette is not represented in the theme.}
 
 \item{call}{The \code{call} used to construct the scale for reporting messages.}
 


### PR DESCRIPTION
This PR aims to fix #6669.

Briefly, instead of having a function 'guess' a fallback function for a scale, we now populate this as an explicit argument to scales.
This ensures that non-standard aesthetics that use a standard default scale constructor also pick up a reasonable fallback palette.