### PR TITLE
Improve message of `palette`/`na.value` mismatch

### DIFF
--- a/R/scale-.R
+++ b/R/scale-.R
@@ -1339,8 +1339,11 @@ ScaleDiscrete <- ggproto("ScaleDiscrete", Scale,
     pal_match <-
       vec_slice(pal, match(as.character(x), limits, nomatch = vec_size(pal)))
 
-    if (!is.na(na_value)) {
-      vec_slice(pal_match, vec_detect_missing(x)) <- na_value
+    if (!is.na(na_value) && vec_any_missing(x)) {
+      pal_match <- vec_assign(
+        pal_match, vec_detect_missing(x), na_value,
+        x_arg = "palette", value_arg = "na.value"
+      )
     }
     pal_match
   },

--- a/tests/testthat/_snaps/scale-.md
+++ b/tests/testthat/_snaps/scale-.md
@@ -20,6 +20,14 @@
 
     The `scale_name` argument of `binned_scale()` is deprecated as of ggplot2 3.5.0.
 
+# mismatch between `na.value` and `palette` throws error
+
+    Code
+      sc$map(x)
+    Condition
+      Error in `vec_assign()`:
+      ! Can't convert `na.value` <double> to match type of `palette` <character>.
+
 # continuous scales warn about faulty `limits`
 
     Code

--- a/tests/testthat/test-scale-.R
+++ b/tests/testthat/test-scale-.R
@@ -138,6 +138,16 @@ test_that("Using `scale_name` prompts deprecation message", {
 
 })
 
+test_that("mismatch between `na.value` and `palette` throws error", {
+  x <- c("A", "B", "C", NA)
+  sc <- scale_shape_manual(
+    values = c("circle", "triangle", "square"),
+    na.value = 4
+  )
+  sc$train(x)
+  expect_snapshot(sc$map(x), error = TRUE)
+})
+
 # Continuous scales -------------------------------------------------------
 
 test_that("limits with NA are replaced with the min/max of the data for continuous scales", {


### PR DESCRIPTION
This is a spontaneous PR without a linked issue.

The current error message when using incompatible `palette` and `na.value` is confusing. It is unclear *why* `na.value` should have the character type.

``` r
library(ggplot2)

df <- mpg
df$drv[12] <- NA

ggplot(df, aes(displ, hwy, shape = drv)) +
  geom_point() +
  scale_shape_manual(
    values = c("circle small", "triangle", "square"),
    na.value = 4
  )
#> Error in `vec_slice<-`:
#> ! Can't convert `na_value` <double> to <character>.
```

<sup>Created on 2025-12-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

In this PR, it is more clear (it should match the palette type).

``` r
#> Error in `vec_assign()` at ggplot2/R/scale-.R:1343:7:
#> ! Can't convert `na.value` <double> to match type of `palette` <character>.
```

