### PR TITLE
Update broken blogpost links

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -293,19 +293,19 @@ articles:
 news:
   releases:
   - text: "Version 4.0.0"
-    href: https://www.tidyverse.org/blog/2025/09/ggplot2-4-0-0/
+    href: https://tidyverse.org/blog/2025/09/ggplot2-4-0-0/
   - text: "Version 3.5.0"
-    href: https://www.tidyverse.org/blog/2024/02/ggplot2-3-5-0/
+    href: https://tidyverse.org/blog/2024/02/ggplot2-3-5-0/
   - text: "Version 3.4.0"
-    href: https://www.tidyverse.org/blog/2022/11/ggplot2-3-4-0/
+    href: https://tidyverse.org/blog/2022/11/ggplot2-3-4-0/
   - text: "Version 3.3.0"
-    href: https://www.tidyverse.org/blog/2020/03/ggplot2-3-3-0/
+    href: https://tidyverse.org/blog/2020/03/ggplot2-3-3-0/
   - text: "Version 3.2.0"
-    href: https://www.tidyverse.org/articles/2019/06/ggplot2-3-2-0/
+    href: https://tidyverse.org/blog/2019/06/ggplot2-3-2-0/
   - text: "Version 3.1.0"
-    href: https://www.tidyverse.org/articles/2018/10/ggplot2-3-1-0/
+    href: https://tidyverse.org/blog/2018/10/ggplot2-3-1-0/
   - text: "Version 3.0.0"
-    href: https://www.tidyverse.org/articles/2018/07/ggplot2-3-0-0/
+    href: https://tidyverse.org/blog/2018/07/ggplot2-3-0-0/
   - text: "Version 2.2.0"
     href: https://posit.co/blog/ggplot2-2-2-0/
   - text: "Version 2.1.0"


### PR DESCRIPTION
The URL for a few older blogposts changed. `https://www.tidyverse.org` redirects to `https://tidyverse.org`, so I removed the subdomain also from more recent entries.