### PR TITLE
Update startup tip to extension gallery

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -13,7 +13,7 @@ random_tip <- function() {
     "Learn more about the underlying theory at https://ggplot2-book.org/",
     "Keep up to date with changes at https://tidyverse.org/blog/",
     "Use suppressPackageStartupMessages() to eliminate package startup messages",
-    "Need help? Try Stackoverflow: https://stackoverflow.com/tags/ggplot2",
+    "Explore the ggplot2 extension gallery to extend your plotting capabilities: https://exts.ggplot2.tidyverse.org/",
     "Need help getting started? Try the R Graphics Cookbook: https://r-graphics.org",
     "Want to understand how all the pieces fit together? Read R for Data Science: https://r4ds.hadley.nz/"
   )

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -13,6 +13,7 @@ random_tip <- function() {
     "Learn more about the underlying theory at https://ggplot2-book.org/",
     "Keep up to date with changes at https://tidyverse.org/blog/",
     "Use suppressPackageStartupMessages() to eliminate package startup messages",
+    "Need help? Try Stackoverflow: https://stackoverflow.com/tags/ggplot2",
     "Explore the ggplot2 extension gallery to extend your plotting capabilities: https://exts.ggplot2.tidyverse.org/",
     "Need help getting started? Try the R Graphics Cookbook: https://r-graphics.org",
     "Want to understand how all the pieces fit together? Read R for Data Science: https://r4ds.hadley.nz/"


### PR DESCRIPTION
I replaced the Stack Overflow tip with a pointer to the ggplot2 extension gallery.

I think it could get a larger shakedown with tips on using your favorite LLM but idk, didnt want to get over my head

