### PR TITLE
docs: clarify how vline, hline, and abline affect position scales

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -84,7 +84,7 @@ Config/usethis/last-upkeep: 2025-04-23
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3.9000
+RoxygenNote: 7.3.3
 Collate:
     'aes-delayed-eval.R'
     'aes-variants.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -84,7 +84,7 @@ Config/usethis/last-upkeep: 2025-04-23
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+RoxygenNote: 7.3.3.9000
 Collate:
     'aes-delayed-eval.R'
     'aes-variants.R'

--- a/R/geom-abline-hline-vline.R
+++ b/R/geom-abline-hline-vline.R
@@ -17,7 +17,12 @@ NULL
 #'
 #' Unlike most other geoms, these geoms do not inherit aesthetics from the plot
 #' default, because they do not understand x and y aesthetics which are
-#' commonly set in the plot. They also do not affect the x and y scales.
+#' commonly set in the plot.
+#'
+#' Unlike [geom_abline()], [geom_vline()] and [geom_hline()] include their
+#' intercepts in the position aesthetics. As a result, `xintercept` and
+#' `yintercept` values can affect the x and y scales, particularly when
+#' intercepts fall outside the range of the data.
 #'
 #' @section Aesthetics:
 #' These geoms are drawn using [geom_line()] so they support the

--- a/man/geom_abline.Rd
+++ b/man/geom_abline.Rd
@@ -146,7 +146,12 @@ to vary across facets, construct the data frame yourself and use aesthetics.
 
 Unlike most other geoms, these geoms do not inherit aesthetics from the plot
 default, because they do not understand x and y aesthetics which are
-commonly set in the plot. They also do not affect the x and y scales.
+commonly set in the plot.
+
+Unlike \code{\link[=geom_abline]{geom_abline()}}, \code{\link[=geom_vline]{geom_vline()}} and \code{\link[=geom_hline]{geom_hline()}} include their
+intercepts in the position aesthetics. As a result, \code{xintercept} and
+\code{yintercept} values can affect the x and y scales, particularly when
+intercepts fall outside the range of the data.
 }
 \section{Aesthetics}{
 


### PR DESCRIPTION
This PR updates the documentation for geom_vline(), geom_hline(), and geom_abline() to clarify that these geoms can affect position scales due to their position aesthetics (xintercept, yintercept, slope, intercept).

This reflects the current behavior introduced when position aesthetics were consolidated (#3342), and avoids suggesting that these geoms never affect scales.

Closes #6768.
