### PR TITLE
Don't bother subsetting labels

### DIFF
--- a/R/layer.R
+++ b/R/layer.R
@@ -972,10 +972,8 @@ normalise_label <- function(label) {
     return(NULL)
   }
   if (obj_is_list(label)) {
-    # Ensure that each element in the list has length 1
+    # Ensure no elements are empty
     label[lengths(label) == 0] <- ""
-    truncate <- !vapply(label, is.call, logical(1)) # Don't mess with call/formula
-    label[truncate] <- lapply(label[truncate], `[`, 1)
   }
   if (is.expression(label)) {
     # Classed expressions, when converted to lists, retain their class.


### PR DESCRIPTION
The behaviour removed here was discussed in https://github.com/tidyverse/ggplot2/pull/3740#discussion_r367380217.
It was added just to be sure specifically for scale labels. Howveer, it is a hindrance as a global behaviour because people have wild inputs for the `label` aesthetic. I think the best solution here is to just drop this defensive behaviour and let people deal with bad input themselves.