### PR TITLE
Omit legend items

### DIFF
--- a/R/guide-legend.R
+++ b/R/guide-legend.R
@@ -89,7 +89,7 @@
 #' # override.aes overwrites the alpha
 #' p3 + guides(colour = guide_legend(override.aes = list(alpha = 1)))
 #'
-#' omit legend items
+#' # omit legend items
 #' p4 <- ggplot(mtcars, aes(wt, mpg, colour = factor(cyl))) +
 #'   geom_point()
 #' p4

--- a/man/guide_legend.Rd
+++ b/man/guide_legend.Rd
@@ -114,7 +114,7 @@ p3
 # override.aes overwrites the alpha
 p3 + guides(colour = guide_legend(override.aes = list(alpha = 1)))
 
-omit legend items
+# omit legend items
 p4 <- ggplot(mtcars, aes(wt, mpg, colour = factor(cyl))) +
   geom_point()
 p4


### PR DESCRIPTION
Hi,

I found this in an old branch I had on my fork, just adding an example of using `breaks` to omit legend items.
I wrote a silly [blog post](https://luisdva.github.io/rstats/set-the-breaks/) about this in 2018 and discussed this kind of example with Hadley back in 2019 during LatinR (but at the time I didn't know how to make contributions).



