### PR TITLE
pass plot into `alt` lambda to match S7 method

### DIFF
--- a/R/labels.R
+++ b/R/labels.R
@@ -105,7 +105,12 @@ setup_plot_labels <- function(plot, layers, data) {
     if (!is.function(label)) {
       return(label)
     }
-    label(plot %||% "")
+
+    if (nm %in% c("alt", "alt_insight")) {
+      label(plot %||% "") 
+    } else {
+      label(labels[[nm]] %||% "") 
+    }
   })
 
   dict <- plot_labels$dictionary


### PR DESCRIPTION
This PR fixes #6725 

The bug was that if a lambda was passed into the `alt` parameter of `labs`, the plot could not actually be rendered. However, if the plot was simply crafted but not *built*, the alt text function would work as expected, allowing the user to reference `plot` attributes.

Specifically, the bug was located in `setup_plot_labels`. An `lapply` in the function passed in labels, whereas the `get_alt_text` function passed in the plot.

This is small PR that copies the `get_alt_text` behavior into `setup_plot_labels`, and isolates `alt` text behavior from the non aesthetic and title parameters.