### PR TITLE
Revise as_cli to return a single string without \n characters

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -786,7 +786,12 @@ attach_plot_env <- function(env) {
 }
 
 as_cli <- function(..., env = caller_env()) {
-  cli::cli_fmt(cli::cli_text(..., .envir = env))
+  withr::local_options(cli.width = 1e9)
+  cli::cli_fmt(
+    cli::cli_text(..., .envir = env),
+    collapse = TRUE,
+    strip_newline = TRUE
+  )
 }
 
 as_unordered_factor <- function(x) {

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -786,12 +786,10 @@ attach_plot_env <- function(env) {
 }
 
 as_cli <- function(..., env = caller_env()) {
-  withr::local_options(cli.width = 1e9)
-  cli::cli_fmt(
+  inject(paste(!!!cli::cli_fmt(
     cli::cli_text(..., .envir = env),
-    collapse = TRUE,
     strip_newline = TRUE
-  )
+  ), collapse = ""))
 }
 
 as_unordered_factor <- function(x) {

--- a/tests/testthat/test-properties.R
+++ b/tests/testthat/test-properties.R
@@ -21,7 +21,6 @@ test_that("property_choice works as intended", {
   expect_length(choice$validator(NULL), 0)
   expect_length(choice$validator("B"), 0)
   # Bad input
-  withr::local_options(cli.width = 20)
   expect_length(choice$validator("X"), 1)
   expect_length(choice$validator(12), 1)
 })
@@ -38,7 +37,6 @@ test_that("property_fontface works as intended", {
   expect_length(fontface$validator(2), 0)
   expect_length(fontface$validator("italic"), 0)
   # Bad input
-  withr::local_options(cli.width = 20)
   expect_length(fontface$validator(10), 1)
   expect_length(fontface$validator("foobar"), 1)
 })

--- a/tests/testthat/test-properties.R
+++ b/tests/testthat/test-properties.R
@@ -21,6 +21,7 @@ test_that("property_choice works as intended", {
   expect_length(choice$validator(NULL), 0)
   expect_length(choice$validator("B"), 0)
   # Bad input
+  withr::local_options(cli.width = 20)
   expect_length(choice$validator("X"), 1)
   expect_length(choice$validator(12), 1)
 })
@@ -37,6 +38,7 @@ test_that("property_fontface works as intended", {
   expect_length(fontface$validator(2), 0)
   expect_length(fontface$validator("italic"), 0)
   # Bad input
+  withr::local_options(cli.width = 20)
   expect_length(fontface$validator(10), 1)
   expect_length(fontface$validator("foobar"), 1)
 })

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -230,6 +230,7 @@ test_that("list conversion works for ggplot classes", {
 })
 
 test_that("as_cli returns a single one-line string", {
+  withr::local_options(cli.width = 20)
   text <- as_cli("I am a really long string but despite that {.fn as_cli}
                  will return me as one string without line breaks")
   expect_length(text, 1)

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -228,3 +228,10 @@ test_that("list conversion works for ggplot classes", {
   # Plot should still be buildable
   expect_s3_class(ggplotGrob(x), "gtable")
 })
+
+test_that("as_cli returns a single one-line string", {
+  text <- as_cli("I am a really long string but despite that {.fn as_cli}
+                 will return me as one string without line breaks")
+  expect_length(text, 1)
+  expect_no_match(text, "\n", fixed = TRUE)
+})


### PR DESCRIPTION
Attempts to fix #6789. This PR revises the internal helper function `as_cli`, which is used to richly format text for printing to the console.

Previously, `as_cli(...)` could return a character vector of length > 1 if the text in `...` was longer than the console width. That's a problem for S7 property validators which expect a string (i.e. a length-1 character vector) for signaling an error. So this PR aims to fix that by

1) using the `cli::cli_fmt(collapse = TRUE, strip_newline = TRUE)` options which ensure we get a string but which may have internal `"\n"` characters, and

2) locally setting the `cli.width` global option to an enormous number so that `cli::cli_fmt` thinks the console is enormously wide and thus does not insert any `"\n"`s.

The reason I don't want `cli::cli_fmt` to insert newline characters is that the function generally doesn't have access to the complete text to be printed, and thus it will insert newlines in the wrong places. E.g., with S7 property validators, the text `"- @prop_name "` is prepended to the error message, but cli doesn't account for the length of that text which can lead to strange-looking line wrapping.

Regarding testing, I added a new direct test of the revised `as_cli` behaviour in `test-utilities.R`. I also revised a couple tests of S7 property validators in `test-properties.R` which previously passed but only because they weren't testing the error messages with a narrow console width. Now the tests simulate a narrow console and they still pass but only because of the revision to `as_cli`.

I ran the whole suite of package tests and they all passed (except for a few that were skipped because they're OS-specific), including tests of the behavior of other functions that use `as_cli`, including `check_required_aesthetics` and `validate_subclass`.

I think this is ready for review at your convenience.