### PR TITLE
Violin quantiles

### DIFF
--- a/R/geom-violin.R
+++ b/R/geom-violin.R
@@ -67,6 +67,9 @@
 #' # Show quartiles
 #' p + geom_violin(quantile.linetype = 'solid')
 #'
+#' # Show different quantiles
+#' p + geom_violin(quantiles = c(0.2, 0.4, 0.6, 0.8), quantile.linetype = 'solid')
+#'
 #' # Scales vs. coordinate transforms -------
 #' if (require("ggplot2movies")) {
 #' # Scale transformations occur before the density statistics are computed.

--- a/R/geom-violin.R
+++ b/R/geom-violin.R
@@ -65,7 +65,7 @@
 #' p + geom_violin(fill = "grey80", colour = "#3366FF")
 #'
 #' # Show quartiles
-#' p + geom_violin(draw_quantiles = c(0.25, 0.5, 0.75))
+#' p + geom_violin(quantile.linetype = 'solid')
 #'
 #' # Scales vs. coordinate transforms -------
 #' if (require("ggplot2movies")) {

--- a/R/geom-violin.R
+++ b/R/geom-violin.R
@@ -116,7 +116,8 @@ geom_violin <- function(mapping = NULL, data = NULL,
     deprecate(
       "4.0.0",
       what = "geom_violin(draw_quantiles)",
-      with = "geom_violin(quantiles.linetype)"
+      with = "geom_violin(quantiles.linetype)",
+      details = "Quantile distribution can be changed with geom_violin(quantiles)"
     )
     check_numeric(draw_quantiles)
 

--- a/R/geom-violin.R
+++ b/R/geom-violin.R
@@ -116,8 +116,8 @@ geom_violin <- function(mapping = NULL, data = NULL,
     deprecate(
       "4.0.0",
       what = "geom_violin(draw_quantiles)",
-      with = "geom_violin(quantiles.linetype)",
-      details = "Quantile distribution can be changed with geom_violin(quantiles)"
+      with = "geom_violin(quantile.linetype)",
+      details = "Quantiles can be changed with `geom_violin(quantiles)`"
     )
     check_numeric(draw_quantiles)
 

--- a/man/geom_violin.Rd
+++ b/man/geom_violin.Rd
@@ -238,7 +238,7 @@ p + geom_violin(aes(fill = factor(am)))
 p + geom_violin(fill = "grey80", colour = "#3366FF")
 
 # Show quartiles
-p + geom_violin(draw_quantiles = c(0.25, 0.5, 0.75))
+p + geom_violin(quantile.linetype = 'solid')
 
 # Scales vs. coordinate transforms -------
 if (require("ggplot2movies")) {

--- a/man/geom_violin.Rd
+++ b/man/geom_violin.Rd
@@ -240,6 +240,9 @@ p + geom_violin(fill = "grey80", colour = "#3366FF")
 # Show quartiles
 p + geom_violin(quantile.linetype = 'solid')
 
+# Show different quantiles
+p + geom_violin(quantiles = c(0.2, 0.4, 0.6, 0.8), quantile.linetype = 'solid')
+
 # Scales vs. coordinate transforms -------
 if (require("ggplot2movies")) {
 # Scale transformations occur before the density statistics are computed.


### PR DESCRIPTION
This PR should resolve #6757

Provides better examples on working with quantiles in geom_violin and gives more detailed information in the deprecation message when using argument draw_quantiles