### PR TITLE
Expression aesthetics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ### Bug fixes
 
+* `geom_text()` and `geom_label()` accept expressions as the `label` aesthetic 
+  (@teunbrand, #6638)
 * Fixed regression where `draw_key_rect()` stopped using `fill` colours 
   (@mitchelloharawild, #6609).
 * Fixed regression where `scale_{x,y}_*()` threw an error when an expression

--- a/R/geom-label.R
+++ b/R/geom-label.R
@@ -83,6 +83,7 @@ GeomLabel <- ggproto("GeomLabel", Geom,
     if (parse) {
       lab <- parse_safe(as.character(lab))
     }
+    lab <- validate_labels(lab)
 
     data <- coord$transform(data, panel_params)
     data$vjust <- compute_just(data$vjust, data$y, data$x, data$angle)

--- a/R/geom-text.R
+++ b/R/geom-text.R
@@ -23,6 +23,7 @@ GeomText <- ggproto(
     if (parse) {
       lab <- parse_safe(as.character(lab))
     }
+    lab <- validate_labels(lab)
 
     data <- coord$transform(data, panel_params)
 

--- a/R/layer.R
+++ b/R/layer.R
@@ -176,6 +176,7 @@ layer <- function(geom = NULL, stat = NULL,
   if (check.aes && length(extra_aes) > 0) {
     cli::cli_warn("Ignoring unknown aesthetics: {.field {extra_aes}}", call = call_env)
   }
+  aes_params$label <- normalise_label(aes_params$label)
 
   # adjust the legend draw key if requested
   geom <- set_draw_key(geom, key_glyph %||% params$key_glyph)
@@ -552,6 +553,7 @@ Layer <- ggproto("Layer", NULL,
 
     # Evaluate aesthetics
     evaled <- eval_aesthetics(aesthetics, data)
+    evaled$label <- normalise_label(evaled$label)
     plot@scales$add_defaults(evaled, plot@plot_env)
 
     # Check for discouraged usage in mapping
@@ -962,4 +964,18 @@ cleanup_mismatched_data <- function(data, n, fun) {
 
   data[failed] <- NULL
   data
+}
+
+normalise_label <- function(label) {
+  if (is.null(label)) {
+    return(NULL)
+  }
+  if (obj_is_list(label)) {
+    label[lengths(label) == 0] <- ""
+    labels <- lapply(labels, `[`, i)
+  }
+  if (is.expression(label)) {
+    label <- unclass(as.list(label))
+  }
+  label
 }

--- a/R/scale-.R
+++ b/R/scale-.R
@@ -1182,18 +1182,7 @@ ScaleContinuous <- ggproto("ScaleContinuous", Scale,
         call = self$call
       )
     }
-
-    if (obj_is_list(labels)) {
-      # Guard against list with empty elements
-      labels[lengths(labels) == 0] <- ""
-      # Make sure each element is scalar
-      labels <- lapply(labels, `[`, 1)
-    }
-    if (is.expression(labels)) {
-      labels <- as.list(labels)
-    }
-
-    labels
+    normalise_label(labels)
   },
 
   clone = function(self) {
@@ -1436,11 +1425,7 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
       # Need to ensure that if breaks were dropped, corresponding labels are too
       labels <- labels[attr(breaks, "pos")]
     }
-
-    if (is.expression(labels)) {
-      labels <- as.list(labels)
-    }
-    labels
+    normalise_label(labels)
   },
 
   clone = function(self) {
@@ -1688,10 +1673,7 @@ ScaleBinned <- ggproto("ScaleBinned", Scale,
         call = self$call
       )
     }
-    if (is.expression(labels)) {
-      labels <- as.list(labels)
-    }
-    labels
+    normalise_label(labels)
   },
 
   clone = function(self) {

--- a/tests/testthat/_snaps/geom-text/geom-text-with-expressions.svg
+++ b/tests/testthat/_snaps/geom-text/geom-text-with-expressions.svg
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDAuMTN8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='40.13' y='22.78' width='674.39' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDAuMTN8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='40.13' y='22.78' width='674.39' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='56.49' y='525.70' style='font-size: 11.00px; font-family: sans;' textLength='6.60px' lengthAdjust='spacingAndGlyphs'>α</text>
+<text x='65.12' y='525.70' style='font-size: 11.00px; font-family: sans;' textLength='8.54px' lengthAdjust='spacingAndGlyphs'>+</text>
+<text x='75.70' y='525.70' style='font-size: 11.00px; font-family: sans;' textLength='5.10px' lengthAdjust='spacingAndGlyphs'>β</text>
+<text x='80.80' y='520.18' style='font-size: 7.70px; font-family: sans;' textLength='4.28px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='675.50' y='50.56' style='font-size: 11.00px; font-family: sans;' textLength='5.02px' lengthAdjust='spacingAndGlyphs'>γ</text>
+<polyline points='680.52,47.43 681.88,46.65 683.25,50.69 685.06,40.27 691.73,40.27 ' style='stroke-width: 0.75;' />
+<text x='686.23' y='50.56' style='font-size: 11.00px; font-family: sans;' textLength='4.99px' lengthAdjust='spacingAndGlyphs'>δ</text>
+<rect x='40.13' y='22.78' width='674.39' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='35.20' y='524.40' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>1.00</text>
+<text x='35.20' y='405.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>1.25</text>
+<text x='35.20' y='286.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>1.50</text>
+<text x='35.20' y='168.26' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>1.75</text>
+<text x='35.20' y='49.55' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>2.00</text>
+<polyline points='37.39,521.37 40.13,521.37 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.39,402.66 40.13,402.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.39,283.95 40.13,283.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.39,165.24 40.13,165.24 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.39,46.53 40.13,46.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='70.79,547.85 70.79,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='224.06,547.85 224.06,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='377.33,547.85 377.33,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='530.60,547.85 530.60,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='683.87,547.85 683.87,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='70.79' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>1.00</text>
+<text x='224.06' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>1.25</text>
+<text x='377.33' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>1.50</text>
+<text x='530.60' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>1.75</text>
+<text x='683.87' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>2.00</text>
+<text x='377.33' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
+<text x='40.13' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='162.91px' lengthAdjust='spacingAndGlyphs'>geom_text with expressions</text>
+</g>
+</svg>

--- a/tests/testthat/test-geom-text.R
+++ b/tests/testthat/test-geom-text.R
@@ -33,6 +33,18 @@ test_that("geom_text() rejects exotic units", {
   )
 })
 
+test_that("geom_text() can display expressions", {
+
+  df <- data_frame0(x = 1:2, y = 1:2)
+  df$exp <- expression(alpha + beta^2, gamma * sqrt(delta))
+
+  expect_doppelganger(
+    "geom_text with expressions",
+    ggplot(df, aes(x, y, label = exp)) +
+      geom_text()
+  )
+})
+
 # compute_just ------------------------------------------------------------
 
 test_that("vertical and horizontal positions are equivalent", {


### PR DESCRIPTION
This PR aims to fix #6622 and fix #6638.

Essentially, whenever an expression `label` comes in, we pack it as a list. In the drawing methods of `GeomText` and `GeomLabel` we unpack the list back to expressions. This way, expressions survive internals.