### PR TITLE
Avoid ':::' for exported name in tests

### DIFF
--- a/tests/testthat/test-theme.R
+++ b/tests/testthat/test-theme.R
@@ -158,8 +158,8 @@ test_that("calculating theme element inheritance works", {
 
   theme <- theme_gray() +
     theme(strip.text = element_blank(), strip.text.x = element_text(inherit.blank = TRUE))
-  e1 <- ggplot2:::calc_element("strip.text.x", theme)
-  e2 <- ggplot2:::calc_element("strip.text", theme)
+  e1 <- calc_element("strip.text.x", theme)
+  e2 <- calc_element("strip.text", theme)
   expect_identical(e1, e2)
 
   # Check that rel units are computed appropriately


### PR DESCRIPTION
Came across this while testing `lintr::namespace_linter()`.

This is exported since 14 years ago (6661a5b312810f719556cc422db4d0d29e2ad243):

https://github.com/tidyverse/ggplot2/blob/6870419aa6e106c3580c45c81d5b688cb31758bd/NAMESPACE#L275

This appears to have been an oversight in #3663