### PR TITLE
Add `position_jitterdodge(preserve)` argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ### Bug fixes
 
+* Added `preserve` argument to `position_jitterdodge()` (@teunbrand, #6584).
 * Fixed regression where `draw_key_rect()` stopped using `fill` colours 
   (@mitchelloharawild, #6609).
 * Fixed regression where `scale_{x,y}_*()` threw an error when an expression

--- a/R/position-jitterdodge.R
+++ b/R/position-jitterdodge.R
@@ -21,6 +21,7 @@
 #'   geom_point(pch = 21, position = position_jitterdodge())
 position_jitterdodge <- function(jitter.width = NULL, jitter.height = 0,
                                  dodge.width = 0.75, reverse = FALSE,
+                                 preserve = "total",
                                  seed = NA) {
   if (!is.null(seed) && is.na(seed)) {
     seed <- sample.int(.Machine$integer.max, 1L)
@@ -31,6 +32,7 @@ position_jitterdodge <- function(jitter.width = NULL, jitter.height = 0,
     jitter.width = jitter.width,
     jitter.height = jitter.height,
     dodge.width = dodge.width,
+    preserve = arg_match0(preserve, c("total", "single")),
     reverse = reverse,
     seed = seed
   )
@@ -45,6 +47,8 @@ PositionJitterdodge <- ggproto("PositionJitterdodge", Position,
   jitter.height = NULL,
   dodge.width = NULL,
   reverse = NULL,
+  default_aes = aes(order = NULL),
+  preserve = "total",
 
   required_aes = c("x", "y"),
 
@@ -53,18 +57,27 @@ PositionJitterdodge <- ggproto("PositionJitterdodge", Position,
     data <- flip_data(data, flipped_aes)
     width <- self$jitter.width %||% (resolution(data$x, zero = FALSE, TRUE) * 0.4)
 
-    ndodge <- vec_unique(data[c("group", "PANEL", "x")])
-    ndodge <- vec_group_id(ndodge[c("PANEL", "x")])
-    ndodge <- max(tabulate(ndodge, attr(ndodge, "n")))
+    if (identical(self$preserve, "total")) {
+      n <- NULL
+    } else {
+      n <- vec_unique(data[c("group", "PANEL", "x")])
+      n <- vec_group_id(n[c("PANEL", "x")])
+      n <- max(tabulate(n, attr(n, "n")))
+    }
 
     list(
       dodge.width = self$dodge.width %||% 0.75,
       jitter.height = self$jitter.height %||% 0,
-      jitter.width = width / (ndodge + 2),
+      jitter.width = width / ((n %||% 1) + 2),
+      n = n,
       seed = self$seed,
       flipped_aes = flipped_aes,
       reverse = self$reverse %||% FALSE
     )
+  },
+
+  setup_data = function(self, data, params) {
+    PositionDodge$setup_data(data = data, params = params)
   },
 
   compute_panel = function(data, params, scales) {
@@ -72,8 +85,9 @@ PositionJitterdodge <- ggproto("PositionJitterdodge", Position,
     data <- collide(
       data,
       params$dodge.width,
-      "position_jitterdodge",
+      name = "position_jitterdodge",
       strategy = pos_dodge,
+      n = params$n,
       check.width = FALSE,
       reverse = !params$reverse # for consistency with `position_dodge2()`
     )

--- a/man/position_jitterdodge.Rd
+++ b/man/position_jitterdodge.Rd
@@ -9,6 +9,7 @@ position_jitterdodge(
   jitter.height = 0,
   dodge.width = 0.75,
   reverse = FALSE,
+  preserve = "total",
   seed = NA
 )
 }
@@ -23,6 +24,9 @@ the default \code{position_dodge()} width.}
 
 \item{reverse}{If \code{TRUE}, will reverse the default stacking order.
 This is useful if you're rotating both the plot and legend.}
+
+\item{preserve}{Should dodging preserve the \code{"total"} width of all elements
+at a position, or the width of a \code{"single"} element?}
 
 \item{seed}{A random seed to make the jitter reproducible.
 Useful if you need to apply the same jitter twice, e.g., for a point and

--- a/tests/testthat/test-position-jitterdodge.R
+++ b/tests/testthat/test-position-jitterdodge.R
@@ -9,3 +9,24 @@ test_that("position_jitterdodge preserves widths", {
     rep(0.45, nrow(ld))
   )
 })
+
+test_that("position_jitterdodge can preserve total or single width", {
+
+  df <- data_frame(x = c("a", "b", "b"), y = 1:3)
+
+  # Total
+  p <- ggplot(df, aes(x, y, group = y)) +
+    geom_point(position = position_jitterdodge(
+      preserve = "total", dodge.width = 1,
+      jitter.width = 0, jitter.height = 0
+    ))
+  expect_equal(get_layer_data(p)$x, new_mapped_discrete(c(1, 1.75, 2.25)))
+
+  # Single
+  p <- ggplot(df, aes(x, y, group = y)) +
+    geom_point(position = position_jitterdodge(
+      preserve = "single", dodge.width = 1,
+      jitter.width = 0, jitter.height = 0
+    ))
+  expect_equal(get_layer_data(p)$x, new_mapped_discrete(c(0.75, 1.75, 2.25)))
+})


### PR DESCRIPTION
This PR aims to fix #6584.

It includes the `preserve` logic analogous to `position_dodge()`, as well as the `order` aesthetic.
Reprex from issue:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

ggplot(penguins, aes(species, bill_len, fill = island)) +
  stat_summary(
    geom = "bar",
    fun = "mean",
    show.legend = T,
    position = position_dodge(preserve = "single")
  ) +
  stat_summary(
    geom = "errorbar",
    fun.data = "mean_sdl",
    fun.args = list(mult = 1),
    width = 0.3,
    position = position_dodge(width = 0.9, preserve = "single")
  ) +
  geom_point(
    show.legend = F,
    position = position_jitterdodge(
      jitter.width = 0.3, dodge.width = 0.9, preserve = "single"
    )
  )
#> Warning: Removed 2 rows containing non-finite outside the scale range
#> (`stat_summary()`).
#> Removed 2 rows containing non-finite outside the scale range
#> (`stat_summary()`).
#> Warning: Removed 2 rows containing missing values or values outside the scale range
#> (`geom_point()`).
```

![](https://i.imgur.com/g7jDIvg.png)<!-- -->

<sup>Created on 2025-10-02 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
