### PR TITLE
Add "Supported By Posit" badge to website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -6,6 +6,7 @@ template:
 
   includes:
     in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-hide-below="1200" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
       <script defer data-domain="ggplot2.tidyverse.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
       <script async src="https://widget.kapa.ai/kapa-widget.bundle.js"
       data-button-hide="true"


### PR DESCRIPTION
## Overview

This PR adds the "Supported by Posit" badge to the website.

## Background

The "Supported by Posit" badge is a clickable element that can be added to Quarto and pkgdown websites to indicate that Posit, PBC supports the project. It appears on the far right of the top navigation bar or at the bottom of the hamburger menu. It links to Posit’s main website. See https://posit-dev.github.io/supported-by-posit/ for more information.

## Changes

- Added a line to `_pkgdown.yml` to include the JavaScript file.

## Screenshot

<img width="1200" height="300" alt="screenshot" src="https://github.com/user-attachments/assets/6ab802bb-a7c6-4bb7-b87c-8562fbe08e0a" />

