### PR TITLE
Rephrase part of `?ggplot()` docs

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -2,7 +2,7 @@
 #'
 #' `ggplot()` initializes a ggplot object. It can be used to
 #' declare the input data frame for a graphic and to specify the
-#' set of plot aesthetics intended to be common throughout all
+#' set of aesthetic mappings for the plot, intended to be common throughout all
 #' subsequent layers unless specifically overridden.
 #'
 #' `ggplot()` is used to construct the initial plot object,

--- a/man/ggplot.Rd
+++ b/man/ggplot.Rd
@@ -22,7 +22,7 @@ evaluation.}
 \description{
 \code{ggplot()} initializes a ggplot object. It can be used to
 declare the input data frame for a graphic and to specify the
-set of plot aesthetics intended to be common throughout all
+set of aesthetic mappings for the plot, intended to be common throughout all
 subsequent layers unless specifically overridden.
 }
 \details{


### PR DESCRIPTION
This PR aims to fix #6445.

To avoid the confusion that it is suggested that fixed aesthetics can also be passed to `ggplot()`. They cannot.
There was a second suggestion in the issue:

> and further down, in "Details":
> Static aesthetics can't be set globally with ... like they would in geom_*() functions. To change global static aesthetic values for geometries, use the geom argument in the theme() function.

But I think this is off-topic for the `?ggplot()` docs.