### PR TITLE
Rephrase `stat_ellipse(type)` docs

### DIFF
--- a/R/stat-ellipse.R
+++ b/R/stat-ellipse.R
@@ -36,12 +36,14 @@ StatEllipse <- ggproto(
 #'
 #' @param level The level at which to draw an ellipse,
 #'   or, if `type="euclid"`, the radius of the circle to be drawn.
-#' @param type The type of ellipse.
-#'   The default `"t"` assumes a multivariate t-distribution, and
-#'   `"norm"` assumes a multivariate normal distribution.
-#'   `"euclid"` draws a circle with the radius equal to `level`,
-#'   representing the euclidean distance from the center.
-#'   This ellipse probably won't appear circular unless `coord_fixed()` is applied.
+#' @param type The type of ellipse. One of the following:
+#'   * `"t"` assuming a multivariate t-distribution based on [MASS::cov.trob()].
+#'   * `"norm"` assuming a multivariate normal distribution.
+#'   * `"euclid"` drawing a circle with the radius equal to `level`,
+#'     representing the euclidean distance from the center. This ellipse
+#'     probably won't appear circular unless `coord_fixed()` is applied.
+#'
+#'   The `"norm"` and `"euclid"` options are based on [stats::cov.wt()].
 #' @param segments The number of segments to be used in drawing the ellipse.
 #' @inheritParams layer
 #' @inheritParams geom_point

--- a/man/stat_ellipse.Rd
+++ b/man/stat_ellipse.Rd
@@ -93,12 +93,16 @@ lists which parameters it can accept.
 \link[=draw_key]{key glyphs}, to change the display of the layer in the legend.
 }}
 
-\item{type}{The type of ellipse.
-The default \code{"t"} assumes a multivariate t-distribution, and
-\code{"norm"} assumes a multivariate normal distribution.
-\code{"euclid"} draws a circle with the radius equal to \code{level},
-representing the euclidean distance from the center.
-This ellipse probably won't appear circular unless \code{coord_fixed()} is applied.}
+\item{type}{The type of ellipse. One of the following:
+\itemize{
+\item \code{"t"} assuming a multivariate t-distribution based on \code{\link[MASS:cov.trob]{MASS::cov.trob()}}.
+\item \code{"norm"} assuming a multivariate normal distribution.
+\item \code{"euclid"} drawing a circle with the radius equal to \code{level},
+representing the euclidean distance from the center. This ellipse
+probably won't appear circular unless \code{coord_fixed()} is applied.
+}
+
+The \code{"norm"} and \code{"euclid"} options are based on \code{\link[stats:cov.wt]{stats::cov.wt()}}.}
 
 \item{level}{The level at which to draw an ellipse,
 or, if \code{type="euclid"}, the radius of the circle to be drawn.}


### PR DESCRIPTION
This PR aims to fix #6462.

It links to the covariate functions as suggested in the issue.