### PR TITLE
Warn when position_jitterdodge() groups are inflated beyond fill

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # ggplot2 (development version)
  
+
+* `position_jitterdodge()` now warns when dodge groups appear inflated by
+  additional discrete aesthetics beyond `fill`, with guidance to set
+  `aes(group = <fill variable>)` (@Jesssullivan, #6824).
 * `make_constructor()` no longer captures `rlang::list2()` at build time.
 * The `arrow` and `arrow.fill` arguments are now available in 
   `geom_linerange()` and `geom_pointrange()` layers (@teunbrand, #6481).

--- a/R/position-jitterdodge.R
+++ b/R/position-jitterdodge.R
@@ -12,6 +12,20 @@
 #'   the default `position_dodge()` width.
 #' @inheritParams position_jitter
 #' @inheritParams position_dodge
+#'
+#' @section Interaction with grouping:
+#' When no explicit `group` aesthetic is set, ggplot2 computes groups from the
+#' interaction of all discrete aesthetics in the layer (see [aes_group_order]).
+#' If your point layer maps additional discrete aesthetics beyond the `fill`
+#' used for dodging (e.g., `colour`, `shape`, or `linetype`), the points will
+#' be split into more groups than the dodged boxplots, causing misalignment.
+#'
+#' To fix this, explicitly set `group` to the same variable used for dodging
+#' (typically the `fill` variable):
+#'
+#' \preformatted{geom_point(aes(colour = status, group = fill_var),
+#'            position = position_jitterdodge())}
+#'
 #' @export
 #' @examples
 #' set.seed(596)
@@ -19,6 +33,35 @@
 #' ggplot(dsub, aes(x = cut, y = carat, fill = clarity)) +
 #'   geom_boxplot(outlier.size = 0) +
 #'   geom_point(pch = 21, position = position_jitterdodge())
+#'
+#' # When mapping additional discrete aesthetics (e.g. colour), points
+#' # can misalign with boxes because the implicit groups are inflated.
+#' # Fix by setting group to the fill variable:
+#' \donttest{
+#' set.seed(596)
+#' df <- data.frame(
+#'   x = rep(c("A", "B"), each = 20),
+#'   y = rnorm(40),
+#'   fill_var = rep(c("g1", "g2"), 20),
+#'   colour_var = sample(c(TRUE, FALSE), 40, replace = TRUE)
+#' )
+#'
+#' # Misaligned: colour creates extra implicit groups
+#' ggplot(df, aes(x, y, fill = fill_var)) +
+#'   geom_boxplot(outlier.shape = NA) +
+#'   geom_point(
+#'     aes(colour = colour_var),
+#'     position = position_jitterdodge()
+#'   )
+#'
+#' # Fixed: explicit group aligns points with boxes
+#' ggplot(df, aes(x, y, fill = fill_var)) +
+#'   geom_boxplot(outlier.shape = NA) +
+#'   geom_point(
+#'     aes(colour = colour_var, group = fill_var),
+#'     position = position_jitterdodge()
+#'   )
+#' }
 position_jitterdodge <- function(jitter.width = NULL, jitter.height = 0,
                                  dodge.width = 0.75, reverse = FALSE,
                                  preserve = "total",
@@ -55,6 +98,28 @@ PositionJitterdodge <- ggproto("PositionJitterdodge", Position,
   setup_params = function(self, data) {
     flipped_aes <- has_flipped_aes(data)
     data <- flip_data(data, flipped_aes)
+
+    # Warn when additional discrete aesthetics inflate groups beyond fill
+    if ("fill" %in% names(data) && is_discrete(data[["fill"]])) {
+      groups_per_pos <- vec_unique(data[c("group", "PANEL", "x")])
+      n_groups <- max(tabulate(vec_group_id(groups_per_pos[c("PANEL", "x")])))
+      fills_per_pos <- vec_unique(data[c("fill", "PANEL", "x")])
+      n_fills <- max(tabulate(vec_group_id(fills_per_pos[c("PANEL", "x")])))
+      if (n_groups > n_fills) {
+        cli::cli_warn(c(
+          "Dodge groups are larger than the number of {.field fill} values.",
+          "i" = paste(
+            "This can happen when additional discrete aesthetics (e.g.,",
+            "{.field colour}) inflate the implicit grouping."
+          ),
+          "i" = paste(
+            "Set {.code aes(group = <fill variable>)} to align points",
+            "with the dodged layer."
+          )
+        ))
+      }
+    }
+
     width <- self$jitter.width %||% (resolution(data$x, zero = FALSE, TRUE) * 0.4)
 
     if (identical(self$preserve, "total")) {

--- a/man/position_jitterdodge.Rd
+++ b/man/position_jitterdodge.Rd
@@ -42,12 +42,56 @@ This is primarily used for aligning points generated through
 \code{geom_point()} with dodged boxplots (e.g., a \code{geom_boxplot()} with
 a fill aesthetic supplied).
 }
+\section{Interaction with grouping}{
+
+When no explicit \code{group} aesthetic is set, ggplot2 computes groups from the
+interaction of all discrete aesthetics in the layer (see \link{aes_group_order}).
+If your point layer maps additional discrete aesthetics beyond the \code{fill}
+used for dodging (e.g., \code{colour}, \code{shape}, or \code{linetype}), the points will
+be split into more groups than the dodged boxplots, causing misalignment.
+
+To fix this, explicitly set \code{group} to the same variable used for dodging
+(typically the \code{fill} variable):
+
+\preformatted{geom_point(aes(colour = status, group = fill_var),
+           position = position_jitterdodge())}
+}
+
 \examples{
 set.seed(596)
 dsub <- diamonds[sample(nrow(diamonds), 1000), ]
 ggplot(dsub, aes(x = cut, y = carat, fill = clarity)) +
   geom_boxplot(outlier.size = 0) +
   geom_point(pch = 21, position = position_jitterdodge())
+
+# When mapping additional discrete aesthetics (e.g. colour), points
+# can misalign with boxes because the implicit groups are inflated.
+# Fix by setting group to the fill variable:
+\donttest{
+set.seed(596)
+df <- data.frame(
+  x = rep(c("A", "B"), each = 20),
+  y = rnorm(40),
+  fill_var = rep(c("g1", "g2"), 20),
+  colour_var = sample(c(TRUE, FALSE), 40, replace = TRUE)
+)
+
+# Misaligned: colour creates extra implicit groups
+ggplot(df, aes(x, y, fill = fill_var)) +
+  geom_boxplot(outlier.shape = NA) +
+  geom_point(
+    aes(colour = colour_var),
+    position = position_jitterdodge()
+  )
+
+# Fixed: explicit group aligns points with boxes
+ggplot(df, aes(x, y, fill = fill_var)) +
+  geom_boxplot(outlier.shape = NA) +
+  geom_point(
+    aes(colour = colour_var, group = fill_var),
+    position = position_jitterdodge()
+  )
+}
 }
 \seealso{
 Other position adjustments: 

--- a/tests/testthat/_snaps/position-jitterdodge.md
+++ b/tests/testthat/_snaps/position-jitterdodge.md
@@ -1,0 +1,6 @@
+# position_jitterdodge warns when groups exceed fill levels
+
+    Dodge groups are larger than the number of fill values.
+    i This can happen when additional discrete aesthetics (e.g., colour) inflate the implicit grouping.
+    i Set `aes(group = <fill variable>)` to align points with the dodged layer.
+

--- a/tests/testthat/test-position-jitterdodge.R
+++ b/tests/testthat/test-position-jitterdodge.R
@@ -30,3 +30,66 @@ test_that("position_jitterdodge can preserve total or single width", {
     ))
   expect_equal(get_layer_data(p)$x, new_mapped_discrete(c(0.75, 1.75, 2.25)))
 })
+
+test_that("position_jitterdodge warns when groups exceed fill levels", {
+  # colour must cross with fill within each x to inflate groups
+  df <- data_frame(
+    x      = rep("A", 8),
+    y      = 1:8,
+    fill   = rep(c("f1", "f2"), each = 4),
+    colour = rep(c("c1", "c2"), 4)
+  )
+
+  p <- ggplot(df, aes(x, y, fill = fill, colour = colour)) +
+    geom_point(position = position_jitterdodge(
+      jitter.width = 0, jitter.height = 0
+    ))
+
+  expect_snapshot_warning(ggplot_build(p))
+})
+
+test_that("position_jitterdodge does not warn with explicit group matching fill", {
+  df <- data_frame(
+    x      = rep("A", 8),
+    y      = 1:8,
+    fill   = rep(c("f1", "f2"), each = 4),
+    colour = rep(c("c1", "c2"), 4)
+  )
+
+  p <- ggplot(df, aes(x, y, fill = fill, colour = colour, group = fill)) +
+    geom_point(position = position_jitterdodge(
+      jitter.width = 0, jitter.height = 0
+    ))
+
+  expect_silent(ggplot_build(p))
+})
+
+test_that("position_jitterdodge does not warn with fill only", {
+  df <- data_frame(
+    x    = rep(c("A", "B"), each = 10),
+    y    = 1:20,
+    fill = rep(c("f1", "f2"), 10)
+  )
+
+  p <- ggplot(df, aes(x, y, fill = fill)) +
+    geom_point(position = position_jitterdodge(
+      jitter.width = 0, jitter.height = 0
+    ))
+
+  expect_silent(ggplot_build(p))
+})
+
+test_that("position_jitterdodge does not warn without fill", {
+  df <- data_frame(
+    x      = rep(c("A", "B"), each = 5),
+    y      = 1:10,
+    colour = rep(c("c1", "c2"), 5)
+  )
+
+  p <- ggplot(df, aes(x, y, colour = colour)) +
+    geom_point(position = position_jitterdodge(
+      jitter.width = 0, jitter.height = 0
+    ))
+
+  expect_silent(ggplot_build(p))
+})


### PR DESCRIPTION
Warn when `position_jitterdodge()` groups are inflated beyond fill

Closes #6824.

Depending on thoughts about this 👀  I also am opening a sister PR that instead modifies default behavior, which may or may not be preferable. 

---

`position_jitterdodge()` silently misaligns points when additional discrete aesthetics (e.g., `colour`) are mapped in the point layer. The implicit group becomes finer than the `fill`-based dodge of the boxplot, but no diagnostic is emitted. The workaround (`aes(group = <fill variable>)`) requires understanding the implicit grouping mechanism, which is non-obvious.

```r
# Points land in wrong dodge slots — no error, no warning
ggplot(mtcars, aes(factor(cyl), mpg, fill = factor(am))) +
  geom_boxplot(outlier.shape = NA) +
  geom_point(aes(colour = factor(vs)),
             position = position_jitterdodge(seed = 1))
```


**Warning** (`R/position-jitterdodge.R`): In `setup_params()`, when `fill` is present and discrete, compare the number of unique groups per x-position against the number of unique fill values. When groups exceed fills, emit a `cli::cli_warn()` with the fix. Uses the same `vec_unique`/`vec_group_id`/`tabulate` pattern already at lines 63-65 of the function.

Does not fire when: the user has already set `group = <fill_var>`, only `fill` is mapped, `fill` is absent, or `fill` is continuous.

**Documentation** (`R/position-jitterdodge.R`): New `@section Interaction with grouping:` explains the mechanism and the `aes(group = ...)` fix. New `\donttest{}` example demonstrates the pitfall and solution using a small data frame.

**Tests** (`tests/testthat/test-position-jitterdodge.R`): 4 new tests covering warning/no-warning scenarios; these may be overkill.

**NEWS** (`NEWS.md`): Entry added.

### Checklist

- [x] Motivation described above and in NEWS entry (`@Jesssullivan, #6824`)
- [x] Only related changes (warning + docs for this single issue)
- [x] Tidyverse style — follows existing `cli::cli_warn()` patterns in position code
- [x] roxygen2 docs updated, `devtools::document()` run
- [x] Unit tests added (4 new, all passing)
- [ ] Visual tests — N/A (not a graphical output change)
- [x] Minimal example added to `@examples
