### PR TITLE
Snapshot upkeep

### DIFF
--- a/tests/testthat/test-geom-label.R
+++ b/tests/testthat/test-geom-label.R
@@ -29,7 +29,11 @@ test_that("geom_label handles line parameters and colours", {
   p <- ggplot(df, aes(x, label = labels, colour = labels, linewidth = x)) +
     geom_label(aes(y = 1), border.colour = "black", linetype = 1) +
     geom_label(aes(y = 2), text.colour = "black", linetype = 2) +
-    scale_linewidth(range = c(0.1, 1))
+    scale_linewidth(range = c(0.1, 1)) +
+    guides(
+      colour = guide_legend(order = 1),
+      linewidth = guide_legend(order = 2)
+    )
 
   expect_doppelganger("geom_label with line parameters", p)
 })

--- a/tests/testthat/test-guide-legend.R
+++ b/tests/testthat/test-guide-legend.R
@@ -263,10 +263,12 @@ test_that("legend.key.justification works as intended", {
   p <- ggplot(mtcars, aes(mpg, disp, colour = factor(cyl), size = drat)) +
     geom_point() +
     scale_size_continuous(
-      range = c(0, 20), breaks = c(3, 4, 5), limits = c(2.5, 5)
+      range = c(0, 20), breaks = c(3, 4, 5), limits = c(2.5, 5),
+      guide = guide_legend(order = 1)
     ) +
     scale_colour_discrete(
-      labels = c("one line", "up\nto\nfour\nlines", "up\nto\nfive\nwhole\nlines")
+      labels = c("one line", "up\nto\nfour\nlines", "up\nto\nfive\nwhole\nlines"),
+      guide = guide_legend(order = 2)
     ) +
     theme(legend.key.justification = c(1, 0))
 

--- a/tests/testthat/test-guides.R
+++ b/tests/testthat/test-guides.R
@@ -239,14 +239,16 @@ test_that("guides are positioned correctly", {
               theme = theme(
                 legend.position.inside = c(0, 1),
                 legend.justification.inside = c(0, 1)
-              )
+              ),
+              order = 2
           ),
           fill = guide_legend(
               position = "inside",
               theme = theme(
                 legend.position.inside = c(1, 0),
                 legend.justification.inside = c(1, 0)
-              )
+              ),
+              order = 1
           )
       )
   )

--- a/tests/testthat/test-theme.R
+++ b/tests/testthat/test-theme.R
@@ -678,6 +678,10 @@ test_that("legends are placed correctly when using stretchy spacing", {
 
   p <- ggplot(df, aes(x, y, colour = a, shape = factor(x))) +
     geom_point() +
+    guides(
+      colour = guide_legend(order = 1),
+      shape = guide_legend(order = 2)
+    ) +
     theme(
       legend.box.background = element_rect(colour = "blue", fill = NA),
       legend.background = element_rect(colour = "red", fill = NA)

--- a/tests/testthat/test-utilities-patterns.R
+++ b/tests/testthat/test-utilities-patterns.R
@@ -60,6 +60,12 @@ test_that("fill_alpha works as expected", {
 
 test_that("geoms can use pattern fills", {
 
+  # This prevents deletion of snapshots when skipped
+  announce_snapshot_file("pattern-fills-no-alpha.svg")
+  announce_snapshot_file("pattern-fills-through-scale.svg")
+  announce_snapshot_file("pattern-fills-with-alpha.svg")
+  announce_snapshot_file("single-pattern-fill.svg")
+
   skip_if_not_installed("grid", "4.2.0")
   skip_if_not_installed("svglite", "2.1.2")
   # TODO: ideally we should test this on all platforms, but currently they


### PR DESCRIPTION
Added two things to upkeep snapshots:

* Fixed legend order, to prevent frivolous placement of legends depending on hash algorithm. Needed because of a recent change in rlang hashing.
* Announcing skippable snapshot files to prevent deleting the snapshots by just running the tests on non-windows machines. First time I'm personally running the tests on macos, which prevented me from spotting the issue before.