### PR TITLE
add stats:: in front of stats functions that were not explicitly imported

### DIFF
--- a/R/position-dodge.R
+++ b/R/position-dodge.R
@@ -150,13 +150,13 @@ PositionDodge <- ggproto("PositionDodge", Position,
     }
 
     data$order <- xtfrm( # xtfrm makes anything 'sortable'
-      data$order %||% stats::ave(data$group, data$x, data$PANEL, FUN = match_sorted)
+      data$order %||% vec_ave(data$group, data[c("x", "PANEL")], fn = match_sorted)
     )
     if (isTRUE(params$reverse)) {
       data$order <- -data$order
     }
     if (is.null(params$n)) { # preserve = "total"
-      data$order <- stats::ave(data$order, data$x, data$PANEL, FUN = match_sorted)
+      data$order <- vec_ave(data$order, data[c("x", "PANEL")], fn = match_sorted)
     } else { # preserve = "single"
       data$order <- match_sorted(data$order)
     }

--- a/R/position-dodge.R
+++ b/R/position-dodge.R
@@ -150,13 +150,13 @@ PositionDodge <- ggproto("PositionDodge", Position,
     }
 
     data$order <- xtfrm( # xtfrm makes anything 'sortable'
-      data$order %||% ave(data$group, data$x, data$PANEL, FUN = match_sorted)
+      data$order %||% stats::ave(data$group, data$x, data$PANEL, FUN = match_sorted)
     )
     if (isTRUE(params$reverse)) {
       data$order <- -data$order
     }
     if (is.null(params$n)) { # preserve = "total"
-      data$order <- ave(data$order, data$x, data$PANEL, FUN = match_sorted)
+      data$order <- stats::ave(data$order, data$x, data$PANEL, FUN = match_sorted)
     } else { # preserve = "single"
       data$order <- match_sorted(data$order)
     }

--- a/R/stat-ydensity.R
+++ b/R/stat-ydensity.R
@@ -79,7 +79,7 @@ StatYdensity <- ggproto(
           "{.arg quantiles} for weighted data is not implemented."
         )
       }
-      quants <- quantile(data$y, probs = quantiles)
+      quants <- stats::quantile(data$y, probs = quantiles)
       quants <- data_frame0(
         y = unname(quants),
         quantile = quantiles
@@ -88,7 +88,7 @@ StatYdensity <- ggproto(
       # Interpolate other metrics
       for (var in setdiff(names(dens), names(quants))) {
         quants[[var]] <-
-          approx(dens$y, dens[[var]], xout = quants$y, ties = "ordered")$y
+          stats::approx(dens$y, dens[[var]], xout = quants$y, ties = "ordered")$y
       }
 
       dens <- vec_slice(dens, !dens$y %in% quants$y)


### PR DESCRIPTION
This problem of not explicitly putting `stats::` in front of stats package functions was previously documented in #5186. Previously the fix was done in eg #5514

This PR is similar, cleaning up more calls to stats functions that do not have `stats::` in front of them. 