### PR TITLE
Drop `Suggests: RColorBrewer`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,6 @@ Suggests:
     quantreg,
     quarto,
     ragg (>= 1.2.6),
-    RColorBrewer,
     roxygen2,
     rpart,
     sf (>= 0.7-3),

--- a/icons/icons.R
+++ b/icons/icons.R
@@ -510,6 +510,7 @@ write_icon("scale_colour_continuous", {
 })
 
 write_icon("scale_colour_viridis_d", {
+  g <- scale_colour_viridis_d()
   rectGrob(
     c(0.1, 0.3, 0.5, 0.7, 0.9),
     width = 0.21,

--- a/icons/icons.R
+++ b/icons/icons.R
@@ -488,7 +488,7 @@ write_icon("scale_colour_brewer", {
   rectGrob(
     c(0.1, 0.3, 0.5, 0.7, 0.9),
     width = 0.21,
-    gp = gpar(fill = RColorBrewer::brewer.pal(5, "PuOr"), col = NA)
+    gp = gpar(fill = scales::pal_brewer(palette = "PuOr")(5), col = NA)
   )
 })
 


### PR DESCRIPTION
This does not correspond to an issue, but by chance I noticed that the only place `RColorBrewer` was used was in the script for generating icons. I replaced it with the equivalent call to `pal_brewer()` and dropped the dependency. The only remaining reference to `RColorBrewer` is in `man/scale_brewer.Rd`, pulled in indirectly by `@inheritParams scales::pal_brewer`.

The unrelated bugfix is just because the icon script wouldn't run as `g` was undefined at that line.