### PR TITLE
Correct version in deprecation messages

### DIFF
--- a/R/fortify-map.R
+++ b/R/fortify-map.R
@@ -28,7 +28,7 @@
 #' }
 fortify.map <- function(model, data, ...) {
   lifecycle::deprecate_warn(
-    "3.6.0", I("`fortify(<map>)`"), "map_data()"
+    "4.0.0", I("`fortify(<map>)`"), "map_data()"
   )
   df <- data_frame0(
     long = model$x,

--- a/R/fortify-models.R
+++ b/R/fortify-models.R
@@ -39,7 +39,7 @@
 #'   geom_point()
 fortify.lm <- function(model, data = model$model, ...) {
   lifecycle::deprecate_warn(
-    "3.6.0", I("`fortify(<lm>)`"), I("`broom::augment(<lm>)`")
+    "4.0.0", I("`fortify(<lm>)`"), I("`broom::augment(<lm>)`")
   )
   infl <- stats::influence(model, do.coef = FALSE)
   data$.hat <- infl$hat
@@ -102,7 +102,7 @@ NULL
 #' @export
 fortify.glht <- function(model, data, ...) {
   lifecycle::deprecate_warn(
-    "3.6.0", I("`fortify(<glht>)`"), I("`broom::tidy(<glht>)`")
+    "4.0.0", I("`fortify(<glht>)`"), I("`broom::tidy(<glht>)`")
   )
   base::data.frame(
     lhs = rownames(model$linfct),
@@ -118,7 +118,7 @@ fortify.glht <- function(model, data, ...) {
 #' @export
 fortify.confint.glht <- function(model, data, ...) {
   lifecycle::deprecate_warn(
-    "3.6.0", I("`fortify(<confint.glht>)`"), I("`broom::tidy(<confint.glht>)`")
+    "4.0.0", I("`fortify(<confint.glht>)`"), I("`broom::tidy(<confint.glht>)`")
   )
   coef <- model$confint
   colnames(coef) <- to_lower_ascii(colnames(coef))
@@ -137,7 +137,7 @@ fortify.confint.glht <- function(model, data, ...) {
 #' @export
 fortify.summary.glht <- function(model, data, ...) {
   lifecycle::deprecate_warn(
-    "3.6.0", I("`fortify(<summary.glht>)`"), I("`broom::tidy(<summary.glht>)`")
+    "4.0.0", I("`fortify(<summary.glht>)`"), I("`broom::tidy(<summary.glht>)`")
   )
   coef <- as.data.frame(
     model$test[c("coefficients", "sigma", "tstat", "pvalues")])
@@ -158,7 +158,7 @@ fortify.summary.glht <- function(model, data, ...) {
 #' @export
 fortify.cld <- function(model, data, ...) {
   lifecycle::deprecate_warn(
-    "3.6.0", I("`fortify(<summary.glht>)`"), I("`broom::tidy(<summary.glht>)`")
+    "4.0.0", I("`fortify(<summary.glht>)`"), I("`broom::tidy(<summary.glht>)`")
   )
   base::data.frame(
     lhs = names(model$mcletters$Letters),


### PR DESCRIPTION
This PR aims to fix #6703.

We were under the assumption that the next version would be 3.6.0 when the messages were written, but this later became 4.0.0.
