### PR TITLE
Correct links for ggplot2 version history

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -301,11 +301,11 @@ news:
   - text: "Version 3.3.0"
     href: https://www.tidyverse.org/blog/2020/03/ggplot2-3-3-0/
   - text: "Version 3.2.0"
-    href: https://www.tidyverse.org/articles/2019/06/ggplot2-3-2-0/
+    href: https://www.tidyverse.org/blog/2019/06/ggplot2-3-2-0/
   - text: "Version 3.1.0"
-    href: https://www.tidyverse.org/articles/2018/10/ggplot2-3-1-0/
+    href: https://www.tidyverse.org/blog/2018/10/ggplot2-3-1-0/
   - text: "Version 3.0.0"
-    href: https://www.tidyverse.org/articles/2018/07/ggplot2-3-0-0/
+    href: https://www.tidyverse.org/blog/2018/07/ggplot2-3-0-0/
   - text: "Version 2.2.0"
     href: https://posit.co/blog/ggplot2-2-2-0/
   - text: "Version 2.1.0"


### PR DESCRIPTION
Hi! Just a small PR to correct invalid urls in the news section. For example, it currently has: https://tidyverse.org/articles/2019/06/ggplot2-3-2-0/, while the actual url should be https://tidyverse.org/blog/2019/06/ggplot2-3-2-0/

Other urls in the news section are valid.