### PR TITLE
update mentions of RStudio Community

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,7 +5,7 @@ about: Submit a bug report to help us improve ggplot2
 
 ### Tips for a helpful bug report:
 
-* If you have a question, please don't use this form. Instead, ask on <https://stackoverflow.com/> or <https://community.rstudio.com/>.
+* If you have a question, please don't use this form. Instead, ask on <https://stackoverflow.com/> or <https://forum.posit.co/>.
 
 * Please include a **minimal reproducible example**, a reprex, to demonstrate the bug.
 If you've never heard of a reprex, please read ["Make a reprex"](https://www.tidyverse.org/help/#reprex).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
   - name: Help or discussion
     url: https://forum.posit.co/
-    about: "Check out options for getting help on the Posit (formerly RStudio) Community."
+    about: "Check out options for getting help on the Posit Community (formerly RStudio Community)."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
   - name: Help or discussion
-    url: https://community.rstudio.com/
-    about: "Check out options for getting help on the RStudio Community."
+    url: https://forum.posit.co/
+    about: "Check out options for getting help on the Posit (formerly RStudio) Community."

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,7 +5,7 @@ about: Suggest a change or new feature in ggplot2
 
 ### Tips for a helpful feature request:
 
-* If you have a question, please don't use this form. Instead, ask on <https://stackoverflow.com/> or <https://community.rstudio.com/>.
+* If you have a question, please don't use this form. Instead, ask on <https://stackoverflow.com/> or <https://forum.posit.co/>.
 
 * See the [contributing guidelines](https://github.com/tidyverse/ggplot2/blob/main/CONTRIBUTING.md).
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,7 +9,7 @@
 
 random_tip <- function() {
   tips <- c(
-    "posit Community (formerly RStudio community) is a great place to get help: https://forum.posit.co/c/tidyverse",
+    "Posit Community (formerly RStudio Community) is a great place to get help: https://forum.posit.co/c/tidyverse",
     "Learn more about the underlying theory at https://ggplot2-book.org/",
     "Keep up to date with changes at https://tidyverse.org/blog/",
     "Use suppressPackageStartupMessages() to eliminate package startup messages",

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,7 +9,7 @@
 
 random_tip <- function() {
   tips <- c(
-    "RStudio Community is a great place to get help: https://forum.posit.co/c/tidyverse",
+    "posit Community (formerly RStudio community) is a great place to get help: https://forum.posit.co/c/tidyverse",
     "Learn more about the underlying theory at https://ggplot2-book.org/",
     "Keep up to date with changes at https://tidyverse.org/blog/",
     "Use suppressPackageStartupMessages() to eliminate package startup messages",

--- a/README.Rmd
+++ b/README.Rmd
@@ -103,7 +103,7 @@ If you are new to ggplot2 you are better off starting with a systematic introduc
 
 There are two main places to get help with ggplot2:
 
-1.  The [posit community][community] (formerly RStudio Community) is a friendly place to ask any
+1.  The [Posit Community][community] (formerly RStudio Community) is a friendly place to ask any
     questions about ggplot2.
 
 1.  [Stack Overflow][so] is a great source of answers to common ggplot2

--- a/README.Rmd
+++ b/README.Rmd
@@ -103,7 +103,7 @@ If you are new to ggplot2 you are better off starting with a systematic introduc
 
 There are two main places to get help with ggplot2:
 
-1.  The [RStudio community][community] is a friendly place to ask any
+1.  The [posit community][community] (formerly RStudio Community) is a friendly place to ask any
     questions about ggplot2.
 
 1.  [Stack Overflow][so] is a great source of answers to common ggplot2

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ documentation pages. Currently, there are several good places to start:
 
 There are two main places to get help with ggplot2:
 
-1.  The [RStudio community](https://forum.posit.co/) is a friendly place
-    to ask any questions about ggplot2.
+1.  The [Posit Community](https://forum.posit.co/) (formerly RStudio
+    Community) is a friendly place to ask any questions about ggplot2.
 
 2.  [Stack
     Overflow](https://stackoverflow.com/questions/tagged/ggplot2?sort=frequent&pageSize=50)


### PR DESCRIPTION
discussed in #6681
I've updated all mentions and urls of RStudio Community to posit Community, but added "(formerly RStudio community)" when relevant for context and disambiguation