### PR TITLE
Total dodge width depends on unique `order` values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggplot2 (development version)
 
+* Fixed bug in `width` computation when `position_dodge(preserve = "single")` 
+  had duplicated `order` aesthetic values (@teunbrand, #6775).
 * The `arrow` and `arrow.fill` arguments are now available in 
   `geom_linerange()` and `geom_pointrange()` layers (@teunbrand, #6481).
 * (internal) `zeroGrob()` now returns a `grid::nullGrob()` (#6390).

--- a/R/position-dodge.R
+++ b/R/position-dodge.R
@@ -128,9 +128,10 @@ PositionDodge <- ggproto("PositionDodge", Position,
       n <- NULL
     } else {
       data$xmin <- data$xmin %||% data$x
-      cols <- intersect(colnames(data), c("group", "PANEL", "xmin"))
+      cols <- intersect(colnames(data), c("PANEL", "xmin"))
+      cols <- c(cols, if ("order" %in% names(data)) "order" else "group")
       n <- vec_unique(data[cols])
-      n <- vec_group_id(n[setdiff(cols, "group")])
+      n <- vec_group_id(n[setdiff(cols, c("group", "order"))])
       n <- max(tabulate(n, attr(n, "n")))
     }
 

--- a/tests/testthat/test-position-dodge.R
+++ b/tests/testthat/test-position-dodge.R
@@ -53,6 +53,18 @@ test_that("position_dodge() can use the order aesthetic", {
   expect_equal(ld$x, major + c(-0.2, 0, 0.2)[minor], ignore_attr = TRUE)
 })
 
+test_that("position_dodge() with duplicated order computes the correct width", {
+  df <- data_frame0(
+    group = c("A", "B", "C"),
+    order = c(1, 2, 2)
+  )
+  ld <- layer_data(
+    ggplot(df, aes("X", 1, group = group, order = order)) +
+      geom_col(position = position_dodge(preserve = "single", width = 1), width = 1)
+  )
+  expect_all_equal(ld$xmax - ld$xmin, 0.5)
+})
+
 test_that("position_dodge warns about missing required aesthetics", {
 
   # Bit of a contrived geom to not have a required 'x' aesthetic


### PR DESCRIPTION
This PR aims to fix #6775.

Briefly, when `order` has duplicates, these were considered as 'separate' groups to be accommodated and contributed to the `width` computation. But because they overlap, the width computation can ignore duplicates.
This PR just counts `order` if available, and else counts `group`.

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2

df <- data.frame(
  y = c(1, 3, 2),
  g = c("A", "B", "C"),
  o = c(1, 2, 2)
)

ggplot(df, aes("x", y, fill = g, order = o)) +
  geom_col(position = position_dodge(preserve = "single"))
```

![](https://i.imgur.com/QJ3NnUg.png)<!-- -->

<sup>Created on 2025-12-18 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
