### PR TITLE
Document `labs()` options more explicitly

### DIFF
--- a/R/labels.R
+++ b/R/labels.R
@@ -155,7 +155,13 @@ setup_plot_labels <- function(plot, layers, data) {
 #'        See [get_alt_text] for examples. `alt` can also be a function that
 #'        takes the plot as input and returns text as output. `alt` also accepts
 #'        rlang [lambda][rlang::as_function()] function notation.
-#' @param ... A list of new name-value pairs. The name should be an aesthetic.
+#' @param ...
+#' New name-value pairs. The name should be an aesthetic. The values can be
+#' one of the following:
+#' * A string or expression to set a label verbatim.
+#' * A function to use as formatter for the default label.
+#' * `NULL` to remove a label.
+#' * A [`waiver()`] to use the default label.
 #' @export
 #'
 #' @seealso

--- a/man/labs.Rd
+++ b/man/labs.Rd
@@ -28,7 +28,14 @@ ggtitle(label, subtitle = waiver())
 get_labs(plot = get_last_plot())
 }
 \arguments{
-\item{...}{A list of new name-value pairs. The name should be an aesthetic.}
+\item{...}{New name-value pairs. The name should be an aesthetic. The values can be
+one of the following:
+\itemize{
+\item A string or expression to set a label verbatim.
+\item A function to use as formatter for the default label.
+\item \code{NULL} to remove a label.
+\item A \code{\link[=waiver]{waiver()}} to use the default label.
+}}
 
 \item{title}{The text for the title.}
 


### PR DESCRIPTION
This PR aims to fix #6700.

It just lists out the different types of input `labs()` accepts.