### PR TITLE
Wrap `list2` usage in `make_contructor()`

### DIFF
--- a/R/make-constructor.R
+++ b/R/make-constructor.R
@@ -140,7 +140,7 @@ make_constructor.Geom <- function(x, ..., checks = exprs(), omit = character(),
   body <- call2("{", !!!checks, body)
 
   # We encapsulate rlang::list2
-  new_env <- new_environment(list(list2 = list2), env)
+  new_env <- new_environment(list(list2 = list2_wrapper), env)
 
   new_function(fmls, body, new_env)
 }
@@ -225,8 +225,11 @@ make_constructor.Stat <- function(x, ..., checks = exprs(), omit = character(),
   body <- call2("{", !!!checks, body)
 
   # We encapsulate rlang::list2
-  new_env <- new_environment(list(list2 = list2), env)
+  new_env <- new_environment(list(list2 = list2_wrapper), env)
 
   new_function(fmls, body, new_env)
 }
 
+list2_wrapper = function(...) {
+  rlang::list2(...)
+}


### PR DESCRIPTION
This PR aims to fix #6796.

It prevents attach `rlang::list2()` as a variable direclty. I've tested the built time dependency by building ggplot2 with rlang 1.1.6, upgrading to rlang 1.1.7 and seeing if there are warnings when using the fruits of `make_contructor()`. There were no longer such warnings. Note PR targets the rc/4.0.2 branch, not the main branch.