### PR TITLE
Fix snapshot test for `warn_dots_used()`

### DIFF
--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -1,7 +1,7 @@
 test_that("ggplot() throws informative errors", {
   expect_snapshot_error(ggplot(mapping = letters))
   expect_snapshot_error(ggplot(data))
-  expect_snapshot_warning(ggplot(foobar = "nonsense"))
+  expect_snapshot_warning(ggplot(NULL, foobar = "nonsense"))
 })
 
 test_that("construction have user friendly errors", {


### PR DESCRIPTION
rlang now uses the new R API for environments and dots to figure out whether a promise is forced or not: https://github.com/r-lib/rlang/pull/1880. One concrete change from this is that we can only see the state of the final promise in a promise chain, which causes a revdep failure with ggplot2 (https://github.com/r-lib/rlang/issues/1891).

Here is the flow:

- `ggplot(foobar = "nonsense")` dispatches on the first argument, in this case `"nonsense"`. This forces the promise in the `ggplot()` frame here: https://github.com/tidyverse/ggplot2/blob/c02c05aa6303e9592e37289d780224a06be5a27e/R/plot.R#L112

- `fortify()` is called and passes `"nonsense"` via `...` to the `NULL` method: https://github.com/tidyverse/ggplot2/blob/c02c05aa6303e9592e37289d780224a06be5a27e/R/plot.R#L126

- The `NULL` method returns to the generic, which checks for dots used here, hitting the new rlang behaviour: https://github.com/tidyverse/ggplot2/blob/c02c05aa6303e9592e37289d780224a06be5a27e/R/fortify.R#L14

The workaround implemented in this PR is to explicitly pass `data = NULL` to `ggplot()` to avoid forcing the promise on dispatch.