### PR TITLE
Fix `geom_ribbon(stat = "align")` dropping single groups

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ### Bug fixes
 
+* Fixed regression where `geom_area()` didn't draw panels with single groups 
+  when `stat = "align"` (@teunbrand, #6680)
 * Fixed regression where `draw_key_rect()` stopped using `fill` colours 
   (@mitchelloharawild, #6609).
 * Fixed regression where `scale_{x,y}_*()` threw an error when an expression

--- a/R/geom-ribbon.R
+++ b/R/geom-ribbon.R
@@ -124,7 +124,12 @@ GeomRibbon <- ggproto("GeomRibbon", Geom,
     data <- unclass(data) #for faster indexing
 
     # In case the data comes from stat_align
-    upper_keep <- if (is.null(data$align_padding)) TRUE else !data$align_padding
+    upper_keep <- TRUE
+    if (!is.null(data$align_padding)) {
+      upper_keep <- !data$align_padding
+      # `align_padding` can be NA when group is the only group in panel
+      upper_keep[is.na(upper_keep)] <- TRUE
+    }
 
     # The upper line and lower line need to processed separately (#4023)
     positions_upper <- data_frame0(


### PR DESCRIPTION
This PR aims to fix #6680.

The issue was caused by single groups that don't get assigned an `align_padding` computed aesthetic, because of the early exit here:

https://github.com/tidyverse/ggplot2/blob/081806c57e4d525bcb1cabc975a8ff08ae68ca71/R/stat-align.R#L19-L21

These would get `NA` values for `align_padding`, which this PR now keeps around.

Reprex from issue:

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

df <- data.frame(
  x = c(1, 2, 1, 2, 1, 2),
  y = c(1, 1, 1, 1, 1, 1),
  g = c("A", "A", "B", "B", "C", "C"),
  f = c("x", "x", "x", "x", "y", "y")
)

ggplot(df, aes(x, y, fill = g)) +
  geom_area(position = "stack") +
  facet_wrap(vars(f))
```

![](https://i.imgur.com/lfJxSgA.png)<!-- -->

<sup>Created on 2025-10-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
