### PR TITLE
don't mention build_ggplot() in documentation #6869

### DIFF
--- a/R/plot-build.R
+++ b/R/plot-build.R
@@ -1,10 +1,9 @@
 #' Build ggplot for rendering.
 #'
-#' `build_ggplot()` takes the plot object, and performs all steps necessary
+#' `ggplot_build()` takes the plot object, and performs all steps necessary
 #' to produce an object that can be rendered.  This function outputs two pieces:
 #' a list of data frames (one for each layer), and a panel object, which
-#' contain all information about axis limits, breaks etc. The `ggplot_build()`
-#' function is vestigial and `build_ggplot()` should be used instead.
+#' contain all information about axis limits, breaks etc.
 #'
 #' `get_layer_data()`, `get_layer_grob()`, and `get_panel_scales()` are helper
 #' functions that return the data, grob, or scales associated with a given

--- a/man/ggplot_build.Rd
+++ b/man/ggplot_build.Rd
@@ -37,11 +37,10 @@ plot). In \code{get_panel_scales()} (only integers allowed), the row of a facet 
 scales for.}
 }
 \description{
-\code{build_ggplot()} takes the plot object, and performs all steps necessary
+\code{ggplot_build()} takes the plot object, and performs all steps necessary
 to produce an object that can be rendered.  This function outputs two pieces:
 a list of data frames (one for each layer), and a panel object, which
-contain all information about axis limits, breaks etc. The \code{ggplot_build()}
-function is vestigial and \code{build_ggplot()} should be used instead.
+contain all information about axis limits, breaks etc.
 }
 \details{
 \code{get_layer_data()}, \code{get_layer_grob()}, and \code{get_panel_scales()} are helper


### PR DESCRIPTION
Small documentation update to remove mentions of the `build_ggplot()` since it isn't available. It's also mentionned in `NEWS.md` but I haven't touched it. Original issue: #6869